### PR TITLE
op-node: gate local-safe derivation on cross-safe verification lag

### DIFF
--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -275,6 +275,13 @@ var (
 		Value:    0,
 		Category: SequencerCategory,
 	}
+	VerifierMaxCrossSafeLagFlag = &cli.Uint64Flag{
+		Name:     "verifier.max-cross-safe-lag",
+		Usage:    "Maximum number of L2 blocks that the local-safe head may advance beyond the cross-safe (interop-verified) head before derivation pauses. Bounds the depth of engine rewinds caused by late block invalidations. Disabled if 0.",
+		EnvVars:  prefixEnvVars("VERIFIER_MAX_CROSS_SAFE_LAG"),
+		Value:    0,
+		Category: RollupCategory,
+	}
 	SequencerL1Confs = &cli.Uint64Flag{
 		Name:     "sequencer.l1-confs",
 		Usage:    "Number of L1 blocks to keep distance from the L1 head as a sequencer for picking an L1 origin.",
@@ -469,6 +476,7 @@ var optionalFlags = []cli.Flag{
 	SequencerEnabledFlag,
 	SequencerStoppedFlag,
 	SequencerMaxSafeLagFlag,
+	VerifierMaxCrossSafeLagFlag,
 	SequencerL1Confs,
 	SequencerRecoverMode,
 	SequencerSealingDurationFlag,

--- a/op-node/rollup/driver/config.go
+++ b/op-node/rollup/driver/config.go
@@ -27,6 +27,11 @@ type Config struct {
 	// Disabled if 0.
 	SequencerMaxSafeLag uint64 `json:"sequencer_max_safe_lag"`
 
+	// MaxCrossSafeLag is the maximum number of L2 blocks that the local-safe head may advance
+	// beyond the cross-safe (verifier) head before derivation pauses. Bounds the depth of
+	// engine rewinds caused by late block invalidations. Disabled if 0.
+	MaxCrossSafeLag uint64 `json:"max_cross_safe_lag"`
+
 	// RecoverMode forces the sequencer to select the next L1 Origin exactly, and create an empty block,
 	// to be compatible with verifiers forcefully generating the same block while catching up the sequencing window timeout.
 	RecoverMode bool `json:"recover_mode"`

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -96,9 +96,10 @@ func NewDriver(
 		L1:             l1,
 		L1Tracker:      l1Tracker,
 		L2:             l2,
-		Log:            log,
-		Ctx:            driverCtx,
-		StepDeriver:    schedDeriv,
+		Log:             log,
+		Ctx:             driverCtx,
+		StepDeriver:     schedDeriv,
+		MaxCrossSafeLag: driverCfg.MaxCrossSafeLag,
 	}
 	ec.SyncDeriver = syncDeriver
 	sys.Register("sync", syncDeriver)

--- a/op-node/rollup/driver/sync_deriver.go
+++ b/op-node/rollup/driver/sync_deriver.go
@@ -44,6 +44,11 @@ type SyncDeriver struct {
 	Ctx context.Context
 
 	StepDeriver StepDeriver
+
+	// MaxCrossSafeLag, if non-zero, pauses local-safe derivation whenever the
+	// local-safe head is more than this many blocks ahead of the cross-safe
+	// (verifier) head, bounding the depth of block-invalidation rewinds.
+	MaxCrossSafeLag uint64
 }
 
 func (s *SyncDeriver) AttachEmitter(em event.Emitter) {
@@ -274,6 +279,18 @@ func (s *SyncDeriver) SyncStep() {
 			// May need a single reset to trigger sequencer block building
 			s.Engine.TryInitialResetEngineForSequencer(s.Ctx)
 		}
+		return
+	}
+
+	if s.Engine.CrossSafeLagExceeded(s.MaxCrossSafeLag) {
+		// Derivation may not run further ahead of cross-safe verification than
+		// the configured window: a late invalidation rewinds everything built
+		// beyond the verified frontier, so holding here caps rewind depth.
+		// The verifier consumes already-derived blocks only, so it catches up
+		// while we wait, and OnL1Unsafe re-requests a step every L1 block.
+		s.Log.Debug("Rollup driver is backing off: local-safe too far ahead of cross-safe verification",
+			"max_cross_safe_lag", s.MaxCrossSafeLag)
+		s.StepDeriver.ResetStepBackoff(s.Ctx)
 		return
 	}
 

--- a/op-node/rollup/engine/cross_safe_lag_test.go
+++ b/op-node/rollup/engine/cross_safe_lag_test.go
@@ -1,0 +1,123 @@
+package engine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-node/metrics"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/sync"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-service/testutils"
+)
+
+func newLagTestController(t *testing.T, sa rollup.SuperAuthority, mockEngine *testutils.MockEngine) *EngineController {
+	return NewEngineController(
+		context.Background(),
+		mockEngine,
+		testlog.Logger(t, 0),
+		metrics.NoopMetrics,
+		&rollup.Config{BlockTime: 2},
+		&sync.Config{},
+		&testutils.MockL1Source{},
+		&testutils.MockEmitter{},
+		sa,
+	)
+}
+
+// TestCrossSafeLagExceeded_Disabled: maxLag 0 disables the gate regardless of
+// how far local-safe has run ahead. No verifier or EL reads are made.
+func TestCrossSafeLagExceeded_Disabled(t *testing.T) {
+	sa := &mockSuperAuthority{
+		fullyVerifiedL2Head:       eth.BlockID{Hash: common.Hash{0xcc}, Number: 10},
+		fullyVerifiedL2HeadSource: rollup.VerifierHeadVerified,
+	}
+	ec := newLagTestController(t, sa, &testutils.MockEngine{})
+	ec.SetLocalSafeHead(eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100_000})
+	require.False(t, ec.CrossSafeLagExceeded(0))
+}
+
+// TestCrossSafeLagExceeded_NoSuperAuthority: without a registered verifier
+// (standalone op-node) the gate is inert.
+func TestCrossSafeLagExceeded_NoSuperAuthority(t *testing.T) {
+	ec := newLagTestController(t, nil, &testutils.MockEngine{})
+	ec.SetLocalSafeHead(eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100_000})
+	require.False(t, ec.CrossSafeLagExceeded(50))
+}
+
+// TestCrossSafeLagExceeded_VerifiedBoundary: with a verified cross-safe head,
+// the gate engages strictly beyond crossSafe+maxLag and not at the boundary.
+func TestCrossSafeLagExceeded_VerifiedBoundary(t *testing.T) {
+	verifiedBlock := eth.BlockID{Hash: common.Hash{0xcc}, Number: 100}
+	verifiedRef := eth.L2BlockRef{Hash: verifiedBlock.Hash, Number: verifiedBlock.Number}
+
+	for _, tc := range []struct {
+		name      string
+		localSafe uint64
+		exceeded  bool
+	}{
+		{"at_window", 150, false},
+		{"beyond_window", 151, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mockEngine := &testutils.MockEngine{}
+			sa := &mockSuperAuthority{
+				fullyVerifiedL2Head:       verifiedBlock,
+				fullyVerifiedL2HeadSource: rollup.VerifierHeadVerified,
+				finalizedL2HeadSource:     rollup.VerifierHeadPreActivation,
+			}
+			ec := newLagTestController(t, sa, mockEngine)
+			ec.SetLocalSafeHead(eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: tc.localSafe})
+
+			// Verified branch of SafeL2Head validates against the EL.
+			mockEngine.ExpectL2BlockRefByHash(verifiedBlock.Hash, verifiedRef, nil)
+			mockEngine.ExpectL2BlockRefByNumber(verifiedBlock.Number, verifiedRef, nil)
+
+			require.Equal(t, tc.exceeded, ec.CrossSafeLagExceeded(50))
+		})
+	}
+}
+
+// TestCrossSafeLagExceeded_Anchor: a fresh verifier DB (Anchor source) gates
+// relative to the resolved activation-anchor block, so a cold-start backfill
+// cannot sprint past anchor+window before verification begins.
+func TestCrossSafeLagExceeded_Anchor(t *testing.T) {
+	// BlockTime 2, genesis time 0: cap timestamp 999 -> anchor block 499.
+	anchorRef := eth.L2BlockRef{Hash: common.Hash{0xa1}, Number: 499}
+
+	mockEngine := &testutils.MockEngine{}
+	sa := &mockSuperAuthority{
+		fullyVerifiedL2HeadSource: rollup.VerifierHeadAnchor,
+		fullyVerifiedTimestamp:    999,
+	}
+	ec := newLagTestController(t, sa, mockEngine)
+	ec.SetLocalSafeHead(eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 600})
+
+	mockEngine.ExpectL2BlockRefByNumber(anchorRef.Number, anchorRef, nil)
+	require.True(t, ec.CrossSafeLagExceeded(50), "local-safe 600 vs anchor 499 exceeds window 50")
+
+	mockEngine.ExpectL2BlockRefByNumber(anchorRef.Number, anchorRef, nil)
+	require.False(t, ec.CrossSafeLagExceeded(101), "local-safe 600 vs anchor 499 within window 101")
+}
+
+// TestCrossSafeLagExceeded_VerifierOutage_StaysGated: on a transient verifier
+// read failure, SafeL2Head floors at finalized (no cache populated), so a
+// node far ahead of verification stays gated during a verifier outage rather
+// than resuming its sprint exactly when verification is blind.
+func TestCrossSafeLagExceeded_VerifierOutage_StaysGated(t *testing.T) {
+	mockEngine := &testutils.MockEngine{}
+	sa := &mockSuperAuthority{
+		holdPreviousVerified:  true,
+		finalizedL2HeadSource: rollup.VerifierHeadPreActivation,
+	}
+	ec := newLagTestController(t, sa, mockEngine)
+	ec.SetLocalSafeHead(eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 1000})
+	ec.SetFinalizedHead(eth.L2BlockRef{Hash: common.Hash{0xbb}, Number: 100})
+
+	require.True(t, ec.CrossSafeLagExceeded(50),
+		"verifier outage must not release the gate: fallback floors at finalized (100), local-safe 1000 exceeds 100+50")
+}

