### PR TITLE
op-supernode: reverse-adapt interop recovery invariants

### DIFF
--- a/op-acceptance-tests/tests/interop/reorgs/l2_reorgs_after_l1_reorg_test.go
+++ b/op-acceptance-tests/tests/interop/reorgs/l2_reorgs_after_l1_reorg_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 
@@ -38,19 +39,58 @@ func TestL2ReorgAfterL1Reorg(gt *testing.T) {
 	})
 
 	gt.Run("unsafe, local-safe, cross-unsafe, cross-safe reorgs", func(gt *testing.T) {
-		var crossSafeRef, crossUnsafeRef, localSafeRef, unsafeRef eth.BlockID
+		var crossSafeA, crossUnsafeA, localSafeA, unsafeA eth.L2BlockRef
+		var crossSafeB, crossUnsafeB, localSafeB, unsafeB eth.L2BlockRef
+		var verifiedTimestamp uint64
+		var staleSuperRoot eth.Bytes32
 		pre := func(t devtest.T, sys *presets.TwoL2SupernodeInterop) {
-			ss := sys.L2ACL.SyncStatus()
-			crossUnsafeRef = ss.CrossUnsafeL2.ID()
-			crossSafeRef = ss.SafeL2.ID()
-			localSafeRef = ss.LocalSafeL2.ID()
-			unsafeRef = ss.UnsafeL2.ID()
+			ssA := sys.L2ACL.SyncStatus()
+			ssB := sys.L2BCL.SyncStatus()
+			crossUnsafeA, crossSafeA = ssA.CrossUnsafeL2, ssA.SafeL2
+			localSafeA, unsafeA = ssA.LocalSafeL2, ssA.UnsafeL2
+			crossUnsafeB, crossSafeB = ssB.CrossUnsafeL2, ssB.SafeL2
+			localSafeB, unsafeB = ssB.LocalSafeL2, ssB.UnsafeL2
+
+			verifiedTimestamp = min(crossSafeA.Time, crossSafeB.Time)
+			sys.Supernode.AwaitValidatedTimestamp(verifiedTimestamp)
+			staleSuperRoot = sys.Supernode.SuperRootAt(
+				verifiedTimestamp, sys.L2A.ChainID(), sys.L2B.ChainID(),
+			).Data.SuperRoot
 		}
 		post := func(t devtest.T, sys *presets.TwoL2SupernodeInterop) {
-			require.False(t, sys.L2ELA.IsCanonical(crossSafeRef), "Previous cross-safe block should have been reorged")
-			require.False(t, sys.L2ELA.IsCanonical(crossUnsafeRef), "Previous cross-unsafe block should have been reorged")
-			require.False(t, sys.L2ELA.IsCanonical(localSafeRef), "Previous local-safe block should have been reorged")
-			require.False(t, sys.L2ELA.IsCanonical(unsafeRef), "Previous unsafe block should have been reorged")
+			for chain, refs := range map[string]struct {
+				el                                        *dsl.L2ELNode
+				crossSafe, crossUnsafe, localSafe, unsafe eth.L2BlockRef
+			}{
+				"A": {sys.L2ELA, crossSafeA, crossUnsafeA, localSafeA, unsafeA},
+				"B": {sys.L2ELB, crossSafeB, crossUnsafeB, localSafeB, unsafeB},
+			} {
+				require.False(t, refs.el.IsCanonical(refs.crossSafe.ID()), "chain %s previous cross-safe block should have been reorged", chain)
+				require.False(t, refs.el.IsCanonical(refs.crossUnsafe.ID()), "chain %s previous cross-unsafe block should have been reorged", chain)
+				require.False(t, refs.el.IsCanonical(refs.localSafe.ID()), "chain %s previous local-safe block should have been reorged", chain)
+				require.False(t, refs.el.IsCanonical(refs.unsafe.ID()), "chain %s previous unsafe block should have been reorged", chain)
+			}
+
+			replacementA := sys.L2ELA.BlockRefByNumber(crossSafeA.Number)
+			replacementB := sys.L2ELB.BlockRefByNumber(crossSafeB.Number)
+			require.NotEqual(t, replacementA.Hash, replacementB.Hash,
+				"replacement lineages were contaminated across sibling chains")
+			_, err := sys.L2ELA.Escape().L2EthClient().L2BlockRefByHash(t.Ctx(), replacementB.Hash)
+			require.Error(t, err, "chain B replacement unexpectedly resolved in chain A's engine")
+			_, err = sys.L2ELB.Escape().L2EthClient().L2BlockRefByHash(t.Ctx(), replacementA.Hash)
+			require.Error(t, err, "chain A replacement unexpectedly resolved in chain B's engine")
+
+			require.Eventually(t, func() bool {
+				resp, err := sys.SuperNodeClient().SuperRootAtTimestamp(t.Ctx(), verifiedTimestamp)
+				return err == nil && resp.Data != nil && resp.Data.SuperRoot != staleSuperRoot
+			}, 2*time.Minute, time.Second,
+				"verified super-root at the reorged timestamp remained stale")
+			newRoot := sys.Supernode.SuperRootAt(
+				verifiedTimestamp, sys.L2A.ChainID(), sys.L2B.ChainID(),
+			)
+			canonicalL1 := sys.L1EL.BlockRefByNumber(newRoot.Data.VerifiedRequiredL1.Number)
+			require.Equal(t, canonicalL1.Hash, newRoot.Data.VerifiedRequiredL1.Hash,
+				"replacement super-root retained an orphaned L1 dependency")
 		}
 		preEarly := func(t devtest.T, sys *presets.TwoL2SupernodeInterop) {}
 		testL2ReorgAfterL1Reorg(gt, 10, preEarly, pre, post)
@@ -68,7 +108,7 @@ func TestL2ReorgAfterL1Reorg(gt *testing.T) {
 // to-be-reorged window.
 // postChecks runs after the reorg has been recovered.
 func testL2ReorgAfterL1Reorg(gt *testing.T, n int, preEarlyChecks, preChecks, postChecks checksFunc) {
-	t := devtest.ParallelT(gt)
+	t := devtest.SerialT(gt)
 	ctx := t.Ctx()
 
 	sys := presets.NewTwoL2SupernodeInterop(t, 0)
@@ -78,7 +118,10 @@ func testL2ReorgAfterL1Reorg(gt *testing.T, n int, preEarlyChecks, preChecks, po
 	// Build a stable cross-safe foundation before we stop the L1 CL and manually sequence.
 	// This ensures the supernode has verified state that references canonical L1 blocks,
 	// so after the reorg it doesn't need to rewind all the way back to genesis.
-	sys.L2ACL.Advanced(safety.CrossSafe, 20, 100)
+	dsl.CheckAll(t,
+		sys.L2ACL.AdvancedFn(safety.CrossSafe, 20, 100),
+		sys.L2BCL.AdvancedFn(safety.CrossSafe, 20, 100),
+	)
 
 	preEarlyChecks(t, sys)
 
@@ -108,7 +151,8 @@ func testL2ReorgAfterL1Reorg(gt *testing.T, n int, preEarlyChecks, preChecks, po
 	// pre reorg trigger validations and checks
 	preChecks(t, sys)
 
-	tipL2_preReorg := sys.L2ELA.BlockRefByLabel(eth.Unsafe)
+	tipL2APreReorg := sys.L2ELA.BlockRefByLabel(eth.Unsafe)
+	tipL2BPreReorg := sys.L2ELB.BlockRefByLabel(eth.Unsafe)
 
 	// reorg the L1 chain -- sequence an alternative L1 block from divergence block parent
 	sys.TestSequencer.SequenceBlock(t, sys.L1Network.ChainID(), divergence.ParentHash)
@@ -119,66 +163,63 @@ func testL2ReorgAfterL1Reorg(gt *testing.T, n int, preEarlyChecks, preChecks, po
 	// confirm L1 reorged
 	sys.L1EL.ReorgTriggered(divergence, 5)
 
-	// Wait until L2 chain A cross-safe ref caught up to where it was before the reorg.
+	// Wait until both L2 cross-safe refs catch up to where they were before the reorg.
 	// Use require.Eventually instead of sys.L2ACL.Reached because the supernode rewinds
 	// one timestamp at a time after an L1 reorg, stopping and restarting VNs each cycle.
 	// During these rewinds the CL RPC is temporarily unavailable, and Reached() would
 	// fatally fail via require.NoError on the transient RPC error.
 	require.Eventually(t, func() bool {
-		ss, err := sys.L2ACL.Escape().RollupAPI().SyncStatus(ctx)
+		ssA, err := sys.L2ACL.Escape().RollupAPI().SyncStatus(ctx)
 		if err != nil {
-			sys.Log.Info("SyncStatus unavailable during rewind, retrying", "err", err)
+			sys.Log.Info("chain A SyncStatus unavailable during rewind, retrying", "err", err)
 			return false
 		}
-		sys.Log.Info("waiting for cross-safe to reach pre-reorg tip",
-			"cross_safe", ss.SafeL2.Number, "target", tipL2_preReorg.Number)
-		return ss.SafeL2.Number >= tipL2_preReorg.Number
-	}, 10*time.Minute, 5*time.Second, "L2 chain A cross-safe should reach pre-reorg tip %d", tipL2_preReorg.Number)
-
-	// test that latest chain A unsafe is not referencing a reorged L1 block (through the L1Origin field)
-	require.Eventually(t, func() bool {
-		unsafe := sys.L2ELA.BlockRefByLabel(eth.Unsafe)
-
-		block, err := sys.L1EL.Escape().EthClient().InfoByNumber(ctx, unsafe.L1Origin.Number)
+		ssB, err := sys.L2BCL.Escape().RollupAPI().SyncStatus(ctx)
 		if err != nil {
-			sys.Log.Warn("failed to get L1 block info by number", "number", unsafe.L1Origin.Number, "err", err)
+			sys.Log.Info("chain B SyncStatus unavailable during rewind, retrying", "err", err)
 			return false
 		}
+		sys.Log.Info("waiting for both cross-safe heads to reach their pre-reorg tips",
+			"chain_a_cross_safe", ssA.SafeL2.Number, "chain_a_target", tipL2APreReorg.Number,
+			"chain_b_cross_safe", ssB.SafeL2.Number, "chain_b_target", tipL2BPreReorg.Number)
+		return ssA.SafeL2.Number >= tipL2APreReorg.Number && ssB.SafeL2.Number >= tipL2BPreReorg.Number
+	}, 10*time.Minute, 5*time.Second,
+		"both L2 cross-safe heads should reach their pre-reorg tips A=%d B=%d",
+		tipL2APreReorg.Number, tipL2BPreReorg.Number)
 
-		sys.Log.Info("current unsafe ref", "tip", unsafe, "tip_origin", unsafe.L1Origin, "l1blk", eth.InfoToL1BlockRef(block))
-
-		// print the chains so we have information to debug if the test fails
-		sys.L2A.PrintChain()
-		sys.L1Network.PrintChain()
-
-		return block.Hash() == unsafe.L1Origin.Hash
-	}, 120*time.Second, 7*time.Second, "L1 block origin hash should match hash of block on L1 at that number. If not, it means there was a reorg, and L2 blocks L1Origin field is referencing a reorged block.")
-
-	// confirm all L1Origin fields point to canonical blocks
+	// Test that neither latest unsafe head references a reorged L1 block.
 	require.Eventually(t, func() bool {
-		ref := sys.L2ELA.BlockRefByLabel(eth.Unsafe)
-		var err error
-
-		// wait until L2 chains' L1Origin points to a L1 block after the one that was reorged
-		if ref.L1Origin.Number < divergence.Number {
-			return false
-		}
-
-		sys.Log.Info("L2 chain progressed, pointing to newer L1 block", "ref", ref, "ref_origin", ref.L1Origin, "divergence", divergence)
-
-		for i := ref.Number; i > 0 && ref.L1Origin.Number >= divergence.Number; i-- {
-			ref, err = sys.L2ELA.Escape().L2EthClient().L2BlockRefByNumber(ctx, i)
+		for chain, el := range map[string]*dsl.L2ELNode{"A": sys.L2ELA, "B": sys.L2ELB} {
+			unsafe := el.BlockRefByLabel(eth.Unsafe)
+			block, err := sys.L1EL.Escape().EthClient().InfoByNumber(ctx, unsafe.L1Origin.Number)
 			if err != nil {
+				sys.Log.Warn("failed to get L1 block info by number", "chain", chain, "number", unsafe.L1Origin.Number, "err", err)
 				return false
 			}
-
-			if !sys.L1EL.IsCanonical(ref.L1Origin) {
+			if block.Hash() != unsafe.L1Origin.Hash {
 				return false
 			}
 		}
-
 		return true
-	}, 120*time.Second, 5*time.Second, "all L1Origin fields should point to canonical L1 blocks")
+	}, 120*time.Second, 7*time.Second, "both L2 unsafe heads should reference canonical L1 origins")
+
+	// Confirm all recent L1Origin fields on both chains point to canonical blocks.
+	require.Eventually(t, func() bool {
+		for _, el := range []*dsl.L2ELNode{sys.L2ELA, sys.L2ELB} {
+			ref := el.BlockRefByLabel(eth.Unsafe)
+			if ref.L1Origin.Number < divergence.Number {
+				return false
+			}
+			for i := ref.Number; i > 0 && ref.L1Origin.Number >= divergence.Number; i-- {
+				var err error
+				ref, err = el.Escape().L2EthClient().L2BlockRefByNumber(ctx, i)
+				if err != nil || !sys.L1EL.IsCanonical(ref.L1Origin) {
+					return false
+				}
+			}
+		}
+		return true
+	}, 120*time.Second, 5*time.Second, "all recent L1 origins on both chains should be canonical")
 
 	// post reorg test validations and checks
 	postChecks(t, sys)

--- a/op-acceptance-tests/tests/supernode/interop/follow_l2/p2p_sync_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/follow_l2/p2p_sync_test.go
@@ -9,34 +9,55 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 
 	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
+	"github.com/ethereum/go-ethereum/common"
 )
 
 // TestFollowSource_P2PSync checks that a follower CL syncs unsafe blocks from the
 // sequencer via P2P. After stopping and restarting the follower, it reconnects to
 // the sequencer and catches up to the same unsafe head.
 func TestFollowSource_P2PSync(gt *testing.T) {
-	t := devtest.ParallelT(gt)
+	t := devtest.SerialT(gt)
+	require := t.Require()
 
 	sys := presets.NewTwoL2SupernodeFollowL2(t, 0)
 	logger := sys.Log.With("Test", "TestFollowSource_P2PSync")
 
-	logger.Info("Make sure sequencer and follower unsafe head advances")
+	logger.Info("Make sure both sequencers and followers advance")
 	dsl.CheckAll(t,
 		sys.L2ACL.AdvancedFn(safety.LocalUnsafe, 5, 30),
 		sys.L2AFollowCL.AdvancedFn(safety.LocalUnsafe, 5, 30),
+		sys.L2BCL.AdvancedFn(safety.LocalUnsafe, 5, 30),
+		sys.L2BFollowCL.AdvancedFn(safety.LocalUnsafe, 5, 30),
 	)
+	beforeA := sys.L2AFollowCL.HeadBlockRef(safety.LocalUnsafe)
+	beforeB := sys.L2BFollowCL.HeadBlockRef(safety.LocalUnsafe)
 
-	logger.Info("Stop follower CL")
+	logger.Info("Stop chain A follower CL")
 	sys.L2AFollowCL.Stop()
 
-	logger.Info("Make sure follower EL does not advance")
-	sys.L2AFollowEL.NotAdvanced(eth.Unsafe, 5)
+	logger.Info("Make sure chain A stays stopped while chain B remains live")
+	dsl.CheckAll(t,
+		sys.L2AFollowEL.NotAdvancedFn(eth.Unsafe, 5),
+		sys.L2BCL.AdvancedFn(safety.LocalUnsafe, 5, 30),
+		sys.L2BFollowCL.AdvancedFn(safety.LocalUnsafe, 5, 30),
+	)
+	duringB := sys.L2BFollowCL.HeadBlockRef(safety.LocalUnsafe)
+	canonicalB := make(map[uint64]common.Hash, duringB.Number-beforeB.Number)
+	for height := beforeB.Number + 1; height <= duringB.Number; height++ {
+		canonicalB[height] = sys.L2BFollowEL.BlockRefByNumber(height).Hash
+	}
 
-	logger.Info("Restart follower CL")
+	logger.Info("Restart chain A follower CL")
 	sys.L2AFollowCL.Start()
 
 	logger.Info("Reconnect follower P2P to sequencer")
 	sys.L2AFollowCL.ConnectPeer(sys.L2ACL)
+	sys.L2AFollowCL.Reached(safety.LocalUnsafe, beforeA.Number, 30)
+	restoredA := sys.L2AFollowCL.HeadBlockRef(safety.LocalUnsafe)
+	require.GreaterOrEqual(restoredA.Number, beforeA.Number,
+		"chain A follower did not restore its pre-restart head")
+	require.Equal(beforeA.Hash, sys.L2AFollowEL.BlockRefByNumber(beforeA.Number).Hash,
+		"chain A follower rewrote its pre-restart head")
 
 	logger.Info("Make sure both advance")
 	dsl.CheckAll(t,
@@ -46,4 +67,10 @@ func TestFollowSource_P2PSync(gt *testing.T) {
 
 	logger.Info("Check sequencer and follower converged on the same canonical chain")
 	sys.L2AFollowCL.InSync(sys.L2ACL, safety.LocalUnsafe, 30)
+	for height, expected := range canonicalB {
+		require.Equal(expected, sys.L2BFollowEL.BlockRefByNumber(height).Hash,
+			"chain B follower rewrote height %d during chain A restart", height)
+		require.Equal(expected, sys.L2ELB.BlockRefByNumber(height).Hash,
+			"chain B source disagreed at height %d after chain A restart", height)
+	}
 }

--- a/op-acceptance-tests/tests/supernode/interop/follow_l2/source_outage_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/follow_l2/source_outage_test.go
@@ -1,0 +1,108 @@
+package follow_l2
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// TestFollowSourceOutageIsolation verifies that an outage of one chain's
+// follow-source route does not stall or rewrite either chain. Follow-L2 nodes
+// retain their independent gossip and EL P2P data paths during this control-
+// plane outage; after the route resumes, every safety head must reconverge.
+func TestFollowSourceOutageIsolation(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	require := t.Require()
+
+	proxies := sysgo.NewStallableFollowSourceProxies()
+	sys := presets.NewTwoL2SupernodeFollowL2(t, 0,
+		presets.WithGlobalL2CLOption(proxies.L2CLOption()),
+	)
+
+	dsl.CheckAll(t,
+		sys.L2AFollowCL.InSyncFn(sys.L2ACL, safety.LocalUnsafe, 30),
+		sys.L2BFollowCL.InSyncFn(sys.L2BCL, safety.LocalUnsafe, 30),
+	)
+
+	proxyA := proxies.ForChain(t, sys.L2A.ChainID())
+	proxyA.Stall()
+	t.Cleanup(proxyA.Resume)
+	require.Eventually(func() bool {
+		return proxyA.StalledRequests() > 0
+	}, 30*time.Second, 250*time.Millisecond,
+		"chain A follower never exercised its stalled follow-source route")
+
+	sourceABefore := sys.L2ACL.HeadBlockRef(safety.LocalUnsafe)
+	followerABefore := sys.L2AFollowCL.HeadBlockRef(safety.LocalUnsafe)
+	sourceBBefore := sys.L2BCL.HeadBlockRef(safety.LocalUnsafe)
+	followerBBefore := sys.L2BFollowCL.HeadBlockRef(safety.LocalUnsafe)
+	targetA := max(sourceABefore.Number, followerABefore.Number) + 4
+	targetB := max(sourceBBefore.Number, followerBBefore.Number) + 4
+
+	dsl.CheckAll(t,
+		sys.L2ACL.ReachedFn(safety.LocalUnsafe, targetA, 30),
+		sys.L2AFollowCL.ReachedFn(safety.LocalUnsafe, targetA, 30),
+		sys.L2BCL.ReachedFn(safety.LocalUnsafe, targetB, 30),
+		sys.L2BFollowCL.ReachedFn(safety.LocalUnsafe, targetB, 30),
+	)
+
+	sourceAAfter := sys.L2ACL.HeadBlockRef(safety.LocalUnsafe)
+	followerAAfter := sys.L2AFollowCL.HeadBlockRef(safety.LocalUnsafe)
+	sourceBAfter := sys.L2BCL.HeadBlockRef(safety.LocalUnsafe)
+	followerBAfter := sys.L2BFollowCL.HeadBlockRef(safety.LocalUnsafe)
+	firstCanonicalA := max(sourceABefore.Number, followerABefore.Number) + 1
+	lastCanonicalA := min(sourceAAfter.Number, followerAAfter.Number)
+	canonicalA := make(map[uint64]common.Hash, lastCanonicalA-firstCanonicalA+1)
+	for height := firstCanonicalA; height <= lastCanonicalA; height++ {
+		sourceRef := sys.L2ELA.BlockRefByNumber(height)
+		followerRef := sys.L2AFollowEL.BlockRefByNumber(height)
+		require.Equal(sourceRef.Hash, followerRef.Hash,
+			"chain A follower disagreed with its source at outage height %d", height)
+		canonicalA[height] = followerRef.Hash
+	}
+
+	firstCanonicalB := max(sourceBBefore.Number, followerBBefore.Number) + 1
+	lastCanonicalB := min(sourceBAfter.Number, followerBAfter.Number)
+	canonicalB := make(map[uint64]common.Hash, lastCanonicalB-firstCanonicalB+1)
+	for height := firstCanonicalB; height <= lastCanonicalB; height++ {
+		sourceRef := sys.L2ELB.BlockRefByNumber(height)
+		followerRef := sys.L2BFollowEL.BlockRefByNumber(height)
+		require.Equal(sourceRef.Hash, followerRef.Hash,
+			"chain B follower disagreed with its source at outage height %d", height)
+		canonicalB[height] = followerRef.Hash
+	}
+
+	proxyA.Resume()
+	dsl.CheckAll(t,
+		sys.L2AFollowCL.InSyncFn(sys.L2ACL, safety.LocalUnsafe, 60),
+		sys.L2AFollowCL.InSyncFn(sys.L2ACL, safety.LocalSafe, 60),
+		sys.L2AFollowCL.InSyncFn(sys.L2ACL, safety.CrossSafe, 60),
+		sys.L2BFollowCL.InSyncFn(sys.L2BCL, safety.LocalUnsafe, 60),
+		sys.L2BFollowCL.InSyncFn(sys.L2BCL, safety.LocalSafe, 60),
+		sys.L2BFollowCL.InSyncFn(sys.L2BCL, safety.CrossSafe, 60),
+	)
+
+	for height, expected := range canonicalA {
+		require.Equal(expected, sys.L2ELA.BlockRefByNumber(height).Hash,
+			"chain A source rewrote outage height %d", height)
+		require.Equal(expected, sys.L2AFollowEL.BlockRefByNumber(height).Hash,
+			"chain A follower rewrote outage height %d", height)
+	}
+	for height, expected := range canonicalB {
+		require.Equal(expected, sys.L2ELB.BlockRefByNumber(height).Hash,
+			"chain B source rewrote outage height %d", height)
+		require.Equal(expected, sys.L2BFollowEL.BlockRefByNumber(height).Hash,
+			"chain B follower rewrote outage height %d", height)
+	}
+
+	require.Greater(proxyA.StalledRequests(), int64(0))
+	require.LessOrEqual(proxyA.MaxConcurrentStalledRequests(), int64(1),
+		"chain A follower opened concurrent follow-source requests during the outage")
+}

--- a/op-acceptance-tests/tests/supernode/interop/reorg/future_initiation_reorg_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/reorg/future_initiation_reorg_test.go
@@ -1,0 +1,86 @@
+package reorg
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/core/types"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/eth/safety"
+	"github.com/ethereum-optimism/optimism/op-service/txplan"
+)
+
+// TestSupernodeRejectsExecutionBeforeInitiation proves that an EVM-valid
+// executing message cannot become cross-safe before its declared initiation
+// timestamp. The executing block is replaced with deposits only, the later
+// initiating block stays canonical, and sequencing continues on the replacement.
+func TestSupernodeRejectsExecutionBeforeInitiation(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	require := t.Require()
+	setup := presets.NewTwoL2SupernodeInterop(t, 0).ForSameTimestampTesting(t)
+
+	blockTime := setup.L2A.Escape().RollupConfig().BlockTime
+	initTimestamp := setup.NextTimestamp + blockTime
+	pair := setup.Alice.PrepareSameTimestampInit(
+		rand.New(rand.NewSource(902_901)),
+		setup.EventLoggerA,
+		setup.ExpectedBlockNumA+1,
+		0,
+		initTimestamp,
+	)
+
+	execTx := pair.SubmitExecTo(setup.Bob)
+	txplan.WithStaticNonce(setup.Bob.PendingNonce())(execTx)
+	parentB := setup.L2ELB.BlockRefByLabel(eth.Unsafe)
+	execHash := setup.TestSequencer.SequencePlannedBlock(
+		t, setup.L2B.ChainID(), parentB.Hash, execTx,
+	)[0]
+	execReceipt := setup.L2ELB.WaitForReceipt(execHash)
+	require.Equal(types.ReceiptStatusSuccessful, execReceipt.Status,
+		"ordering fault must be an interop conflict, not an EVM failure")
+	invalidRef := setup.L2ELB.BlockRefByHash(execReceipt.BlockHash)
+	require.Equal(setup.NextTimestamp, invalidRef.Time)
+	require.Less(invalidRef.Time, initTimestamp)
+
+	parentA := setup.L2ELA.BlockRefByLabel(eth.Unsafe)
+	setup.TestSequencer.SequenceBlock(t, setup.L2A.ChainID(), parentA.Hash)
+	preInitRef := setup.L2ELA.BlockRefByNumber(setup.ExpectedBlockNumA)
+	require.Equal(setup.NextTimestamp, preInitRef.Time)
+
+	initTx := pair.SubmitInit()
+	txplan.WithStaticNonce(setup.Alice.PendingNonce())(initTx)
+	initHash := setup.TestSequencer.SequencePlannedBlock(
+		t, setup.L2A.ChainID(), preInitRef.Hash, initTx,
+	)[0]
+	initReceipt := setup.L2ELA.WaitForReceipt(initHash)
+	require.Equal(types.ReceiptStatusSuccessful, initReceipt.Status)
+	initRef := setup.L2ELA.BlockRefByHash(initReceipt.BlockHash)
+	require.Equal(initTimestamp, initRef.Time)
+
+	setup.Supernode.ResumeInterop()
+	setup.Supernode.AwaitValidatedTimestamp(invalidRef.Time)
+
+	replacement := setup.L2ELB.BlockRefByNumber(invalidRef.Number)
+	require.NotEqual(invalidRef.Hash, replacement.Hash,
+		"execution-before-initiation block was not replaced")
+	setup.L2ELB.AssertTxNotInBlock(invalidRef.Number, execHash)
+	setup.L2ELB.AssertBlockDepositOnly(invalidRef.Number)
+	require.Equal(preInitRef.Hash, setup.L2ELA.BlockRefByNumber(preInitRef.Number).Hash,
+		"unrelated chain-A prefix changed during chain-B invalidation")
+	require.Equal(initRef.Hash, setup.L2ELA.BlockRefByNumber(initRef.Number).Hash,
+		"later initiating block changed during chain-B invalidation")
+
+	dsl.CheckAll(t,
+		setup.L2ACL.ReachedRefFn(safety.CrossSafe, initRef.ID(), 60),
+		setup.L2BCL.ReachedFn(safety.CrossSafe, replacement.Number+2, 60),
+	)
+	setup.Supernode.AwaitValidatedTimestamp(initRef.Time)
+	require.Equal(replacement.Hash, setup.L2ELB.BlockRefByNumber(replacement.Number).Hash,
+		"replacement lineage changed after sequencing resumed")
+	require.Equal(replacement.Hash, setup.L2ELB.BlockRefByNumber(replacement.Number+1).ParentHash,
+		"sequencing did not continue from the replacement block")
+}

--- a/op-acceptance-tests/tests/supernode/interop/startup_resync/engine_outage_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/startup_resync/engine_outage_test.go
@@ -1,0 +1,66 @@
+package startup_resync
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/eth/safety"
+)
+
+// TestSupernodeChainContainerEngineOutageIsolation proves that losing one
+// chain's execution engine does not stop the sibling chain container. Chain B
+// keeps building and deriving local-safe blocks while chain A's engine is down,
+// and neither chain rewrites the canonical history produced before recovery.
+func TestSupernodeChainContainerEngineOutageIsolation(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	require := t.Require()
+	sys := presets.NewTwoL2SupernodeInterop(t, 0,
+		presets.WithUniformL2BlockTimes(l2BlockTime),
+	)
+
+	dsl.CheckAll(t,
+		sys.L2ACL.ReachedFn(safety.LocalUnsafe, 4, 60),
+		sys.L2BCL.ReachedFn(safety.LocalUnsafe, 4, 60),
+		sys.L2ACL.ReachedFn(safety.LocalSafe, 3, 60),
+		sys.L2BCL.ReachedFn(safety.LocalSafe, 3, 60),
+	)
+	beforeA := sys.L2ELA.BlockRefByLabel(eth.Unsafe)
+	beforeB := sys.L2ELB.BlockRefByLabel(eth.Unsafe)
+	beforeSafeB := sys.L2BCL.HeadBlockRef(safety.LocalSafe)
+
+	sys.L2ELA.Stop()
+	t.Cleanup(sys.L2ELA.Start)
+
+	dsl.CheckAll(t,
+		sys.L2BCL.ReachedFn(safety.LocalUnsafe, beforeB.Number+4, 90),
+		sys.L2BCL.ReachedFn(safety.LocalSafe, beforeSafeB.Number+2, 90),
+	)
+	duringB := sys.L2ELB.BlockRefByLabel(eth.Unsafe)
+	canonicalB := make(map[uint64]common.Hash, duringB.Number-beforeB.Number+1)
+	for number := beforeB.Number; number <= duringB.Number; number++ {
+		canonicalB[number] = sys.L2ELB.BlockRefByNumber(number).Hash
+	}
+
+	sys.L2ELA.Start()
+	sys.L2ELA.WaitForOnline()
+	dsl.CheckAll(t,
+		sys.L2ACL.ReachedFn(safety.LocalUnsafe, beforeA.Number+2, 120),
+		sys.L2BCL.ReachedFn(safety.LocalUnsafe, duringB.Number+2, 60),
+		sys.L2ACL.ReachedFn(safety.CrossSafe, beforeA.Number+1, 120),
+		sys.L2BCL.ReachedFn(safety.CrossSafe, beforeB.Number+1, 120),
+	)
+
+	require.Equal(beforeA.Hash, sys.L2ELA.BlockRefByNumber(beforeA.Number).Hash,
+		"chain A rewrote its pre-outage canonical head during recovery")
+	require.Equal(beforeA.Hash, sys.L2ELA.BlockRefByNumber(beforeA.Number+1).ParentHash,
+		"chain A did not resume contiguously after its engine restarted")
+	for number, expected := range canonicalB {
+		require.Equal(expected, sys.L2ELB.BlockRefByNumber(number).Hash,
+			"chain B canonical hash changed at outage-produced height %d", number)
+	}
+}

--- a/op-acceptance-tests/tests/supernode/interop/startup_resync/restart_persistence_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/startup_resync/restart_persistence_test.go
@@ -1,0 +1,68 @@
+package startup_resync
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-service/eth/safety"
+)
+
+// TestSupernodeRestoresVerifiedCrossHeadsAfterRestart checkpoints a live
+// supernode with verified history, restarts it without deleting its data, and
+// proves that the first restored cross-safe reads never regress or change the
+// canonical lineage. The stored super-root must also remain byte-for-byte
+// stable while both chains continue advancing after restart.
+func TestSupernodeRestoresVerifiedCrossHeadsAfterRestart(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	require := t.Require()
+	sys := presets.NewTwoL2SupernodeInterop(t, 0,
+		presets.WithUniformL2BlockTimes(l2BlockTime),
+	)
+
+	dsl.CheckAll(t,
+		sys.L2ACL.ReachedFn(safety.CrossSafe, 4, 90),
+		sys.L2BCL.ReachedFn(safety.CrossSafe, 4, 90),
+	)
+	safeA := sys.L2ACL.HeadBlockRef(safety.CrossSafe)
+	safeB := sys.L2BCL.HeadBlockRef(safety.CrossSafe)
+	verifiedTimestamp := min(safeA.Time, safeB.Time)
+	sys.Supernode.AwaitValidatedTimestamp(verifiedTimestamp)
+	beforeRoot := sys.Supernode.SuperRootAt(
+		verifiedTimestamp, sys.L2A.ChainID(), sys.L2B.ChainID(),
+	)
+
+	sys.Supernode.Stop()
+	sys.Supernode.Start()
+
+	// These are intentionally immediate, single-shot reads after Start. A
+	// transient reset to genesis is itself a restart regression.
+	restoredA := sys.L2ACL.HeadBlockRef(safety.CrossSafe)
+	restoredB := sys.L2BCL.HeadBlockRef(safety.CrossSafe)
+	require.GreaterOrEqual(restoredA.Number, safeA.Number,
+		"chain A cross-safe head regressed across restart")
+	require.GreaterOrEqual(restoredB.Number, safeB.Number,
+		"chain B cross-safe head regressed across restart")
+	require.Equal(safeA.Hash, sys.L2ELA.BlockRefByNumber(safeA.Number).Hash,
+		"chain A rewrote its pre-restart cross-safe block")
+	require.Equal(safeB.Hash, sys.L2ELB.BlockRefByNumber(safeB.Number).Hash,
+		"chain B rewrote its pre-restart cross-safe block")
+	afterRoot := sys.Supernode.SuperRootAt(
+		verifiedTimestamp, sys.L2A.ChainID(), sys.L2B.ChainID(),
+	)
+	require.Equal(beforeRoot.Data.SuperRoot, afterRoot.Data.SuperRoot,
+		"verified super-root changed across restart")
+
+	dsl.CheckAll(t,
+		sys.L2ACL.ReachedFn(safety.CrossSafe, safeA.Number+2, 120),
+		sys.L2BCL.ReachedFn(safety.CrossSafe, safeB.Number+2, 120),
+	)
+	require.Equal(safeA.Hash, sys.L2ELA.BlockRefByNumber(safeA.Number).Hash,
+		"chain A rewrote restored history while extending")
+	require.Equal(safeB.Hash, sys.L2ELB.BlockRefByNumber(safeB.Number).Hash,
+		"chain B rewrote restored history while extending")
+	require.Equal(beforeRoot.Data.SuperRoot, sys.Supernode.SuperRootAt(
+		verifiedTimestamp, sys.L2A.ChainID(), sys.L2B.ChainID(),
+	).Data.SuperRoot, "verified super-root changed after post-restart extension")
+}

--- a/op-devstack/dsl/l2_el.go
+++ b/op-devstack/dsl/l2_el.go
@@ -688,6 +688,22 @@ func (el *L2ELNode) AssertTxInBlock(blockNumber uint64, txHash common.Hash) {
 	el.require.Fail("transaction should exist in block", "blockNumber", blockNumber, "txHash", txHash)
 }
 
+// AssertBlockDepositOnly asserts that the canonical block at blockNumber is a
+// deposits-only block. Interop invalidation uses this block shape to replace an
+// invalid unsafe payload without retaining any user transactions.
+func (el *L2ELNode) AssertBlockDepositOnly(blockNumber uint64) {
+	ctx, cancel := context.WithTimeout(el.ctx, DefaultTimeout)
+	defer cancel()
+
+	_, txs, err := el.inner.EthClient().InfoAndTxsByNumber(ctx, blockNumber)
+	el.require.NoError(err, "failed to fetch block %d", blockNumber)
+	el.require.NotEmpty(txs, "deposit-only block %d must contain its L1 attributes deposit", blockNumber)
+	for _, tx := range txs {
+		el.require.Truef(tx.IsDepositTx(), "block %d contains non-deposit transaction %s", blockNumber, tx.Hash())
+	}
+	el.log.Info("confirmed deposit-only block", "blockNumber", blockNumber, "transactions", len(txs))
+}
+
 // ResendUntilSafe broadcasts a transaction from makeTx and waits for it to derive onto this
 // node's irreversible safe chain, retrying with a newly built transaction whenever a broadcast
 // fails to settle. It returns the block number and hash where the transaction landed, and fails

--- a/op-devstack/dsl/sequencer.go
+++ b/op-devstack/dsl/sequencer.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/txplan"
 	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
@@ -68,4 +69,22 @@ func (s *TestSequencer) SequenceBlockWithTxs(t devtest.T, chainID eth.ChainID, p
 	// Publish is optional - it broadcasts via P2P which may not be enabled in tests.
 	// The block is already committed and canonical at this point.
 	_ = ca.Publish(ctx) // ignore publish errors
+}
+
+// SequencePlannedBlock signs the supplied planned transactions and includes
+// them in a deterministic block at parent.Time + blockTime. Callers must set
+// any nonces that need to be stable before invoking this method.
+func (s *TestSequencer) SequencePlannedBlock(t devtest.T, chainID eth.ChainID, parent common.Hash, txs ...*txplan.PlannedTx) []common.Hash {
+	rawTxs := make([][]byte, 0, len(txs))
+	txHashes := make([]common.Hash, 0, len(txs))
+	for _, tx := range txs {
+		signed, err := tx.Signed.Eval(t.Ctx())
+		require.NoError(t, err, "failed to sign planned transaction")
+		raw, err := signed.MarshalBinary()
+		require.NoError(t, err, "failed to marshal planned transaction")
+		rawTxs = append(rawTxs, raw)
+		txHashes = append(txHashes, signed.Hash())
+	}
+	s.SequenceBlockWithTxs(t, chainID, parent, rawTxs)
+	return txHashes
 }

--- a/op-devstack/presets/option_validation.go
+++ b/op-devstack/presets/option_validation.go
@@ -206,11 +206,12 @@ const twoL2SupernodeInteropPresetSupportedOptionKinds = optionKindDeployer |
 	optionKindPreGenesisSuperGame |
 	optionKindSupernodeVNSequencerForBootstrap
 
-// twoL2SupernodeLightSequencerPresetSupportedOptionKinds additionally accepts
-// L2 CL options: the light-sequencer runtime is the only two-L2 supernode
-// variant that wires GlobalL2CLOptions (to the light sequencer CLs), so the
-// option is accepted here and nowhere else to avoid a silent no-op.
+// The light-sequencer and follow-L2 presets additionally accept L2 CL options:
+// both variants wire GlobalL2CLOptions to their standalone op-node CLs.
 const twoL2SupernodeLightSequencerPresetSupportedOptionKinds = twoL2SupernodeInteropPresetSupportedOptionKinds |
+	optionKindGlobalL2CL
+
+const twoL2SupernodeFollowL2PresetSupportedOptionKinds = twoL2SupernodeInteropPresetSupportedOptionKinds |
 	optionKindGlobalL2CL
 
 const singleChainWithFlashblocksPresetSupportedOptionKinds = optionKindDeployer |

--- a/op-devstack/presets/twol2_follow_l2.go
+++ b/op-devstack/presets/twol2_follow_l2.go
@@ -20,6 +20,6 @@ type TwoL2SupernodeFollowL2 struct {
 // NewTwoL2SupernodeFollowL2 creates a fresh follow-source variant of the two-L2
 // supernode interop preset for the current test.
 func NewTwoL2SupernodeFollowL2(t devtest.T, delaySeconds uint64, opts ...Option) *TwoL2SupernodeFollowL2 {
-	presetCfg, _ := collectSupportedPresetConfig(t, "NewTwoL2SupernodeFollowL2", opts, twoL2SupernodeInteropPresetSupportedOptionKinds)
+	presetCfg, _ := collectSupportedPresetConfig(t, "NewTwoL2SupernodeFollowL2", opts, twoL2SupernodeFollowL2PresetSupportedOptionKinds)
 	return twoL2SupernodeFollowL2FromRuntime(t, sysgo.NewTwoL2SupernodeFollowL2RuntimeWithConfig(t, delaySeconds, presetCfg))
 }

--- a/op-devstack/sysgo/multichain_supernode_runtime.go
+++ b/op-devstack/sysgo/multichain_supernode_runtime.go
@@ -99,8 +99,8 @@ func NewTwoL2SupernodeLightSequencerInteropRuntimeWithConfig(t devtest.T, delayS
 
 func NewTwoL2SupernodeFollowL2RuntimeWithConfig(t devtest.T, delaySeconds uint64, cfg PresetConfig) *MultiChainRuntime {
 	runtime := NewTwoL2SupernodeInteropRuntimeWithConfig(t, delaySeconds, cfg)
-	addMultiChainFollowL2Node(t, runtime, "l2a", "follower")
-	addMultiChainFollowL2Node(t, runtime, "l2b", "follower")
+	addMultiChainFollowL2Node(t, runtime, "l2a", "follower", cfg.GlobalL2CLOptions)
+	addMultiChainFollowL2Node(t, runtime, "l2b", "follower", cfg.GlobalL2CLOptions)
 	return runtime
 }
 
@@ -516,7 +516,7 @@ func l2NetworkFromWorldBuilder(t devtest.T, wb *worldBuilder, l1ChainID, l2Chain
 	}
 }
 
-func addMultiChainFollowL2Node(t devtest.T, runtime *MultiChainRuntime, chainKey string, name string) *SingleChainNodeRuntime {
+func addMultiChainFollowL2Node(t devtest.T, runtime *MultiChainRuntime, chainKey string, name string, l2CLOptions []L2CLOption) *SingleChainNodeRuntime {
 	chain := runtime.Chains[chainKey]
 	t.Require().NotNil(chain, "missing %s runtime chain", chainKey)
 	t.Require().NotNil(chain.CL, "%s runtime chain missing CL follow source", chainKey)
@@ -530,6 +530,7 @@ func addMultiChainFollowL2Node(t devtest.T, runtime *MultiChainRuntime, chainKey
 		NoDiscovery:    true,
 		EnableReqResp:  false,
 		L2FollowSource: chain.CL.UserRPC(),
+		L2CLOptions:    l2CLOptions,
 		DependencySet:  runtime.DependencySet,
 		// Follow nodes catch up to their follow source via EL sync.
 		SyncMode: nodeSync.ELSync,

--- a/op-node/p2p/cli/load_signer.go
+++ b/op-node/p2p/cli/load_signer.go
@@ -28,7 +28,7 @@ func LoadSignerSetup(ctx cliiface.Context, logger log.Logger) (p2p.SignerSetup, 
 			return nil, fmt.Errorf("failed to read sequencer p2p key: %w", err)
 		}
 
-		return &p2p.PreparedSigner{Signer: opsigner.NewLocalSigner(priv)}, nil
+		return p2p.NewLocalSignerSetup(priv), nil
 	} else if signerCfg.Enabled() {
 		remoteSigner, err := opsigner.NewRemoteSigner(logger, signerCfg)
 		if err != nil {

--- a/op-node/p2p/signer.go
+++ b/op-node/p2p/signer.go
@@ -2,6 +2,7 @@ package p2p
 
 import (
 	"context"
+	"crypto/ecdsa"
 
 	opsigner "github.com/ethereum-optimism/optimism/op-service/signer"
 )
@@ -20,4 +21,18 @@ func (p *PreparedSigner) SetupSigner(ctx context.Context) (Signer, error) {
 
 type SignerSetup interface {
 	SetupSigner(ctx context.Context) (Signer, error)
+}
+
+// LocalSignerSetup creates a fresh signer for each node lifecycle. Unlike a
+// PreparedSigner, it can be reused after a prior node closes its signer.
+type LocalSignerSetup struct {
+	privateKey *ecdsa.PrivateKey
+}
+
+func NewLocalSignerSetup(privateKey *ecdsa.PrivateKey) *LocalSignerSetup {
+	return &LocalSignerSetup{privateKey: privateKey}
+}
+
+func (s *LocalSignerSetup) SetupSigner(context.Context) (Signer, error) {
+	return opsigner.NewLocalSigner(s.privateKey), nil
 }

--- a/op-node/p2p/signer_test.go
+++ b/op-node/p2p/signer_test.go
@@ -1,0 +1,31 @@
+package p2p
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+func TestLocalSignerSetupCreatesFreshSigner(t *testing.T) {
+	privateKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	setup := NewLocalSignerSetup(privateKey)
+
+	first, err := setup.SetupSigner(t.Context())
+	require.NoError(t, err)
+	_, err = first.SignBlockV1(t.Context(), eth.ChainIDFromUInt64(901), common.Hash{0x1})
+	require.NoError(t, err)
+	require.NoError(t, first.Close())
+
+	second, err := setup.SetupSigner(context.Background())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, second.Close()) })
+	require.NotSame(t, first, second)
+	_, err = second.SignBlockV1(t.Context(), eth.ChainIDFromUInt64(901), common.Hash{0x2})
+	require.NoError(t, err, "closing one node's signer must not poison the next lifecycle")
+}

--- a/op-supernode/supernode/chain_container/chain_container.go
+++ b/op-supernode/supernode/chain_container/chain_container.go
@@ -179,6 +179,7 @@ type simpleChainContainer struct {
 	pause              atomic.Bool
 	stop               atomic.Bool
 	resetting          atomic.Bool
+	rpcWarmReady       atomic.Bool
 	stopped            chan struct{}
 	log                gethlog.Logger
 	chainID            eth.ChainID
@@ -321,14 +322,49 @@ func (c *simpleChainContainer) setVN(vn virtual_node.VirtualNode) {
 }
 
 // IsRPCReady reports whether the chain's router handler may serve requests.
-// Pause and stop close the gate immediately; otherwise the current virtual node
-// must be installed and running.
+// Pause and stop close the gate immediately. A running virtual node on a warm
+// start must also have restored the verifier's durable cross-safe frontier;
+// otherwise the route could transiently expose genesis after restart. This is
+// a one-time barrier for the chain container: later intentional rewinds rely on
+// the normal VN lifecycle gate and may legitimately move below that frontier.
 func (c *simpleChainContainer) IsRPCReady() bool {
 	if c.pause.Load() || c.stop.Load() {
 		return false
 	}
 	vn := c.getVN()
-	return vn != nil && vn.State() == virtual_node.VNStateRunning
+	if vn == nil || vn.State() != virtual_node.VNStateRunning {
+		return false
+	}
+	if c.rpcWarmReady.Load() {
+		return true
+	}
+
+	verifier := c.registeredVerifier()
+	if verifier == nil {
+		c.rpcWarmReady.Store(true)
+		return true
+	}
+	verified, _, err := verifier.LatestVerifiedL2Block(c.chainID)
+	if err != nil {
+		return false
+	}
+	if verified == (eth.BlockID{}) {
+		c.rpcWarmReady.Store(true)
+		return true
+	}
+	status, err := vn.SyncStatus(context.Background())
+	if err != nil {
+		return false
+	}
+	if status.SafeL2.Number > verified.Number {
+		c.rpcWarmReady.Store(true)
+		return true
+	}
+	ready := status.SafeL2.ID() == verified
+	if ready {
+		c.rpcWarmReady.Store(true)
+	}
+	return ready
 }
 
 // WaitReady polls IsRPCReady() until true or ctx is done. If ctx has no

--- a/op-supernode/supernode/chain_container/chain_container_test.go
+++ b/op-supernode/supernode/chain_container/chain_container_test.go
@@ -572,6 +572,37 @@ func TestChainContainerIsRPCReady(t *testing.T) {
 	}
 }
 
+func TestChainContainerIsRPCReadyWaitsForVerifiedHead(t *testing.T) {
+	t.Parallel()
+
+	chainID := eth.ChainIDFromUInt64(420)
+	verified := eth.BlockID{Number: 10, Hash: common.HexToHash("0x1234")}
+	container := newTestChainContainer(t, chainID)
+	vn := container.vn.(*mockVirtualNode)
+	vn.setState(virtual_node.VNStateRunning)
+	container.RegisterVerifier(&mockVerificationActivityForSuperAuthority{
+		latestVerifiedBlock: verified,
+		latestVerifiedTS:    100,
+	})
+
+	setStatus := func(ref eth.L2BlockRef) {
+		vn.syncStatusOverride = func() (*eth.SyncStatus, error) {
+			return &eth.SyncStatus{SafeL2: ref}, nil
+		}
+	}
+
+	setStatus(eth.L2BlockRef{})
+	require.False(t, container.IsRPCReady(), "genesis must stay gated during warm restore")
+	setStatus(eth.L2BlockRef{Number: verified.Number, Hash: common.HexToHash("0x5678")})
+	require.False(t, container.IsRPCReady(), "a conflicting block at the verified height must stay gated")
+	setStatus(eth.L2BlockRef{Number: verified.Number, Hash: verified.Hash})
+	require.True(t, container.IsRPCReady(), "the exact verified frontier should open the route")
+	setStatus(eth.L2BlockRef{Number: verified.Number + 1, Hash: common.HexToHash("0x9abc")})
+	require.True(t, container.IsRPCReady(), "a head beyond the verified frontier should stay routable")
+	setStatus(eth.L2BlockRef{Number: verified.Number - 1, Hash: common.HexToHash("0xdef0")})
+	require.True(t, container.IsRPCReady(), "an intentional post-start rewind should use the normal lifecycle gate")
+}
+
 // TestChainContainer_Lifecycle tests Start/Stop behavior
 func TestChainContainer_Lifecycle(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary

Reverse-adapts the highest-signal `op-con-node` interop acceptance invariants from `ethereum-optimism/opql@57e0d5414f68e23fb83c6dcab5bd1abfd05464f4` to the existing op-supernode devstack seams.

- rejects an executing message sequenced before its declared initiation timestamp, replaces the invalid block with deposits only, preserves the sibling lineage, and keeps extending
- proves a chain-container Engine outage does not stall or rewrite the sibling chain
- proves warm supernode restart restores verified cross-safe heads and historical super-roots before reopening routed RPC
- strengthens the existing L1-reorg scenario across both chain containers, every safety head, super-root replacement, and sibling isolation
- adds follow-L2 source-route outage isolation and strengthens per-chain follower restart/P2P recovery

## Product bugs fixed

1. **Warm supernode routes opened before verified state was restored.** `VNStateRunning` could become visible while the restarted VN still reported genesis, regressing routed cross-safe reads despite a durable verified frontier. The route now has a one-time warm-start barrier against the verifier's exact latest verified block. Once satisfied, later intentional internal rewinds remain routable through the normal VN lifecycle gate.
2. **Local P2P signer setup was not reusable across node lifecycles.** The CLI returned the same closable `LocalSigner` on every setup; the first stop closed it, so restarted nodes logged `signer is closed` and stopped publishing signed payloads. Local-key setup now creates a fresh signer per lifecycle.

Both fixes have focused unit coverage and live restart regression coverage.

## Divergence classification

- **Harness mismatch:** `ResumeInterop` already resumes the affected containers/sequencers; explicit extra `StartSequencer` calls raced the resumed world and were removed.
- **Harness mismatch:** global L2 CL options were accepted by related presets but were not wired to the two follow-L2 follower CLs (and the follow preset rejected the option). The existing option seam is now wired and allow-listed so the outage probe cannot pass vacuously.
- **Intentional architecture difference:** a follow-L2 follower retains independent CL gossip and EL P2P data paths while its follow-source status/control route is unavailable. The test therefore checks isolation, continued canonical progress, bounded source requests, and reconvergence—not the OpQL Direct Sync implementation contract that the affected chain must stall.
- **Timing assumptions:** a stopped batcher can have already-posted data still deriving, and a directly controlled follower `Start` returns before its asynchronous engine reset completes. Assertions use the appropriate readiness/catch-up boundary while preserving canonical-hash and no-regression checks.
- **Environment mismatch:** inherited `RUST_LOG=warn` suppresses op-reth startup lines parsed by the devstack harness. Live validation unsets `RUST_LOG` and uses `LOG_LEVEL=warn` for Go logging.

## Deliberate non-ports

- no replay-ring, `opql_*` RPC, Direct Sync listener/admin, or op-con-node source-cursor contracts
- no max-safe-lag or per-chain sequencing-control duplication that only retests op-node behavior
- no copies of filtering, message-shape, sequencing-window expiry, or load scenarios: the existing generic tests already instantiate `NewTwoL2SupernodeInterop` (load/filter also enable the interop filter)
- the follow-source outage test includes the bounded resource invariant by requiring at most one stalled request in flight

## Validation

All live worlds used op-reth, `devtest.SerialT` for added/strengthened live tests, `-parallel 1`, `GOMAXPROCS=1`, `GOFLAGS=-p=1`, and ran one at a time:

```text
env -u RUST_LOG LOG_LEVEL=warn GOMAXPROCS=1 GOFLAGS=-p=1 \
  RUST_BINARY_PATH_OP_RETH=<op-reth> DEVSTACK_L2EL_KIND=op-reth \
  mise exec -- go test -v -count=1 -timeout 30m -parallel 1 \
  ./op-acceptance-tests/tests/supernode/interop/reorg \
  ./op-acceptance-tests/tests/supernode/interop/startup_resync \
  ./op-acceptance-tests/tests/supernode/interop/follow_l2 \
  ./op-acceptance-tests/tests/interop/reorgs
```

Final run on `4bd953ec74` + this branch:

- `tests/supernode/interop/reorg`: PASS, 217.653s
  - future-initiation invalidation: PASS, 44.69s
- `tests/supernode/interop/startup_resync`: PASS, 264.820s
  - Engine outage isolation: PASS, 26.04s
  - verified-head restart persistence: PASS, 19.98s
- `tests/supernode/interop/follow_l2`: PASS, 208.195s
  - per-chain follower restart: PASS, 55.22s
  - source-route outage isolation: PASS, 33.33s
- `tests/interop/reorgs`: PASS, 497.103s
  - combined L1-reorg scenarios: PASS, 270.25s
- aggregate wall time: 1205.52s

Focused post-rebase unit/compile validation:

```text
go test ./op-supernode/supernode/chain_container        PASS 81.006s
go test ./op-node/p2p                                   PASS 8.658s
go test ./op-node/p2p/cli                               PASS 0.733s
go test ./op-devstack/presets                           PASS 0.827s
go test ./op-devstack/sysgo                             PASS 1.376s
go test ./op-devstack/dsl                               PASS 14.840s
go test -run '^$' <four affected acceptance packages>  PASS
```

Repository checks:

```text
mise exec -- just lint-go  PASS, 0 issues, 141.15s
git diff --check           PASS
```

The first lint attempt stopped during type-check because the host Go build cache exhausted the temp volume (`no space left on device`); after clearing only that disposable cache, the exact command passed. No tests were skipped.
