### PR TITLE
op-reth: report both gas senses to the payload commit hook

### DIFF
--- a/rust/op-reth/crates/payload/src/builder.rs
+++ b/rust/op-reth/crates/payload/src/builder.rs
@@ -614,6 +614,23 @@ impl<Txs> OpBuilder<'_, Txs> {
     }
 }
 
+/// The gas a committed transaction used, in both of the senses a block builder needs.
+///
+/// Both are reported because which one is correct depends on the question being asked:
+/// [`Self::evm_gas_used`] for anything comparing against the block gas limit, since that is
+/// what [`ExecutionInfo::is_tx_over_limits`] measures, and [`Self::canonical_gas_used`] for
+/// anything accounting in receipt-visible terms.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CommittedTxGas {
+    /// Receipt-visible gas after post-exec (SDM) settlement — the block header's `gasUsed`
+    /// and the basis for what the sender pays.
+    pub canonical_gas_used: u64,
+    /// Gas the EVM burned before post-exec (SDM) settlement — the real compute performed.
+    /// Settlement only rebates today, so this is `>= canonical_gas_used`; refunds return gas
+    /// but not build time, which is why block-limit admission is gated on this figure.
+    pub evm_gas_used: u64,
+}
+
 /// A [`PayloadTransactions`] iterator that is notified of the gas used by each
 /// yielded transaction once it is actually committed to the block.
 ///
@@ -631,9 +648,12 @@ pub trait PayloadTransactionsWithCommitHook: PayloadTransactions {
     /// after it is successfully executed and committed to the block, and BEFORE any
     /// subsequent `next()` call, with the gas that transaction used. It is NOT invoked
     /// for transactions that are skipped or rejected — whether or not `mark_invalid`
-    /// was called for them. Implementors may therefore attribute `gas_used` to the
+    /// was called for them. Implementors may therefore attribute the gas to the
     /// most-recently-yielded transaction.
-    fn on_commit(&mut self, gas_used: u64);
+    ///
+    /// The two figures in [`CommittedTxGas`] are not interchangeable; see its docs for
+    /// which one a given use calls for.
+    fn on_commit(&mut self, gas: CommittedTxGas);
 }
 
 /// Adapts a plain [`PayloadTransactions`] to [`PayloadTransactionsWithCommitHook`] by ignoring
@@ -655,7 +675,7 @@ impl<T: PayloadTransactions> PayloadTransactions for RethPayloadTransactions<T> 
 }
 
 impl<T: PayloadTransactions> PayloadTransactionsWithCommitHook for RethPayloadTransactions<T> {
-    fn on_commit(&mut self, _gas_used: u64) {}
+    fn on_commit(&mut self, _gas: CommittedTxGas) {}
 }
 
 /// A type that returns a the [`PayloadTransactions`] that should be included in the pool.
@@ -1177,7 +1197,7 @@ where
             // Report the gas used by each committed transaction so a custom
             // `best_txs` can update its own per-inclusion state. `RethPayloadTransactions`
             // makes this a no-op for a plain `PayloadTransactions`.
-            best_txs.on_commit(tx_gas_used);
+            best_txs.on_commit(CommittedTxGas { canonical_gas_used: tx_gas_used, evm_gas_used });
 
             // Record the successfully committed transaction for callers that want per-call
             // visibility.