--- a/op-node/rollup/engine/engine_controller.go
+++ b/op-node/rollup/engine/engine_controller.go
@@ -292,6 +292,16 @@ func (e *EngineController) resolveAnchorAsSafe(ts uint64) eth.L2BlockRef {
 	return br
 }
 
+// CrossSafeLagExceeded reports whether the local-safe head has advanced more
+// than maxLag blocks beyond the cross-safe head. A late block invalidation
+// from the verifier rewinds everything derived past the point of
+// invalidation, so bounding this lag bounds the rewind depth. A maxLag of 0,
+// or the absence of a SuperAuthority, disables the check.
+func (e *EngineController) CrossSafeLagExceeded(maxLag uint64) bool {
+	return maxLag != 0 && e.superAuthority != nil &&
+		e.localSafeHead.Number > e.SafeL2Head().Number+maxLag
+}
+
 // crossSafeFallback is the cross-safe fallback path. It first tries the
 // canonicality-validated cross-safe cache (so a transient verifier outage
 // doesn't drop cross-safe to FinalizedHead), and otherwise floors at

--- a/op-node/service.go
+++ b/op-node/service.go
@@ -199,6 +199,7 @@ func NewDriverConfig(ctx cliiface.Context) *driver.Config {
 		SequencerEnabled:         ctx.Bool(flags.SequencerEnabledFlag.Name),
 		SequencerStopped:         ctx.Bool(flags.SequencerStoppedFlag.Name),
 		SequencerMaxSafeLag:      ctx.Uint64(flags.SequencerMaxSafeLagFlag.Name),
+		MaxCrossSafeLag:          ctx.Uint64(flags.VerifierMaxCrossSafeLagFlag.Name),
 		RecoverMode:              ctx.Bool(flags.SequencerRecoverMode.Name),
 		SequencerSealingDuration: ctx.Duration(flags.SequencerSealingDurationFlag.Name),
 	}


