### PR TITLE
op-core,op-service,op-chain-ops: receipt wrapping constructor and codec cleanups

### DIFF
--- a/op-chain-ops/cmd/check-karst/main.go
+++ b/op-chain-ops/cmd/check-karst/main.go
@@ -179,14 +179,14 @@ func makeAllCommand() *cli.Command {
 type ethclientLatestBlockAdapter struct{ *ethclient.Client }
 
 // TransactionReceipt adapts the go-ethereum receipt to the optypes shape the
-// karst checks consume; the OP extension fields stay nil (the checks read only
-// standard fields).
+// karst checks consume; the JSON-only OP fee fields stay nil (the checks read
+// only standard fields).
 func (a *ethclientLatestBlockAdapter) TransactionReceipt(ctx context.Context, txHash common.Hash) (*optypes.Receipt, error) {
 	receipt, err := a.Client.TransactionReceipt(ctx, txHash)
 	if err != nil || receipt == nil {
 		return nil, err
 	}
-	return &optypes.Receipt{Receipt: *receipt}, nil
+	return optypes.FromGethReceipt(receipt), nil
 }
 
 func (a *ethclientLatestBlockAdapter) InfoAndTxsByLabel(ctx context.Context, label eth.BlockLabel) (eth.BlockInfo, types.Transactions, error) {

--- a/op-chain-ops/cmd/receipt-reference-builder/pull.go
+++ b/op-chain-ops/cmd/receipt-reference-builder/pull.go
@@ -316,9 +316,6 @@ func processBlockRange(
 	return results, nil
 }
 
-// batchBlockByNumber will batch a list of block numbers into a single batch rpc request
-// it uses the iterative batch call to make the request
-// and returns the results
 // rpcBlock is a minimal eth_getBlockBy* result carrying what this tool reads.
 // Transactions decode as op-geth typed transactions: the tool extracts the
 // effective deposit nonce, JSON-only data that op-geth's decoder captures.
@@ -327,6 +324,9 @@ type rpcBlock struct {
 	Transactions []*types.Transaction `json:"transactions"`
 }
 
+// batchBlockByNumber will batch a list of block numbers into a single batch rpc request
+// it uses the iterative batch call to make the request
+// and returns the results
 func batchBlockByNumber(ctx context.Context, c *ethclient.Client, blockNumbers []rpc.BlockNumber) ([]*rpcBlock, error) {
 	makeBlockByNumberRequest := func(blockNumber rpc.BlockNumber) (*rpcBlock, rpc.BatchElem) {
 		out := new(rpcBlock)

--- a/op-core/types/receipt_consensus.go
+++ b/op-core/types/receipt_consensus.go
@@ -25,19 +25,26 @@ type Receipts []*Receipt
 
 var _ types.DerivableList = (Receipts)(nil)
 
-// FromGethReceipts wraps go-ethereum receipts into Receipts. The receipt
-// structs are shallow-copied (reference fields like Logs still alias the
-// source). While go-ethereum resolves to op-geth, the deposit receipt fields
-// are mirrored to the authoritative outer copies so consensus encoding stays
-// correct; those two assignments stop compiling at the final cutover and are
-// removed then.
+// FromGethReceipt wraps a go-ethereum receipt. The receipt struct is
+// shallow-copied (reference fields like Logs still alias the source). While
+// go-ethereum resolves to op-geth, the deposit receipt fields are mirrored to
+// the authoritative outer copies so consensus encoding stays correct; those two
+// assignments stop compiling at the final cutover and are removed then.
+//
+// Use this rather than wrapping by hand: a Receipt built as &Receipt{Receipt: *r}
+// leaves the outer deposit fields nil and encodes a deposit receipt without them.
+func FromGethReceipt(r *types.Receipt) *Receipt {
+	wrapped := &Receipt{Receipt: *r}
+	wrapped.DepositNonce = r.DepositNonce
+	wrapped.DepositReceiptVersion = r.DepositReceiptVersion
+	return wrapped
+}
+
+// FromGethReceipts wraps go-ethereum receipts into Receipts, per FromGethReceipt.
 func FromGethReceipts(rs types.Receipts) Receipts {
 	out := make(Receipts, len(rs))
 	for i, r := range rs {
-		wrapped := &Receipt{Receipt: *r}
-		wrapped.DepositNonce = r.DepositNonce
-		wrapped.DepositReceiptVersion = r.DepositReceiptVersion
-		out[i] = wrapped
+		out[i] = FromGethReceipt(r)
 	}
 	return out
 }

--- a/op-core/types/receipt_consensus_test.go
+++ b/op-core/types/receipt_consensus_test.go
@@ -151,6 +151,30 @@ func TestReceiptsEncodeIndexOuterFieldsAuthoritative(t *testing.T) {
 	require.NotEqual(t, mirroredBuf.Bytes(), desyncedBuf.Bytes())
 }
 
+// TestFromGethReceiptMirrorsDepositFields covers the wrapping constructor
+// against the hazard above: it carries the deposit fields to the authoritative
+// outer copies, where wrapping by hand leaves them nil.
+func TestFromGethReceiptMirrorsDepositFields(t *testing.T) {
+	gr := *consensusReceiptCases()[0] // legacy shape, mutate into a deposit
+	gr.Type = gethtypes.DepositTxType
+	gr.DepositNonce = uint64Ptr(7)
+	gr.DepositReceiptVersion = uint64Ptr(gethtypes.CanyonDepositReceiptVersion)
+
+	wrapped := optypes.FromGethReceipt(&gr)
+	require.Equal(t, gr.DepositNonce, wrapped.DepositNonce)
+	require.Equal(t, gr.DepositReceiptVersion, wrapped.DepositReceiptVersion)
+
+	var wrappedBuf, handBuiltBuf bytes.Buffer
+	optypes.Receipts{wrapped}.EncodeIndex(0, &wrappedBuf)
+	optypes.Receipts{{Receipt: gr}}.EncodeIndex(0, &handBuiltBuf)
+	require.NotEqual(t, handBuiltBuf.Bytes(), wrappedBuf.Bytes())
+
+	// The list constructor wraps identically.
+	var listBuf bytes.Buffer
+	optypes.FromGethReceipts(gethtypes.Receipts{&gr}).EncodeIndex(0, &listBuf)
+	require.Equal(t, wrappedBuf.Bytes(), listBuf.Bytes())
+}
+
 // TestReceiptUnmarshalBinaryDifferential asserts the consensus decode against
 // op-geth's MarshalBinary for every encoding arm. It will be removed in the
 // final cutover, when the op-geth dependency is replaced with upstream

--- a/op-service/eth/receipts.go
+++ b/op-service/eth/receipts.go
@@ -11,19 +11,6 @@ import (
 	optypes "github.com/ethereum-optimism/optimism/op-core/types"
 )
 
-// EncodeReceipts encodes a list of receipts into raw receipts. Some non-consensus meta-data may be lost.
-func EncodeReceipts(elems []*types.Receipt) ([]hexutil.Bytes, error) {
-	out := make([]hexutil.Bytes, len(elems))
-	for i, el := range elems {
-		dat, err := el.MarshalBinary()
-		if err != nil {
-			return nil, fmt.Errorf("failed to marshal receipt %d: %w", i, err)
-		}
-		out[i] = dat
-	}
-	return out, nil
-}
-
 // DecodeRawReceipts decodes receipts and adds additional blocks metadata.
 // The contract-deployment addresses are not set however (high cost, depends on nonce values, unused by op-node).
 // The OP JSON-only fee fields (L1GasPrice, OperatorFeeScalar, ...) are not part

--- a/op-service/eth/transactions.go
+++ b/op-service/eth/transactions.go
@@ -42,15 +42,6 @@ func DecodeTransactions(data []hexutil.Bytes) ([]*types.Transaction, error) {
 	return dest, nil
 }
 
-// TransactionsToHashes computes the transaction-hash for every transaction in the input.
-func TransactionsToHashes(elems []*types.Transaction) []common.Hash {
-	out := make([]common.Hash, len(elems))
-	for i, el := range elems {
-		out[i] = el.Hash()
-	}
-	return out
-}
-
 // CheckRecentTxs checks the depth recent blocks for txs from the account with address addr
 // and returns either:
 //   - blockNum containing the last tx and true if any was found

--- a/op-service/sources/raw_transaction_test.go
+++ b/op-service/sources/raw_transaction_test.go
@@ -177,6 +177,53 @@ func TestRawTransactionJSONEmptyPostExecRejected(t *testing.T) {
 	require.ErrorContains(t, err, "invalid post-exec tx")
 }
 
+// TestRawTransactionJSONLegacyWithoutType covers an RPC transaction object with
+// no type field, which decodes as a legacy transaction.
+func TestRawTransactionJSONLegacyWithoutType(t *testing.T) {
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	to := common.HexToAddress("0x4242424242424242424242424242424242424242")
+	tx := types.MustSignNewTx(key, types.LatestSignerForChainID(big.NewInt(10)), &types.LegacyTx{
+		Nonce: 3, GasPrice: big.NewInt(2), Gas: 21000, To: &to, Value: big.NewInt(1),
+	})
+	txJSON, err := tx.MarshalJSON()
+	require.NoError(t, err)
+	obj := map[string]json.RawMessage{}
+	require.NoError(t, json.Unmarshal(txJSON, &obj))
+	delete(obj, "type")
+	stripped, err := json.Marshal(obj)
+	require.NoError(t, err)
+
+	var raw RawTransaction
+	require.NoError(t, json.Unmarshal(stripped, &raw))
+	want, err := tx.MarshalBinary()
+	require.NoError(t, err)
+	require.Equal(t, want, []byte(raw))
+	require.Equal(t, tx.Hash(), raw.Hash())
+}
+
+// TestRPCBlockNullTransactionRejected pins what a JSON null transaction costs: it
+// decodes to an empty RawTransaction, which has no canonical encoding and no
+// hash, so block verification must reject the block rather than pass it on.
+func TestRPCBlockNullTransactionRejected(t *testing.T) {
+	blockJSON := l2RPCBlockJSON(t, l2BlockTxs(t))
+	obj := map[string]json.RawMessage{}
+	require.NoError(t, json.Unmarshal(blockJSON, &obj))
+	var txsJSON []json.RawMessage
+	require.NoError(t, json.Unmarshal(obj["transactions"], &txsJSON))
+	txsJSON[1] = json.RawMessage("null")
+	var err error
+	obj["transactions"], err = json.Marshal(txsJSON)
+	require.NoError(t, err)
+	withNull, err := json.Marshal(obj)
+	require.NoError(t, err)
+
+	var block RPCBlock
+	require.NoError(t, json.Unmarshal(withNull, &block))
+	require.Empty(t, block.Transactions[1])
+	require.ErrorContains(t, block.Verify(), "block tx 1 is nil or empty")
+}
+
 func TestRawTransactionsGeth(t *testing.T) {
 	txs := l2BlockTxs(t)
 	blockJSON := l2RPCBlockJSON(t, txs)

--- a/op-service/txplan/txplan.go
+++ b/op-service/txplan/txplan.go
@@ -306,7 +306,7 @@ type GethReceiptGetter interface {
 }
 
 // FromGethReceipts adapts a go-ethereum receipt getter to ReceiptGetter.
-// The OP Stack extension fields stay nil — suitable for L1 clients.
+// The JSON-only OP fee fields stay nil — suitable for L1 clients.
 func FromGethReceipts(cl GethReceiptGetter) ReceiptGetter {
 	return gethReceiptGetter{inner: cl}
 }
@@ -318,7 +318,7 @@ func (g gethReceiptGetter) TransactionReceipt(ctx context.Context, txHash common
 	if err != nil || receipt == nil {
 		return nil, err
 	}
-	return &optypes.Receipt{Receipt: *receipt}, nil
+	return optypes.FromGethReceipt(receipt), nil
 }
 
 // WithAssumedInclusion assumes inclusion at the time of evaluation,


### PR DESCRIPTION
Follow-ups from the review of the op-geth decoupling stack (#20264 — #21907, #21908, #21911). None of them blocked those PRs.

- **`optypes.FromGethReceipt`** wraps a single go-ethereum receipt, mirroring the deposit fields to the authoritative outer copies. Wrapping by hand leaves them nil, which encodes a deposit receipt without them — the hazard `TestReceiptsEncodeIndexOuterFieldsAuthoritative` already pins. The two adapters that wrapped by hand (txplan's geth receipt getter, check-karst) now use it; `FromGethReceipts` is defined in terms of it.
- **`op-service/eth`**: delete `TransactionsToHashes` and `EncodeReceipts` — no callers left since receipts moved to `op-core/types`.
- **receipt-reference-builder**: the `rpcBlock` doc comment had absorbed `batchBlockByNumber`'s; split them back.
- **`op-service/sources`**: cover two `RawTransaction` JSON decode rules that had none — a transaction object without a `type` field decodes as legacy, and a JSON `null` transaction decodes to an empty entry that block verification rejects.

Not added: a test for the full-uint64 type dispatch (`"type":"0x17e"` must not route to the deposit codec). No EL emits a type outside a byte, and the OP JSON decoders reject any object whose `type` field isn't exactly theirs, so it would pin an unreachable defense.

🤖 *Co-created with Claude Opus 5*
