### PR TITLE
rust: update reth dep to d7d34e7

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2529,7 +2529,7 @@ dependencies = [
  "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "regex",
@@ -3397,7 +3397,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3984,7 +3984,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5936,7 +5936,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-layer",
@@ -9225,7 +9225,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 3.5.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -10722,7 +10722,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "once_cell",
@@ -10742,7 +10742,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -10755,7 +10755,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -10856,7 +10856,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -10895,7 +10895,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -11412,7 +11412,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -11439,7 +11439,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -11472,7 +11472,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.1.1",
@@ -11492,7 +11492,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -11505,7 +11505,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.1.1",
@@ -11594,7 +11594,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -11604,7 +11604,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-eips 2.1.1",
  "alloy-primitives",
@@ -11657,7 +11657,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -11673,7 +11673,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eip7928 0.4.5",
@@ -11687,7 +11687,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -11700,7 +11700,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -11725,7 +11725,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -11754,7 +11754,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -11780,7 +11780,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-genesis",
@@ -11810,7 +11810,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-eips 2.1.1",
  "alloy-primitives",
@@ -11825,7 +11825,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -11850,7 +11850,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -11874,7 +11874,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -11898,7 +11898,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -11933,7 +11933,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -11990,7 +11990,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -12017,7 +12017,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -12040,7 +12040,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -12067,7 +12067,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eip7928 0.4.5",
@@ -12122,7 +12122,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -12152,7 +12152,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -12170,7 +12170,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -12186,7 +12186,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -12209,7 +12209,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -12220,7 +12220,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -12249,7 +12249,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.1.1",
@@ -12274,7 +12274,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth 2.1.1",
@@ -12315,7 +12315,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "clap",
  "eyre",
@@ -12338,7 +12338,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -12354,7 +12354,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-eips 2.1.1",
  "alloy-primitives",
@@ -12370,7 +12370,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -12384,7 +12384,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -12414,7 +12414,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -12428,7 +12428,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -12438,7 +12438,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eip7928 0.4.5",
@@ -12463,7 +12463,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -12483,7 +12483,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -12501,7 +12501,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -12514,7 +12514,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -12533,7 +12533,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -12571,7 +12571,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-test-utils"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-eips 2.1.1",
  "eyre",
@@ -12603,7 +12603,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-eips 2.1.1",
  "alloy-primitives",
@@ -12617,7 +12617,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "serde",
  "serde_json",
@@ -12627,7 +12627,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -12653,7 +12653,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "bytes",
  "futures",
@@ -12673,7 +12673,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -12690,7 +12690,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "bindgen",
  "cc",
@@ -12699,7 +12699,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "futures",
  "metrics",
@@ -12712,7 +12712,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -12721,7 +12721,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "futures-util",
  "if-addrs 0.14.0",
@@ -12735,7 +12735,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -12793,7 +12793,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -12818,7 +12818,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eip7928 0.4.5",
@@ -12842,7 +12842,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -12857,7 +12857,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -12871,7 +12871,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -12888,7 +12888,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -12912,7 +12912,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -12980,7 +12980,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -13035,7 +13035,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -13084,7 +13084,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -13108,7 +13108,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -13132,7 +13132,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "bytes",
  "eyre",
@@ -13161,7 +13161,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -13788,7 +13788,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -13812,7 +13812,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -13824,7 +13824,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -13847,7 +13847,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-util"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -13857,7 +13857,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-rpc-types-engine",
@@ -13900,7 +13900,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eip7928 0.4.5",
@@ -13948,7 +13948,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -13975,7 +13975,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -13991,7 +13991,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -14006,7 +14006,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-dyn-abi",
@@ -14083,7 +14083,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-eips 2.1.1",
  "alloy-genesis",
@@ -14113,7 +14113,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-network 2.1.1",
  "alloy-provider",
@@ -14156,7 +14156,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-evm",
@@ -14176,7 +14176,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-eips 2.1.1",
  "alloy-primitives",
@@ -14207,7 +14207,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-dyn-abi",
@@ -14254,7 +14254,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.1.1",
@@ -14305,7 +14305,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -14319,7 +14319,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-eips 2.1.1",
  "alloy-primitives",
@@ -14350,7 +14350,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -14401,7 +14401,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-eips 2.1.1",
  "alloy-primitives",
@@ -14429,7 +14429,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -14443,7 +14443,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -14463,7 +14463,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -14478,7 +14478,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eip7928 0.4.5",
@@ -14504,7 +14504,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-eips 2.1.1",
  "alloy-primitives",
@@ -14521,7 +14521,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -14542,7 +14542,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -14558,7 +14558,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -14568,7 +14568,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "clap",
  "eyre",
@@ -14588,7 +14588,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -14607,7 +14607,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -14652,7 +14652,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -14677,7 +14677,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -14704,7 +14704,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -14723,7 +14723,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -14747,7 +14747,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",
@@ -18344,7 +18344,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5f7c95348f20c1c913d72157b3c6dee6ea3e30b3d19502c5a7f6d3f160dacbf"
 dependencies = [
  "cc",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -19010,7 +19010,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -354,76 +354,76 @@ reth-rpc-traits = { version = "0.5.0", default-features = false }
 reth-zstd-compressors = { version = "0.5.0", default-features = false }
 
 # ==================== RETH CRATES (git) ====================
-reth = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-chain-state = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d", default-features = false }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d", default-features = false }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d", default-features = false }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-db-common = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d", default-features = false }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-eth-wire = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-ethereum-forks = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d", default-features = false }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d", default-features = false }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-exex = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-exex-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-execution-errors = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d", default-features = false }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d", default-features = false }
-reth-fs-util = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-network = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-node-events = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-payload-builder-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-payload-util = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-payload-validator = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-prune = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d", default-features = false }
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d", default-features = false }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-rpc-engine-api = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d", default-features = false }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-stages-types = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d", default-features = false }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d", default-features = false }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d", default-features = false }
-reth-storage-errors = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d", default-features = false }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d", default-features = false }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d", default-features = false }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
+reth = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-chain-state = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc", default-features = false }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc", default-features = false }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc", default-features = false }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-db-common = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc", default-features = false }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-eth-wire = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-ethereum-forks = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc", default-features = false }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc", default-features = false }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-exex = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-exex-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-execution-errors = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc", default-features = false }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc", default-features = false }
+reth-fs-util = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-network = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-node-events = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-payload-builder-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-payload-util = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-payload-validator = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-prune = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc", default-features = false }
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc", default-features = false }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-rpc-engine-api = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc", default-features = false }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-stages-types = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc", default-features = false }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc", default-features = false }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc", default-features = false }
+reth-storage-errors = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc", default-features = false }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc", default-features = false }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc", default-features = false }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
 
 # ==================== REVM (latest: op-reth versions) ====================
 revm = { version = "41.0.0", default-features = false }

