### PR TITLE
ci: build superchain bundle in go-release

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -2449,9 +2449,6 @@ jobs:
       - attach_workspace: {at: "."}
       # goreleaser compiles the Go release binaries on the host.
       - restore-go-mod-cache
-      # The release binaries link op-core/superchain, which //go:embeds the
-      # gitignored superchain-configs.zip. The tag-triggered release workflows have
-      # no prep-superchain job, so build the bundle in-job.
       - run:
           name: Build superchain bundle
           command: just build-superchain-go

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -2449,6 +2449,12 @@ jobs:
       - attach_workspace: {at: "."}
       # goreleaser compiles the Go release binaries on the host.
       - restore-go-mod-cache
+      # The release binaries link op-core/superchain, which //go:embeds the
+      # gitignored superchain-configs.zip. The tag-triggered release workflows have
+      # no prep-superchain job, so build the bundle in-job.
+      - run:
+          name: Build superchain bundle
+          command: just build-superchain-go
       - run:
           name: Configure Docker
           command: |


### PR DESCRIPTION
Human here: the op-deployer go-release job is failing because of a missing go-embed. You can see the failure occurring on a test release branch [here](https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/132056/details?workflowId=71ca4570-0603-4be5-815c-c0f521e62f92&job=d7ce904c-ce88-4db4-837f-8f24c31ad41b&buildNumber=5433880&jobType=build#step-120-). That failure was fixed by [this commit](https://github.com/ethereum-optimism/optimism/commit/955482ab9fbf), so this is basically a cherry pick of that fix.

Bot writeup:

The shared `go-release` job never provisions `op-core/superchain/superchain-configs.zip`. The zip is gitignored and generated only by `just build-superchain-go` / the `prep-superchain` job, but `op-core/superchain` `//go:embed`s it — and both `op-deployer` and `op-up` link that package. The tag-triggered `go-release-*` workflows have no `prep-superchain` job, and their only upstream (`contracts-bedrock-build`) persists forge artifacts, not the bundle.

So every `op-deployer` / `op-up` release has failed in the goreleaser build step since op-core/superchain was wired across the monorepo (#21487). It passes locally because developers already have the zip on disk.

Failure this fixes: [go-release-1 #5433880, step 120](https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/132056/details?workflowId=71ca4570-0603-4be5-815c-c0f521e62f92&job=d7ce904c-ce88-4db4-837f-8f24c31ad41b&buildNumber=5433880&jobType=build#step-120-)

```
⨯ release failed after 3s
  error=
  │ build failed: exit status 1: ../op-core/superchain/chain.go:21:12: pattern superchain-configs.zip: no matching files found
  target=linux_arm64_v8.0
```

Adds an in-job `just build-superchain-go` step, the same pattern `rust-e2e` and `go-tests-with-fault-proof-deps` use for workflows without a `prep-superchain` job. The recipe depends on `update-superchain-registry-submodule`, so it initializes the submodule itself — no checkout change needed.

Verified green on a tag release from a branch carrying this fix: `op-deployer/v0.8.0-pcd-test.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)