### PR TITLE
op-deployer: fix superchainconfig resolution in InitLiveStrategy

### DIFF
--- a/op-deployer/pkg/deployer/pipeline/init.go
+++ b/op-deployer/pkg/deployer/pipeline/init.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-chain-ops/script"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient"
 )
 
 func IsSupportedStateVersion(version int) bool {
@@ -55,8 +56,7 @@ func InitLiveStrategy(ctx context.Context, env *Env, intent *state.Intent, st *s
 
 		// If only an OPCM address is provided, resolve SuperchainConfigProxy from it on-chain.
 		if superchainConfigAddr == (common.Address{}) && opcmAddr != (common.Address{}) {
-			opcmContract := opcm.NewContract(opcmAddr, env.L1Client)
-			resolved, err := opcmContract.SuperchainConfig(ctx)
+			resolved, err := resolveSuperchainConfig(ctx, env.L1Client, opcmAddr)
 			if err != nil {
 				return fmt.Errorf("error resolving SuperchainConfig from OPCM at %s: %w", opcmAddr, err)
 			}
@@ -146,6 +146,15 @@ func InitGenesisStrategy(env *Env, intent *state.Intent, st *state.State) error 
 
 func immutableErr(field string, was, is any) error {
 	return fmt.Errorf("%s is immutable: was %v, is %v", field, was, is)
+}
+
+func resolveSuperchainConfig(ctx context.Context, client *ethclient.Client, opcmAddr common.Address) (common.Address, error) {
+	opcmContract := opcm.NewContract(opcmAddr, client)
+	validatorAddr, err := opcmContract.OPCMStandardValidator(ctx)
+	if err == nil {
+		return opcm.NewContract(validatorAddr, client).SuperchainConfig(ctx)
+	}
+	return opcmContract.SuperchainConfig(ctx)
 }
 
 func PopulateSuperchainState(env *Env, opcmAddr common.Address, superchainConfigProxy common.Address) (*addresses.SuperchainContracts, *addresses.SuperchainRoles, error) {

--- a/op-deployer/pkg/deployer/standard/standard.go
+++ b/op-deployer/pkg/deployer/standard/standard.go
@@ -55,7 +55,8 @@ const (
 	ContractsV410Tag        = "op-contracts/v4.1.0"
 	ContractsV500Tag        = "op-contracts/v5.0.0"
 	ContractsV600Tag        = "op-contracts/v6.0.0-rc.2"
-	CurrentTag              = ContractsV600Tag
+	ContractsV700Tag        = "op-contracts/v7.0.0-rc.4"
+	CurrentTag              = ContractsV700Tag
 )
 
 var DisputeAbsolutePrestate = common.HexToHash("0x038512e02c4c3f7bdaec27d00edf55b7155e0905301e1a88083e4e0a6764d54c")

--- a/op-deployer/pkg/deployer/standard/standard.go
+++ b/op-deployer/pkg/deployer/standard/standard.go
@@ -55,7 +55,7 @@ const (
 	ContractsV410Tag        = "op-contracts/v4.1.0"
 	ContractsV500Tag        = "op-contracts/v5.0.0"
 	ContractsV600Tag        = "op-contracts/v6.0.0-rc.2"
-	ContractsV700Tag        = "op-contracts/v7.0.0"
+	ContractsV700Tag        = "op-contracts/v7.0.0-rc.4"
 	CurrentTag              = ContractsV700Tag
 )
 

--- a/op-deployer/pkg/deployer/standard/standard.go
+++ b/op-deployer/pkg/deployer/standard/standard.go
@@ -55,7 +55,7 @@ const (
 	ContractsV410Tag        = "op-contracts/v4.1.0"
 	ContractsV500Tag        = "op-contracts/v5.0.0"
 	ContractsV600Tag        = "op-contracts/v6.0.0-rc.2"
-	ContractsV700Tag        = "op-contracts/v7.0.0-rc.4"
+	ContractsV700Tag        = "op-contracts/v7.0.0"
 	CurrentTag              = ContractsV700Tag
 )
 


### PR DESCRIPTION
## Context

On the path where an intent supplies only `opcmAddress`, `InitLiveStrategy` resolves the SuperchainConfig proxy by calling `superchainConfig()` on the OPCM (`pipeline/init.go:59`). OPCMv2 (op-contracts >= 7.0.0) dropped that getter, so the call reverts. This has been a latent issue for some time now no but `CurrentTag` still pointed at `v6.0.0-rc.2`, whose OPCM
retains the getter. Bumping the tag surfaces the issue.

## Changes

- `standard.go`: `CurrentTag` bumped to `op-contracts/v7.0.0-rc.4`.
- `init.go`: resolve  `superchainConfig()` via `opcmStandardValidator()`, falling back to the OPCM's getter.

## Tests

With the bump applied: `TestInitLiveStrategy_FlowSelection_OPCMV1` and `TestInitLiveStrategy_OPCMReuseLogicSepolia/embedded_L1_locator_with_standard_intent_types_and_standard_roles` fail, confirming the issue. 