--- a/rust/op-rbuilder/Cargo.lock
+++ b/rust/op-rbuilder/Cargo.lock
@@ -1523,7 +1523,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1534,7 +1534,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2810,7 +2810,7 @@ version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
 dependencies = [
- "darling 0.20.11",
+ "darling 0.23.0",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -3986,7 +3986,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4329,7 +4329,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4825,8 +4825,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -5459,7 +5459,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "system-configuration",
  "tokio",
  "tower-layer",
@@ -5495,7 +5495,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -7626,7 +7626,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9093,7 +9093,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -9133,9 +9133,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9597,7 +9597,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-primitives 1.6.0",
  "alloy-rpc-types 2.1.1",
@@ -9638,7 +9638,7 @@ dependencies = [
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -9665,7 +9665,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -9698,7 +9698,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.1.1",
@@ -9718,7 +9718,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-genesis 2.1.1",
  "clap",
@@ -9731,7 +9731,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.1.1",
@@ -9815,7 +9815,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -9825,7 +9825,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-eips 2.1.1",
  "alloy-primitives 1.6.0",
@@ -9876,7 +9876,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -9892,7 +9892,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eip7928 0.4.5",
@@ -9906,7 +9906,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -9919,7 +9919,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -9944,7 +9944,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-primitives 1.6.0",
  "derive_more",
@@ -9973,7 +9973,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives 1.6.0",
@@ -9999,7 +9999,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-genesis 2.1.1",
@@ -10029,7 +10029,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-eips 2.1.1",
  "alloy-primitives 1.6.0",
@@ -10044,7 +10044,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-primitives 1.6.0",
  "alloy-rlp",
@@ -10069,7 +10069,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-primitives 1.6.0",
  "alloy-rlp",
@@ -10093,7 +10093,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-primitives 1.6.0",
  "dashmap",
@@ -10117,7 +10117,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -10152,7 +10152,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "aes",
  "alloy-primitives 1.6.0",
@@ -10179,7 +10179,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives 1.6.0",
@@ -10202,7 +10202,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -10229,7 +10229,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eip7928 0.4.5",
@@ -10284,7 +10284,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives 1.6.0",
@@ -10314,7 +10314,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -10332,7 +10332,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-primitives 1.6.0",
  "bytes",
@@ -10348,7 +10348,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives 1.6.0",
@@ -10371,7 +10371,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -10382,7 +10382,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-chains",
  "alloy-primitives 1.6.0",
@@ -10410,7 +10410,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.1.1",
@@ -10432,7 +10432,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "clap",
  "eyre",
@@ -10455,7 +10455,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -10471,7 +10471,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-eips 2.1.1",
  "alloy-primitives 1.6.0",
@@ -10487,7 +10487,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -10500,7 +10500,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -10530,7 +10530,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -10544,7 +10544,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -10554,7 +10554,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eip7928 0.4.5",
@@ -10579,7 +10579,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -10599,7 +10599,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-primitives 1.6.0",
  "fixed-cache",
@@ -10617,7 +10617,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-evm",
  "alloy-primitives 1.6.0",
@@ -10630,7 +10630,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -10649,7 +10649,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -10687,7 +10687,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-eips 2.1.1",
  "alloy-primitives 1.6.0",
@@ -10701,7 +10701,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "serde",
  "serde_json",
@@ -10711,7 +10711,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives 1.6.0",
@@ -10737,7 +10737,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "bytes",
  "futures",
@@ -10757,7 +10757,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "bitflags 2.13.0",
  "byteorder",
@@ -10774,7 +10774,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "bindgen",
  "cc",
@@ -10783,7 +10783,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "futures",
  "metrics",
@@ -10796,7 +10796,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-primitives 1.6.0",
  "ipnet",
@@ -10805,7 +10805,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "futures-util",
  "if-addrs 0.14.0",
@@ -10819,7 +10819,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -10877,7 +10877,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives 1.6.0",
@@ -10902,7 +10902,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eip7928 0.4.5",
@@ -10926,7 +10926,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-primitives 1.6.0",
  "alloy-rlp",
@@ -10941,7 +10941,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10955,7 +10955,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -10972,7 +10972,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10996,7 +10996,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -11064,7 +11064,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -11119,7 +11119,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -11168,7 +11168,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives 1.6.0",
@@ -11192,7 +11192,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -11216,7 +11216,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "bytes",
  "eyre",
@@ -11245,7 +11245,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -11736,7 +11736,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives 1.6.0",
@@ -11760,7 +11760,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -11772,7 +11772,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -11795,7 +11795,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-util"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives 1.6.0",
@@ -11805,7 +11805,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-rpc-types-engine",
@@ -11848,7 +11848,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eip7928 0.4.5",
@@ -11896,7 +11896,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives 1.6.0",
@@ -11923,7 +11923,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-primitives 1.6.0",
  "arbitrary",
@@ -11939,7 +11939,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-primitives 1.6.0",
  "alloy-rlp",
@@ -11954,7 +11954,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-dyn-abi",
@@ -12031,7 +12031,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-eips 2.1.1",
  "alloy-genesis 2.1.1",
@@ -12061,7 +12061,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-network 2.1.1",
  "alloy-provider 2.1.1",
@@ -12104,7 +12104,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-evm",
@@ -12124,7 +12124,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-eips 2.1.1",
  "alloy-primitives 1.6.0",
@@ -12155,7 +12155,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-dyn-abi",
@@ -12202,7 +12202,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.1.1",
@@ -12253,7 +12253,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -12267,7 +12267,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-eips 2.1.1",
  "alloy-primitives 1.6.0",
@@ -12298,7 +12298,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives 1.6.0",
@@ -12349,7 +12349,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-eips 2.1.1",
  "alloy-primitives 1.6.0",
@@ -12377,7 +12377,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-primitives 1.6.0",
  "arbitrary",
@@ -12391,7 +12391,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-primitives 1.6.0",
  "parking_lot",
@@ -12411,7 +12411,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-primitives 1.6.0",
  "clap",
@@ -12426,7 +12426,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eip7928 0.4.5",
@@ -12452,7 +12452,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-eips 2.1.1",
  "alloy-primitives 1.6.0",
@@ -12469,7 +12469,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -12490,7 +12490,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -12506,7 +12506,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -12516,7 +12516,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "clap",
  "eyre",
@@ -12534,7 +12534,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -12553,7 +12553,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -12596,7 +12596,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -12621,7 +12621,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives 1.6.0",
@@ -12648,7 +12648,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-primitives 1.6.0",
  "metrics",
@@ -12667,7 +12667,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-evm",
  "alloy-primitives 1.6.0",
@@ -12691,7 +12691,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-primitives 1.6.0",
  "alloy-trie",
@@ -13224,7 +13224,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13313,7 +13313,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.8",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13987,7 +13987,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -14337,7 +14337,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -14426,7 +14426,7 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows 0.62.2",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -15726,7 +15726,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/rust/op-rbuilder/Cargo.toml
+++ b/rust/op-rbuilder/Cargo.toml
@@ -46,7 +46,7 @@ unreachable_pub = "deny"
 unused_async = "warn"
 
 [workspace.dependencies]
-reth = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d", default-features = false, features = [
+reth = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc", default-features = false, features = [
     "jemalloc",
     "otlp",
     "otlp-logs",
@@ -55,50 +55,50 @@ reth = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e4
     "asm-keccak",
     "min-trace-logs",
 ] }
