### PR TITLE
op-reth: relax op-proofs command

### DIFF
--- a/rust/op-reth/crates/cli/src/commands/op_proofs/backfill.rs
+++ b/rust/op-reth/crates/cli/src/commands/op_proofs/backfill.rs
@@ -1,15 +1,14 @@
 //! Command that backfills OP proofs storage to an older earliest block.
 
 use clap::Parser;
+use reth_chainspec::EthChainSpec;
 use reth_cli::chainspec::ChainSpecParser;
 use reth_cli_commands::common::{AccessRights, CliNodeTypes, Environment, EnvironmentArgs};
 use reth_node_core::version::version_metadata;
-use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_node::args::{
     ProofsHistoryBackfillArgs, ProofsHistoryStorageArgs, ProofsHistoryWindowArg,
     ProofsStorageVersion,
 };
-use reth_optimism_primitives::OpPrimitives;
 use reth_optimism_trie::{
     BackfillJob, OpProofsBackfillStore, OpProofsProviderRO, db::MdbxProofsStorageV2,
 };
@@ -40,9 +39,9 @@ pub struct BackfillCommand<C: ChainSpecParser> {
     pub backfill_args: ProofsHistoryBackfillArgs,
 }
 
-impl<C: ChainSpecParser<ChainSpec = OpChainSpec>> BackfillCommand<C> {
+impl<C: ChainSpecParser<ChainSpec: EthChainSpec>> BackfillCommand<C> {
     /// Execute [`BackfillCommand`].
-    pub async fn execute<N: CliNodeTypes<ChainSpec = C::ChainSpec, Primitives = OpPrimitives>>(
+    pub async fn execute<N: CliNodeTypes<ChainSpec = C::ChainSpec>>(
         self,
         runtime: reth_tasks::Runtime,
     ) -> eyre::Result<()> {

--- a/rust/op-reth/crates/cli/src/commands/op_proofs/init.rs
+++ b/rust/op-reth/crates/cli/src/commands/op_proofs/init.rs
@@ -1,16 +1,14 @@
 //! Command that initializes the OP proofs storage with the current state of the chain.
 
 use clap::Parser;
-use reth_chainspec::ChainInfo;
+use reth_chainspec::{ChainInfo, EthChainSpec};
 use reth_cli::chainspec::ChainSpecParser;
 use reth_cli_commands::common::{AccessRights, CliNodeTypes, Environment, EnvironmentArgs};
 use reth_node_core::version::version_metadata;
-use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_node::args::{
     ProofsHistoryBackfillArgs, ProofsHistoryStorageArgs, ProofsHistoryWindowArg,
     ProofsStorageVersion,
 };
-use reth_optimism_primitives::OpPrimitives;
 use reth_optimism_trie::{
     BackfillJob, InitializationJob, OpProofsProviderRO, OpProofsStorageError, OpProofsStore,
     RethTrieStorageLayout,
@@ -54,9 +52,9 @@ pub struct InitCommand<C: ChainSpecParser> {
     pub backfill_args: ProofsHistoryBackfillArgs,
 }
 
-impl<C: ChainSpecParser<ChainSpec = OpChainSpec>> InitCommand<C> {
+impl<C: ChainSpecParser<ChainSpec: EthChainSpec>> InitCommand<C> {
     /// Execute `initialize-op-proofs` command
-    pub async fn execute<N: CliNodeTypes<ChainSpec = C::ChainSpec, Primitives = OpPrimitives>>(
+    pub async fn execute<N: CliNodeTypes<ChainSpec = C::ChainSpec>>(
         self,
         runtime: reth_tasks::Runtime,
     ) -> eyre::Result<()> {

--- a/rust/op-reth/crates/cli/src/commands/op_proofs/mod.rs
+++ b/rust/op-reth/crates/cli/src/commands/op_proofs/mod.rs
@@ -1,11 +1,10 @@
 //! OP Proofs management commands
 
 use clap::{Parser, Subcommand};
+use reth_chainspec::EthChainSpec;
 use reth_cli::chainspec::ChainSpecParser;
 use reth_cli_commands::common::CliNodeTypes;
 use reth_node_metrics::recorder::install_prometheus_recorder;
-use reth_optimism_chainspec::OpChainSpec;
-use reth_optimism_primitives::OpPrimitives;
 use std::sync::Arc;
 
 pub mod backfill;
@@ -21,9 +20,9 @@ pub struct Command<C: ChainSpecParser> {
     command: Subcommands<C>,
 }
 
-impl<C: ChainSpecParser<ChainSpec = OpChainSpec>> Command<C> {
+impl<C: ChainSpecParser<ChainSpec: EthChainSpec>> Command<C> {
     /// Execute `op-proofs` command
-    pub async fn execute<N: CliNodeTypes<ChainSpec = C::ChainSpec, Primitives = OpPrimitives>>(
+    pub async fn execute<N: CliNodeTypes<ChainSpec = C::ChainSpec>>(
         self,
         runtime: reth_tasks::Runtime,
     ) -> eyre::Result<()> {

--- a/rust/op-reth/crates/cli/src/commands/op_proofs/prune.rs
+++ b/rust/op-reth/crates/cli/src/commands/op_proofs/prune.rs
@@ -1,14 +1,13 @@
 //! Command that prunes the OP proofs storage.
 
 use clap::Parser;
+use reth_chainspec::EthChainSpec;
 use reth_cli::chainspec::ChainSpecParser;
 use reth_cli_commands::common::{AccessRights, CliNodeTypes, Environment, EnvironmentArgs};
 use reth_node_core::version::version_metadata;
-use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_node::args::{
     ProofsHistoryStorageArgs, ProofsHistoryWindowArg, ProofsStorageVersion,
 };
-use reth_optimism_primitives::OpPrimitives;
 use reth_optimism_trie::{
     OpProofStoragePruner, OpProofsProviderRO, OpProofsStore,
     db::{MdbxProofsStorage, MdbxProofsStorageV2},
@@ -39,9 +38,9 @@ pub struct PruneCommand<C: ChainSpecParser> {
     pub proofs_history_prune_batch_size: u64,
 }
 
-impl<C: ChainSpecParser<ChainSpec = OpChainSpec>> PruneCommand<C> {
+impl<C: ChainSpecParser<ChainSpec: EthChainSpec>> PruneCommand<C> {
     /// Execute [`PruneCommand`].
-    pub async fn execute<N: CliNodeTypes<ChainSpec = C::ChainSpec, Primitives = OpPrimitives>>(
+    pub async fn execute<N: CliNodeTypes<ChainSpec = C::ChainSpec>>(
         self,
         runtime: reth_tasks::Runtime,
     ) -> eyre::Result<()> {

--- a/rust/op-reth/crates/cli/src/commands/op_proofs/snapshot/drop.rs
+++ b/rust/op-reth/crates/cli/src/commands/op_proofs/snapshot/drop.rs
@@ -1,12 +1,11 @@
 //! Command that drops the OP proofs trie-state snapshot.
 
 use clap::Parser;
+use reth_chainspec::EthChainSpec;
 use reth_cli::chainspec::ChainSpecParser;
 use reth_cli_commands::common::{AccessRights, CliNodeTypes, Environment, EnvironmentArgs};
 use reth_node_core::version::version_metadata;
-use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_node::args::{ProofsHistoryStorageArgs, ProofsStorageVersion};
-use reth_optimism_primitives::OpPrimitives;
 use reth_optimism_trie::{
     OpProofsBackfillProvider, OpProofsBackfillStore, db::MdbxProofsStorageV2,
 };
@@ -24,9 +23,9 @@ pub struct SnapshotDropCommand<C: ChainSpecParser> {
     pub history: ProofsHistoryStorageArgs,
 }
 
-impl<C: ChainSpecParser<ChainSpec = OpChainSpec>> SnapshotDropCommand<C> {
+impl<C: ChainSpecParser<ChainSpec: EthChainSpec>> SnapshotDropCommand<C> {
     /// Execute [`SnapshotDropCommand`].
-    pub async fn execute<N: CliNodeTypes<ChainSpec = C::ChainSpec, Primitives = OpPrimitives>>(
+    pub async fn execute<N: CliNodeTypes<ChainSpec = C::ChainSpec>>(
         self,
         runtime: reth_tasks::Runtime,
     ) -> eyre::Result<()> {

--- a/rust/op-reth/crates/cli/src/commands/op_proofs/snapshot/init.rs
+++ b/rust/op-reth/crates/cli/src/commands/op_proofs/snapshot/init.rs
@@ -1,12 +1,11 @@
 //! Command that builds the OP proofs trie-state snapshot at a target block.
 
 use clap::Parser;
+use reth_chainspec::EthChainSpec;
 use reth_cli::chainspec::ChainSpecParser;
 use reth_cli_commands::common::{AccessRights, CliNodeTypes, Environment, EnvironmentArgs};
 use reth_node_core::version::version_metadata;
-use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_node::args::{ProofsHistoryStorageArgs, ProofsStorageVersion};
-use reth_optimism_primitives::OpPrimitives;
 use reth_optimism_trie::{
     OpProofsProviderRO, OpProofsStore, SnapshotInitJob, db::MdbxProofsStorageV2,
 };
@@ -31,9 +30,9 @@ pub struct SnapshotInitCommand<C: ChainSpecParser> {
     pub target_block: Option<u64>,
 }
 
-impl<C: ChainSpecParser<ChainSpec = OpChainSpec>> SnapshotInitCommand<C> {
+impl<C: ChainSpecParser<ChainSpec: EthChainSpec>> SnapshotInitCommand<C> {
     /// Execute [`SnapshotInitCommand`].
-    pub async fn execute<N: CliNodeTypes<ChainSpec = C::ChainSpec, Primitives = OpPrimitives>>(
+    pub async fn execute<N: CliNodeTypes<ChainSpec = C::ChainSpec>>(
         self,
         runtime: reth_tasks::Runtime,
     ) -> eyre::Result<()> {

--- a/rust/op-reth/crates/cli/src/commands/op_proofs/snapshot/mod.rs
+++ b/rust/op-reth/crates/cli/src/commands/op_proofs/snapshot/mod.rs
@@ -3,10 +3,9 @@
 //! Exposes `op-reth op-proofs snapshot {init,drop}`.
 
 use clap::{Parser, Subcommand};
+use reth_chainspec::EthChainSpec;
 use reth_cli::chainspec::ChainSpecParser;
 use reth_cli_commands::common::CliNodeTypes;
-use reth_optimism_chainspec::OpChainSpec;
-use reth_optimism_primitives::OpPrimitives;
 use std::sync::Arc;
 
 pub mod drop;
@@ -19,9 +18,9 @@ pub struct SnapshotCommand<C: ChainSpecParser> {
     command: SnapshotSubcommand<C>,
 }
 
-impl<C: ChainSpecParser<ChainSpec = OpChainSpec>> SnapshotCommand<C> {
+impl<C: ChainSpecParser<ChainSpec: EthChainSpec>> SnapshotCommand<C> {
     /// Execute the snapshot subcommand.
-    pub async fn execute<N: CliNodeTypes<ChainSpec = C::ChainSpec, Primitives = OpPrimitives>>(
+    pub async fn execute<N: CliNodeTypes<ChainSpec = C::ChainSpec>>(
         self,
         runtime: reth_tasks::Runtime,
     ) -> eyre::Result<()> {

--- a/rust/op-reth/crates/cli/src/commands/op_proofs/unwind.rs
+++ b/rust/op-reth/crates/cli/src/commands/op_proofs/unwind.rs
@@ -2,12 +2,11 @@
 
 use alloy_consensus::{BlockHeader, EMPTY_ROOT_HASH};
 use clap::Parser;
+use reth_chainspec::EthChainSpec;
 use reth_cli::chainspec::ChainSpecParser;
 use reth_cli_commands::common::{AccessRights, CliNodeTypes, Environment, EnvironmentArgs};
 use reth_node_core::version::version_metadata;
-use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_node::args::{ProofsHistoryStorageArgs, ProofsStorageVersion};
-use reth_optimism_primitives::OpPrimitives;
 use reth_optimism_trie::{
     OpProofsProviderRO, OpProofsProviderRw, OpProofsStorageError, OpProofsStore,
     db::{MdbxProofsStorage, MdbxProofsStorageV2},
@@ -63,9 +62,9 @@ impl<C: ChainSpecParser> UnwindCommand<C> {
     }
 }
 
-impl<C: ChainSpecParser<ChainSpec = OpChainSpec>> UnwindCommand<C> {
+impl<C: ChainSpecParser<ChainSpec: EthChainSpec>> UnwindCommand<C> {
     /// Execute [`UnwindCommand`].
-    pub async fn execute<N: CliNodeTypes<ChainSpec = C::ChainSpec, Primitives = OpPrimitives>>(
+    pub async fn execute<N: CliNodeTypes<ChainSpec = C::ChainSpec>>(
         self,
         runtime: reth_tasks::Runtime,
     ) -> eyre::Result<()> {


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

This PR relaxes the `op-proofs` command to make it work for all node types, even nodes that don't use `OpPrimitives` as primitive type.

Otherwise different nodes that want this same command to work would need to wrap the optimism `Cli`, which seems useless as the `op-proofs` command can work fine even without hard coding it to `OpPrimitives`.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
