### PR TITLE
op-supernode: gate backfill startup on finalized frontier

### DIFF
--- a/op-supernode/supernode/activity/interop/log_backfill.go
+++ b/op-supernode/supernode/activity/interop/log_backfill.go
@@ -12,9 +12,10 @@ import (
 
 // advanceColdStartInit runs one best-effort pass at cold-start initialization:
 // it collects every chain's first SafeDB entry timestamp, picks
-// verificationStartTimestamp = max(activation, max_c T_c), runs backfill, and
-// signals advance=true on success. Returns advance=false when any chain's
-// SafeDB is still empty (caller backs off and retries). Errors from the
+// verificationStartTimestamp = max(activation, max_c T_c), waits for that
+// first verification block to be finalized when backfill is enabled, runs
+// backfill, and signals advance=true on success. Returns advance=false when
+// any chain is not ready (caller backs off and retries). Errors from the
 // backfill phase are fatal.
 func (i *Interop) advanceColdStartInit() (bool, error) {
 	i.backfillAttempts.Add(1)
@@ -33,6 +34,15 @@ func (i *Interop) advanceColdStartInit() (bool, error) {
 			verificationStart = ts
 		}
 	}
+	if i.logBackfillDepth > 0 {
+		finalized, err := i.firstVerificationBlocksFinalized(verificationStart)
+		if err != nil {
+			return false, err
+		}
+		if !finalized {
+			return false, nil
+		}
+	}
 	i.verificationStartTimestamp = verificationStart
 	// Flip initialized before backfill: backfill seals into logsDB, and
 	// sealBlockDataIntoLogsDB queries firstVerifiableTimestamp to validate
@@ -44,6 +54,30 @@ func (i *Interop) advanceColdStartInit() (bool, error) {
 		return false, fmt.Errorf("backfill: %w", err)
 	}
 	i.backfillCompleted.Store(true)
+	return true, nil
+}
+
+// firstVerificationBlocksFinalized ensures a cold-start backfill cannot anchor
+// verification to reorgable L2 history.
+func (i *Interop) firstVerificationBlocksFinalized(timestamp uint64) (bool, error) {
+	for _, chain := range i.chains {
+		target, err := chain.TimestampToBlockNumber(i.ctx, timestamp)
+		if err != nil {
+			return false, fmt.Errorf("chain %s: first verification block: %w", chain.ID(), err)
+		}
+		status, err := chain.SyncStatus(i.ctx)
+		if err != nil {
+			return false, fmt.Errorf("chain %s: sync status: %w", chain.ID(), err)
+		}
+		if status == nil {
+			return false, fmt.Errorf("chain %s: nil sync status", chain.ID())
+		}
+		if status.FinalizedL2.Number < target {
+			i.log.Debug("interop cold start: waiting for first verification block to finalize",
+				"chain", chain.ID(), "target", target, "finalized", status.FinalizedL2.Number)
+			return false, nil
+		}
+	}
 	return true, nil
 }
 

--- a/op-supernode/supernode/activity/interop/startup_test.go
+++ b/op-supernode/supernode/activity/interop/startup_test.go
@@ -260,6 +260,52 @@ func TestColdStartBackfill_NoOpWhenNoChains(t *testing.T) {
 	require.Equal(t, uint64(1000), h.interop.verificationStartTimestamp)
 }
 
+// TestAdvanceColdStartInit_BackfillWaitsForFinality confirms cold-start
+// initialization does not mutate logsDB or expose a verification frontier
+// until the first verification block is irreversible on every chain.
+func TestAdvanceColdStartInit_BackfillWaitsForFinality(t *testing.T) {
+	const safeTs uint64 = 110
+	h := newInteropTestHarness(t).
+		WithActivation(100).
+		WithLogBackfillDepth(20*time.Second).
+		WithChain(10, func(m *mockChainContainer) {
+			m.firstSafeHeadTimestamp = safeTs
+			m.firstSafeHeadTimestampSet = true
+			m.syncStatusFull = &eth.SyncStatus{FinalizedL2: eth.L2BlockRef{Number: safeTs}}
+		}).
+		WithChain(20, func(m *mockChainContainer) {
+			m.firstSafeHeadTimestamp = safeTs
+			m.firstSafeHeadTimestampSet = true
+			m.syncStatusFull = &eth.SyncStatus{FinalizedL2: eth.L2BlockRef{Number: safeTs - 1}}
+		}).
+		Build()
+	h.interop.initialized.Store(false)
+	h.interop.verificationStartTimestamp = 0
+
+	advanced, err := h.interop.advanceColdStartInit()
+	require.NoError(t, err)
+	require.False(t, advanced)
+	require.False(t, h.interop.initialized.Load())
+	require.Zero(t, h.interop.verificationStartTimestamp)
+	require.False(t, h.interop.backfillCompleted.Load())
+	for _, chainID := range []uint64{10, 20} {
+		_, has := h.interop.logsDBs[eth.ChainIDFromUInt64(chainID)].LatestSealedBlock()
+		require.False(t, has, "backfill must not run before every first verification block finalizes")
+	}
+
+	mock := h.Mock(20)
+	mock.mu.Lock()
+	mock.syncStatusFull = &eth.SyncStatus{FinalizedL2: eth.L2BlockRef{Number: safeTs}}
+	mock.mu.Unlock()
+
+	advanced, err = h.interop.advanceColdStartInit()
+	require.NoError(t, err)
+	require.True(t, advanced)
+	require.True(t, h.interop.initialized.Load())
+	require.Equal(t, safeTs, h.interop.verificationStartTimestamp)
+	require.True(t, h.interop.backfillCompleted.Load())
+}
+
 // TestColdStartBackfill_GenesisClamp exercises the per-chain genesis clamp.
 // activationTimestamp=0, depth=1000s, verificationStart=2000 would naively
 // yield start=1000; but the chain's genesis time is 1500, so backfill must