-reth-chain-state = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-db-common = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-rpc-engine-api = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-trie-parallel = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-primitives = { package = "reth-ethereum-primitives", git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
+reth-chain-state = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-db-common = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-rpc-engine-api = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-trie-parallel = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-primitives = { package = "reth-ethereum-primitives", git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
 reth-primitives-traits = { version = "0.5.0", default-features = false }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d", features = [
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc", features = [
     "test-utils",
 ] }
 
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-execution-errors = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-exex = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-payload-builder-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-payload-util = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-rpc-layer = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-testing-utils = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-tracing-otlp = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-ipc = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-execution-errors = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-exex = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-payload-builder-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-payload-util = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-rpc-layer = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-testing-utils = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-tracing-otlp = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-ipc = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
 
 # reth optimism
 reth-optimism-primitives = { path = "../op-reth/crates/primitives/", default-features = false }

--- a/rust/rollup-boost/Cargo.lock
+++ b/rust/rollup-boost/Cargo.lock
@@ -1875,7 +1875,7 @@ version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.20.11",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -2726,7 +2726,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4239,7 +4239,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-layer",
@@ -6916,7 +6916,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6955,7 +6955,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -7399,7 +7399,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7426,7 +7426,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7459,7 +7459,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7479,7 +7479,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -7492,7 +7492,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7576,7 +7576,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7586,7 +7586,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7635,7 +7635,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -7651,7 +7651,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -7665,7 +7665,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7678,7 +7678,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7703,7 +7703,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -7732,7 +7732,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7758,7 +7758,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -7788,7 +7788,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7803,7 +7803,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7828,7 +7828,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7852,7 +7852,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -7876,7 +7876,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7911,7 +7911,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7968,7 +7968,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -7995,7 +7995,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8018,7 +8018,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8045,7 +8045,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8100,7 +8100,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8130,7 +8130,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8148,7 +8148,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -8164,7 +8164,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8187,7 +8187,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -8198,7 +8198,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -8226,7 +8226,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8248,7 +8248,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8264,7 +8264,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8280,7 +8280,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -8293,7 +8293,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8323,7 +8323,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8337,7 +8337,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -8347,7 +8347,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8372,7 +8372,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8392,7 +8392,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -8410,7 +8410,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -8423,7 +8423,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8442,7 +8442,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8480,7 +8480,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8494,7 +8494,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "serde",
  "serde_json",
