### PR TITLE
kona-node: validate admin unsafe payload block hashes

### DIFF
--- a/op-acceptance-tests/tests/sync/elsync/gap_elp2p/sync_test.go
+++ b/op-acceptance-tests/tests/sync/elsync/gap_elp2p/sync_test.go
@@ -406,14 +406,6 @@ func TestSafeDoesNotAdvanceWhenUnsafeIsSyncing_NoELP2P(gt *testing.T) {
 // invalid payloads—whether rejected at the CL or EL—do not advance the chain.
 func TestInvalidPayloadThroughCLP2P(gt *testing.T) {
 	t := devtest.ParallelT(gt)
-	// Example error with kona-node:
-	//
-	// assertions.go:387:             ERROR[03-31|10:42:03.034]
-	// assertions.go:387:             	Error Trace:	/Users/josh/repos/optimism/op-acceptance-tests/tests/sync/elsync/gap_elp2p/sync_test.go:436
-	// assertions.go:387:             	Error:      	An error is expected but got nil.
-	// assertions.go:387:             	Test:       	TestInvalidPayloadThroughCLP2P
-	// assertions.go:387:
-	sysgo.SkipOnKonaNode(t, "not supported")
 	sys := newGapELP2PSystem(t)
 	logger := t.Logger()
 	require := t.Require()
@@ -442,7 +434,7 @@ func TestInvalidPayloadThroughCLP2P(gt *testing.T) {
 	payload.ExecutionPayload.StateRoot = eth.Bytes32{}
 	logger.Info("Injected fault to payload but not updated hash")
 	// Post invalid payload with the fault that can be checked at the CL side
-	require.Error(sys.L2CLB.Escape().RollupAPI().PostUnsafePayload(ctx, payload))
+	require.ErrorContains(sys.L2CLB.Escape().RollupAPI().PostUnsafePayload(ctx, payload), "bad block hash")
 	// ex) op-node error msg: "payload has bad block hash"
 	// CL will not send the payload but drop immediately due to hash mismatch
 	// EL did not advance
@@ -480,10 +472,10 @@ func TestInvalidPayloadThroughCLP2P(gt *testing.T) {
 	require.False(ok)
 	logger.Info("Updated payload parent to invalid payload", "newHash", newHash)
 	payload2.ExecutionPayload.BlockHash = newHash
-	_, ok = payload.CheckBlockHash()
+	_, ok = payload2.CheckBlockHash()
 	require.True(ok)
 	// Post invalid payload with the fault that can be only checked at the EL side
-	sys.L2CLB.PostUnsafePayload(payload)
+	sys.L2CLB.PostUnsafePayload(payload2)
 	// ex) op-geth error msg: "ignoring bad block: links to previously rejected block"
 	sys.L2CLB.NotAdvanced(safety.LocalUnsafe, attempts)
 	sys.L2ELB.NotAdvanced(eth.Unsafe, attempts)

--- a/rust/kona/crates/node/rpc/src/admin.rs
+++ b/rust/kona/crates/node/rpc/src/admin.rs
@@ -2,13 +2,15 @@
 
 use crate::{AdminApiServer, SequencerAdminAPIClient};
 use alloy_primitives::B256;
+use alloy_rpc_types_engine::PayloadError;
 use async_trait::async_trait;
 use core::fmt::Debug;
 use jsonrpsee::{
     core::RpcResult,
     types::{ErrorCode, ErrorObject},
 };
-use op_alloy_rpc_types_engine::OpExecutionPayloadEnvelope;
+use op_alloy_consensus::OpTxEnvelope;
+use op_alloy_rpc_types_engine::{OpExecutionPayloadEnvelope, OpPayloadError};
 
 /// The query types to the network actor for the admin api.
 #[derive(Debug)]
@@ -64,6 +66,28 @@ where
         payload: OpExecutionPayloadEnvelope,
     ) -> RpcResult<()> {
         kona_macros::inc!(gauge, kona_gossip::Metrics::RPC_CALLS, "method" => "admin_postUnsafePayload");
+
+        payload
+            .clone()
+            .into_execution_data()
+            .try_into_checked_block::<OpTxEnvelope>()
+            .map_err(|err| {
+                tracing::warn!(
+                    target: "rpc",
+                    %err,
+                    "admin_postUnsafePayload: rejecting payload"
+                );
+                let message = match &err {
+                    OpPayloadError::Eth(PayloadError::BlockHash { execution, consensus }) => {
+                        format!(
+                            "payload has bad block hash: {consensus}, actual block hash is: {execution}"
+                        )
+                    }
+                    _ => format!("invalid payload: {err}"),
+                };
+                ErrorObject::owned(ErrorCode::InvalidParams.code(), message, None::<()>)
+            })?;
+
         self.network_sender
             .send(NetworkAdminQuery::PostUnsafePayload { payload })
             .await

--- a/rust/op-alloy/crates/rpc-types-engine/src/envelope.rs
+++ b/rust/op-alloy/crates/rpc-types-engine/src/envelope.rs
@@ -742,7 +742,7 @@ impl PayloadHash {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_primitives::{Bytes, b256};
+    use alloy_primitives::{Address, Bloom, Bytes, U256, b256};
 
     #[test]
     #[cfg(feature = "std")]
@@ -770,6 +770,98 @@ mod tests {
         let expected = b256!("9999999999999999999999999999999999999999999999999999999999999999");
         assert_eq!(envelope.parent_beacon_block_root.unwrap(), expected);
         let _ = serde_json::to_string(&envelope).unwrap();
+    }
+
+    fn execution_payload_v1(block_hash: B256) -> ExecutionPayloadV1 {
+        ExecutionPayloadV1 {
+            parent_hash: b256!("1111111111111111111111111111111111111111111111111111111111111111"),
+            fee_recipient: Address::repeat_byte(0x22),
+            state_root: b256!("3333333333333333333333333333333333333333333333333333333333333333"),
+            receipts_root: b256!(
+                "4444444444444444444444444444444444444444444444444444444444444444"
+            ),
+            logs_bloom: Bloom::ZERO,
+            prev_randao: b256!("5555555555555555555555555555555555555555555555555555555555555555"),
+            block_number: 1,
+            gas_limit: 30_000_000,
+            gas_used: 21_000,
+            timestamp: 123_456_789,
+            extra_data: Bytes::from_static(&[0x12, 0x34]),
+            base_fee_per_gas: U256::from(1_000_000_000),
+            block_hash,
+            transactions: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn test_try_into_checked_block() {
+        // Pin hashes produced by op-service's independent ExecutionPayloadEnvelope.CheckBlockHash.
+        // The V3 case uses a zero beacon root because engine insertion defaults a missing root.
+        let v1_hash = b256!("55e9427d0f33b1e09e76c229aa4d685336ebc151a26820914652439a69e46791");
+        let v2_hash = b256!("de05d55fdc91f15fc85cbf222ab05a586a3b7b6afd1a7abb7f353d3522dfff15");
+        let v3_hash = b256!("f27a826220863770f4c8f5599c19a8dc82b8b2bbbc1bc689cb1b0dab6418886e");
+        let v4_hash = b256!("4034384737b7667a4015c0083ba2262ca3d196cc6fa6c3e763ee0a69ff95e780");
+
+        let cases = [
+            OpExecutionPayloadEnvelope {
+                parent_beacon_block_root: None,
+                execution_payload: OpExecutionPayload::V1(execution_payload_v1(v1_hash)),
+            },
+            OpExecutionPayloadEnvelope {
+                parent_beacon_block_root: None,
+                execution_payload: OpExecutionPayload::V2(ExecutionPayloadV2 {
+                    payload_inner: execution_payload_v1(v2_hash),
+                    withdrawals: Vec::new(),
+                }),
+            },
+            OpExecutionPayloadEnvelope {
+                parent_beacon_block_root: None,
+                execution_payload: OpExecutionPayload::V3(ExecutionPayloadV3 {
+                    payload_inner: ExecutionPayloadV2 {
+                        payload_inner: execution_payload_v1(v3_hash),
+                        withdrawals: Vec::new(),
+                    },
+                    blob_gas_used: 0,
+                    excess_blob_gas: 0,
+                }),
+            },
+            OpExecutionPayloadEnvelope {
+                parent_beacon_block_root: Some(b256!(
+                    "7777777777777777777777777777777777777777777777777777777777777777"
+                )),
+                execution_payload: OpExecutionPayload::V4(OpExecutionPayloadV4 {
+                    payload_inner: ExecutionPayloadV3 {
+                        payload_inner: ExecutionPayloadV2 {
+                            payload_inner: execution_payload_v1(v4_hash),
+                            withdrawals: Vec::new(),
+                        },
+                        blob_gas_used: 0,
+                        excess_blob_gas: 0,
+                    },
+                    withdrawals_root: b256!(
+                        "6666666666666666666666666666666666666666666666666666666666666666"
+                    ),
+                }),
+            },
+        ];
+
+        for mut envelope in cases {
+            let claimed = envelope.execution_payload.block_hash();
+            let block: Block<op_alloy_consensus::OpTxEnvelope> =
+                envelope.clone().into_execution_data().try_into_checked_block().unwrap();
+            assert_eq!(block.header.hash_slow(), claimed);
+
+            envelope.execution_payload.as_v1_mut().state_root = B256::ZERO;
+            assert!(matches!(
+                envelope
+                    .into_execution_data()
+                    .try_into_checked_block::<op_alloy_consensus::OpTxEnvelope>(),
+                Err(OpPayloadError::Eth(PayloadError::BlockHash {
+                    execution,
+                    consensus,
+                })) if execution != claimed && consensus == claimed
+            ));
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Overview

Stacked on #22280.

Validate unsafe payloads before Kona queues an `admin_postUnsafePayload` request.

op-node performs structural block-hash validation synchronously at the RPC boundary. Kona previously returned success and queued malformed envelopes, so callers could not distinguish a CL-detectable mismatch from an accepted payload. Convert the envelope into complete execution data and call `OpExecutionData::try_into_checked_block` directly, returning `InvalidParams` on conversion or hash failures, and enable `TestInvalidPayloadThroughCLP2P` on Kona.

Authoritative execution and state validation remains asynchronous in the EL: payloads that pass complete block reconstruction may still subsequently be rejected by the execution client.

## Tests

- `cargo test -p op-alloy-rpc-types-engine`
- `cargo test -p kona-rpc`
- `cargo clippy -p op-alloy-rpc-types-engine --all-targets --all-features -- -D warnings`
- `cargo clippy -p kona-rpc --all-targets --all-features -- -D warnings`
- `DEVSTACK_L2CL_KIND=kona-node DEVSTACK_L2EL_KIND=op-reth go test -parallel=1 -count=3 -run '^TestInvalidPayloadThroughCLP2P$' ./op-acceptance-tests/tests/sync/elsync/gap_elp2p/`
- `DEVSTACK_L2CL_KIND=op-node DEVSTACK_L2EL_KIND=op-reth go test -count=1 -run '^TestInvalidPayloadThroughCLP2P$' ./op-acceptance-tests/tests/sync/elsync/gap_elp2p/`

Closes #22250
