### PR TITLE
op-deployer: update contracts tag to op-contracts/v8.0.0-pcdtest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0
 	github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.4-0.20251001155152-4eb15ccedf7e
-	github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20260611202829-ac4e48516794
+	github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20260804210749-8336d2aedd19
 	github.com/ethereum/go-ethereum v1.17.0
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/golang/snappy v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -173,8 +173,6 @@ github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.4-0.20251001155152-4eb15c
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.4-0.20251001155152-4eb15ccedf7e/go.mod h1:DYj7+vYJ4cIB7zera9mv4LcAynCL5u4YVfoeUu6Wa+w=
 github.com/ethereum-optimism/op-geth v1.101702.3-rc.5 h1:Fxs5iYFDinl1V1zpPtLOK+q/6sdpMvuvdGsQOuCborQ=
 github.com/ethereum-optimism/op-geth v1.101702.3-rc.5/go.mod h1:HzvOtk7c9KwFaSxRvUBPFHGSjIjomWtw4iSXX6vruQE=
-github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20260611202829-ac4e48516794 h1:pZtEiAqYCO5MzgPmoNOv/b/Wy8oDRC4xlNcZB0CEY7U=
-github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20260611202829-ac4e48516794/go.mod h1:NZ816PzLU1TLv1RdAvYAb6KWOj4Zm5aInT0YpDVml2Y=
 github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20260804210749-8336d2aedd19 h1:85QOfmm7CklGrwkR2yjafQY4TZoIQ4vObS+BsCI+kvs=
 github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20260804210749-8336d2aedd19/go.mod h1:NZ816PzLU1TLv1RdAvYAb6KWOj4Zm5aInT0YpDVml2Y=
 github.com/ethereum/c-kzg-4844/v2 v2.1.6 h1:xQymkKCT5E2Jiaoqf3v4wsNgjZLY0lRSkZn27fRjSls=

--- a/go.sum
+++ b/go.sum
@@ -175,6 +175,8 @@ github.com/ethereum-optimism/op-geth v1.101702.3-rc.5 h1:Fxs5iYFDinl1V1zpPtLOK+q
 github.com/ethereum-optimism/op-geth v1.101702.3-rc.5/go.mod h1:HzvOtk7c9KwFaSxRvUBPFHGSjIjomWtw4iSXX6vruQE=
 github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20260611202829-ac4e48516794 h1:pZtEiAqYCO5MzgPmoNOv/b/Wy8oDRC4xlNcZB0CEY7U=
 github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20260611202829-ac4e48516794/go.mod h1:NZ816PzLU1TLv1RdAvYAb6KWOj4Zm5aInT0YpDVml2Y=
+github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20260804210749-8336d2aedd19 h1:85QOfmm7CklGrwkR2yjafQY4TZoIQ4vObS+BsCI+kvs=
+github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20260804210749-8336d2aedd19/go.mod h1:NZ816PzLU1TLv1RdAvYAb6KWOj4Zm5aInT0YpDVml2Y=
 github.com/ethereum/c-kzg-4844/v2 v2.1.6 h1:xQymkKCT5E2Jiaoqf3v4wsNgjZLY0lRSkZn27fRjSls=
 github.com/ethereum/c-kzg-4844/v2 v2.1.6/go.mod h1:8HMkUZ5JRv4hpw/XUrYWSQNAUzhHMg2UDb/U+5m+XNw=
 github.com/ethereum/go-bigmodexpfix v0.0.0-20250911101455-f9e208c548ab h1:rvv6MJhy07IMfEKuARQ9TKojGqLVNxQajaXEp/BoqSk=

--- a/op-deployer/pkg/deployer/pipeline/init_test.go
+++ b/op-deployer/pkg/deployer/pipeline/init_test.go
@@ -72,6 +72,12 @@ func TestInitLiveStrategy_OPCMReuseLogicSepolia(t *testing.T) {
 	})
 
 	t.Run("embedded L1 locator with standard intent types and standard roles", func(t *testing.T) {
+		if standard.CurrentTag == standard.ContractsV800PCDTag {
+			// The pcdtest OPCM resolves to its own Sepolia superchain deployment, not the canonical
+			// one in the Registry.
+			t.Skip("skipping while CurrentTag is a non-canonical test tag")
+		}
+
 		runTest := func(configType state.IntentType) {
 			_, afacts := testutil.LocalArtifacts(t)
 			host, err := env.DefaultForkedScriptHost(

--- a/op-deployer/pkg/deployer/standard/standard.go
+++ b/op-deployer/pkg/deployer/standard/standard.go
@@ -55,7 +55,8 @@ const (
 	ContractsV410Tag        = "op-contracts/v4.1.0"
 	ContractsV500Tag        = "op-contracts/v5.0.0"
 	ContractsV600Tag        = "op-contracts/v6.0.0-rc.2"
-	CurrentTag              = ContractsV600Tag
+	ContractsV800PCDTag     = "op-contracts/v8.0.0-pcdtest"
+	CurrentTag              = ContractsV800PCDTag
 )
 
 var DisputeAbsolutePrestate = common.HexToHash("0x038512e02c4c3f7bdaec27d00edf55b7155e0905301e1a88083e4e0a6764d54c")


### PR DESCRIPTION
## Description

Add support for `op-contracts/v8.0.0-pcdtest` from [proposal/v8.0.0-pcdtest](https://github.com/ethereum-optimism/optimism/tree/proposal/op-contracts/v8.0.0-pcdtest)