@@ -8504,7 +8504,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8530,7 +8530,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "bytes",
  "futures",
@@ -8550,7 +8550,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -8567,7 +8567,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "bindgen",
  "cc",
@@ -8576,7 +8576,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "futures",
  "metrics",
@@ -8589,7 +8589,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -8598,7 +8598,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -8612,7 +8612,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8670,7 +8670,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8695,7 +8695,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8719,7 +8719,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8734,7 +8734,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -8748,7 +8748,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -8765,7 +8765,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -8789,7 +8789,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8857,7 +8857,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8912,7 +8912,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8961,7 +8961,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8985,7 +8985,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9009,7 +9009,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "bytes",
  "eyre",
@@ -9032,7 +9032,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -9523,7 +9523,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9547,7 +9547,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -9559,7 +9559,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9582,7 +9582,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-util"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9592,7 +9592,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9635,7 +9635,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9683,7 +9683,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9710,7 +9710,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9726,7 +9726,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9741,7 +9741,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9818,7 +9818,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -9848,7 +9848,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -9891,7 +9891,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -9911,7 +9911,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9942,7 +9942,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9989,7 +9989,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10040,7 +10040,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -10054,7 +10054,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10085,7 +10085,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10136,7 +10136,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10164,7 +10164,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10178,7 +10178,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10198,7 +10198,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10213,7 +10213,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10239,7 +10239,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10256,7 +10256,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -10277,7 +10277,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10293,7 +10293,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10303,7 +10303,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "clap",
  "eyre",
