### PR TITLE
kona-engine: reuse inserted block info

### DIFF
--- a/rust/kona/crates/node/engine/src/task_queue/tasks/insert/task.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/insert/task.rs
@@ -45,11 +45,11 @@ impl<EngineClient_: EngineClient> InsertTask<EngineClient_> {
 
 #[async_trait]
 impl<EngineClient_: EngineClient> EngineTaskExt for InsertTask<EngineClient_> {
-    type Output = ();
+    type Output = L2BlockInfo;
 
     type Error = InsertTaskError;
 
-    async fn execute(&self, state: &mut EngineState) -> Result<(), InsertTaskError> {
+    async fn execute(&self, state: &mut EngineState) -> Result<L2BlockInfo, InsertTaskError> {
         let time_start = Instant::now();
 
         // Insert the new payload.
@@ -120,6 +120,6 @@ impl<EngineClient_: EngineClient> EngineTaskExt for InsertTask<EngineClient_> {
             "Inserted new unsafe block"
         );
 
-        Ok(())
+        Ok(new_unsafe_ref)
     }
 }

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/seal/error.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/seal/error.rs
@@ -2,7 +2,6 @@
 
 use crate::{EngineTaskError, InsertTaskError, task_queue::tasks::task::EngineTaskErrorSeverity};
 use alloy_transport::{RpcError, TransportErrorKind};
-use kona_protocol::FromBlockError;
 use op_alloy_rpc_types_engine::OpExecutionPayloadEnvelope;
 use thiserror::Error;
 use tokio::sync::mpsc;
@@ -26,12 +25,6 @@ pub enum SealTaskError {
     /// be flushed post-holocene.
     #[error("Invalid payload, must flush post-holocene")]
     HoloceneInvalidFlush,
-    /// Failed to convert a [`OpExecutionPayload`] to a [`L2BlockInfo`].
-    ///
-    /// [`OpExecutionPayload`]: op_alloy_rpc_types_engine::OpExecutionPayload
-    /// [`L2BlockInfo`]: kona_protocol::L2BlockInfo
-    #[error(transparent)]
-    FromBlock(#[from] FromBlockError),
     /// Error sending the built payload envelope.
     #[error(transparent)]
     MpscSend(#[from] Box<mpsc::error::SendError<Result<OpExecutionPayloadEnvelope, Self>>>),
@@ -56,7 +49,6 @@ impl EngineTaskError for SealTaskError {
             Self::HoloceneInvalidFlush => EngineTaskErrorSeverity::Flush,
             Self::DepositOnlyPayloadReattemptFailed |
             Self::DepositOnlyPayloadFailed |
-            Self::FromBlock(_) |
             Self::MpscSend(_) |
             Self::ClockWentBackwards |
             Self::UnsafeHeadChangedSinceBuild => EngineTaskErrorSeverity::Critical,

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/seal/task.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/seal/task.rs
@@ -134,14 +134,14 @@ impl<EngineClient_: EngineClient> SealTask<EngineClient_> {
     /// 2. Handling deposits-only payload failures
     /// 3. Holocene fallback via `build_and_seal` if needed
     ///
-    /// Returns Ok(()) if the payload is successfully inserted, or an error if insertion fails.
+    /// Returns the inserted block information, or an error if insertion fails.
     async fn insert_payload(
         &self,
         state: &mut EngineState,
         execution_data: OpExecutionData,
-    ) -> Result<(), SealTaskError> {
+    ) -> Result<L2BlockInfo, SealTaskError> {
         // Insert the new block into the engine.
-        match InsertTask::new(
+        let new_block_ref = match InsertTask::new(
             Arc::clone(&self.engine),
             self.cfg.clone(),
             execution_data,
@@ -187,12 +187,13 @@ impl<EngineClient_: EngineClient> SealTask<EngineClient_> {
                 error!(target: "engine", "Payload import failed: {e}");
                 return Err(Box::new(e).into());
             }
-            Ok(_) => {
-                info!(target: "engine", "Successfully imported payload")
+            Ok(new_block_ref) => {
+                info!(target: "engine", "Successfully imported payload");
+                new_block_ref
             }
-        }
+        };
 
-        Ok(())
+        Ok(new_block_ref)
     }
 
     /// Seals and canonicalizes the block by fetching the payload and importing it.
@@ -212,12 +213,9 @@ impl<EngineClient_: EngineClient> SealTask<EngineClient_> {
             .await?;
 
         let execution_data = new_payload.clone().into_execution_data();
-        let new_block_ref =
-            L2BlockInfo::from_execution_data_and_genesis(execution_data.clone(), &self.cfg.genesis)
-                .map_err(SealTaskError::FromBlock)?;
 
-        // Insert the payload into the engine.
-        self.insert_payload(state, execution_data).await?;
+        // Insert the payload into the engine and reuse its decoded block information.
+        let new_block_ref = self.insert_payload(state, execution_data).await?;
 
         let block_import_duration = block_import_start_time.elapsed();
 

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/task.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/task.rs
@@ -110,7 +110,9 @@ impl<EngineClient_: EngineClient> EngineTask<EngineClient_> {
     /// Executes the task without consuming it.
     async fn execute_inner(&self, state: &mut EngineState) -> Result<(), EngineTaskErrors> {
         match self {
-            Self::Insert(task) => task.execute(state).await?,
+            Self::Insert(task) => {
+                task.execute(state).await?;
+            }
             Self::Seal(task) => task.execute(state).await?,
             Self::Consolidate(task) => task.execute(state).await?,
             Self::Finalize(task) => task.execute(state).await?,

--- a/rust/kona/crates/node/service/src/actors/sequencer/actor.rs
+++ b/rust/kona/crates/node/service/src/actors/sequencer/actor.rs
@@ -533,7 +533,6 @@ fn is_seal_task_err_fatal(err: &SealTaskError) -> bool {
         SealTaskError::UnsafeHeadChangedSinceBuild => false,
         SealTaskError::DepositOnlyPayloadFailed |
         SealTaskError::DepositOnlyPayloadReattemptFailed |
-        SealTaskError::FromBlock(_) |
         SealTaskError::MpscSend(_) |
         SealTaskError::ClockWentBackwards => true,
     }

--- a/rust/kona/crates/protocol/protocol/src/block.rs
+++ b/rust/kona/crates/protocol/protocol/src/block.rs
@@ -10,8 +10,7 @@ use alloy_primitives::{B256, Bytes, Sealed};
 use alloy_rpc_types_eth::Block as RpcBlock;
 use derive_more::Display;
 use kona_genesis::ChainGenesis;
-use op_alloy_consensus::{OpBlock, OpTransaction, OpTxEnvelope};
-use op_alloy_rpc_types_engine::{OpExecutionData, OpPayloadError};
+use op_alloy_consensus::{OpTransaction, OpTxEnvelope};
 
 /// Block Header Info
 #[derive(Debug, Clone, Display, Copy, Eq, Hash, PartialEq, Default)]
@@ -146,9 +145,6 @@ pub enum FromBlockError {
     /// Failed to decode the [`L1BlockInfoTx`] from the deposit transaction.
     #[error("Failed to decode the L1BlockInfoTx from the deposit transaction: {0}")]
     BlockInfoDecodeError(#[from] DecodeError),
-    /// Failed to convert [`OpExecutionData`] to [`OpBlock`].
-    #[error(transparent)]
-    OpPayload(#[from] OpPayloadError),
 }
 
 impl PartialEq<Self> for FromBlockError {
@@ -252,15 +248,6 @@ impl L2BlockInfo {
                 .transpose()?
         };
         Self::from_block_info_and_first_tx(block_info, first_tx.as_ref(), genesis)
-    }
-
-    /// Constructs an [`L2BlockInfo`] from complete execution data and a [`ChainGenesis`].
-    pub fn from_execution_data_and_genesis(
-        execution_data: OpExecutionData,
-        genesis: &ChainGenesis,
-    ) -> Result<Self, FromBlockError> {
-        let block: OpBlock = execution_data.try_into_block()?;
-        Self::from_block_and_genesis(&block, genesis)
     }
 }
 


### PR DESCRIPTION
## Overview

Stacked on #22251.

Return the `L2BlockInfo` already constructed by `InsertTask` and reuse it in `SealTask`. Previously, sealing decoded the same execution payload once before insertion and then `InsertTask` decoded it again while importing the block.

This removes the duplicate transaction decoding and block-info construction without changing payload insertion, forkchoice synchronization, or Holocene fallback behavior. It also removes the now-unused execution-data-to-`L2BlockInfo` helper and associated error paths.

## Tests

- `cargo test -p kona-engine -p kona-protocol -p kona-node-service --all-features -- --skip test_chain_label_metrics`
- `cargo clippy -p kona-engine -p kona-protocol -p kona-node-service --all-targets --all-features -- -D warnings`
- `cargo check -p kona-protocol --no-default-features`
- `cargo check -p kona-engine --no-default-features`