### PR DESCRIPTION
## Problem

When a SuperAuthority verifier is registered (supernode vnodes), derivation free-runs arbitrarily far ahead of the cross-safe verified frontier — nothing bounds the gap. A late block invalidation then rewinds everything derived past the invalidation point.

Observed on `interop-reorg-5` (2026-08-05, full resync of supernode-1): derivation ran at ~40 blk/s vs ~2-20 blk/s for the verifier. At the moment the verifier invalidated `420120191:14926` (an invalid executing message found **15 blocks above its own frontier**), local_safe was at **31,777** — a ~16.9k-block gap. The engine rewind walked back **16,852 blocks over ~95 minutes** of `engine_newPayload` timeouts (op-reth deep-reorg changeset walk, single-core, ~170 blk/min). Multiple invalidation waves × three chains multiplied the cost.

Rewind depth = verification lag at deny time. Live operation has seconds of lag; resync has hours. Bounding the lag bounds the rewind.

## Change (45 insertions incl. comments; default off)

New flag `verifier.max-cross-safe-lag` (default `0` = disabled, zero behavior change): when the local-safe head is more than the window beyond cross-safe (`SafeL2Head()`), `SyncDeriver.SyncStep` backs off before `RequestPendingSafeUpdate` — the single point downstream of which all local-safe promotion happens — until the verifier catches up. The gate itself is a one-line predicate reusing the existing `SafeL2Head()` resolution (verified/anchor/pre-activation + cached fallback), so a transient verifier outage holds the gate at the last-known cross-safe rather than releasing it.

- No deadlock: the verifier consumes already-derived blocks only (logsDB / receipts of the existing chain), so it always progresses while derivation holds; each verified timestamp releases the gate.
- Wake-up: `OnL1Unsafe` re-requests a step every L1 block; resume latency ≤ ~1 L1 slot after the verifier catches up.
- Supernode picks the flag up per-vnode automatically via `FullDynamicFlags` → `OP_SUPERNODE_VN_ALL_VERIFIER_MAX_CROSS_SAFE_LAG` (or per-chain). Standalone op-node without a SuperAuthority: gate is inert.
- Overshoot is bounded at ~1-2 blocks (attributes already in flight past the check still land).

Suggested devnet value: a few hundred to a few thousand blocks — worst-case rewind becomes the window instead of the full backfill sprint.

## Context

Companion to the double-batch derivation investigation (overlap check #22214 / #22215): faster, bounded rewinds also shrink the window during which cross-chain verification runs against a stale local view.

## Testing

- `go build ./op-node/... ./op-supernode/...` and `go vet` clean.
- Default-off: no behavior change without the flag.
- Unit tests: `TestCrossSafeLagExceeded_*` (disabled, no-authority, verified boundary at/beyond window, anchor cold-start, verifier-outage-stays-gated) — all passing; full `rollup/engine` and `rollup/driver` packages pass.
- Draft: still wants a devnet soak with a real window before undraft. Note `SafeL2Head()` in the verified branch performs 1-2 EL header lookups per SyncStep while the gate is configured — fine for devnets; worth a cached short-circuit if profiling ever shows it on the hot path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