@@ -10321,7 +10321,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -10339,7 +10339,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10382,7 +10382,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10407,7 +10407,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10434,7 +10434,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -10453,7 +10453,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -10477,7 +10477,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.4.0"
-source = "git+https://github.com/paradigmxyz/reth.git?rev=f2eecc65482af4085e43eedb27a32024bf177a0d#f2eecc65482af4085e43eedb27a32024bf177a0d"
+source = "git+https://github.com/paradigmxyz/reth.git?rev=d7d34e741bb2f66a5a8253a912ddb0aaa86853dc#d7d34e741bb2f66a5a8253a912ddb0aaa86853dc"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",
@@ -13272,7 +13272,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/rust/rollup-boost/crates/flashblocks-rpc/Cargo.toml
+++ b/rust/rollup-boost/crates/flashblocks-rpc/Cargo.toml
@@ -16,19 +16,19 @@ reth-optimism-chainspec = { path = "../../../op-reth/crates/chainspec/", default
 reth-optimism-rpc = { path = "../../../op-reth/crates/rpc/" }
 reth-optimism-evm = { path = "../../../op-reth/crates/evm/", default-features = false }
 reth-optimism-forks = { path = "../../../op-reth/crates/hardforks/", default-features = false }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
 reth-primitives-traits = { version = "0.5.0", default-features = false }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d", features = [
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc", features = [
     "test-utils",
 ] }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d", default-features = false }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d", default-features = false }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc", default-features = false }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc", default-features = false }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
 
 alloy-eips.workspace = true
 alloy-primitives.workspace = true

--- a/rust/rollup-boost/crates/rollup-boost/Cargo.toml
+++ b/rust/rollup-boost/crates/rollup-boost/Cargo.toml
@@ -69,7 +69,7 @@ backoff.workspace = true
 uuid = { version = "1.17.0", features = ["v4", "v7"] }
 bytes = "1.10.1"
 lru = "0.16"
-reth-rpc-layer = { git = "https://github.com/paradigmxyz/reth.git", rev = "f2eecc65482af4085e43eedb27a32024bf177a0d" }
+reth-rpc-layer = { git = "https://github.com/paradigmxyz/reth.git", rev = "d7d34e741bb2f66a5a8253a912ddb0aaa86853dc" }
 
 [dev-dependencies]
 serial_test = "3"


### PR DESCRIPTION
## Description

Pins the monorepo reth dependencies to `d7d34e7`, the commit from [reth#26585](https://github.com/paradigmxyz/reth/pull/26585).

This exposes `PayloadStateRootHandle::take_state_root_rx`, allowing downstream consumers to apply custom timeout handling without spawning a dedicated waiter thread.

The target commit is a direct child of the previous `f2eecc6` pin, so no shared `revm`/`alloy` updates or production-code adaptations are required. All reth-dependent manifests and lockfiles are updated together.