@@ -275,6 +321,7 @@ func TestColdStartBackfill_GenesisClamp(t *testing.T) {
 		WithChain(10, func(m *mockChainContainer) {
 			m.firstSafeHeadTimestamp = 2000
 			m.firstSafeHeadTimestampSet = true
+			m.syncStatusFull = &eth.SyncStatus{FinalizedL2: eth.L2BlockRef{Number: 2000}}
 			m.blockNumberToTimestampOverride = func(_ context.Context, n uint64) (uint64, error) {
 				if n == 0 {
 					return 1500, nil
@@ -328,6 +375,7 @@ func TestColdStartBackfill_MisalignedActivation(t *testing.T) {
 		WithChain(10, func(m *mockChainContainer) {
 			m.firstSafeHeadTimestamp = safeTs
 			m.firstSafeHeadTimestampSet = true
+			m.syncStatusFull = &eth.SyncStatus{FinalizedL2: eth.L2BlockRef{Number: safeTs / blockTime}}
 			m.blockTimeOverride = blockTime
 			m.blockInfoTimeFn = blockNumToTime
 			m.timestampToBlockNumberOverride = func(_ context.Context, ts uint64) (uint64, error) {
@@ -380,6 +428,7 @@ func TestColdStartBackfill_RecoversFromOfflineReorg(t *testing.T) {
 		WithChain(10, func(m *mockChainContainer) {
 			m.firstSafeHeadTimestamp = safeTs
 			m.firstSafeHeadTimestampSet = true
+			m.syncStatusFull = &eth.SyncStatus{FinalizedL2: eth.L2BlockRef{Number: safeTs}}
 		}).
 		Build()
 	h.interop.initialized.Store(false)
@@ -434,6 +483,7 @@ func TestColdStartBackfill_LeavesAheadLogsDBUnchanged(t *testing.T) {
 		WithChain(10, func(m *mockChainContainer) {
 			m.firstSafeHeadTimestamp = safeTs
 			m.firstSafeHeadTimestampSet = true
+			m.syncStatusFull = &eth.SyncStatus{FinalizedL2: eth.L2BlockRef{Number: safeTs}}
 		}).
 		Build()
 	h.interop.initialized.Store(false)
@@ -482,6 +532,7 @@ func TestColdStartBackfill_TrimsNonCanonicalAheadLogsDBAndCatchesUp(t *testing.T
 		WithChain(10, func(m *mockChainContainer) {
 			m.firstSafeHeadTimestamp = safeTs
 			m.firstSafeHeadTimestampSet = true
+			m.syncStatusFull = &eth.SyncStatus{FinalizedL2: eth.L2BlockRef{Number: safeTs}}
 		}).
 		Build()
 	h.interop.initialized.Store(false)


### PR DESCRIPTION
## Description

Addresses an RV audit finding involving the interaction between cold-start log backfill and a later rewind past the first `verifiedDB` entry.

The full-rewind transition deliberately clears both `verifiedDB` and every logsDB so they can be rebuilt from the canonical chain. That remains the correct recovery behavior and is left unchanged. The problematic case only exists when cold-start backfill has inserted logs from before the first verification timestamp: those logs are seeded once at startup, so a full clear during normal operation cannot recreate them.

## Safety invariant

When log backfill is enabled, cold-start initialization now waits until every chain's L2 block at `verificationStartTimestamp` is finalized before it exposes that frontier or runs backfill.

`FinalizedL2` is derived entirely from finalized L1 information. Once the first verification block is finalized, an ordinary L1 reorg cannot move verification behind the first `verifiedDB` entry and reach the full-clear case. This prevents the backfill-specific failure mode without adding exceptions to rewind planning or transition application.

The gate checks the first verification block itself, rather than only the last block in the backfill range (`verificationStartTimestamp - 1`), so the initial verified frontier is also irreversible. It is only active when `--interop.log-backfill-depth` is non-zero; startup without backfill is unchanged.

## Tests

- Cold start with backfill waits when any chain's first verification block is not finalized.
- While waiting, initialization state, the verification timestamp, backfill completion, and all logsDBs remain untouched.
- Startup and backfill complete once every chain reaches the required finalized block.
- Existing zero-depth and backfill behavior remains covered.

The full `op-supernode` test suite and targeted `go vet` pass.
