### PR TITLE
apko: add busybox and apk-tools to all images

### DIFF
--- a/apko/cannon.yaml
+++ b/apko/cannon.yaml
@@ -7,6 +7,8 @@ contents:
     - ca-certificates-bundle
     - wolfi-baselayout
     - cannon@local
+    - busybox
+    - apk-tools
 
 environment:
   PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin

--- a/apko/da-server.yaml
+++ b/apko/da-server.yaml
@@ -7,6 +7,8 @@ contents:
     - ca-certificates-bundle
     - wolfi-baselayout
     - da-server@local
+    - busybox
+    - apk-tools
 
 environment:
   PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin

--- a/apko/kona-client.yaml
+++ b/apko/kona-client.yaml
@@ -13,6 +13,7 @@ contents:
     - libstdc++
     - openssl
     - kona-client@local
+    - apk-tools
 
 environment:
   PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin

--- a/apko/kona-host.yaml
+++ b/apko/kona-host.yaml
@@ -13,6 +13,7 @@ contents:
     - libstdc++
     - openssl
     - kona-host@local
+    - apk-tools
 
 environment:
   PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin

--- a/apko/kona-node.yaml
+++ b/apko/kona-node.yaml
@@ -13,6 +13,7 @@ contents:
     - libstdc++
     - openssl
     - kona-node@local
+    - apk-tools
 
 environment:
   PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin

--- a/apko/kona-sp1-proposer.yaml
+++ b/apko/kona-sp1-proposer.yaml
@@ -13,6 +13,7 @@ contents:
     - libstdc++
     - openssl
     - kona-sp1-proposer@local
+    - apk-tools
 
 environment:
   PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin

--- a/apko/op-batcher.yaml
+++ b/apko/op-batcher.yaml
@@ -7,6 +7,8 @@ contents:
     - ca-certificates-bundle
     - wolfi-baselayout
     - op-batcher@local
+    - busybox
+    - apk-tools
 
 environment:
   PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin

--- a/apko/op-challenger.yaml
+++ b/apko/op-challenger.yaml
@@ -8,6 +8,8 @@ contents:
     - https://packages.wolfi.dev/os
   packages:
     - ca-certificates-bundle
+    - busybox
+    - apk-tools
     # ca-certificates provides update-ca-certificates binary (ca-certificates-bundle is cert data only).
     # Required: the chart's /init/entrypoint.sh calls update-ca-certificates before exec.
     - ca-certificates

--- a/apko/op-conductor.yaml
+++ b/apko/op-conductor.yaml
@@ -7,6 +7,8 @@ contents:
     - ca-certificates-bundle
     - wolfi-baselayout
     - op-conductor@local
+    - busybox
+    - apk-tools
 
 environment:
   PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin

--- a/apko/op-deployer.yaml
+++ b/apko/op-deployer.yaml
@@ -7,6 +7,8 @@ contents:
     - ca-certificates-bundle
     - wolfi-baselayout
     - op-deployer@local
+    - busybox
+    - apk-tools
 
 archs:
   - amd64

--- a/apko/op-dispute-mon.yaml
+++ b/apko/op-dispute-mon.yaml
@@ -7,6 +7,8 @@ contents:
     - ca-certificates-bundle
     - wolfi-baselayout
     - op-dispute-mon@local
+    - busybox
+    - apk-tools
 
 environment:
   PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin

--- a/apko/op-dripper.yaml
+++ b/apko/op-dripper.yaml
@@ -7,6 +7,8 @@ contents:
     - ca-certificates-bundle
     - wolfi-baselayout
     - op-dripper@local
+    - busybox
+    - apk-tools
 
 environment:
   PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin

--- a/apko/op-faucet.yaml
+++ b/apko/op-faucet.yaml
@@ -7,6 +7,8 @@ contents:
     - ca-certificates-bundle
     - wolfi-baselayout
     - op-faucet@local
+    - busybox
+    - apk-tools
 
 environment:
   PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin

--- a/apko/op-interop-filter.yaml
+++ b/apko/op-interop-filter.yaml
@@ -7,6 +7,8 @@ contents:
     - ca-certificates-bundle
     - wolfi-baselayout
     - op-interop-filter@local
+    - busybox
+    - apk-tools
 
 environment:
   PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin

--- a/apko/op-interop-mon.yaml
+++ b/apko/op-interop-mon.yaml
@@ -7,6 +7,8 @@ contents:
     - ca-certificates-bundle
     - wolfi-baselayout
     - op-interop-mon@local
+    - busybox
+    - apk-tools
 
 environment:
   PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin

--- a/apko/op-node.yaml
+++ b/apko/op-node.yaml
@@ -7,6 +7,8 @@ contents:
     - ca-certificates-bundle
     - wolfi-baselayout
     - op-node@local
+    - busybox
+    - apk-tools
 
 environment:
   PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin

--- a/apko/op-proposer.yaml
+++ b/apko/op-proposer.yaml
@@ -7,6 +7,8 @@ contents:
     - ca-certificates-bundle
     - wolfi-baselayout
     - op-proposer@local
+    - busybox
+    - apk-tools
 
 environment:
   PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin

--- a/apko/op-rbuilder.yaml
+++ b/apko/op-rbuilder.yaml
@@ -13,6 +13,7 @@ contents:
     - libstdc++
     - openssl
     - op-rbuilder@local
+    - apk-tools
 
 environment:
   PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin

--- a/apko/op-reth.yaml
+++ b/apko/op-reth.yaml
@@ -13,6 +13,7 @@ contents:
     - libstdc++
     - openssl
     - op-reth@local
+    - apk-tools
 
 environment:
   PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin

--- a/apko/op-supernode.yaml
+++ b/apko/op-supernode.yaml
@@ -7,6 +7,8 @@ contents:
     - ca-certificates-bundle
     - wolfi-baselayout
     - op-supernode@local
+    - busybox
+    - apk-tools
 
 environment:
   PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin

--- a/apko/op-test-sequencer.yaml
+++ b/apko/op-test-sequencer.yaml
@@ -7,6 +7,8 @@ contents:
     - ca-certificates-bundle
     - wolfi-baselayout
     - op-test-sequencer@local
+    - busybox
+    - apk-tools
 
 environment:
   PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin

--- a/apko/rollup-boost.yaml
+++ b/apko/rollup-boost.yaml
@@ -13,6 +13,7 @@ contents:
     - libstdc++
     - openssl
     - rollup-boost@local
+    - apk-tools
 
 environment:
   PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin


### PR DESCRIPTION
Adds `busybox` (shell + coreutils) and `apk-tools` (the apk package manager) to every apko image under `apko/`, so each image has a shell and can install packages at runtime. `busybox` is added only where not already present; additive only (22 files).