### PR TITLE
op-acceptance-tests: enforce multi EL sync on kona

### DIFF
--- a/op-acceptance-tests/tests/sync_tester/sync_tester_elsync_multi/sync_test.go
+++ b/op-acceptance-tests/tests/sync_tester/sync_tester_elsync_multi/sync_test.go
@@ -30,7 +30,6 @@ func simpleWithSyncTesterOpts() []presets.Option {
 
 func TestMultiELSync(gt *testing.T) {
 	t := devtest.ParallelT(gt)
-	sysgo.FlakyOnKonaNode(t, "fails in ci but passes locally")
 	sys := presets.NewSimpleWithSyncTester(t, simpleWithSyncTesterOpts()...)
 	require := t.Require()
 


### PR DESCRIPTION
## Overview

Remove the Kona flaky marker from `TestMultiELSync` so failures are enforced normally.

The marker was added for a CI race where `L2CL2` could leave a payload in the sync tester's `WindowSyncPolicy` cache. #20783 fixed the root cause by clearing that cache during session reset and updated this test to call `ResetAllSessions` after stopping `L2CL2`. The marker is now stale.

## Tests

- `DEVSTACK_L2CL_KIND=kona-node DEVSTACK_L2EL_KIND=op-reth go test -count=1 -run '^TestMultiELSync$' ./op-acceptance-tests/tests/sync_tester/sync_tester_elsync_multi/`
- `DEVSTACK_L2CL_KIND=kona-node DEVSTACK_L2EL_KIND=op-reth go test -parallel=1 -count=10 -run '^TestMultiELSync$' ./op-acceptance-tests/tests/sync_tester/sync_tester_elsync_multi/`

Closes #22248
