### PR TITLE
op-alloy: centralize OP execution data conversion

### DIFF
--- a/rust/kona/crates/node/engine/src/task_queue/tasks/insert/task.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/insert/task.rs
@@ -4,17 +4,12 @@ use crate::{
     EngineClient, EngineState, EngineTaskExt, InsertTaskError, SynchronizeTask,
     state::EngineSyncStateUpdate,
 };
-use alloy_eips::eip7685::EMPTY_REQUESTS_HASH;
-use alloy_rpc_types_engine::{
-    CancunPayloadFields, ExecutionPayloadInputV2, PayloadStatusEnum, PraguePayloadFields,
-};
+use alloy_rpc_types_engine::{ExecutionPayloadInputV2, PayloadStatusEnum};
 use async_trait::async_trait;
 use kona_genesis::RollupConfig;
 use kona_protocol::L2BlockInfo;
 use op_alloy_consensus::OpBlock;
-use op_alloy_rpc_types_engine::{
-    OpExecutionPayload, OpExecutionPayloadEnvelope, OpExecutionPayloadSidecar,
-};
+use op_alloy_rpc_types_engine::{OpExecutionData, OpExecutionPayload};
 use std::{sync::Arc, time::Instant};
 
 /// The task to insert a payload into the execution engine.
@@ -24,8 +19,8 @@ pub struct InsertTask<EngineClient_: EngineClient> {
     client: Arc<EngineClient_>,
     /// The rollup config.
     rollup_config: Arc<RollupConfig>,
-    /// The network payload envelope.
-    envelope: OpExecutionPayloadEnvelope,
+    /// Complete execution data for the payload.
+    execution_data: OpExecutionData,
     /// If the payload is safe this is true.
     /// A payload is safe if it is derived from a safe block.
     is_payload_safe: bool,
@@ -36,10 +31,10 @@ impl<EngineClient_: EngineClient> InsertTask<EngineClient_> {
     pub const fn new(
         client: Arc<EngineClient_>,
         rollup_config: Arc<RollupConfig>,
-        envelope: OpExecutionPayloadEnvelope,
+        execution_data: OpExecutionData,
         is_attributes_derived: bool,
     ) -> Self {
-        Self { client, rollup_config, envelope, is_payload_safe: is_attributes_derived }
+        Self { client, rollup_config, execution_data, is_payload_safe: is_attributes_derived }
     }
 
     /// Checks the response of the `engine_newPayload` call.
@@ -59,53 +54,28 @@ impl<EngineClient_: EngineClient> EngineTaskExt for InsertTask<EngineClient_> {
 
         // Insert the new payload.
         // Form the new unsafe block ref from the execution payload.
-        let parent_beacon_block_root = self.envelope.parent_beacon_block_root.unwrap_or_default();
+        let execution_data = self.execution_data.clone();
+        let parent_beacon_block_root =
+            execution_data.sidecar.parent_beacon_block_root().unwrap_or_default();
         let insert_time_start = Instant::now();
-        let (response, block): (_, OpBlock) = match self.envelope.execution_payload.clone() {
-            OpExecutionPayload::V1(payload) => (
-                self.client.new_payload_v1(payload).await,
-                self.envelope
-                    .execution_payload
-                    .clone()
-                    .try_into_block()
-                    .map_err(InsertTaskError::FromBlockError)?,
-            ),
+        let response = match execution_data.payload.clone() {
+            OpExecutionPayload::V1(payload) => self.client.new_payload_v1(payload).await,
             OpExecutionPayload::V2(payload) => {
                 let payload_input = ExecutionPayloadInputV2 {
                     execution_payload: payload.payload_inner,
                     withdrawals: Some(payload.withdrawals),
                 };
-                (
-                    self.client.new_payload_v2(payload_input).await,
-                    self.envelope
-                        .execution_payload
-                        .clone()
-                        .try_into_block()
-                        .map_err(InsertTaskError::FromBlockError)?,
-                )
+                self.client.new_payload_v2(payload_input).await
             }
-            OpExecutionPayload::V3(payload) => (
-                self.client.new_payload_v3(payload, parent_beacon_block_root).await,
-                self.envelope
-                    .execution_payload
-                    .clone()
-                    .try_into_block_with_sidecar(&OpExecutionPayloadSidecar::v3(
-                        CancunPayloadFields::new(parent_beacon_block_root, vec![]),
-                    ))
-                    .map_err(InsertTaskError::FromBlockError)?,
-            ),
-            OpExecutionPayload::V4(payload) => (
-                self.client.new_payload_v4(payload, parent_beacon_block_root).await,
-                self.envelope
-                    .execution_payload
-                    .clone()
-                    .try_into_block_with_sidecar(&OpExecutionPayloadSidecar::v4(
-                        CancunPayloadFields::new(parent_beacon_block_root, vec![]),
-                        PraguePayloadFields::new(EMPTY_REQUESTS_HASH),
-                    ))
-                    .map_err(InsertTaskError::FromBlockError)?,
-            ),
+            OpExecutionPayload::V3(payload) => {
+                self.client.new_payload_v3(payload, parent_beacon_block_root).await
+            }
+            OpExecutionPayload::V4(payload) => {
+                self.client.new_payload_v4(payload, parent_beacon_block_root).await
+            }
         };
+        let block: OpBlock =
+            execution_data.try_into_block().map_err(InsertTaskError::FromBlockError)?;
 
         // Check the `engine_newPayload` response.
         let response = match response {

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/seal/task.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/seal/task.rs
@@ -10,7 +10,7 @@ use async_trait::async_trait;
 use derive_more::Constructor;
 use kona_genesis::RollupConfig;
 use kona_protocol::{L2BlockInfo, OpAttributesWithParent};
-use op_alloy_rpc_types_engine::{OpExecutionPayload, OpExecutionPayloadEnvelope};
+use op_alloy_rpc_types_engine::{OpExecutionData, OpExecutionPayload, OpExecutionPayloadEnvelope};
 use std::{sync::Arc, time::Instant};
 use tokio::sync::mpsc;
 
@@ -138,13 +138,13 @@ impl<EngineClient_: EngineClient> SealTask<EngineClient_> {
     async fn insert_payload(
         &self,
         state: &mut EngineState,
-        new_payload: OpExecutionPayloadEnvelope,
+        execution_data: OpExecutionData,
     ) -> Result<(), SealTaskError> {
         // Insert the new block into the engine.
         match InsertTask::new(
             Arc::clone(&self.engine),
             self.cfg.clone(),
-            new_payload.clone(),
+            execution_data,
             self.is_attributes_derived,
         )
         .execute(state)
@@ -211,15 +211,13 @@ impl<EngineClient_: EngineClient> SealTask<EngineClient_> {
             .seal_payload(&self.cfg, &self.engine, self.payload_id, self.attributes.clone())
             .await?;
 
-        let new_block_ref = L2BlockInfo::from_payload_and_genesis(
-            new_payload.execution_payload.clone(),
-            self.attributes.attributes().payload_attributes.parent_beacon_block_root,
-            &self.cfg.genesis,
-        )
-        .map_err(SealTaskError::FromBlock)?;
+        let execution_data = new_payload.clone().into_execution_data();
+        let new_block_ref =
+            L2BlockInfo::from_execution_data_and_genesis(execution_data.clone(), &self.cfg.genesis)
+                .map_err(SealTaskError::FromBlock)?;
 
         // Insert the payload into the engine.
-        self.insert_payload(state, new_payload.clone()).await?;
+        self.insert_payload(state, execution_data).await?;
 
         let block_import_duration = block_import_start_time.elapsed();
 

--- a/rust/kona/crates/node/gossip/Cargo.toml
+++ b/rust/kona/crates/node/gossip/Cargo.toml
@@ -24,7 +24,6 @@ kona-disc.workspace = true
 
 # Alloy
 alloy-rlp.workspace = true
-alloy-eips.workspace = true
 alloy-consensus.workspace = true
 alloy-rpc-types-engine.workspace = true
 alloy-primitives = { workspace = true, features = ["k256", "getrandom"] }

--- a/rust/kona/crates/node/gossip/src/block_validity.rs
+++ b/rust/kona/crates/node/gossip/src/block_validity.rs
@@ -3,14 +3,14 @@ use std::time::Instant;
 use std::time::SystemTime;
 
 use alloy_consensus::Block;
-use alloy_eips::eip7685::EMPTY_REQUESTS_HASH;
 use alloy_primitives::{Address, B256};
 use alloy_rpc_types_engine::{ExecutionPayloadV3, PayloadError};
 use kona_genesis::RollupConfig;
 use libp2p::gossipsub::MessageAcceptance;
 use op_alloy_consensus::OpTxEnvelope;
 use op_alloy_rpc_types_engine::{
-    OpExecutionPayload, OpExecutionPayloadV4, OpNetworkPayloadEnvelope, OpPayloadError,
+    OpExecutionPayload, OpExecutionPayloadEnvelope, OpExecutionPayloadV4, OpNetworkPayloadEnvelope,
+    OpPayloadError,
 };
 
 use super::BlockHandler;
@@ -53,8 +53,8 @@ pub enum BlockInvalidError {
     /// Invalid block.
     #[error(transparent)]
     InvalidBlock(#[from] OpPayloadError),
-    /// The block has an invalid parent beacon block root.
-    #[error("Payload is on v3+ topic, but has empty parent beacon root")]
+    /// The block has a parent beacon block root incompatible with its payload version.
+    #[error("Payload has an invalid parent beacon block root")]
     ParentBeaconRoot,
     /// The block has an invalid blob gas used.
     #[error("Payload is on v3+ topic, but has non-zero blob gas used")]
@@ -209,12 +209,9 @@ impl BlockHandler {
 
         // CHECK: Ensure the block hash is valid.
         let expected = envelope.payload.block_hash();
-        let mut block: Block<OpTxEnvelope> = envelope.payload.clone().try_into_block()?;
-        block.header.parent_beacon_block_root = envelope.parent_beacon_block_root;
-        // If isthmus is active, set the requests hash to the empty hash.
-        if self.rollup_config.is_isthmus_active(envelope.payload.timestamp()) {
-            block.header.requests_hash = Some(EMPTY_REQUESTS_HASH);
-        }
+        let execution_data =
+            OpExecutionPayloadEnvelope::from(envelope.clone()).into_execution_data();
+        let block: Block<OpTxEnvelope> = execution_data.try_into_block()?;
         let received = block.header.hash_slow();
         if received != expected {
             return Err(BlockInvalidError::BlockHash { expected, received });
@@ -281,12 +278,11 @@ impl BlockHandler {
         // 3. The block should not have any blob gas used
         // 4. The block should not have any excess blob gas
         // 5. The block should not have any withdrawals root
-        // 6. The block should not have any parent beacon block root (validated because ignored by
-        //    the decoder, this causes a hash mismatch. See tests)
+        // 6. The block should not have any parent beacon block root (checked below)
 
         // Same as v1, except:
         // 1. The block should have an empty withdrawals list. This is checked during the call to
-        //    [`OpExecutionPayload::try_into_block`].
+        //    [`op_alloy_rpc_types_engine::OpExecutionData::try_into_block`].
 
         // Same as v2, except:
         // 1. The block should have a zero blob gas used
@@ -324,7 +320,12 @@ impl BlockHandler {
         }
 
         match &envelope.payload {
-            OpExecutionPayload::V1(_) | OpExecutionPayload::V2(_) => Ok(()),
+            OpExecutionPayload::V1(_) | OpExecutionPayload::V2(_) => {
+                if envelope.parent_beacon_block_root.is_some() {
+                    return Err(BlockInvalidError::ParentBeaconRoot);
+                }
+                Ok(())
+            }
             OpExecutionPayload::V3(payload) => {
                 validate_v3(&self.rollup_config, payload, envelope.parent_beacon_block_root)
             }
@@ -341,7 +342,7 @@ pub(crate) mod tests {
     use super::*;
     use alloy_chains::Chain;
     use alloy_consensus::{Block, EMPTY_OMMER_ROOT_HASH};
-    use alloy_eips::{eip2718::Encodable2718, eip4895::Withdrawal};
+    use alloy_eips::{eip2718::Encodable2718, eip4895::Withdrawal, eip7685::EMPTY_REQUESTS_HASH};
     use alloy_primitives::{Address, B256, Bytes, Signature};
     use alloy_rlp::BufMut;
     use alloy_rpc_types_engine::{ExecutionPayloadV1, ExecutionPayloadV2, ExecutionPayloadV3};
@@ -438,7 +439,9 @@ pub(crate) mod tests {
 
     /// Make the block v4 compatible
     pub(crate) fn v4_valid_block() -> Block<OpTxEnvelope> {
-        v3_valid_block()
+        let mut block = v3_valid_block();
+        block.header.requests_hash = Some(EMPTY_REQUESTS_HASH);
+        block
     }
 
     /// Generates a random valid block and ensure it is v1 compatible
@@ -687,9 +690,7 @@ pub(crate) mod tests {
         assert!(matches!(handler.block_valid(&envelope), Err(BlockInvalidError::Signer { .. })));
     }
 
-    /// If we specify a non empty parent beacon block root for blocks with v1/v2 payloads we
-    /// get a hash mismatch error because the decoder enforces that these versions of the execution
-    /// payload don't contain the parent beacon block root.
+    /// V1/V2 payloads reject a parent beacon block root because those versions do not include it.
     #[test]
     fn test_v1_v2_block_invalid_parent_beacon_block_root() {
         let block = v1_valid_block();
@@ -712,7 +713,7 @@ pub(crate) mod tests {
             unsafe_signer,
         );
 
-        assert!(matches!(handler.block_valid(&envelope), Err(BlockInvalidError::BlockHash { .. })));
+        assert!(matches!(handler.block_valid(&envelope), Err(BlockInvalidError::ParentBeaconRoot)));
 
         let block = v2_valid_block();
 
@@ -734,7 +735,7 @@ pub(crate) mod tests {
             unsafe_signer,
         );
 
-        assert!(matches!(handler.block_valid(&envelope), Err(BlockInvalidError::BlockHash { .. })));
+        assert!(matches!(handler.block_valid(&envelope), Err(BlockInvalidError::ParentBeaconRoot)));
     }
 
     #[test]

--- a/rust/kona/crates/node/service/src/actors/engine/actor.rs
+++ b/rust/kona/crates/node/service/src/actors/engine/actor.rs
@@ -261,7 +261,7 @@ where
                 let task = EngineTask::Insert(Box::new(InsertTask::new(
                     self.client.clone(),
                     self.rollup.clone(),
-                    *envelope,
+                    (*envelope).into_execution_data(),
                     false, /* The payload is not derived in this case. This is an unsafe
                             * block. */
                 )));

--- a/rust/kona/crates/protocol/protocol/src/block.rs
+++ b/rust/kona/crates/protocol/protocol/src/block.rs
@@ -1,20 +1,17 @@
 //! Block Types for Optimism.
 
 use crate::{DecodeError, L1BlockInfoTx};
-use alloc::vec::Vec;
 use alloy_consensus::{Block, Header, Transaction, Typed2718};
 use alloy_eips::{
     BlockNumHash,
     eip2718::{Decodable2718, Eip2718Error},
-    eip7685::EMPTY_REQUESTS_HASH,
 };
 use alloy_primitives::{B256, Bytes, Sealed};
-use alloy_rpc_types_engine::{CancunPayloadFields, PraguePayloadFields};
 use alloy_rpc_types_eth::Block as RpcBlock;
 use derive_more::Display;
 use kona_genesis::ChainGenesis;
 use op_alloy_consensus::{OpBlock, OpTransaction, OpTxEnvelope};
-use op_alloy_rpc_types_engine::{OpExecutionPayload, OpExecutionPayloadSidecar, OpPayloadError};
+use op_alloy_rpc_types_engine::{OpExecutionData, OpPayloadError};
 
 /// Block Header Info
 #[derive(Debug, Clone, Display, Copy, Eq, Hash, PartialEq, Default)]
@@ -149,7 +146,7 @@ pub enum FromBlockError {
     /// Failed to decode the [`L1BlockInfoTx`] from the deposit transaction.
     #[error("Failed to decode the L1BlockInfoTx from the deposit transaction: {0}")]
     BlockInfoDecodeError(#[from] DecodeError),
-    /// Failed to convert [`OpExecutionPayload`] to [`OpBlock`].
+    /// Failed to convert [`OpExecutionData`] to [`OpBlock`].
     #[error(transparent)]
     OpPayload(#[from] OpPayloadError),
 }
@@ -257,32 +254,12 @@ impl L2BlockInfo {
         Self::from_block_info_and_first_tx(block_info, first_tx.as_ref(), genesis)
     }
 
-    /// Constructs an [`L2BlockInfo`] From a given [`OpExecutionPayload`] and [`ChainGenesis`].
-    pub fn from_payload_and_genesis(
-        payload: OpExecutionPayload,
-        parent_beacon_block_root: Option<B256>,
+    /// Constructs an [`L2BlockInfo`] from complete execution data and a [`ChainGenesis`].
+    pub fn from_execution_data_and_genesis(
+        execution_data: OpExecutionData,
         genesis: &ChainGenesis,
     ) -> Result<Self, FromBlockError> {
-        let block: OpBlock = match payload {
-            OpExecutionPayload::V4(_) => {
-                let sidecar = OpExecutionPayloadSidecar::v4(
-                    CancunPayloadFields::new(
-                        parent_beacon_block_root.unwrap_or_default(),
-                        Vec::new(),
-                    ),
-                    PraguePayloadFields::new(EMPTY_REQUESTS_HASH),
-                );
-                payload.try_into_block_with_sidecar(&sidecar)?
-            }
-            OpExecutionPayload::V3(_) => {
-                let sidecar = OpExecutionPayloadSidecar::v3(CancunPayloadFields::new(
-                    parent_beacon_block_root.unwrap_or_default(),
-                    Vec::new(),
-                ));
-                payload.try_into_block_with_sidecar(&sidecar)?
-            }
-            _ => payload.try_into_block()?,
-        };
+        let block: OpBlock = execution_data.try_into_block()?;
         Self::from_block_and_genesis(&block, genesis)
     }
 }

--- a/rust/op-alloy/crates/rpc-types-engine/src/envelope.rs
+++ b/rust/op-alloy/crates/rpc-types-engine/src/envelope.rs
@@ -5,15 +5,19 @@
 
 use crate::{
     OpExecutionPayload, OpExecutionPayloadSidecar, OpExecutionPayloadV4, OpFlashblockError,
-    OpFlashblockPayload,
+    OpFlashblockPayload, OpPayloadError,
 };
 use alloc::vec::Vec;
 use alloy_consensus::{Block, BlockHeader, Sealable, Transaction};
-use alloy_eips::{Encodable2718, eip4895::Withdrawal, eip7685::Requests};
+use alloy_eips::{
+    Decodable2718, Encodable2718, Typed2718,
+    eip4895::Withdrawal,
+    eip7685::{EMPTY_REQUESTS_HASH, Requests},
+};
 use alloy_primitives::{B256, Signature, keccak256};
 use alloy_rpc_types_engine::{
     CancunPayloadFields, ExecutionPayloadInputV2, ExecutionPayloadV1, ExecutionPayloadV2,
-    ExecutionPayloadV3, PraguePayloadFields,
+    ExecutionPayloadV3, PayloadError, PraguePayloadFields,
 };
 
 /// A thin wrapper around [`OpExecutionPayload`] that includes the parent beacon block root.
@@ -28,6 +32,29 @@ pub struct OpExecutionPayloadEnvelope {
 }
 
 impl OpExecutionPayloadEnvelope {
+    /// Converts this envelope into the complete data supplied to the execution engine.
+    ///
+    /// OP payloads have no blob versioned hashes or execution requests. For V3 and V4 payloads,
+    /// a missing parent beacon block root is represented as the zero hash because the corresponding
+    /// Engine API methods require the root as an argument.
+    pub fn into_execution_data(self) -> OpExecutionData {
+        let parent_beacon_block_root = self.parent_beacon_block_root.unwrap_or_default();
+        match self.execution_payload {
+            payload @ (OpExecutionPayload::V1(_) | OpExecutionPayload::V2(_)) => {
+                OpExecutionData::new(payload, OpExecutionPayloadSidecar::default())
+            }
+            OpExecutionPayload::V3(payload) => {
+                OpExecutionData::v3(payload, Vec::new(), parent_beacon_block_root)
+            }
+            OpExecutionPayload::V4(payload) => OpExecutionData::v4(
+                payload,
+                Vec::new(),
+                parent_beacon_block_root,
+                Requests::default(),
+            ),
+        }
+    }
+
     /// Returns the payload hash over the ssz encoded payload envelope data.
     ///
     /// <https://specs.optimism.io/protocol/rollup-node-p2p.html#block-signatures>
@@ -121,6 +148,81 @@ impl OpExecutionData {
     /// Creates new instance of [`OpExecutionData`].
     pub const fn new(payload: OpExecutionPayload, sidecar: OpExecutionPayloadSidecar) -> Self {
         Self { payload, sidecar }
+    }
+
+    /// Converts this execution data into a block with decoded transactions.
+    pub fn try_into_block<T>(self) -> Result<Block<T>, OpPayloadError>
+    where
+        T: Decodable2718 + Typed2718,
+    {
+        let check_blob_transactions =
+            matches!(&self.payload, OpExecutionPayload::V3(_) | OpExecutionPayload::V4(_));
+        let block = self.try_into_block_raw()?.try_map_transactions(|tx| {
+            T::decode_2718_exact(tx.as_ref())
+                .map_err(alloy_rlp::Error::from)
+                .map_err(PayloadError::from)
+        })?;
+        if check_blob_transactions && block.body.has_eip4844_transactions() {
+            return Err(OpPayloadError::BlobTransaction);
+        }
+
+        Ok(block)
+    }
+
+    /// Converts this execution data into a complete block with raw transactions.
+    fn try_into_block_raw(self) -> Result<Block<alloy_primitives::Bytes>, OpPayloadError> {
+        let Self { payload, sidecar } = self;
+        if let Some(payload) = payload.as_v2() &&
+            !payload.withdrawals.is_empty()
+        {
+            return Err(OpPayloadError::NonEmptyL1Withdrawals);
+        }
+        let block = match payload {
+            OpExecutionPayload::V1(payload) => payload.into_block_raw()?,
+            OpExecutionPayload::V2(payload) => payload.into_block_raw()?,
+            OpExecutionPayload::V3(payload) => payload.into_block_raw()?,
+            OpExecutionPayload::V4(payload) => {
+                let mut block = payload.payload_inner.into_block_raw()?;
+                block.header.withdrawals_root = Some(payload.withdrawals_root);
+                block
+            }
+        };
+
+        Self::apply_sidecar(block, &sidecar)
+    }
+
+    /// Converts this execution data into a block and verifies its claimed block hash.
+    pub fn try_into_checked_block<T>(self) -> Result<Block<T>, OpPayloadError>
+    where
+        T: Decodable2718 + Typed2718,
+    {
+        let consensus = self.payload.block_hash();
+        let block = self.try_into_block()?;
+        let execution = block.header.hash_slow();
+        if execution != consensus {
+            return Err(PayloadError::BlockHash { execution, consensus }.into());
+        }
+
+        Ok(block)
+    }
+
+    fn apply_sidecar<T>(
+        mut block: Block<T>,
+        sidecar: &OpExecutionPayloadSidecar,
+    ) -> Result<Block<T>, OpPayloadError> {
+        if let Some(versioned_hashes) = sidecar.versioned_hashes() &&
+            !versioned_hashes.is_empty()
+        {
+            return Err(OpPayloadError::NonEmptyBlobVersionedHashes);
+        }
+        if let Some(requests_hash) = sidecar.requests_hash() {
+            if requests_hash != EMPTY_REQUESTS_HASH {
+                return Err(OpPayloadError::NonEmptyELRequests);
+            }
+            block.header.requests_hash = Some(EMPTY_REQUESTS_HASH);
+        }
+        block.header.parent_beacon_block_root = sidecar.parent_beacon_block_root();
+        Ok(block)
     }
 
     /// Conversion from [`alloy_consensus::Block`]. Also returns the [`OpExecutionPayloadSidecar`]

--- a/rust/op-alloy/crates/rpc-types-engine/src/payload/mod.rs
+++ b/rust/op-alloy/crates/rpc-types-engine/src/payload/mod.rs
@@ -7,13 +7,12 @@ pub mod v4;
 use crate::{OpExecutionPayloadSidecar, OpExecutionPayloadV4};
 use alloc::vec::Vec;
 use alloy_consensus::{Block, BlockHeader, HeaderInfo, Transaction};
-use alloy_eips::{Decodable2718, Encodable2718, Typed2718, eip7685::EMPTY_REQUESTS_HASH};
+use alloy_eips::{Decodable2718, Encodable2718};
 use alloy_primitives::{Address, B256, Bytes, Sealable, U256};
 use alloy_rpc_types_engine::{
     ExecutionPayload, ExecutionPayloadInputV2, ExecutionPayloadV1, ExecutionPayloadV2,
-    ExecutionPayloadV3, PayloadError,
+    ExecutionPayloadV3,
 };
-use error::OpPayloadError;
 
 /// An execution payload, which can be either [`ExecutionPayloadV2`], [`ExecutionPayloadV3`], or
 /// [`OpExecutionPayloadV4`].
@@ -516,170 +515,6 @@ impl OpExecutionPayload {
             mix_hash: Some(self.prev_randao()),
             slot_number: None,
         }
-    }
-
-    /// Converts [`OpExecutionPayload`] to [`Block`] with raw transactions.
-    ///
-    /// Caution: This does not set fields that are not part of the payload and only part of the
-    /// [`OpExecutionPayloadSidecar`]:
-    /// - `parent_beacon_block_root`
-    ///
-    /// See also: [`OpExecutionPayload::into_block_with_sidecar_raw`]
-    pub fn into_block_raw(self) -> Result<Block<alloy_primitives::Bytes>, PayloadError> {
-        match self {
-            Self::V1(payload) => payload.into_block_raw(),
-            Self::V2(payload) => payload.into_block_raw(),
-            Self::V3(payload) => payload.into_block_raw(),
-            Self::V4(payload) => payload.into_block_raw(),
-        }
-    }
-
-    /// Creates a new unsealed block from the given payload and payload sidecar with raw
-    /// transactions.
-    ///
-    /// This sets the `parent_beacon_block_root` and `requests_hash` if present in the sidecar.
-    /// Also validates that L1 withdrawals are empty.
-    ///
-    /// See also: [`OpExecutionPayload::try_into_block_with_sidecar`]
-    pub fn into_block_with_sidecar_raw(
-        self,
-        sidecar: &OpExecutionPayloadSidecar,
-    ) -> Result<Block<alloy_primitives::Bytes>, OpPayloadError> {
-        if let Some(payload) = self.as_v2() &&
-            !payload.withdrawals.is_empty()
-        {
-            return Err(OpPayloadError::NonEmptyL1Withdrawals);
-        }
-
-        let mut block = self.into_block_raw()?;
-
-        if let Some(blobs_hashes) = sidecar.versioned_hashes() &&
-            !blobs_hashes.is_empty()
-        {
-            return Err(OpPayloadError::NonEmptyBlobVersionedHashes);
-        }
-        if let Some(reqs_hash) = sidecar.requests_hash() {
-            if reqs_hash != EMPTY_REQUESTS_HASH {
-                return Err(OpPayloadError::NonEmptyELRequests);
-            }
-            block.header.requests_hash = Some(EMPTY_REQUESTS_HASH)
-        }
-        block.header.parent_beacon_block_root = sidecar.parent_beacon_block_root();
-
-        Ok(block)
-    }
-
-    #[allow(rustdoc::broken_intra_doc_links)]
-    /// Converts [`OpExecutionPayload`] to [`Block`].
-    ///
-    /// Checks that payload doesn't contain:
-    /// - blob transactions
-    /// - L1 withdrawals
-    ///
-    /// Caution: This does not set fields that are not part of the payload and only part of the
-    /// [`OpExecutionPayloadSidecar`]:
-    /// - `parent_beacon_block_root`
-    ///
-    /// See also: [`OpExecutionPayload::try_into_block_with_sidecar`]
-    pub fn try_into_block<T: Decodable2718 + Typed2718>(self) -> Result<Block<T>, OpPayloadError> {
-        self.try_into_block_with(|tx| {
-            T::decode_2718_exact(tx.as_ref())
-                .map_err(alloy_rlp::Error::from)
-                .map_err(PayloadError::from)
-        })
-    }
-
-    #[allow(rustdoc::broken_intra_doc_links)]
-    /// Converts [`OpExecutionPayload`] to [`Block`] with a custom transaction mapper.
-    ///
-    /// Checks that payload doesn't contain:
-    /// - blob transactions
-    /// - L1 withdrawals
-    ///
-    /// Caution: This does not set fields that are not part of the payload and only part of the
-    /// [`OpExecutionPayloadSidecar`]:
-    /// - `parent_beacon_block_root`
-    ///
-    /// See also: [`OpExecutionPayload::try_into_block_with_sidecar_with`]
-    pub fn try_into_block_with<T, F, E>(self, f: F) -> Result<Block<T>, OpPayloadError>
-    where
-        T: Typed2718,
-        F: FnMut(alloy_primitives::Bytes) -> Result<T, E>,
-        E: Into<PayloadError>,
-    {
-        if let Some(payload) = self.as_v2() &&
-            !payload.withdrawals.is_empty()
-        {
-            return Err(OpPayloadError::NonEmptyL1Withdrawals);
-        }
-        let block = match self {
-            Self::V1(payload) => return Ok(payload.try_into_block_with(f)?),
-            Self::V2(payload) => return Ok(payload.try_into_block_with(f)?),
-            Self::V3(payload) => payload.try_into_block_with(f)?,
-            Self::V4(payload) => payload.try_into_block_with(f)?,
-        };
-        if block.body.has_eip4844_transactions() {
-            return Err(OpPayloadError::BlobTransaction);
-        }
-
-        Ok(block)
-    }
-
-    /// Tries to create a new unsealed block from the given payload and payload sidecar.
-    ///
-    /// Additional to checks performed in [`OpExecutionPayload::try_into_block`], which is called
-    /// under the hood, also checks that sidecar doesn't contain:
-    /// - blob versioned hashes
-    /// - execution layer requests
-    ///
-    /// See also docs for
-    /// [`ExecutionPayload::try_into_block_with_sidecar`](alloy_rpc_types_engine::ExecutionPayload::try_into_block_with_sidecar).
-    pub fn try_into_block_with_sidecar<T: Decodable2718 + Typed2718>(
-        self,
-        sidecar: &OpExecutionPayloadSidecar,
-    ) -> Result<Block<T>, OpPayloadError> {
-        self.try_into_block_with_sidecar_with(sidecar, |tx| {
-            T::decode_2718_exact(tx.as_ref())
-                .map_err(alloy_rlp::Error::from)
-                .map_err(PayloadError::from)
-        })
-    }
-
-    /// Tries to create a new unsealed block from the given payload and payload sidecar with a
-    /// custom transaction mapper.
-    ///
-    /// Additional to checks performed in [`OpExecutionPayload::try_into_block_with`], which is
-    /// called under the hood, also checks that sidecar doesn't contain:
-    /// - blob versioned hashes
-    /// - execution layer requests
-    ///
-    /// See also docs for
-    /// [`ExecutionPayload::try_into_block_with_sidecar_with`](alloy_rpc_types_engine::ExecutionPayload::try_into_block_with_sidecar_with).
-    pub fn try_into_block_with_sidecar_with<T, F, E>(
-        self,
-        sidecar: &OpExecutionPayloadSidecar,
-        f: F,
-    ) -> Result<Block<T>, OpPayloadError>
-    where
-        T: Typed2718,
-        F: FnMut(alloy_primitives::Bytes) -> Result<T, E>,
-        E: Into<PayloadError>,
-    {
-        let mut base_payload = self.try_into_block_with(f)?;
-        if let Some(blobs_hashes) = sidecar.versioned_hashes() &&
-            !blobs_hashes.is_empty()
-        {
-            return Err(OpPayloadError::NonEmptyBlobVersionedHashes);
-        }
-        if let Some(reqs_hash) = sidecar.requests_hash() {
-            if reqs_hash != EMPTY_REQUESTS_HASH {
-                return Err(OpPayloadError::NonEmptyELRequests);
-            }
-            base_payload.header.requests_hash = Some(EMPTY_REQUESTS_HASH)
-        }
-        base_payload.header.parent_beacon_block_root = sidecar.parent_beacon_block_root();
-
-        Ok(base_payload)
     }
 
     /// Returns an iterator over the decoded transactions in this payload.

--- a/rust/op-alloy/crates/rpc-types-engine/src/payload/v4.rs
+++ b/rust/op-alloy/crates/rpc-types-engine/src/payload/v4.rs
@@ -1,10 +1,8 @@
 //! Optimism execution payload envelope V3.
 
 use alloc::vec::Vec;
-use alloy_consensus::Block;
-use alloy_eips::Decodable2718;
 use alloy_primitives::{B256, Bytes, U256};
-use alloy_rpc_types_engine::{BlobsBundleV1, ExecutionPayloadV3, PayloadError};
+use alloy_rpc_types_engine::{BlobsBundleV1, ExecutionPayloadV3};
 
 /// The Opstack execution payload for `newPayloadV4` of the engine API introduced with isthmus.
 /// See also <https://specs.optimism.io/protocol/isthmus/exec-engine.html#engine_newpayloadv4-api>
@@ -31,49 +29,6 @@ impl OpExecutionPayloadV4 {
         withdrawals_root: B256,
     ) -> Self {
         Self { withdrawals_root, payload_inner: payload }
-    }
-
-    /// Converts [`OpExecutionPayloadV4`] to [`Block`] with raw transactions.
-    ///
-    /// This performs the same conversion as the underlying V3 payload, but inserts the L2
-    /// withdrawals root and returns raw transaction bytes instead of decoded transactions.
-    pub fn into_block_raw(self) -> Result<Block<Bytes>, PayloadError> {
-        let mut base_block = self.payload_inner.into_block_raw()?;
-
-        // overwrite l1 withdrawals root with l2 withdrawals root
-        base_block.header.withdrawals_root = Some(self.withdrawals_root);
-
-        Ok(base_block)
-    }
-
-    /// Converts [`OpExecutionPayloadV4`] to [`Block`].
-    ///
-    /// This performs the same conversion as the underlying V3 payload, but inserts the L2
-    /// withdrawals root.
-    ///
-    /// See also [`ExecutionPayloadV3::try_into_block`].
-    pub fn try_into_block<T: Decodable2718>(self) -> Result<Block<T>, PayloadError> {
-        let block = self.into_block_raw()?;
-        block.try_map_transactions(|tx| {
-            T::decode_2718_exact(tx.as_ref())
-                .map_err(alloy_rlp::Error::from)
-                .map_err(PayloadError::from)
-        })
-    }
-
-    /// Converts [`OpExecutionPayloadV4`] to [`Block`] with a custom transaction mapper.
-    ///
-    /// This performs the same conversion as the underlying V3 payload, but inserts the L2
-    /// withdrawals root.
-    ///
-    /// See also [`ExecutionPayloadV3::try_into_block_with`].
-    pub fn try_into_block_with<T, F, E>(self, f: F) -> Result<Block<T>, PayloadError>
-    where
-        F: FnMut(Bytes) -> Result<T, E>,
-        E: Into<PayloadError>,
-    {
-        let block = self.into_block_raw()?;
-        block.try_map_transactions(f).map_err(|e| e.into())
     }
 }
 

--- a/rust/op-reth/crates/payload/src/validator.rs
+++ b/rust/op-reth/crates/payload/src/validator.rs
@@ -2,7 +2,6 @@
 
 use alloc::sync::Arc;
 use alloy_consensus::Block;
-use alloy_rpc_types_engine::PayloadError;
 use derive_more::{Constructor, Deref};
 use op_alloy_rpc_types_engine::{OpExecutionData, OpPayloadError};
 use reth_optimism_forks::OpHardforks;
@@ -64,17 +63,10 @@ where
     ChainSpec: OpHardforks,
     T: SignedTransaction,
 {
-    let OpExecutionData { payload, sidecar } = payload;
+    let sidecar = payload.sidecar.clone();
 
-    let expected_hash = payload.block_hash();
-
-    // First parse the block
-    let sealed_block = payload.try_into_block_with_sidecar(&sidecar)?.seal_slow();
-
-    // Ensure the hash included in the payload matches the block hash
-    if expected_hash != sealed_block.hash() {
-        Err(PayloadError::BlockHash { execution: sealed_block.hash(), consensus: expected_hash })?;
-    }
+    // First parse the block and ensure its hash matches the payload's claim.
+    let sealed_block = payload.try_into_checked_block()?.seal_slow();
 
     shanghai::ensure_well_formed_fields(
         sealed_block.body(),


### PR DESCRIPTION
## Overview

Use `OpExecutionData` as the complete Engine API input and the only public path for reconstructing decoded OP blocks. Kona now converts payload envelopes into execution data at its engine, sealing, gossip, and protocol boundaries, matching op-reth's design.

Remove the block-conversion methods from `OpExecutionPayload` and `OpExecutionPayloadV4`. Complete raw and decoded reconstruction now live directly on `OpExecutionData`, with no payload-only block conversion API. Reuse `OpExecutionData::{try_into_block, try_into_checked_block}` from Kona and op-reth. Envelope normalization also uses the same `OpExecutionData::{v3,v4}` constructors as op-reth's RPC boundary, keeping fork-specific sidecar layout in one place. The follow-up #22251 uses this complete conversion for payload-envelope block-hash verification.

## Benefits

- **Eliminates incomplete block-conversion footguns:** callers can no longer publicly reconstruct blocks from `OpExecutionPayload` while accidentally omitting sidecar fields.
- **Uses one complete execution input:** `OpExecutionData` keeps the payload together with its parent beacon root, requests hash, and versioned hashes.
- **Centralizes OP-specific conversion and validation:** withdrawals, blob transactions, versioned hashes, and execution requests are handled consistently.
- **Aligns Kona with op-reth:** both carry complete execution data through consensus-critical paths and use the same constructors for V3/V4 sidecars.
- **Removes duplicated field patching:** Kona no longer manually applies beacon roots or requests hashes in multiple places.
- **Improves V3/V4 correctness:** reconstruction consistently includes every header field supplied separately through the corresponding Engine API method.
- **Reduces API and implementation surface:** the change removes more code than it adds while preserving independent execution implementations.

## Tests

- `cargo test -p op-alloy-rpc-types-engine --all-features`
- `cargo check -p op-alloy-rpc-types-engine --no-default-features`
- `cargo test -p kona-protocol --all-features`
- `cargo test -p kona-engine --all-features -- --skip test_chain_label_metrics`
- `cargo test -p kona-gossip --all-features`
- `cargo test -p kona-node-service --all-features`
- `cargo test -p reth-optimism-payload-builder --all-features`
- `cargo clippy -p op-alloy-rpc-types-engine -p kona-protocol -p kona-engine -p kona-gossip -p kona-node-service -p reth-optimism-payload-builder --all-targets --all-features -- -D warnings`
- `cargo build --bin op-reth`