--- a/rust/op-reth/crates/payload/src/builder/tests.rs
+++ b/rust/op-reth/crates/payload/src/builder/tests.rs
@@ -1,6 +1,6 @@
 use super::{
-    ExecutionInfo, OpPayloadBuilderCtx, PayloadTransactionsWithCommitHook, RethPayloadTransactions,
-    build_post_exec_recovered_tx, try_include_post_exec_tx,
+    CommittedTxGas, ExecutionInfo, OpPayloadBuilderCtx, PayloadTransactionsWithCommitHook,
+    RethPayloadTransactions, build_post_exec_recovered_tx, try_include_post_exec_tx,
 };
 use crate::{OpPayloadBuilderAttributes, config::OpBuilderConfig};
 use alloy_consensus::{
@@ -15,12 +15,14 @@ use alloy_eips::{
 use alloy_evm::RecoveredTx;
 use alloy_primitives::{Address, B64, B256, Bytes, Signature, TxHash, TxKind, U256};
 use alloy_rpc_types_eth::erc4337::TransactionConditional;
-use op_alloy_consensus::{SDMGasEntry, build_post_exec_tx};
+use op_alloy_consensus::{
+    POST_EXEC_PAYLOAD_VERSION, PostExecPayload, SDMGasEntry, build_post_exec_tx,
+};
 use reth_basic_payload_builder::PayloadConfig;
 use reth_chainspec::MIN_TRANSACTION_GAS;
 use reth_evm::execute::{BlockBuilder, BlockExecutionError};
 use reth_optimism_chainspec::{OpChainSpec, OpChainSpecBuilder};
-use reth_optimism_evm::{OpEvmConfig, PostExecMode};
+use reth_optimism_evm::{OpEvmConfig, PostExecMode, PreRefundGasUsed};
 use reth_optimism_primitives::{OpPrimitives, OpTransactionSigned};
 use reth_optimism_txpool::{
     OpPooledTransaction, OpPooledTx,
@@ -437,10 +439,10 @@ fn execute_best_transactions_committed_txs_preserves_execution() {
     assert_eq!(committed_info.total_fees, none_info.total_fees);
 }
 
-/// `on_commit(gas)` fires once per committed tx, in commit order, with that tx's gas — never for a
-/// skipped one. Gas is pinned to the executor's own value via an oracle re-execution, and an
-/// over-gas-limit tx between the committed ones is skipped yet still yielded, exercising both
-/// halves of the contract.
+/// `on_commit(gas)` fires once per committed tx, in commit order, with that tx's canonical and
+/// pre-refund gas — never for a skipped one. Both figures are pinned to the executor's own values
+/// via an oracle re-execution, and an over-gas-limit tx between the committed ones is skipped yet
+/// still yielded, exercising both halves of the contract.
 #[test]
 fn execute_best_transactions_on_commit_hook_execution() {
     use reth_payload_util::PayloadTransactions;
@@ -449,8 +451,8 @@ fn execute_best_transactions_on_commit_hook_execution() {
     /// The gas an `on_commit` reported, attributed to the most-recently-yielded tx hash — the
     /// per-inclusion accounting a real consumer would keep.
     #[derive(Debug, PartialEq, Eq)]
-    struct CommittedGas {
-        gas_used: u64,
+    struct ReportedGas {
+        gas: CommittedTxGas,
         tx_hash: TxHash,
     }
 
@@ -459,7 +461,7 @@ fn execute_best_transactions_on_commit_hook_execution() {
     struct TestPayloadTxsImpl {
         inner: PayloadTransactionsFixed<OpPooledTransaction>,
         yielded_hashes: Rc<RefCell<Vec<TxHash>>>,
-        committed_txs_gas: Rc<RefCell<Vec<CommittedGas>>>,
+        committed_txs_gas: Rc<RefCell<Vec<ReportedGas>>>,
     }
 
     impl PayloadTransactions for TestPayloadTxsImpl {
@@ -477,9 +479,9 @@ fn execute_best_transactions_on_commit_hook_execution() {
     }
 
     impl PayloadTransactionsWithCommitHook for TestPayloadTxsImpl {
-        fn on_commit(&mut self, gas_used: u64) {
+        fn on_commit(&mut self, gas: CommittedTxGas) {
             let tx_hash = *self.yielded_hashes.borrow().last().expect("on_commit after a next()");
-            self.committed_txs_gas.borrow_mut().push(CommittedGas { gas_used, tx_hash });
+            self.committed_txs_gas.borrow_mut().push(ReportedGas { gas, tx_hash });
         }
     }
 
@@ -511,8 +513,8 @@ fn execute_best_transactions_on_commit_hook_execution() {
         Default::default(),
     );
 
-    // Re-execute each tx that should be committed so we know the gas used passed to on_commit.
-    let expected_committed_gas: Vec<CommittedGas> = {
+    // Re-execute each tx that should be committed so we know the gas passed to on_commit.
+    let expected_committed_gas: Vec<ReportedGas> = {
         let mut oracle_db = State::builder()
             .with_database(StateProviderDatabase::new(&state_provider))
             .with_bundle_update()
@@ -520,12 +522,19 @@ fn execute_best_transactions_on_commit_hook_execution() {
         let mut oracle = ctx.block_builder(&mut oracle_db).expect("oracle block builder");
         committed_order
             .iter()
-            .map(|tx| CommittedGas {
-                tx_hash: *tx.hash(),
-                gas_used: oracle
-                    .execute_transaction(tx.clone().into_consensus())
+            .map(|tx| {
+                let mut evm_gas_used = 0;
+                let canonical_gas_used = oracle
+                    .execute_transaction_with_result_closure(
+                        tx.clone().into_consensus(),
+                        |result| evm_gas_used = result.evm_gas_used(),
+                    )
                     .expect("oracle executes committed tx")
-                    .tx_gas_used(),
+                    .tx_gas_used();
+                ReportedGas {
+                    tx_hash: *tx.hash(),
+                    gas: CommittedTxGas { canonical_gas_used, evm_gas_used },
+                }
             })
             .collect()
     };
@@ -538,7 +547,7 @@ fn execute_best_transactions_on_commit_hook_execution() {
     let mut info = ExecutionInfo::new();
 
     let yielded_hashes = Rc::new(RefCell::new(Vec::<TxHash>::new()));
-    let committed_txs_gas = Rc::new(RefCell::new(Vec::<CommittedGas>::new()));
+    let committed_txs_gas = Rc::new(RefCell::new(Vec::<ReportedGas>::new()));
     let best_txs = TestPayloadTxsImpl {
         inner: PayloadTransactionsFixed::new(txs),
         yielded_hashes: yielded_hashes.clone(),
@@ -549,7 +558,7 @@ fn execute_best_transactions_on_commit_hook_execution() {
         .expect("best transactions execute");
 
     let distinct_gas: std::collections::HashSet<u64> =
-        expected_committed_gas.iter().map(|a| a.gas_used).collect();
+        expected_committed_gas.iter().map(|a| a.gas.canonical_gas_used).collect();
     assert_eq!(
         distinct_gas.len(),
         expected_committed_gas.len(),
@@ -561,6 +570,104 @@ fn execute_best_transactions_on_commit_hook_execution() {
         *committed_txs_gas.borrow(),
         expected_committed_gas,
         "committed txs and gas do not match expected"
+    );
+}
+
+/// With an SDM refund applied, the two figures `on_commit` reports must actually differ, and each
+/// must match the counter it feeds: `canonical` the receipt-visible total, `evm` the pre-refund
+/// total that block-limit admission is measured against. The plumbing test above cannot catch a
+/// swap of the two fields, because without a refund they are equal.
+#[test]
+fn on_commit_reports_canonical_and_pre_refund_gas_separately_under_sdm_refund() {
+    use reth_payload_util::PayloadTransactions;
+    use std::{cell::RefCell, rc::Rc};
+
+    struct RefundProbe {
+        inner: PayloadTransactionsFixed<OpPooledTransaction>,
+        reported: Rc<RefCell<Vec<CommittedTxGas>>>,
+    }
+
+    impl PayloadTransactions for RefundProbe {
+        type Transaction = OpPooledTransaction;
+
+        fn next(&mut self, ctx: ()) -> Option<Self::Transaction> {
+            self.inner.next(ctx)
+        }
+
+        fn mark_invalid(&mut self, sender: Address, nonce: u64) {
+            self.inner.mark_invalid(sender, nonce);
+        }
+    }
+
+    impl PayloadTransactionsWithCommitHook for RefundProbe {
+        fn on_commit(&mut self, gas: CommittedTxGas) {
+            self.reported.borrow_mut().push(gas);
+        }
+    }
+
+    const REFUND: u64 = 5_000;
+
+    let gas_limit = 10_000_000;
+    let signer = Address::repeat_byte(0x11);
+    let recipient = Address::repeat_byte(0x22);
+    let tx = op_pooled_tx_with_input(0, signer, recipient, Bytes::from(vec![0x11; 64]));
+
+    let chain_spec = Arc::new(OpChainSpecBuilder::optimism_mainnet().lagoon_activated().build());
+    let mut ctx = payload_builder_ctx(chain_spec, gas_limit);
+    // Holocene/Jovian are active under Lagoon; supply the EIP-1559 params and min base fee that
+    // next-env construction requires (zero means "use chain defaults", matching op-node).
+    ctx.config.attributes.eip_1559_params = Some(B64::ZERO);
+    ctx.config.attributes.min_base_fee = Some(0);
+
+    let mut state_provider = StateProviderTest::default();
+    state_provider.insert_account(
+        signer,
+        Account { balance: U256::MAX, ..Default::default() },
+        None,
+        Default::default(),
+    );
+
+    // Verify mode takes the refund straight from an embedded payload keyed by tx index, so a
+    // refund can be injected without the SDM contract state that Produce mode's inspector needs.
+    let post_exec_payload = PostExecPayload {
+        version: POST_EXEC_PAYLOAD_VERSION,
+        block_number: 1,
+        gas_refund_entries: entries(&[(0, REFUND)]),
+    };
+
+    let mut db = State::builder()
+        .with_database(StateProviderDatabase::new(&state_provider))
+        .with_bundle_update()
+        .build();
+    let mut builder = ctx
+        .block_builder_with_mode(&mut db, PostExecMode::Verify(post_exec_payload))
+        .expect("block builder can be created");
+    let mut info = ExecutionInfo::new();
+
+    let reported = Rc::new(RefCell::new(Vec::<CommittedTxGas>::new()));
+    let best_txs =
+        RefundProbe { inner: PayloadTransactionsFixed::new(vec![tx]), reported: reported.clone() };
+
+    ctx.execute_best_transactions(&mut info, &mut builder, best_txs, None, None)
+        .expect("best transactions execute");
+
+    let reported = reported.borrow();
+    let [gas] = reported.as_slice() else {
+        panic!("expected exactly one committed tx, got {reported:?}");
+    };
+
+    assert_eq!(
+        gas.evm_gas_used - gas.canonical_gas_used,
+        REFUND,
+        "the two reported figures must differ by exactly the refund",
+    );
+    assert_eq!(
+        gas.canonical_gas_used, info.cumulative_gas_used,
+        "canonical gas must match the receipt counter",
+    );
+    assert_eq!(
+        gas.evm_gas_used, info.cumulative_evm_gas_used,
+        "evm gas must match the pre-refund counter that admission is gated on",
     );
 }
 

--- a/rust/op-reth/crates/payload/src/lib.rs
+++ b/rust/op-reth/crates/payload/src/lib.rs
@@ -12,7 +12,9 @@
 extern crate alloc;
 
 pub mod builder;
-pub use builder::{OpPayloadBuilder, PayloadTransactionsWithCommitHook, RethPayloadTransactions};
+pub use builder::{
+    CommittedTxGas, OpPayloadBuilder, PayloadTransactionsWithCommitHook, RethPayloadTransactions,
+};
 pub mod error;
 pub mod payload;
 use op_alloy_rpc_types_engine::OpExecutionData;


### PR DESCRIPTION
## What

`PayloadTransactionsWithCommitHook::on_commit` reported a single `u64`. It now reports both gas figures a committed transaction produces:

```rust
pub struct CommittedTxGas {
    pub canonical_gas_used: u64,  // post-settlement, receipt-visible
    pub evm_gas_used: u64,        // pre-settlement, real compute
}
```

## Why

The hook reported canonical gas, but `ExecutionInfo::is_tx_over_limits` measures `cumulative_evm_gas_used` — so the one figure the hook exposed was not the one the builder enforces against, and once SDM refunds accrue the two diverge. Any per-inclusion state derived from the reported gas is therefore measured in a different unit than the limit it is compared against, with no way for an implementor to recover the difference.

## Design notes

- **Both figures rather than switching to pre-settlement.** Which one is correct depends on the question — block-limit comparisons need `evm_gas_used`, receipt-visible accounting needs `canonical_gas_used`. A hook handing over one number named "gas used" is what let them drift apart. Both are already locals at the call site, so this costs nothing.
- **Names follow the producing site.** `alloy-op-evm` already computes `canonical_gas_used = evm_gas_used.saturating_sub(post_exec_refund)`. Naming the pair after the settlement direction (`pre_refund`/`post_refund`) reads better in isolation but asserts a direction; settlement only rebates today, and `post_exec.rs` notes the payload may gain fields later. Provenance names stay accurate either way, with the `>=` relationship stated in the doc comment.
- **Breaking, deliberately.** In-tree implementors are `RethPayloadTransactions` (no-op) and one test type. Out-of-tree implementors get a compile error naming the new type; a silently-compiling `on_commit(u64)` would keep the bug.

## Testing

- New `on_commit_reports_canonical_and_pre_refund_gas_separately_under_sdm_refund` drives a 5,000-gas refund through `execute_best_transactions` and asserts the two figures differ by exactly the refund and each matches its counter on `ExecutionInfo`. Uses `PostExecMode::Verify`, so refunds come from an `SDMGasEntry` payload and no SDM contract state is needed.
- Mutation-checked: swapping the fields fails the new test. The pre-existing `execute_best_transactions_on_commit_hook_execution` passes under that same mutation — it runs on Regolith where no refund applies and the two figures are equal, so it cannot detect a swap. It is extended here to assert both figures, with its oracle capturing the pre-settlement value through the same result closure production uses.
- `cargo fmt` (nightly-2026-02-20), `clippy --all-targets -D warnings` clean, 25/25 `reth-optimism-payload-builder` tests pass.

**Not verified:** anything outside `reth-optimism-payload-builder` — no workspace-wide build or test run. CI is the check for that.