### PR TITLE
op-alloy: make execution payload envelopes complete

### DIFF
--- a/docs/public-docs/node-operators/kona-node/design/p2p.mdx
+++ b/docs/public-docs/node-operators/kona-node/design/p2p.mdx
@@ -106,9 +106,9 @@ The [libp2p Swarm][swarm] listens on a specified
 
 As mentioned in [the previous section](#gossip), L2 blocks
 are published as payloads through the [libp2p Swarm][swarm],
-which is done using the `GossipDriver`. The actual payload
-type that is published is an [`OpNetworkPayloadEnvelope`][env],
-which is well documented in the [OP Stack P2P Specs][p2p-specs].
+which is done using the `GossipDriver`. The `GossipDriver` accepts an `OpExecutionPayloadEnvelope` and its
+signature, then privately encodes them in the wire format documented
+in the [OP Stack P2P Specs][p2p-specs].
 
 L2 blocks published through the `GossipDriver` are published on
 a "topic". The topic is used by the gossipsub protocol to publish
@@ -124,8 +124,9 @@ snappy compressed, they need to be decompressed and then decoded
 for the correct [block topic][block-topic] those messages are
 published on.
 
-Only once the [`OpNetworkPayloadEnvelope`][env] is successfully
-decoded for the corresponding block topic, is the block validated.
+After decompression, kona separates the signature from the exact encoded
+envelope bytes. It authenticates those bytes before decoding the envelope
+according to the corresponding block topic and validating the block contents.
 
 <Info>
 
@@ -136,13 +137,14 @@ Block validity in kona follows the [OP Stack block validation specs][validation]
 As of writing these docs, block validation follows a few rules.
 
 - The timestamp is between 60 seconds in the past and at most 5 seconds in the future.
-- The block hash is valid. This is checked by transforming the payload into a block
-  and then hashing the block header to produce the payload hash.
+- The block signature authenticates the exact encoded envelope bytes.
+- The block hash is valid. This is checked by computing the transaction trie root directly from
+  the encoded transaction bytes and hashing the reconstructed header. Transaction decoding and
+  execution remain the execution layer's responsibility.
 - The contents of the payload envelope are correct for its version. Since different
   versions introduce new contents to the payload from hardforks, the
   forwards-compatible payload envelope cannot have fields with content that don't exist
   for previous versions.
-- The block signature is valid.
 
 
 ### Node Identification
@@ -160,8 +162,6 @@ TODO
 [block-topic]: https://specs.optimism.io/protocol/rollup-node-p2p.html#gossip-topics
 
 [multiaddr]: https://docs.rs/libp2p/0.56.0/libp2p/struct.Multiaddr.html
-
-[env]: https://docs.rs/op-alloy-rpc-types-engine/latest/op_alloy_rpc_types_engine/struct.OpNetworkPayloadEnvelope.html
 
 [swarm]: https://docs.rs/libp2p/latest/libp2p/struct.Swarm.html
 

--- a/op-acceptance-tests/tests/sync/elsync/gap_elp2p/sync_test.go
+++ b/op-acceptance-tests/tests/sync/elsync/gap_elp2p/sync_test.go
@@ -406,14 +406,6 @@ func TestSafeDoesNotAdvanceWhenUnsafeIsSyncing_NoELP2P(gt *testing.T) {
 // invalid payloads—whether rejected at the CL or EL—do not advance the chain.
 func TestInvalidPayloadThroughCLP2P(gt *testing.T) {
 	t := devtest.ParallelT(gt)
-	// Example error with kona-node:
-	//
-	// assertions.go:387:             ERROR[03-31|10:42:03.034]
-	// assertions.go:387:             	Error Trace:	/Users/josh/repos/optimism/op-acceptance-tests/tests/sync/elsync/gap_elp2p/sync_test.go:436
-	// assertions.go:387:             	Error:      	An error is expected but got nil.
-	// assertions.go:387:             	Test:       	TestInvalidPayloadThroughCLP2P
-	// assertions.go:387:
-	sysgo.SkipOnKonaNode(t, "not supported")
 	sys := newGapELP2PSystem(t)
 	logger := t.Logger()
 	require := t.Require()
@@ -442,7 +434,7 @@ func TestInvalidPayloadThroughCLP2P(gt *testing.T) {
 	payload.ExecutionPayload.StateRoot = eth.Bytes32{}
 	logger.Info("Injected fault to payload but not updated hash")
 	// Post invalid payload with the fault that can be checked at the CL side
-	require.Error(sys.L2CLB.Escape().RollupAPI().PostUnsafePayload(ctx, payload))
+	require.ErrorContains(sys.L2CLB.Escape().RollupAPI().PostUnsafePayload(ctx, payload), "bad block hash")
 	// ex) op-node error msg: "payload has bad block hash"
 	// CL will not send the payload but drop immediately due to hash mismatch
 	// EL did not advance
@@ -480,10 +472,10 @@ func TestInvalidPayloadThroughCLP2P(gt *testing.T) {
 	require.False(ok)
 	logger.Info("Updated payload parent to invalid payload", "newHash", newHash)
 	payload2.ExecutionPayload.BlockHash = newHash
-	_, ok = payload.CheckBlockHash()
+	_, ok = payload2.CheckBlockHash()
 	require.True(ok)
 	// Post invalid payload with the fault that can be only checked at the EL side
-	sys.L2CLB.PostUnsafePayload(payload)
+	sys.L2CLB.PostUnsafePayload(payload2)
 	// ex) op-geth error msg: "ignoring bad block: links to previously rejected block"
 	sys.L2CLB.NotAdvanced(safety.LocalUnsafe, attempts)
 	sys.L2ELB.NotAdvanced(eth.Unsafe, attempts)

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -7040,6 +7040,7 @@ dependencies = [
  "arbitrary",
  "derive_more 2.1.1",
  "discv5 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethereum_ssz",
  "futures",
  "ipnet",
  "kona-disc",
@@ -9447,7 +9448,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "snap",
  "thiserror 2.0.18",
 ]
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -7555,7 +7555,6 @@ dependencies = [
  "kona-protocol",
  "libp2p",
  "metrics",
- "op-alloy-consensus",
  "op-alloy-rpc-jsonrpsee",
  "op-alloy-rpc-types",
  "op-alloy-rpc-types-engine",

--- a/rust/kona/bin/node/src/commands/net.rs
+++ b/rust/kona/bin/node/src/commands/net.rs
@@ -123,7 +123,7 @@ impl NetCommand {
         loop {
             tokio::select! {
                 Some(payload) = block_rx.recv() => {
-                    info!(target: "net", "Received unsafe payload: {:?}", payload.execution_payload.block_hash());
+                    info!(target: "net", "Received unsafe payload: {:?}", payload.block_hash());
                 }
                 _ = interval.tick(), if !rpc.is_closed() => {
                     let (otx, mut orx) = tokio::sync::oneshot::channel();

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/insert/task.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/insert/task.rs
@@ -4,17 +4,12 @@ use crate::{
     EngineClient, EngineState, EngineTaskExt, InsertTaskError, SynchronizeTask,
     state::EngineSyncStateUpdate,
 };
-use alloy_eips::eip7685::EMPTY_REQUESTS_HASH;
-use alloy_rpc_types_engine::{
-    CancunPayloadFields, ExecutionPayloadInputV2, PayloadStatusEnum, PraguePayloadFields,
-};
+use alloy_rpc_types_engine::{ExecutionPayloadInputV2, PayloadStatusEnum};
 use async_trait::async_trait;
 use kona_genesis::RollupConfig;
 use kona_protocol::L2BlockInfo;
 use op_alloy_consensus::OpBlock;
-use op_alloy_rpc_types_engine::{
-    OpExecutionPayload, OpExecutionPayloadEnvelope, OpExecutionPayloadSidecar,
-};
+use op_alloy_rpc_types_engine::OpExecutionPayloadEnvelope;
 use std::{sync::Arc, time::Instant};
 
 /// The task to insert a payload into the execution engine.
@@ -24,8 +19,8 @@ pub struct InsertTask<EngineClient_: EngineClient> {
     client: Arc<EngineClient_>,
     /// The rollup config.
     rollup_config: Arc<RollupConfig>,
-    /// The network payload envelope.
-    envelope: OpExecutionPayloadEnvelope,
+    /// The complete execution payload envelope.
+    payload: OpExecutionPayloadEnvelope,
     /// If the payload is safe this is true.
     /// A payload is safe if it is derived from a safe block.
     is_payload_safe: bool,
@@ -36,10 +31,10 @@ impl<EngineClient_: EngineClient> InsertTask<EngineClient_> {
     pub const fn new(
         client: Arc<EngineClient_>,
         rollup_config: Arc<RollupConfig>,
-        envelope: OpExecutionPayloadEnvelope,
+        payload: OpExecutionPayloadEnvelope,
         is_attributes_derived: bool,
     ) -> Self {
-        Self { client, rollup_config, envelope, is_payload_safe: is_attributes_derived }
+        Self { client, rollup_config, payload, is_payload_safe: is_attributes_derived }
     }
 
     /// Checks the response of the `engine_newPayload` call.
@@ -59,53 +54,25 @@ impl<EngineClient_: EngineClient> EngineTaskExt for InsertTask<EngineClient_> {
 
         // Insert the new payload.
         // Form the new unsafe block ref from the execution payload.
-        let parent_beacon_block_root = self.envelope.parent_beacon_block_root.unwrap_or_default();
+        let payload = self.payload.clone();
         let insert_time_start = Instant::now();
-        let (response, block): (_, OpBlock) = match self.envelope.execution_payload.clone() {
-            OpExecutionPayload::V1(payload) => (
-                self.client.new_payload_v1(payload).await,
-                self.envelope
-                    .execution_payload
-                    .clone()
-                    .try_into_block()
-                    .map_err(InsertTaskError::FromBlockError)?,
-            ),
-            OpExecutionPayload::V2(payload) => {
+        let response = match payload.clone() {
+            OpExecutionPayloadEnvelope::V1(payload) => self.client.new_payload_v1(payload).await,
+            OpExecutionPayloadEnvelope::V2(payload) => {
                 let payload_input = ExecutionPayloadInputV2 {
                     execution_payload: payload.payload_inner,
                     withdrawals: Some(payload.withdrawals),
                 };
-                (
-                    self.client.new_payload_v2(payload_input).await,
-                    self.envelope
-                        .execution_payload
-                        .clone()
-                        .try_into_block()
-                        .map_err(InsertTaskError::FromBlockError)?,
-                )
+                self.client.new_payload_v2(payload_input).await
             }
-            OpExecutionPayload::V3(payload) => (
-                self.client.new_payload_v3(payload, parent_beacon_block_root).await,
-                self.envelope
-                    .execution_payload
-                    .clone()
-                    .try_into_block_with_sidecar(&OpExecutionPayloadSidecar::v3(
-                        CancunPayloadFields::new(parent_beacon_block_root, vec![]),
-                    ))
-                    .map_err(InsertTaskError::FromBlockError)?,
-            ),
-            OpExecutionPayload::V4(payload) => (
-                self.client.new_payload_v4(payload, parent_beacon_block_root).await,
-                self.envelope
-                    .execution_payload
-                    .clone()
-                    .try_into_block_with_sidecar(&OpExecutionPayloadSidecar::v4(
-                        CancunPayloadFields::new(parent_beacon_block_root, vec![]),
-                        PraguePayloadFields::new(EMPTY_REQUESTS_HASH),
-                    ))
-                    .map_err(InsertTaskError::FromBlockError)?,
-            ),
+            OpExecutionPayloadEnvelope::V3 { payload, parent_beacon_block_root } => {
+                self.client.new_payload_v3(payload, parent_beacon_block_root).await
+            }
+            OpExecutionPayloadEnvelope::V4 { payload, parent_beacon_block_root } => {
+                self.client.new_payload_v4(payload, parent_beacon_block_root).await
+            }
         };
+        let block: OpBlock = payload.try_into_block().map_err(InsertTaskError::FromBlockError)?;
 
         // Check the `engine_newPayload` response.
         let response = match response {

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/insert/task.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/insert/task.rs
@@ -45,11 +45,11 @@ impl<EngineClient_: EngineClient> InsertTask<EngineClient_> {
 
 #[async_trait]
 impl<EngineClient_: EngineClient> EngineTaskExt for InsertTask<EngineClient_> {
-    type Output = ();
+    type Output = L2BlockInfo;
 
     type Error = InsertTaskError;
 
-    async fn execute(&self, state: &mut EngineState) -> Result<(), InsertTaskError> {
+    async fn execute(&self, state: &mut EngineState) -> Result<L2BlockInfo, InsertTaskError> {
         let time_start = Instant::now();
 
         // Insert the new payload.
@@ -117,6 +117,6 @@ impl<EngineClient_: EngineClient> EngineTaskExt for InsertTask<EngineClient_> {
             "Inserted new unsafe block"
         );
 
-        Ok(())
+        Ok(new_unsafe_ref)
     }
 }

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/seal/error.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/seal/error.rs
@@ -2,8 +2,7 @@
 
 use crate::{EngineTaskError, InsertTaskError, task_queue::tasks::task::EngineTaskErrorSeverity};
 use alloy_transport::{RpcError, TransportErrorKind};
-use kona_protocol::FromBlockError;
-use op_alloy_rpc_types_engine::{OpExecutionPayloadEnvelope, OpPayloadError};
+use op_alloy_rpc_types_engine::OpExecutionPayloadEnvelope;
 use thiserror::Error;
 use tokio::sync::mpsc;
 
@@ -16,9 +15,6 @@ pub enum SealTaskError {
     /// The get payload call to the engine api failed.
     #[error(transparent)]
     GetPayloadFailed(RpcError<TransportErrorKind>),
-    /// The execution payload could not be converted into a block.
-    #[error(transparent)]
-    InvalidExecutionPayload(#[from] OpPayloadError),
     /// A deposit-only payload failed to import.
     #[error("Deposit-only payload failed to import")]
     DepositOnlyPayloadFailed,
@@ -29,11 +25,6 @@ pub enum SealTaskError {
     /// be flushed post-holocene.
     #[error("Invalid payload, must flush post-holocene")]
     HoloceneInvalidFlush,
-    /// Failed to construct an [`L2BlockInfo`] from the decoded block.
-    ///
-    /// [`L2BlockInfo`]: kona_protocol::L2BlockInfo
-    #[error(transparent)]
-    FromBlock(#[from] FromBlockError),
     /// Error sending the built payload envelope.
     #[error(transparent)]
     MpscSend(#[from] Box<mpsc::error::SendError<Result<OpExecutionPayloadEnvelope, Self>>>),
@@ -56,10 +47,8 @@ impl EngineTaskError for SealTaskError {
             Self::PayloadInsertionFailed(inner) => inner.severity(),
             Self::GetPayloadFailed(_) => EngineTaskErrorSeverity::Temporary,
             Self::HoloceneInvalidFlush => EngineTaskErrorSeverity::Flush,
-            Self::InvalidExecutionPayload(_) |
             Self::DepositOnlyPayloadReattemptFailed |
             Self::DepositOnlyPayloadFailed |
-            Self::FromBlock(_) |
             Self::MpscSend(_) |
             Self::ClockWentBackwards |
             Self::UnsafeHeadChangedSinceBuild => EngineTaskErrorSeverity::Critical,

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/seal/error.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/seal/error.rs
@@ -3,7 +3,7 @@
 use crate::{EngineTaskError, InsertTaskError, task_queue::tasks::task::EngineTaskErrorSeverity};
 use alloy_transport::{RpcError, TransportErrorKind};
 use kona_protocol::FromBlockError;
-use op_alloy_rpc_types_engine::OpExecutionPayloadEnvelope;
+use op_alloy_rpc_types_engine::{OpExecutionPayloadEnvelope, OpPayloadError};
 use thiserror::Error;
 use tokio::sync::mpsc;
 
@@ -16,6 +16,9 @@ pub enum SealTaskError {
     /// The get payload call to the engine api failed.
     #[error(transparent)]
     GetPayloadFailed(RpcError<TransportErrorKind>),
+    /// The execution payload could not be converted into a block.
+    #[error(transparent)]
+    InvalidExecutionPayload(#[from] OpPayloadError),
     /// A deposit-only payload failed to import.
     #[error("Deposit-only payload failed to import")]
     DepositOnlyPayloadFailed,
@@ -26,9 +29,8 @@ pub enum SealTaskError {
     /// be flushed post-holocene.
     #[error("Invalid payload, must flush post-holocene")]
     HoloceneInvalidFlush,
-    /// Failed to convert a [`OpExecutionPayload`] to a [`L2BlockInfo`].
+    /// Failed to construct an [`L2BlockInfo`] from the decoded block.
     ///
-    /// [`OpExecutionPayload`]: op_alloy_rpc_types_engine::OpExecutionPayload
     /// [`L2BlockInfo`]: kona_protocol::L2BlockInfo
     #[error(transparent)]
     FromBlock(#[from] FromBlockError),
@@ -54,6 +56,7 @@ impl EngineTaskError for SealTaskError {
             Self::PayloadInsertionFailed(inner) => inner.severity(),
             Self::GetPayloadFailed(_) => EngineTaskErrorSeverity::Temporary,
             Self::HoloceneInvalidFlush => EngineTaskErrorSeverity::Flush,
+            Self::InvalidExecutionPayload(_) |
             Self::DepositOnlyPayloadReattemptFailed |
             Self::DepositOnlyPayloadFailed |
             Self::FromBlock(_) |

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/seal/task.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/seal/task.rs
@@ -10,7 +10,6 @@ use async_trait::async_trait;
 use derive_more::Constructor;
 use kona_genesis::RollupConfig;
 use kona_protocol::{L2BlockInfo, OpAttributesWithParent};
-use op_alloy_consensus::OpBlock;
 use op_alloy_rpc_types_engine::OpExecutionPayloadEnvelope;
 use std::{sync::Arc, time::Instant};
 use tokio::sync::mpsc;
@@ -132,14 +131,14 @@ impl<EngineClient_: EngineClient> SealTask<EngineClient_> {
     /// 2. Handling deposits-only payload failures
     /// 3. Holocene fallback via `build_and_seal` if needed
     ///
-    /// Returns Ok(()) if the payload is successfully inserted, or an error if insertion fails.
+    /// Returns the inserted block information, or an error if insertion fails.
     async fn insert_payload(
         &self,
         state: &mut EngineState,
         payload: OpExecutionPayloadEnvelope,
-    ) -> Result<(), SealTaskError> {
+    ) -> Result<L2BlockInfo, SealTaskError> {
         // Insert the new block into the engine.
-        match InsertTask::new(
+        let new_block_ref = match InsertTask::new(
             Arc::clone(&self.engine),
             self.cfg.clone(),
             payload,
@@ -185,12 +184,13 @@ impl<EngineClient_: EngineClient> SealTask<EngineClient_> {
                 error!(target: "engine", "Payload import failed: {e}");
                 return Err(Box::new(e).into());
             }
-            Ok(_) => {
-                info!(target: "engine", "Successfully imported payload")
+            Ok(new_block_ref) => {
+                info!(target: "engine", "Successfully imported payload");
+                new_block_ref
             }
-        }
+        };
 
-        Ok(())
+        Ok(new_block_ref)
     }
 
     /// Seals and canonicalizes the block by fetching the payload and importing it.
@@ -209,12 +209,8 @@ impl<EngineClient_: EngineClient> SealTask<EngineClient_> {
             .seal_payload(&self.cfg, &self.engine, self.payload_id, self.attributes.clone())
             .await?;
 
-        let block: OpBlock = new_payload.clone().try_into_block()?;
-        let new_block_ref = L2BlockInfo::from_block_and_genesis(&block, &self.cfg.genesis)
-            .map_err(SealTaskError::FromBlock)?;
-
-        // Insert the payload into the engine.
-        self.insert_payload(state, new_payload.clone()).await?;
+        // Insert the payload into the engine and reuse its decoded block information.
+        let new_block_ref = self.insert_payload(state, new_payload.clone()).await?;
 
         let block_import_duration = block_import_start_time.elapsed();
 

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/seal/task.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/seal/task.rs
@@ -10,7 +10,8 @@ use async_trait::async_trait;
 use derive_more::Constructor;
 use kona_genesis::RollupConfig;
 use kona_protocol::{L2BlockInfo, OpAttributesWithParent};
-use op_alloy_rpc_types_engine::{OpExecutionPayload, OpExecutionPayloadEnvelope};
+use op_alloy_consensus::OpBlock;
+use op_alloy_rpc_types_engine::OpExecutionPayloadEnvelope;
 use std::{sync::Arc, time::Instant};
 use tokio::sync::mpsc;
 
@@ -80,9 +81,9 @@ impl<EngineClient_: EngineClient> SealTask<EngineClient_> {
                     SealTaskError::GetPayloadFailed(e)
                 })?;
 
-                OpExecutionPayloadEnvelope {
-                    parent_beacon_block_root: Some(payload.parent_beacon_block_root),
-                    execution_payload: OpExecutionPayload::V4(payload.execution_payload),
+                OpExecutionPayloadEnvelope::V4 {
+                    parent_beacon_block_root: payload.parent_beacon_block_root,
+                    payload: payload.execution_payload,
                 }
             }
             EngineGetPayloadVersion::V4 => {
@@ -91,9 +92,9 @@ impl<EngineClient_: EngineClient> SealTask<EngineClient_> {
                     SealTaskError::GetPayloadFailed(e)
                 })?;
 
-                OpExecutionPayloadEnvelope {
-                    parent_beacon_block_root: Some(payload.parent_beacon_block_root),
-                    execution_payload: OpExecutionPayload::V4(payload.execution_payload),
+                OpExecutionPayloadEnvelope::V4 {
+                    parent_beacon_block_root: payload.parent_beacon_block_root,
+                    payload: payload.execution_payload,
                 }
             }
             EngineGetPayloadVersion::V3 => {
@@ -102,9 +103,9 @@ impl<EngineClient_: EngineClient> SealTask<EngineClient_> {
                     SealTaskError::GetPayloadFailed(e)
                 })?;
 
-                OpExecutionPayloadEnvelope {
-                    parent_beacon_block_root: Some(payload.parent_beacon_block_root),
-                    execution_payload: OpExecutionPayload::V3(payload.execution_payload),
+                OpExecutionPayloadEnvelope::V3 {
+                    parent_beacon_block_root: payload.parent_beacon_block_root,
+                    payload: payload.execution_payload,
                 }
             }
             EngineGetPayloadVersion::V2 => {
@@ -113,13 +114,10 @@ impl<EngineClient_: EngineClient> SealTask<EngineClient_> {
                     SealTaskError::GetPayloadFailed(e)
                 })?;
 
-                OpExecutionPayloadEnvelope {
-                    parent_beacon_block_root: None,
-                    execution_payload: match payload.execution_payload.into_payload() {
-                        ExecutionPayload::V1(payload) => OpExecutionPayload::V1(payload),
-                        ExecutionPayload::V2(payload) => OpExecutionPayload::V2(payload),
-                        _ => unreachable!("the response should be a V1 or V2 payload"),
-                    },
+                match payload.execution_payload.into_payload() {
+                    ExecutionPayload::V1(payload) => OpExecutionPayloadEnvelope::V1(payload),
+                    ExecutionPayload::V2(payload) => OpExecutionPayloadEnvelope::V2(payload),
+                    _ => unreachable!("the response should be a V1 or V2 payload"),
                 }
             }
         };
@@ -138,13 +136,13 @@ impl<EngineClient_: EngineClient> SealTask<EngineClient_> {
     async fn insert_payload(
         &self,
         state: &mut EngineState,
-        new_payload: OpExecutionPayloadEnvelope,
+        payload: OpExecutionPayloadEnvelope,
     ) -> Result<(), SealTaskError> {
         // Insert the new block into the engine.
         match InsertTask::new(
             Arc::clone(&self.engine),
             self.cfg.clone(),
-            new_payload.clone(),
+            payload,
             self.is_attributes_derived,
         )
         .execute(state)
@@ -211,12 +209,9 @@ impl<EngineClient_: EngineClient> SealTask<EngineClient_> {
             .seal_payload(&self.cfg, &self.engine, self.payload_id, self.attributes.clone())
             .await?;
 
-        let new_block_ref = L2BlockInfo::from_payload_and_genesis(
-            new_payload.execution_payload.clone(),
-            self.attributes.attributes().payload_attributes.parent_beacon_block_root,
-            &self.cfg.genesis,
-        )
-        .map_err(SealTaskError::FromBlock)?;
+        let block: OpBlock = new_payload.clone().try_into_block()?;
+        let new_block_ref = L2BlockInfo::from_block_and_genesis(&block, &self.cfg.genesis)
+            .map_err(SealTaskError::FromBlock)?;
 
         // Insert the payload into the engine.
         self.insert_payload(state, new_payload.clone()).await?;

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/task.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/task.rs
@@ -110,7 +110,9 @@ impl<EngineClient_: EngineClient> EngineTask<EngineClient_> {
     /// Executes the task without consuming it.
     async fn execute_inner(&self, state: &mut EngineState) -> Result<(), EngineTaskErrors> {
         match self {
-            Self::Insert(task) => task.execute(state).await?,
+            Self::Insert(task) => {
+                task.execute(state).await?;
+            }
             Self::Seal(task) => task.execute(state).await?,
             Self::Consolidate(task) => task.execute(state).await?,
             Self::Finalize(task) => task.execute(state).await?,

--- a/rust/kona/crates/node/gossip/Cargo.toml
+++ b/rust/kona/crates/node/gossip/Cargo.toml
@@ -24,16 +24,17 @@ kona-disc.workspace = true
 
 # Alloy
 alloy-rlp.workspace = true
-alloy-consensus.workspace = true
 alloy-rpc-types-engine.workspace = true
 alloy-primitives = { workspace = true, features = ["k256", "getrandom"] }
 
 # Op Alloy
-op-alloy-consensus = { workspace = true, features = ["k256"] }
 op-alloy-rpc-types-engine = { workspace = true, features = ["std", "serde"] }
 
-# Networking
+# Encoding
+ethereum_ssz.workspace = true
 snap.workspace = true
+
+# Networking
 futures.workspace = true
 libp2p-stream.workspace = true
 discv5 = { workspace = true, features = ["libp2p"] }

--- a/rust/kona/crates/node/gossip/Cargo.toml
+++ b/rust/kona/crates/node/gossip/Cargo.toml
@@ -24,7 +24,6 @@ kona-disc.workspace = true
 
 # Alloy
 alloy-rlp.workspace = true
-alloy-eips.workspace = true
 alloy-consensus.workspace = true
 alloy-rpc-types-engine.workspace = true
 alloy-primitives = { workspace = true, features = ["k256", "getrandom"] }

--- a/rust/kona/crates/node/gossip/src/block_validity.rs
+++ b/rust/kona/crates/node/gossip/src/block_validity.rs
@@ -2,20 +2,16 @@
 use std::time::Instant;
 use std::time::SystemTime;
 
-use alloy_consensus::Block;
 use alloy_primitives::{Address, B256};
 use alloy_rpc_types_engine::{ExecutionPayloadV3, PayloadError};
 use kona_genesis::RollupConfig;
 use libp2p::gossipsub::MessageAcceptance;
-use op_alloy_consensus::OpTxEnvelope;
-use op_alloy_rpc_types_engine::{
-    OpExecutionPayload, OpExecutionPayloadEnvelope, OpExecutionPayloadV4, OpNetworkPayloadEnvelope,
-    OpPayloadError,
-};
+use op_alloy_rpc_types_engine::{OpExecutionPayloadEnvelope, OpExecutionPayloadV4, OpPayloadError};
 
 use super::BlockHandler;
 #[cfg(feature = "metrics")]
 use crate::Metrics;
+use crate::payload::SignedGossipPayload;
 
 /// Error that can occur when validating a block.
 #[derive(Debug, thiserror::Error)]
@@ -53,9 +49,6 @@ pub enum BlockInvalidError {
     /// Invalid block.
     #[error(transparent)]
     InvalidBlock(#[from] OpPayloadError),
-    /// The block has a parent beacon block root incompatible with its payload version.
-    #[error("Payload has an invalid parent beacon block root")]
-    ParentBeaconRoot,
     /// The block has an invalid blob gas used.
     #[error("Payload is on v3+ topic, but has non-zero blob gas used")]
     BlobGasUsed,
@@ -105,6 +98,30 @@ impl BlockHandler {
     /// <https://specs.optimism.io/protocol/rollup-node-p2p.html#block-validation>
     const MAX_BLOCKS_TO_KEEP: usize = 5;
 
+    /// Validates that the signature authenticates the exact encoded envelope bytes and was
+    /// produced by the configured unsafe block signer.
+    pub(crate) fn validate_signature(
+        &self,
+        payload: &SignedGossipPayload,
+    ) -> Result<(), BlockInvalidError> {
+        let message = payload.payload_hash().signature_message(self.rollup_config.l2_chain_id.id());
+        let expected = *self.signer_recv.borrow();
+        let received = match payload.signature().recover_address_from_prehash(&message) {
+            Ok(received) => received,
+            Err(_) => {
+                #[cfg(feature = "metrics")]
+                kona_macros::inc!(counter, Metrics::BLOCK_VALIDATION_FAILED, "reason" => "invalid_signature");
+                return Err(BlockInvalidError::Signature);
+            }
+        };
+        if received != expected {
+            #[cfg(feature = "metrics")]
+            kona_macros::inc!(counter, Metrics::BLOCK_VALIDATION_FAILED, "reason" => "invalid_signer");
+            return Err(BlockInvalidError::Signer { expected, received });
+        }
+        Ok(())
+    }
+
     /// Determines if a block is valid.
     ///
     /// We validate the block according to the rules defined here:
@@ -114,24 +131,20 @@ impl BlockHandler {
     /// in the handle).
     pub fn block_valid(
         &mut self,
-        envelope: &OpNetworkPayloadEnvelope,
+        envelope: &OpExecutionPayloadEnvelope,
     ) -> Result<(), BlockInvalidError> {
         // Start timing for the validation duration
         #[cfg(feature = "metrics")]
         let validation_start = Instant::now();
 
-        // Record total validation attempts
-        #[cfg(feature = "metrics")]
-        kona_macros::inc!(counter, Metrics::BLOCK_VALIDATION_TOTAL);
-
         // Record block version distribution
         #[cfg(feature = "metrics")]
         {
-            let version = match &envelope.payload {
-                OpExecutionPayload::V1(_) => "v1",
-                OpExecutionPayload::V2(_) => "v2",
-                OpExecutionPayload::V3(_) => "v3",
-                OpExecutionPayload::V4(_) => "v4",
+            let version = match envelope {
+                OpExecutionPayloadEnvelope::V1(_) => "v1",
+                OpExecutionPayloadEnvelope::V2(_) => "v2",
+                OpExecutionPayloadEnvelope::V3 { .. } => "v3",
+                OpExecutionPayloadEnvelope::V4 { .. } => "v4",
             };
             kona_macros::inc!(counter, Metrics::BLOCK_VERSION, "version" => version);
         }
@@ -173,7 +186,6 @@ impl BlockHandler {
                         BlockInvalidError::BlockSeen { .. } => "block_seen",
                         BlockInvalidError::InvalidBlock(_) |
                         BlockInvalidError::BaseFeePerGasOverflow(_) => "invalid_block",
-                        BlockInvalidError::ParentBeaconRoot => "parent_beacon_root",
                         BlockInvalidError::BlobGasUsed => "blob_gas_used",
                         BlockInvalidError::ExcessBlobGas => "excess_blob_gas",
                         BlockInvalidError::WithdrawalsRoot => "withdrawals_root",
@@ -189,80 +201,49 @@ impl BlockHandler {
     /// Internal validation logic extracted for cleaner metrics instrumentation.
     fn validate_block_internal(
         &mut self,
-        envelope: &OpNetworkPayloadEnvelope,
+        envelope: &OpExecutionPayloadEnvelope,
     ) -> Result<(), BlockInvalidError> {
         let current_timestamp =
             SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap().as_secs();
 
         // The timestamp is at most 5 seconds in the future.
-        let is_future = envelope.payload.timestamp() > current_timestamp + 5;
+        let is_future = envelope.timestamp() > current_timestamp + 5;
         // The timestamp is at most 60 seconds in the past.
-        let is_past = envelope.payload.timestamp() < current_timestamp - 60;
+        let is_past = envelope.timestamp() < current_timestamp - 60;
 
         // CHECK: The timestamp is not too far in the future or past.
         if is_future || is_past {
             return Err(BlockInvalidError::Timestamp {
                 current: current_timestamp,
-                received: envelope.payload.timestamp(),
+                received: envelope.timestamp(),
             });
         }
 
-        // CHECK: Ensure the block hash is valid.
-        let expected = envelope.payload.block_hash();
-        let execution_data =
-            OpExecutionPayloadEnvelope::try_from(envelope.clone()).map_err(|err| match err {
-                OpPayloadError::MissingParentBeaconBlockRoot |
-                OpPayloadError::UnexpectedParentBeaconBlockRoot => {
-                    BlockInvalidError::ParentBeaconRoot
-                }
-                err => BlockInvalidError::InvalidBlock(err),
-            })?;
-        let block: Block<OpTxEnvelope> = execution_data.try_into_block()?;
-        let received = block.header.hash_slow();
-        if received != expected {
-            return Err(BlockInvalidError::BlockHash { expected, received });
-        }
+        // CHECK: Ensure the block hash is valid without decoding the transactions.
+        envelope.check_block_hash().map_err(|err| match err {
+            OpPayloadError::Eth(PayloadError::BlockHash { execution, consensus }) => {
+                BlockInvalidError::BlockHash { expected: consensus, received: execution }
+            }
+            err => BlockInvalidError::InvalidBlock(err),
+        })?;
 
         // CHECK: The payload is valid for the specific version of this block.
         self.validate_version_specific_payload(envelope)?;
 
-        if let Some(seen_hashes_at_height) =
-            self.seen_hashes.get_mut(&envelope.payload.block_number())
-        {
+        if let Some(seen_hashes_at_height) = self.seen_hashes.get_mut(&envelope.block_number()) {
             // CHECK: If more than [`Self::MAX_BLOCKS_TO_KEEP`] different blocks have been received
             // for the same height, reject the block.
             if seen_hashes_at_height.len() > Self::MAX_BLOCKS_TO_KEEP {
-                return Err(BlockInvalidError::TooManyBlocks {
-                    height: envelope.payload.block_number(),
-                });
+                return Err(BlockInvalidError::TooManyBlocks { height: envelope.block_number() });
             }
 
             // CHECK: If the block has already been seen, ignore it.
-            if seen_hashes_at_height.contains(&envelope.payload.block_hash()) {
-                return Err(BlockInvalidError::BlockSeen {
-                    block_hash: envelope.payload.block_hash(),
-                });
+            if seen_hashes_at_height.contains(&envelope.block_hash()) {
+                return Err(BlockInvalidError::BlockSeen { block_hash: envelope.block_hash() });
             }
         }
 
-        // CHECK: The signature is valid.
-        let msg = envelope.payload_hash.signature_message(self.rollup_config.l2_chain_id.id());
-        let block_signer = *self.signer_recv.borrow();
-
-        // The block has a valid signature.
-        let Ok(msg_signer) = envelope.signature.recover_address_from_prehash(&msg) else {
-            return Err(BlockInvalidError::Signature);
-        };
-
-        // The block is signed by the expected signer (the unsafe block signer).
-        if msg_signer != block_signer {
-            return Err(BlockInvalidError::Signer { expected: block_signer, received: msg_signer });
-        }
-
-        self.seen_hashes
-            .entry(envelope.payload.block_number())
-            .or_default()
-            .insert(envelope.payload.block_hash());
+        self.seen_hashes.entry(envelope.block_number()).or_default().insert(envelope.block_hash());
 
         // Mark the block as seen.
         if self.seen_hashes.len() >= Self::SEEN_HASH_CACHE_SIZE {
@@ -275,7 +256,7 @@ impl BlockHandler {
     /// Validate version specific contents of the payload.
     fn validate_version_specific_payload(
         &self,
-        envelope: &OpNetworkPayloadEnvelope,
+        envelope: &OpExecutionPayloadEnvelope,
     ) -> Result<(), BlockInvalidError> {
         // Validation for v1 payloads are mostly ensured by type-safety, by decoding the
         // payload to the ExecutionPayloadV1 type:
@@ -284,20 +265,19 @@ impl BlockHandler {
         // 3. The block should not have any blob gas used
         // 4. The block should not have any excess blob gas
         // 5. The block should not have any withdrawals root
-        // 6. The block should not have any parent beacon block root (checked below)
+        // 6. The block cannot have a parent beacon block root by construction
 
         // Same as v1, except:
-        // 1. The block should have an empty withdrawals list. This is checked during the call to
-        //    [`op_alloy_rpc_types_engine::OpExecutionPayloadEnvelope::try_into_block`].
+        // 1. The block should have an empty withdrawals list. This is checked during block
+        //    reconstruction.
 
         // Same as v2, except:
         // 1. The block should have a zero blob gas used
         // 2. The block should have a zero excess blob gas
-        // 3. The block should have a non empty parent beacon block root
+        // 3. The block has a parent beacon block root by construction
         fn validate_v3(
             rollup_config: &RollupConfig,
             block: &ExecutionPayloadV3,
-            parent_beacon_block_root: Option<B256>,
         ) -> Result<(), BlockInvalidError> {
             // If Jovian is not active, the blob gas used should be zero.
             if !rollup_config.is_jovian_active(block.timestamp()) && block.blob_gas_used != 0 {
@@ -308,10 +288,6 @@ impl BlockHandler {
                 return Err(BlockInvalidError::ExcessBlobGas);
             }
 
-            if parent_beacon_block_root.is_none() {
-                return Err(BlockInvalidError::ParentBeaconRoot);
-            }
-
             Ok(())
         }
 
@@ -320,23 +296,17 @@ impl BlockHandler {
         fn validate_v4(
             rollup_config: &RollupConfig,
             block: &OpExecutionPayloadV4,
-            parent_beacon_block_root: Option<B256>,
         ) -> Result<(), BlockInvalidError> {
-            validate_v3(rollup_config, &block.payload_inner, parent_beacon_block_root)
+            validate_v3(rollup_config, &block.payload_inner)
         }
 
-        match &envelope.payload {
-            OpExecutionPayload::V1(_) | OpExecutionPayload::V2(_) => {
-                if envelope.parent_beacon_block_root.is_some() {
-                    return Err(BlockInvalidError::ParentBeaconRoot);
-                }
-                Ok(())
+        match envelope {
+            OpExecutionPayloadEnvelope::V1(_) | OpExecutionPayloadEnvelope::V2(_) => Ok(()),
+            OpExecutionPayloadEnvelope::V3 { payload, .. } => {
+                validate_v3(&self.rollup_config, payload)
             }
-            OpExecutionPayload::V3(payload) => {
-                validate_v3(&self.rollup_config, payload, envelope.parent_beacon_block_root)
-            }
-            OpExecutionPayload::V4(payload) => {
-                validate_v4(&self.rollup_config, payload, envelope.parent_beacon_block_root)
+            OpExecutionPayloadEnvelope::V4 { payload, .. } => {
+                validate_v4(&self.rollup_config, payload)
             }
         }
     }
@@ -355,7 +325,9 @@ pub(crate) mod tests {
     use arbitrary::{Arbitrary, Unstructured};
     use kona_genesis::RollupConfig;
     use op_alloy_consensus::OpTxEnvelope;
-    use op_alloy_rpc_types_engine::{OpExecutionPayload, OpExecutionPayloadV4, PayloadHash};
+    use op_alloy_rpc_types_engine::OpExecutionPayloadV4;
+
+    use crate::payload::GossipPayloadVersion;
 
     fn valid_block() -> Block<OpTxEnvelope> {
         // Simulate some random data
@@ -450,137 +422,114 @@ pub(crate) mod tests {
         block
     }
 
-    /// Generates a random valid block and ensure it is v1 compatible
-    #[test]
-    fn test_block_valid() {
-        let block = v1_valid_block();
-
-        let v1 = ExecutionPayloadV1::from_block_slow(&block);
-
-        let payload = OpExecutionPayload::V1(v1);
-        let envelope = OpNetworkPayloadEnvelope {
-            payload,
-            signature: Signature::test_signature(),
-            payload_hash: PayloadHash(B256::ZERO),
-            parent_beacon_block_root: None,
-        };
-
-        let msg = envelope.payload_hash.signature_message(10);
-        let signer = envelope.signature.recover_address_from_prehash(&msg).unwrap();
-        let (_, unsafe_signer) = tokio::sync::watch::channel(signer);
-        let mut handler = BlockHandler::new(
+    fn handler() -> BlockHandler {
+        let (_, unsafe_signer) = tokio::sync::watch::channel(Address::ZERO);
+        BlockHandler::new(
             RollupConfig { l2_chain_id: Chain::optimism_mainnet(), ..Default::default() },
             unsafe_signer,
-        );
-
-        assert!(handler.block_valid(&envelope).is_ok());
+        )
     }
 
-    /// Generates a random block with an invalid timestamp and ensure it is rejected
+    fn v1_envelope(block: &Block<OpTxEnvelope>) -> OpExecutionPayloadEnvelope {
+        OpExecutionPayloadEnvelope::V1(ExecutionPayloadV1::from_block_slow(block))
+    }
+
+    fn v2_envelope(block: &Block<OpTxEnvelope>) -> OpExecutionPayloadEnvelope {
+        OpExecutionPayloadEnvelope::V2(ExecutionPayloadV2::from_block_slow(block))
+    }
+
+    fn v3_envelope(block: &Block<OpTxEnvelope>) -> OpExecutionPayloadEnvelope {
+        OpExecutionPayloadEnvelope::V3 {
+            payload: ExecutionPayloadV3::from_block_slow(block),
+            parent_beacon_block_root: block.header.parent_beacon_block_root.unwrap(),
+        }
+    }
+
+    fn v4_envelope(block: &Block<OpTxEnvelope>) -> OpExecutionPayloadEnvelope {
+        OpExecutionPayloadEnvelope::V4 {
+            payload: OpExecutionPayloadV4::from_v3_with_withdrawals_root(
+                ExecutionPayloadV3::from_block_slow(block),
+                block.withdrawals_root.unwrap(),
+            ),
+            parent_beacon_block_root: block.header.parent_beacon_block_root.unwrap(),
+        }
+    }
+
+    fn signed_payload(
+        envelope: &OpExecutionPayloadEnvelope,
+        signature: Signature,
+    ) -> SignedGossipPayload {
+        let version = match envelope {
+            OpExecutionPayloadEnvelope::V1(_) => GossipPayloadVersion::V1,
+            OpExecutionPayloadEnvelope::V2(_) => GossipPayloadVersion::V2,
+            OpExecutionPayloadEnvelope::V3 { .. } => GossipPayloadVersion::V3,
+            OpExecutionPayloadEnvelope::V4 { .. } => GossipPayloadVersion::V4,
+        };
+        SignedGossipPayload::from_envelope(envelope, signature, version).unwrap()
+    }
+
+    /// Generates a random valid block and ensures it is V1 compatible.
+    #[test]
+    fn test_block_valid() {
+        let envelope = v1_envelope(&v1_valid_block());
+        assert!(handler().block_valid(&envelope).is_ok());
+    }
+
     #[test]
     fn test_block_invalid_timestamp_early() {
         let mut block = v1_valid_block();
-
         block.header.timestamp -= 61;
+        let envelope = v1_envelope(&block);
 
-        let v1 = ExecutionPayloadV1::from_block_slow(&block);
-
-        let payload = OpExecutionPayload::V1(v1);
-        let envelope = OpNetworkPayloadEnvelope {
-            payload,
-            signature: Signature::test_signature(),
-            payload_hash: PayloadHash(B256::ZERO),
-            parent_beacon_block_root: None,
-        };
-
-        let msg = envelope.payload_hash.signature_message(10);
-        let signer = envelope.signature.recover_address_from_prehash(&msg).unwrap();
-        let (_, unsafe_signer) = tokio::sync::watch::channel(signer);
-        let mut handler = BlockHandler::new(
-            RollupConfig { l2_chain_id: Chain::optimism_mainnet(), ..Default::default() },
-            unsafe_signer,
-        );
-
-        assert!(matches!(handler.block_valid(&envelope), Err(BlockInvalidError::Timestamp { .. })));
+        assert!(matches!(
+            handler().block_valid(&envelope),
+            Err(BlockInvalidError::Timestamp { .. })
+        ));
     }
 
-    /// Generates a random block with an invalid timestamp and ensure it is rejected
     #[test]
     fn test_block_invalid_timestamp_too_far() {
         let mut block = v1_valid_block();
-
         block.header.timestamp += 6;
+        let envelope = v1_envelope(&block);
 
-        let v1 = ExecutionPayloadV1::from_block_slow(&block);
-
-        let payload = OpExecutionPayload::V1(v1);
-        let envelope = OpNetworkPayloadEnvelope {
-            payload,
-            signature: Signature::test_signature(),
-            payload_hash: PayloadHash(B256::ZERO),
-            parent_beacon_block_root: None,
-        };
-
-        let msg = envelope.payload_hash.signature_message(10);
-        let signer = envelope.signature.recover_address_from_prehash(&msg).unwrap();
-        let (_, unsafe_signer) = tokio::sync::watch::channel(signer);
-        let mut handler = BlockHandler::new(
-            RollupConfig { l2_chain_id: Chain::optimism_mainnet(), ..Default::default() },
-            unsafe_signer,
-        );
-
-        assert!(matches!(handler.block_valid(&envelope), Err(BlockInvalidError::Timestamp { .. })));
+        assert!(matches!(
+            handler().block_valid(&envelope),
+            Err(BlockInvalidError::Timestamp { .. })
+        ));
     }
 
-    /// Generates a random block with an invalid hash and ensure it is rejected
     #[test]
     fn test_block_invalid_hash() {
         let block = v1_valid_block();
+        let mut payload = ExecutionPayloadV1::from_block_slow(&block);
+        payload.block_hash = B256::ZERO;
+        let envelope = OpExecutionPayloadEnvelope::V1(payload);
 
-        let mut v1 = ExecutionPayloadV1::from_block_slow(&block);
+        assert!(matches!(
+            handler().block_valid(&envelope),
+            Err(BlockInvalidError::BlockHash { .. })
+        ));
+    }
 
-        v1.block_hash = B256::ZERO;
-
-        let payload = OpExecutionPayload::V1(v1);
-        let envelope = OpNetworkPayloadEnvelope {
-            payload,
-            signature: Signature::test_signature(),
-            payload_hash: PayloadHash(B256::ZERO),
-            parent_beacon_block_root: None,
+    #[test]
+    fn test_block_hash_validation_does_not_decode_transactions() {
+        let mut envelope = v1_envelope(&v1_valid_block());
+        envelope.as_v1_mut().transactions = vec![Bytes::from_static(&[0xff])];
+        let block_hash = match envelope.check_block_hash() {
+            Err(OpPayloadError::Eth(PayloadError::BlockHash { execution, .. })) => execution,
+            result => panic!("expected block hash mismatch, got {result:?}"),
         };
+        envelope.as_v1_mut().block_hash = block_hash;
 
-        let msg = envelope.payload_hash.signature_message(10);
-        let signer = envelope.signature.recover_address_from_prehash(&msg).unwrap();
-        let (_, unsafe_signer) = tokio::sync::watch::channel(signer);
-        let mut handler = BlockHandler::new(
-            RollupConfig { l2_chain_id: Chain::optimism_mainnet(), ..Default::default() },
-            unsafe_signer,
-        );
-
-        assert!(matches!(handler.block_valid(&envelope), Err(BlockInvalidError::BlockHash { .. })));
+        assert!(handler().block_valid(&envelope).is_ok());
+        assert!(envelope.try_into_block::<OpTxEnvelope>().is_err());
     }
 
     #[test]
     fn test_cannot_validate_same_block_twice() {
-        let block = v1_valid_block();
-
-        let v1 = ExecutionPayloadV1::from_block_slow(&block);
-
-        let payload = OpExecutionPayload::V1(v1);
-        let envelope = OpNetworkPayloadEnvelope {
-            payload,
-            signature: Signature::test_signature(),
-            payload_hash: PayloadHash(B256::ZERO),
-            parent_beacon_block_root: None,
-        };
-
-        let msg = envelope.payload_hash.signature_message(10);
-        let signer = envelope.signature.recover_address_from_prehash(&msg).unwrap();
-        let (_, unsafe_signer) = tokio::sync::watch::channel(signer);
-        let mut handler = BlockHandler::new(
-            RollupConfig { l2_chain_id: Chain::optimism_mainnet(), ..Default::default() },
-            unsafe_signer,
-        );
+        let envelope = v1_envelope(&v1_valid_block());
+        let mut handler = handler();
 
         assert!(handler.block_valid(&envelope).is_ok());
         assert!(matches!(handler.block_valid(&envelope), Err(BlockInvalidError::BlockSeen { .. })));
@@ -589,277 +538,99 @@ pub(crate) mod tests {
     #[test]
     fn test_cannot_have_too_many_blocks_for_the_same_height() {
         let first_block = v1_valid_block();
-
         let initial_height = first_block.header.number;
-
-        let v1 = ExecutionPayloadV1::from_block_slow(&first_block);
-
-        let payload = OpExecutionPayload::V1(v1);
-        let envelope = OpNetworkPayloadEnvelope {
-            payload,
-            signature: Signature::test_signature(),
-            payload_hash: PayloadHash(B256::ZERO),
-            parent_beacon_block_root: None,
-        };
-
-        let msg = envelope.payload_hash.signature_message(10);
-        let signer = envelope.signature.recover_address_from_prehash(&msg).unwrap();
-        let (_, unsafe_signer) = tokio::sync::watch::channel(signer);
-        let mut handler = BlockHandler::new(
-            RollupConfig { l2_chain_id: Chain::optimism_mainnet(), ..Default::default() },
-            unsafe_signer,
-        );
-
-        assert!(handler.block_valid(&envelope).is_ok());
+        let first = v1_envelope(&first_block);
+        let mut handler = handler();
+        assert!(handler.block_valid(&first).is_ok());
 
         let next_payloads = (0..=BlockHandler::MAX_BLOCKS_TO_KEEP)
             .map(|_| {
                 let mut block = v1_valid_block();
-                // The blocks have the same height
                 block.header.number = initial_height;
-
-                let v1 = ExecutionPayloadV1::from_block_slow(&block);
-
-                let payload = OpExecutionPayload::V1(v1);
-                OpNetworkPayloadEnvelope {
-                    payload,
-                    signature: Signature::test_signature(),
-                    payload_hash: PayloadHash(B256::ZERO),
-                    parent_beacon_block_root: None,
-                }
+                v1_envelope(&block)
             })
             .collect::<Vec<_>>();
 
         for envelope in &next_payloads[..next_payloads.len() - 1] {
             assert!(handler.block_valid(envelope).is_ok());
         }
-
-        // The last envelope should fail
         assert!(matches!(
             handler.block_valid(next_payloads.last().unwrap()),
             Err(BlockInvalidError::TooManyBlocks { .. })
         ));
     }
 
-    /// Blocks with invalid signatures should be rejected.
     #[test]
     fn test_invalid_signature() {
-        let block = v1_valid_block();
-
-        let v1 = ExecutionPayloadV1::from_block_slow(&block);
-
-        let payload = OpExecutionPayload::V1(v1);
-        let mut envelope = OpNetworkPayloadEnvelope {
-            payload,
-            signature: Signature::test_signature(),
-            payload_hash: PayloadHash(B256::ZERO),
-            parent_beacon_block_root: None,
-        };
-
-        let msg = envelope.payload_hash.signature_message(10);
-        let signer = envelope.signature.recover_address_from_prehash(&msg).unwrap();
+        let envelope = v1_envelope(&v1_valid_block());
+        let signature = Signature::test_signature();
+        let valid = signed_payload(&envelope, signature);
+        let message = valid.payload_hash().signature_message(10);
+        let signer = signature.recover_address_from_prehash(&message).unwrap();
         let (_, unsafe_signer) = tokio::sync::watch::channel(signer);
-        let mut handler = BlockHandler::new(
+        let handler = BlockHandler::new(
             RollupConfig { l2_chain_id: Chain::optimism_mainnet(), ..Default::default() },
             unsafe_signer,
         );
 
-        let mut signature_bytes = envelope.signature.as_bytes();
+        let mut signature_bytes = signature.as_bytes();
         signature_bytes[0] = !signature_bytes[0];
-        envelope.signature = Signature::from_raw_array(&signature_bytes).unwrap();
-
-        assert!(handler.seen_hashes.is_empty());
-        assert!(matches!(handler.block_valid(&envelope), Err(BlockInvalidError::Signature)));
+        let invalid =
+            signed_payload(&envelope, Signature::from_raw_array(&signature_bytes).unwrap());
+        assert!(matches!(
+            handler.validate_signature(&invalid),
+            Err(BlockInvalidError::Signature | BlockInvalidError::Signer { .. })
+        ));
     }
 
-    /// Blocks with invalid signers should be rejected.
     #[test]
     fn test_invalid_signer() {
-        let block = v1_valid_block();
-
-        let v1 = ExecutionPayloadV1::from_block_slow(&block);
-
-        let payload = OpExecutionPayload::V1(v1);
-        let envelope = OpNetworkPayloadEnvelope {
-            payload,
-            signature: Signature::test_signature(),
-            payload_hash: PayloadHash(B256::ZERO),
-            parent_beacon_block_root: None,
-        };
-
-        let (_, unsafe_signer) = tokio::sync::watch::channel(Address::default());
-        let mut handler = BlockHandler::new(
-            RollupConfig { l2_chain_id: Chain::optimism_mainnet(), ..Default::default() },
-            unsafe_signer,
-        );
-
-        assert!(matches!(handler.block_valid(&envelope), Err(BlockInvalidError::Signer { .. })));
-    }
-
-    /// V1/V2 payloads reject a parent beacon block root because those versions do not include it.
-    #[test]
-    fn test_v1_v2_block_invalid_parent_beacon_block_root() {
-        let block = v1_valid_block();
-
-        let v1 = ExecutionPayloadV1::from_block_slow(&block);
-
-        let payload = OpExecutionPayload::V1(v1);
-        let envelope = OpNetworkPayloadEnvelope {
-            payload,
-            signature: Signature::test_signature(),
-            payload_hash: PayloadHash(B256::ZERO),
-            parent_beacon_block_root: Some(B256::ZERO),
-        };
-
-        let msg = envelope.payload_hash.signature_message(10);
-        let signer = envelope.signature.recover_address_from_prehash(&msg).unwrap();
-        let (_, unsafe_signer) = tokio::sync::watch::channel(signer);
-        let mut handler = BlockHandler::new(
-            RollupConfig { l2_chain_id: Chain::optimism_mainnet(), ..Default::default() },
-            unsafe_signer,
-        );
-
-        assert!(matches!(handler.block_valid(&envelope), Err(BlockInvalidError::ParentBeaconRoot)));
-
-        let block = v2_valid_block();
-
-        let v2 = ExecutionPayloadV2::from_block_slow(&block);
-
-        let payload = OpExecutionPayload::V2(v2);
-        let envelope = OpNetworkPayloadEnvelope {
-            payload,
-            signature: Signature::test_signature(),
-            payload_hash: PayloadHash(B256::ZERO),
-            parent_beacon_block_root: Some(B256::ZERO),
-        };
-
-        let msg = envelope.payload_hash.signature_message(10);
-        let signer = envelope.signature.recover_address_from_prehash(&msg).unwrap();
-        let (_, unsafe_signer) = tokio::sync::watch::channel(signer);
-        let mut handler = BlockHandler::new(
-            RollupConfig { l2_chain_id: Chain::optimism_mainnet(), ..Default::default() },
-            unsafe_signer,
-        );
-
-        assert!(matches!(handler.block_valid(&envelope), Err(BlockInvalidError::ParentBeaconRoot)));
+        let envelope = v1_envelope(&v1_valid_block());
+        let signed = signed_payload(&envelope, Signature::test_signature());
+        assert!(matches!(
+            handler().validate_signature(&signed),
+            Err(BlockInvalidError::Signer { .. })
+        ));
     }
 
     #[test]
     fn test_v2_block() {
-        let block = v2_valid_block();
-
-        let v2 = ExecutionPayloadV2::from_block_slow(&block);
-
-        let payload = OpExecutionPayload::V2(v2);
-        let envelope = OpNetworkPayloadEnvelope {
-            payload,
-            signature: Signature::test_signature(),
-            payload_hash: PayloadHash(B256::ZERO),
-            parent_beacon_block_root: None,
-        };
-
-        let msg = envelope.payload_hash.signature_message(10);
-        let signer = envelope.signature.recover_address_from_prehash(&msg).unwrap();
-        let (_, unsafe_signer) = tokio::sync::watch::channel(signer);
-        let mut handler = BlockHandler::new(
-            RollupConfig { l2_chain_id: Chain::optimism_mainnet(), ..Default::default() },
-            unsafe_signer,
-        );
-
-        assert!(handler.block_valid(&envelope).is_ok());
+        let envelope = v2_envelope(&v2_valid_block());
+        assert!(handler().block_valid(&envelope).is_ok());
     }
 
     #[test]
     fn test_v2_non_empty_withdrawals() {
         let mut block = v2_valid_block();
         block.body.withdrawals = Some(vec![Withdrawal::default()].into());
-        let withdrawals_root = alloy_consensus::proofs::calculate_withdrawals_root(
+        block.header.withdrawals_root = Some(alloy_consensus::proofs::calculate_withdrawals_root(
             &block.body.withdrawals.clone().unwrap_or_default(),
-        );
-        block.header.withdrawals_root = Some(withdrawals_root);
-
-        let v2 = ExecutionPayloadV2::from_block_slow(&block);
-
-        let payload = OpExecutionPayload::V2(v2);
-        let envelope = OpNetworkPayloadEnvelope {
-            payload,
-            signature: Signature::test_signature(),
-            payload_hash: PayloadHash(B256::ZERO),
-            parent_beacon_block_root: None,
-        };
-
-        let msg = envelope.payload_hash.signature_message(10);
-        let signer = envelope.signature.recover_address_from_prehash(&msg).unwrap();
-        let (_, unsafe_signer) = tokio::sync::watch::channel(signer);
-        let mut handler = BlockHandler::new(
-            RollupConfig { l2_chain_id: Chain::optimism_mainnet(), ..Default::default() },
-            unsafe_signer,
-        );
+        ));
+        let envelope = v2_envelope(&block);
 
         assert!(matches!(
-            handler.block_valid(&envelope),
+            handler().block_valid(&envelope),
             Err(BlockInvalidError::InvalidBlock(OpPayloadError::NonEmptyL1Withdrawals))
         ));
     }
 
     #[test]
     fn test_v3_block() {
-        let block = v3_valid_block();
-
-        let v3 = ExecutionPayloadV3::from_block_slow(&block);
-
-        let payload = OpExecutionPayload::V3(v3);
-        let envelope = OpNetworkPayloadEnvelope {
-            payload,
-            signature: Signature::test_signature(),
-            payload_hash: PayloadHash(B256::ZERO),
-            parent_beacon_block_root: Some(
-                block.header.parent_beacon_block_root.unwrap_or_default(),
-            ),
-        };
-
-        let msg = envelope.payload_hash.signature_message(10);
-        let signer = envelope.signature.recover_address_from_prehash(&msg).unwrap();
-        let (_, unsafe_signer) = tokio::sync::watch::channel(signer);
-        let mut handler = BlockHandler::new(
-            RollupConfig { l2_chain_id: Chain::optimism_mainnet(), ..Default::default() },
-            unsafe_signer,
-        );
-
-        assert!(handler.block_valid(&envelope).is_ok());
+        let envelope = v3_envelope(&v3_valid_block());
+        assert!(handler().block_valid(&envelope).is_ok());
     }
 
     #[test]
     fn test_v3_non_empty_withdrawals() {
         let mut block = v3_valid_block();
         block.body.withdrawals = Some(vec![Withdrawal::default()].into());
-        let withdrawals_root = alloy_consensus::proofs::calculate_withdrawals_root(
+        block.header.withdrawals_root = Some(alloy_consensus::proofs::calculate_withdrawals_root(
             &block.body.withdrawals.clone().unwrap_or_default(),
-        );
-        block.header.withdrawals_root = Some(withdrawals_root);
-
-        let v3 = ExecutionPayloadV3::from_block_slow(&block);
-
-        let payload = OpExecutionPayload::V3(v3);
-        let envelope = OpNetworkPayloadEnvelope {
-            payload,
-            signature: Signature::test_signature(),
-            payload_hash: PayloadHash(B256::ZERO),
-            parent_beacon_block_root: Some(
-                block.header.parent_beacon_block_root.unwrap_or_default(),
-            ),
-        };
-
-        let msg = envelope.payload_hash.signature_message(10);
-        let signer = envelope.signature.recover_address_from_prehash(&msg).unwrap();
-        let (_, unsafe_signer) = tokio::sync::watch::channel(signer);
-        let mut handler = BlockHandler::new(
-            RollupConfig { l2_chain_id: Chain::optimism_mainnet(), ..Default::default() },
-            unsafe_signer,
-        );
+        ));
+        let envelope = v3_envelope(&block);
 
         assert!(matches!(
-            handler.block_valid(&envelope),
+            handler().block_valid(&envelope),
             Err(BlockInvalidError::InvalidBlock(OpPayloadError::NonEmptyL1Withdrawals))
         ));
     }
@@ -868,150 +639,39 @@ pub(crate) mod tests {
     fn test_v3_gas_params() {
         let mut block = v3_valid_block();
         block.header.blob_gas_used = Some(1);
-
-        let v3 = ExecutionPayloadV3::from_block_slow(&block);
-
-        let payload = OpExecutionPayload::V3(v3);
-        let envelope = OpNetworkPayloadEnvelope {
-            payload,
-            signature: Signature::test_signature(),
-            payload_hash: PayloadHash(B256::ZERO),
-            parent_beacon_block_root: Some(
-                block.header.parent_beacon_block_root.unwrap_or_default(),
-            ),
-        };
-
-        let msg = envelope.payload_hash.signature_message(10);
-        let signer = envelope.signature.recover_address_from_prehash(&msg).unwrap();
-        let (_, unsafe_signer) = tokio::sync::watch::channel(signer);
-        let mut handler = BlockHandler::new(
-            RollupConfig { l2_chain_id: Chain::optimism_mainnet(), ..Default::default() },
-            unsafe_signer,
-        );
-
-        assert!(matches!(handler.block_valid(&envelope), Err(BlockInvalidError::BlobGasUsed)));
+        let envelope = v3_envelope(&block);
+        assert!(matches!(handler().block_valid(&envelope), Err(BlockInvalidError::BlobGasUsed)));
 
         block.header.blob_gas_used = Some(0);
         block.header.excess_blob_gas = Some(1);
-
-        let v3 = ExecutionPayloadV3::from_block_slow(&block);
-
-        let payload = OpExecutionPayload::V3(v3);
-        let envelope = OpNetworkPayloadEnvelope {
-            payload,
-            signature: Signature::test_signature(),
-            payload_hash: PayloadHash(B256::ZERO),
-            parent_beacon_block_root: Some(
-                block.header.parent_beacon_block_root.unwrap_or_default(),
-            ),
-        };
-
-        assert!(matches!(handler.block_valid(&envelope), Err(BlockInvalidError::ExcessBlobGas)));
+        let envelope = v3_envelope(&block);
+        assert!(matches!(handler().block_valid(&envelope), Err(BlockInvalidError::ExcessBlobGas)));
     }
 
     #[test]
     fn test_v4_block() {
-        let block = v4_valid_block();
-
-        let v3 = ExecutionPayloadV3::from_block_slow(&block);
-        let v4 = OpExecutionPayloadV4::from_v3_with_withdrawals_root(
-            v3,
-            block.withdrawals_root.unwrap(),
-        );
-
-        let payload = OpExecutionPayload::V4(v4);
-        let envelope = OpNetworkPayloadEnvelope {
-            payload,
-            signature: Signature::test_signature(),
-            payload_hash: PayloadHash(B256::ZERO),
-            parent_beacon_block_root: Some(
-                block.header.parent_beacon_block_root.unwrap_or_default(),
-            ),
-        };
-
-        let msg = envelope.payload_hash.signature_message(10);
-        let signer = envelope.signature.recover_address_from_prehash(&msg).unwrap();
-        let (_, unsafe_signer) = tokio::sync::watch::channel(signer);
-        let mut handler = BlockHandler::new(
-            RollupConfig { l2_chain_id: Chain::optimism_mainnet(), ..Default::default() },
-            unsafe_signer,
-        );
-
-        assert!(handler.block_valid(&envelope).is_ok());
+        let envelope = v4_envelope(&v4_valid_block());
+        assert!(handler().block_valid(&envelope).is_ok());
     }
 
     #[test]
     #[cfg(feature = "metrics")]
     fn test_metrics_instrumentation() {
-        // This test verifies that metrics code compiles and doesn't panic
-        // The actual metric values would require a metrics registry setup in a real test
-        // environment
-
         use crate::Metrics;
-
-        // Initialize metrics (this should not panic)
         Metrics::init();
 
-        let block = v1_valid_block();
-        let v1 = ExecutionPayloadV1::from_block_slow(&block);
-        let payload = OpExecutionPayload::V1(v1);
-        let envelope = OpNetworkPayloadEnvelope {
-            payload,
-            signature: Signature::test_signature(),
-            payload_hash: PayloadHash(B256::ZERO),
-            parent_beacon_block_root: None,
-        };
-
-        let msg = envelope.payload_hash.signature_message(10);
-        let signer = envelope.signature.recover_address_from_prehash(&msg).unwrap();
-        let (_, unsafe_signer) = tokio::sync::watch::channel(signer);
-        let mut handler = BlockHandler::new(
-            RollupConfig { l2_chain_id: Chain::optimism_mainnet(), ..Default::default() },
-            unsafe_signer,
-        );
-
-        // Test successful validation metrics
+        let envelope = v1_envelope(&v1_valid_block());
+        let mut handler = handler();
         assert!(handler.block_valid(&envelope).is_ok());
 
-        // Test failed validation metrics
         let mut invalid_block = v1_valid_block();
-        invalid_block.header.timestamp = 0; // Invalid timestamp
-
-        let v1_invalid = ExecutionPayloadV1::from_block_slow(&invalid_block);
-        let payload_invalid = OpExecutionPayload::V1(v1_invalid);
-        let envelope_invalid = OpNetworkPayloadEnvelope {
-            payload: payload_invalid,
-            signature: Signature::test_signature(),
-            payload_hash: PayloadHash(B256::ZERO),
-            parent_beacon_block_root: None,
-        };
-
-        // This should increment failure metrics
-        assert!(handler.block_valid(&envelope_invalid).is_err());
+        invalid_block.header.timestamp = 0;
+        assert!(handler.block_valid(&v1_envelope(&invalid_block)).is_err());
     }
 
     #[test]
     fn test_metrics_feature_gating() {
-        // Verify the code compiles and runs without panics even when metrics feature is disabled
-        let block = v1_valid_block();
-        let v1 = ExecutionPayloadV1::from_block_slow(&block);
-        let payload = OpExecutionPayload::V1(v1);
-        let envelope = OpNetworkPayloadEnvelope {
-            payload,
-            signature: Signature::test_signature(),
-            payload_hash: PayloadHash(B256::ZERO),
-            parent_beacon_block_root: None,
-        };
-
-        let msg = envelope.payload_hash.signature_message(10);
-        let signer = envelope.signature.recover_address_from_prehash(&msg).unwrap();
-        let (_, unsafe_signer) = tokio::sync::watch::channel(signer);
-        let mut handler = BlockHandler::new(
-            RollupConfig { l2_chain_id: Chain::optimism_mainnet(), ..Default::default() },
-            unsafe_signer,
-        );
-
-        // Should work regardless of metrics feature
-        assert!(handler.block_valid(&envelope).is_ok());
+        let envelope = v1_envelope(&v1_valid_block());
+        assert!(handler().block_valid(&envelope).is_ok());
     }
 }

--- a/rust/kona/crates/node/gossip/src/block_validity.rs
+++ b/rust/kona/crates/node/gossip/src/block_validity.rs
@@ -3,14 +3,14 @@ use std::time::Instant;
 use std::time::SystemTime;
 
 use alloy_consensus::Block;
-use alloy_eips::eip7685::EMPTY_REQUESTS_HASH;
 use alloy_primitives::{Address, B256};
 use alloy_rpc_types_engine::{ExecutionPayloadV3, PayloadError};
 use kona_genesis::RollupConfig;
 use libp2p::gossipsub::MessageAcceptance;
 use op_alloy_consensus::OpTxEnvelope;
 use op_alloy_rpc_types_engine::{
-    OpExecutionPayload, OpExecutionPayloadV4, OpNetworkPayloadEnvelope, OpPayloadError,
+    OpExecutionPayload, OpExecutionPayloadEnvelope, OpExecutionPayloadV4, OpNetworkPayloadEnvelope,
+    OpPayloadError,
 };
 
 use super::BlockHandler;
@@ -53,8 +53,8 @@ pub enum BlockInvalidError {
     /// Invalid block.
     #[error(transparent)]
     InvalidBlock(#[from] OpPayloadError),
-    /// The block has an invalid parent beacon block root.
-    #[error("Payload is on v3+ topic, but has empty parent beacon root")]
+    /// The block has a parent beacon block root incompatible with its payload version.
+    #[error("Payload has an invalid parent beacon block root")]
     ParentBeaconRoot,
     /// The block has an invalid blob gas used.
     #[error("Payload is on v3+ topic, but has non-zero blob gas used")]
@@ -209,12 +209,15 @@ impl BlockHandler {
 
         // CHECK: Ensure the block hash is valid.
         let expected = envelope.payload.block_hash();
-        let mut block: Block<OpTxEnvelope> = envelope.payload.clone().try_into_block()?;
-        block.header.parent_beacon_block_root = envelope.parent_beacon_block_root;
-        // If isthmus is active, set the requests hash to the empty hash.
-        if self.rollup_config.is_isthmus_active(envelope.payload.timestamp()) {
-            block.header.requests_hash = Some(EMPTY_REQUESTS_HASH);
-        }
+        let execution_data =
+            OpExecutionPayloadEnvelope::try_from(envelope.clone()).map_err(|err| match err {
+                OpPayloadError::MissingParentBeaconBlockRoot |
+                OpPayloadError::UnexpectedParentBeaconBlockRoot => {
+                    BlockInvalidError::ParentBeaconRoot
+                }
+                err => BlockInvalidError::InvalidBlock(err),
+            })?;
+        let block: Block<OpTxEnvelope> = execution_data.try_into_block()?;
         let received = block.header.hash_slow();
         if received != expected {
             return Err(BlockInvalidError::BlockHash { expected, received });
@@ -281,12 +284,11 @@ impl BlockHandler {
         // 3. The block should not have any blob gas used
         // 4. The block should not have any excess blob gas
         // 5. The block should not have any withdrawals root
-        // 6. The block should not have any parent beacon block root (validated because ignored by
-        //    the decoder, this causes a hash mismatch. See tests)
+        // 6. The block should not have any parent beacon block root (checked below)
 
         // Same as v1, except:
         // 1. The block should have an empty withdrawals list. This is checked during the call to
-        //    [`OpExecutionPayload::try_into_block`].
+        //    [`op_alloy_rpc_types_engine::OpExecutionPayloadEnvelope::try_into_block`].
 
         // Same as v2, except:
         // 1. The block should have a zero blob gas used
@@ -324,7 +326,12 @@ impl BlockHandler {
         }
 
         match &envelope.payload {
-            OpExecutionPayload::V1(_) | OpExecutionPayload::V2(_) => Ok(()),
+            OpExecutionPayload::V1(_) | OpExecutionPayload::V2(_) => {
+                if envelope.parent_beacon_block_root.is_some() {
+                    return Err(BlockInvalidError::ParentBeaconRoot);
+                }
+                Ok(())
+            }
             OpExecutionPayload::V3(payload) => {
                 validate_v3(&self.rollup_config, payload, envelope.parent_beacon_block_root)
             }
@@ -341,7 +348,7 @@ pub(crate) mod tests {
     use super::*;
     use alloy_chains::Chain;
     use alloy_consensus::{Block, EMPTY_OMMER_ROOT_HASH};
-    use alloy_eips::{eip2718::Encodable2718, eip4895::Withdrawal};
+    use alloy_eips::{eip2718::Encodable2718, eip4895::Withdrawal, eip7685::EMPTY_REQUESTS_HASH};
     use alloy_primitives::{Address, B256, Bytes, Signature};
     use alloy_rlp::BufMut;
     use alloy_rpc_types_engine::{ExecutionPayloadV1, ExecutionPayloadV2, ExecutionPayloadV3};
@@ -438,7 +445,9 @@ pub(crate) mod tests {
 
     /// Make the block v4 compatible
     pub(crate) fn v4_valid_block() -> Block<OpTxEnvelope> {
-        v3_valid_block()
+        let mut block = v3_valid_block();
+        block.header.requests_hash = Some(EMPTY_REQUESTS_HASH);
+        block
     }
 
     /// Generates a random valid block and ensure it is v1 compatible
@@ -687,9 +696,7 @@ pub(crate) mod tests {
         assert!(matches!(handler.block_valid(&envelope), Err(BlockInvalidError::Signer { .. })));
     }
 
-    /// If we specify a non empty parent beacon block root for blocks with v1/v2 payloads we
-    /// get a hash mismatch error because the decoder enforces that these versions of the execution
-    /// payload don't contain the parent beacon block root.
+    /// V1/V2 payloads reject a parent beacon block root because those versions do not include it.
     #[test]
     fn test_v1_v2_block_invalid_parent_beacon_block_root() {
         let block = v1_valid_block();
@@ -712,7 +719,7 @@ pub(crate) mod tests {
             unsafe_signer,
         );
 
-        assert!(matches!(handler.block_valid(&envelope), Err(BlockInvalidError::BlockHash { .. })));
+        assert!(matches!(handler.block_valid(&envelope), Err(BlockInvalidError::ParentBeaconRoot)));
 
         let block = v2_valid_block();
 
@@ -734,7 +741,7 @@ pub(crate) mod tests {
             unsafe_signer,
         );
 
-        assert!(matches!(handler.block_valid(&envelope), Err(BlockInvalidError::BlockHash { .. })));
+        assert!(matches!(handler.block_valid(&envelope), Err(BlockInvalidError::ParentBeaconRoot)));
     }
 
     #[test]

--- a/rust/kona/crates/node/gossip/src/driver.rs
+++ b/rust/kona/crates/node/gossip/src/driver.rs
@@ -1,6 +1,6 @@
 //! Consensus-layer gossipsub driver for Optimism.
 
-use alloy_primitives::{Address, hex};
+use alloy_primitives::{Address, Signature, hex};
 use derive_more::Debug;
 use discv5::Enr;
 use futures::{AsyncReadExt, AsyncWriteExt, stream::StreamExt};
@@ -13,7 +13,7 @@ use libp2p::{
 };
 use libp2p_identity::Keypair;
 use libp2p_stream::IncomingStreams;
-use op_alloy_rpc_types_engine::OpNetworkPayloadEnvelope;
+use op_alloy_rpc_types_engine::OpExecutionPayloadEnvelope;
 use std::{
     collections::HashMap,
     sync::Arc,
@@ -116,17 +116,15 @@ where
     pub fn publish(
         &mut self,
         selector: impl FnOnce(&BlockHandler) -> IdentTopic,
-        payload: Option<OpNetworkPayloadEnvelope>,
-    ) -> Result<Option<MessageId>, PublishError> {
-        let Some(payload) = payload else {
-            return Ok(None);
-        };
+        payload: OpExecutionPayloadEnvelope,
+        signature: Signature,
+    ) -> Result<MessageId, PublishError> {
         let topic = selector(&self.handler);
         let topic_hash = topic.hash();
-        let data = self.handler.encode(topic, payload)?;
+        let data = self.handler.encode(topic, payload, signature)?;
         let id = self.swarm.behaviour_mut().gossipsub.publish(topic_hash, data)?;
         kona_macros::inc!(gauge, crate::Metrics::UNSAFE_BLOCK_PUBLISHED);
-        Ok(Some(id))
+        Ok(id)
     }
 
     /// Handles the sync request/response protocol.
@@ -284,7 +282,7 @@ where
         }
     }
 
-    fn handle_gossip_event(&mut self, event: Event) -> Option<OpNetworkPayloadEnvelope> {
+    fn handle_gossip_event(&mut self, event: Event) -> Option<OpExecutionPayloadEnvelope> {
         match event {
             Event::Gossipsub(e) => return self.handle_gossipsub_event(*e),
             Event::Ping(libp2p::ping::Event { peer, result, .. }) => {
@@ -344,7 +342,7 @@ where
     fn handle_gossipsub_event(
         &mut self,
         event: libp2p::gossipsub::Event,
-    ) -> Option<OpNetworkPayloadEnvelope> {
+    ) -> Option<OpExecutionPayloadEnvelope> {
         match event {
             libp2p::gossipsub::Event::Message {
                 propagation_source: src,
@@ -384,7 +382,7 @@ where
     }
 
     /// Handles the [`SwarmEvent<Event>`].
-    pub fn handle_event(&mut self, event: SwarmEvent<Event>) -> Option<OpNetworkPayloadEnvelope> {
+    pub fn handle_event(&mut self, event: SwarmEvent<Event>) -> Option<OpExecutionPayloadEnvelope> {
         match event {
             SwarmEvent::Behaviour(behavior_event) => {
                 return self.handle_gossip_event(behavior_event);

--- a/rust/kona/crates/node/gossip/src/error.rs
+++ b/rust/kona/crates/node/gossip/src/error.rs
@@ -33,12 +33,13 @@ pub enum PublishError {
 /// occurring when converting OP Stack data structures to network format.
 #[derive(Debug, Error)]
 pub enum HandlerEncodeError {
-    /// Failed to encode the OP Stack payload envelope.
-    ///
-    /// This error indicates issues with serializing the OP Stack network payload
-    /// structure, which contains the consensus data being gossiped.
-    #[error("Failed to encode payload: {0}")]
-    PayloadEncodeError(#[from] op_alloy_rpc_types_engine::PayloadEnvelopeEncodeError),
+    /// The execution payload version does not match the gossip topic.
+    #[error("Payload version does not match gossip topic")]
+    WrongPayloadVersion,
+
+    /// Failed to Snappy-compress the signed payload.
+    #[error("Failed to compress payload: {0}")]
+    SnapEncoding(#[from] snap::Error),
 
     /// Attempted to publish to an unknown or unsubscribed topic.
     ///

--- a/rust/kona/crates/node/gossip/src/handler.rs
+++ b/rust/kona/crates/node/gossip/src/handler.rs
@@ -1,10 +1,14 @@
 //! Block Handler
 
-use crate::{HandlerEncodeError, config::snappy_decompressed_len_within_bound};
-use alloy_primitives::{Address, B256};
+use crate::{
+    HandlerEncodeError,
+    config::snappy_decompressed_len_within_bound,
+    payload::{GossipPayloadVersion, SignedGossipPayload},
+};
+use alloy_primitives::{Address, B256, Signature};
 use kona_genesis::RollupConfig;
 use libp2p::gossipsub::{IdentTopic, Message, MessageAcceptance, TopicHash};
-use op_alloy_rpc_types_engine::OpNetworkPayloadEnvelope;
+use op_alloy_rpc_types_engine::OpExecutionPayloadEnvelope;
 use std::collections::{BTreeMap, HashSet};
 use tokio::sync::watch::Receiver;
 
@@ -16,7 +20,7 @@ use tokio::sync::watch::Receiver;
 pub trait Handler: Send {
     /// Manages validation and further processing of messages
     /// This is a stateful method, because the handler needs to keep track of seen hashes.
-    fn handle(&mut self, msg: Message) -> (MessageAcceptance, Option<OpNetworkPayloadEnvelope>);
+    fn handle(&mut self, msg: Message) -> (MessageAcceptance, Option<OpExecutionPayloadEnvelope>);
 
     /// Specifies which topics the handler is interested in
     fn topics(&self) -> Vec<TopicHash>;
@@ -43,53 +47,60 @@ pub struct BlockHandler {
 }
 
 impl Handler for BlockHandler {
-    /// Checks validity of a [`OpNetworkPayloadEnvelope`] received over P2P gossip.
-    /// If valid, sends the [`OpNetworkPayloadEnvelope`] to the block update channel.
-    fn handle(&mut self, msg: Message) -> (MessageAcceptance, Option<OpNetworkPayloadEnvelope>) {
-        // Reject frames whose snappy header declares a decompressed size over MAX_GOSSIP_SIZE
-        // before decoding. `OpNetworkPayloadEnvelope::decode_v*` otherwise pre-allocates a
-        // buffer of the declared length (up to ~4 GiB) from a tiny frame. Mirrors op-node's
-        // gossip topic validator, which rejects `outLen > maxGossipSize` before decompressing.
+    /// Authenticates and validates a signed execution payload received over P2P gossip.
+    fn handle(&mut self, msg: Message) -> (MessageAcceptance, Option<OpExecutionPayloadEnvelope>) {
+        // Reject frames whose Snappy header declares a decompressed size over MAX_GOSSIP_SIZE
+        // before decoding. The decoder would otherwise pre-allocate the declared length (up to
+        // roughly 4 GiB) from a tiny frame. This mirrors op-node's gossip topic validator.
         if snappy_decompressed_len_within_bound(&msg.data).is_none() {
-            // The snappy header declares a length that is unreadable or over MAX_GOSSIP_SIZE. Count
-            // for alerting and debug-log for investigation, but never warn: unauthenticated remote
-            // input must not be able to spam warnings just by being invalid.
             kona_macros::inc!(counter, crate::Metrics::INVALID_MESSAGE, "reason" => "invalid_snappy_length");
-            debug!(target: "gossip", len = msg.data.len(), "Rejecting snappy frame with invalid declared length before decode");
+            debug!(target: "gossip", len = msg.data.len(), "Rejecting Snappy frame with invalid declared length before decode");
             return (MessageAcceptance::Reject, None);
         }
 
-        let decoded = if msg.topic == self.blocks_v1_topic.hash() {
-            OpNetworkPayloadEnvelope::decode_v1(&msg.data)
-        } else if msg.topic == self.blocks_v2_topic.hash() {
-            OpNetworkPayloadEnvelope::decode_v2(&msg.data)
-        } else if msg.topic == self.blocks_v3_topic.hash() {
-            OpNetworkPayloadEnvelope::decode_v3(&msg.data)
-        } else if msg.topic == self.blocks_v4_topic.hash() {
-            OpNetworkPayloadEnvelope::decode_v4(&msg.data)
-        } else {
-            // Unreachable in practice (the driver only dispatches known block topics), but count
-            // and debug-log it rather than warn if that ever changes.
+        let Some(version) = self.payload_version(&msg.topic) else {
+            // Unreachable in practice because the driver dispatches only known block topics.
             kona_macros::inc!(counter, crate::Metrics::INVALID_MESSAGE, "reason" => "unknown_topic");
             debug!(target: "gossip", topic = ?msg.topic, "Received block with unknown topic");
             return (MessageAcceptance::Reject, None);
         };
 
-        match decoded {
-            Ok(envelope) => match self.block_valid(&envelope) {
-                Ok(()) => (MessageAcceptance::Accept, Some(envelope)),
-                Err(err) => {
-                    // Already metered by BLOCK_VALIDATION_FAILED; debug-log for investigation
-                    // without letting invalid remote blocks spam warnings.
-                    debug!(target: "gossip", ?err, hash = ?envelope.payload_hash, "Received invalid block");
-                    (err.into(), None)
-                }
-            },
+        let signed = match SignedGossipPayload::decode_snappy(&msg.data) {
+            Ok(signed) => signed,
             Err(err) => {
-                // Undecodable payload from unauthenticated input: count and debug-log, don't warn.
                 kona_macros::inc!(counter, crate::Metrics::INVALID_MESSAGE, "reason" => "decode_error");
-                debug!(target: "gossip", ?err, "Failed to decode block");
-                (MessageAcceptance::Reject, None)
+                debug!(target: "gossip", ?err, "Failed to decode signed gossip payload");
+                return (MessageAcceptance::Reject, None);
+            }
+        };
+        let payload_hash = signed.payload_hash();
+        #[cfg(feature = "metrics")]
+        kona_macros::inc!(counter, crate::Metrics::BLOCK_VALIDATION_TOTAL);
+
+        // Authenticate the exact envelope bytes before decoding the SSZ payload and transactions.
+        if let Err(err) = self.validate_signature(&signed) {
+            debug!(target: "gossip", ?err, hash = ?payload_hash, "Received unauthenticated block");
+            return (err.into(), None);
+        }
+
+        let envelope = match signed.into_envelope(version) {
+            Ok(envelope) => envelope,
+            Err(err) => {
+                kona_macros::inc!(counter, crate::Metrics::INVALID_MESSAGE, "reason" => "decode_error");
+                #[cfg(feature = "metrics")]
+                kona_macros::inc!(counter, crate::Metrics::BLOCK_VALIDATION_FAILED, "reason" => "invalid_block");
+                debug!(target: "gossip", ?err, hash = ?payload_hash, "Failed to decode authenticated execution payload");
+                return (MessageAcceptance::Reject, None);
+            }
+        };
+
+        match self.block_valid(&envelope) {
+            Ok(()) => (MessageAcceptance::Accept, Some(envelope)),
+            Err(err) => {
+                // Already metered by BLOCK_VALIDATION_FAILED; debug-log for investigation without
+                // letting invalid remote blocks spam warnings.
+                debug!(target: "gossip", ?err, hash = ?payload_hash, "Received invalid block");
+                (err.into(), None)
             }
         }
     }
@@ -137,21 +148,33 @@ impl BlockHandler {
         }
     }
 
-    /// Encodes a [`OpNetworkPayloadEnvelope`] into a byte array
-    /// based on the specified topic.
+    /// Encodes an execution payload and signature for the specified gossip topic.
     pub fn encode(
         &self,
         topic: IdentTopic,
-        envelope: OpNetworkPayloadEnvelope,
+        envelope: OpExecutionPayloadEnvelope,
+        signature: Signature,
     ) -> Result<Vec<u8>, HandlerEncodeError> {
-        let encoded = match topic.hash() {
-            hash if hash == self.blocks_v1_topic.hash() => envelope.encode_v1()?,
-            hash if hash == self.blocks_v2_topic.hash() => envelope.encode_v2()?,
-            hash if hash == self.blocks_v3_topic.hash() => envelope.encode_v3()?,
-            hash if hash == self.blocks_v4_topic.hash() => envelope.encode_v4()?,
-            hash => return Err(HandlerEncodeError::UnknownTopic(hash)),
-        };
-        Ok(encoded)
+        let topic_hash = topic.hash();
+        let version = self
+            .payload_version(&topic_hash)
+            .ok_or(HandlerEncodeError::UnknownTopic(topic_hash))?;
+        SignedGossipPayload::from_envelope(&envelope, signature, version)?.encode_snappy()
+    }
+
+    /// Returns the payload version selected by a gossip topic.
+    fn payload_version(&self, topic: &TopicHash) -> Option<GossipPayloadVersion> {
+        if topic == &self.blocks_v1_topic.hash() {
+            Some(GossipPayloadVersion::V1)
+        } else if topic == &self.blocks_v2_topic.hash() {
+            Some(GossipPayloadVersion::V2)
+        } else if topic == &self.blocks_v3_topic.hash() {
+            Some(GossipPayloadVersion::V3)
+        } else if topic == &self.blocks_v4_topic.hash() {
+            Some(GossipPayloadVersion::V4)
+        } else {
+            None
+        }
     }
 }
 
@@ -159,343 +182,162 @@ impl BlockHandler {
 mod tests {
     use alloy_chains::Chain;
     use alloy_rpc_types_engine::{ExecutionPayloadV2, ExecutionPayloadV3};
-    use op_alloy_rpc_types_engine::{OpExecutionPayload, OpExecutionPayloadV4, PayloadHash};
+    use op_alloy_rpc_types_engine::{
+        OpExecutionPayloadEnvelope, OpExecutionPayloadV4, PayloadHash,
+    };
 
     use crate::{v2_valid_block, v3_valid_block, v4_valid_block};
 
     use super::*;
-    use alloy_primitives::{B256, Signature};
+    use alloy_primitives::{Address, B256, Signature};
+
+    fn encode_with_test_signature(
+        handler: &BlockHandler,
+        topic: IdentTopic,
+        envelope: OpExecutionPayloadEnvelope,
+    ) -> (Vec<u8>, Address) {
+        let signature = Signature::test_signature();
+        let message = envelope.payload_hash().signature_message(10);
+        let signer = signature.recover_address_from_prehash(&message).unwrap();
+        let encoded = handler.encode(topic, envelope, signature).unwrap();
+        (encoded, signer)
+    }
+
+    fn message(topic: IdentTopic, data: Vec<u8>) -> Message {
+        Message { source: None, sequence_number: None, topic: topic.into(), data }
+    }
+
+    fn v2_envelope() -> OpExecutionPayloadEnvelope {
+        OpExecutionPayloadEnvelope::V2(ExecutionPayloadV2::from_block_slow(&v2_valid_block()))
+    }
+
+    fn v3_envelope() -> OpExecutionPayloadEnvelope {
+        let block = v3_valid_block();
+        OpExecutionPayloadEnvelope::V3 {
+            payload: ExecutionPayloadV3::from_block_slow(&block),
+            parent_beacon_block_root: block.header.parent_beacon_block_root.unwrap(),
+        }
+    }
+
+    fn v4_envelope() -> OpExecutionPayloadEnvelope {
+        let block = v4_valid_block();
+        OpExecutionPayloadEnvelope::V4 {
+            payload: OpExecutionPayloadV4::from_v3_with_withdrawals_root(
+                ExecutionPayloadV3::from_block_slow(&block),
+                block.withdrawals_root.unwrap(),
+            ),
+            parent_beacon_block_root: block.header.parent_beacon_block_root.unwrap(),
+        }
+    }
+
+    fn handler_with_signer(signer: Address) -> BlockHandler {
+        let (_, unsafe_signer) = tokio::sync::watch::channel(signer);
+        BlockHandler::new(
+            RollupConfig { l2_chain_id: Chain::optimism_mainnet(), ..Default::default() },
+            unsafe_signer,
+        )
+    }
 
     #[test]
     fn test_valid_decode() {
-        let block = v2_valid_block();
+        let mut handler = handler_with_signer(Address::ZERO);
+        let topic = handler.blocks_v2_topic.clone();
+        let (encoded, signer) = encode_with_test_signature(&handler, topic.clone(), v2_envelope());
+        handler.signer_recv = tokio::sync::watch::channel(signer).1;
 
-        let v2 = ExecutionPayloadV2::from_block_slow(&block);
-
-        let payload = OpExecutionPayload::V2(v2);
-        let envelope = OpNetworkPayloadEnvelope {
-            payload,
-            signature: Signature::test_signature(),
-            payload_hash: PayloadHash(B256::ZERO),
-            parent_beacon_block_root: None,
-        };
-
-        let msg = envelope.payload_hash.signature_message(10);
-        let signer = envelope.signature.recover_address_from_prehash(&msg).unwrap();
-        let (_, unsafe_signer) = tokio::sync::watch::channel(signer);
-        let mut handler = BlockHandler::new(
-            RollupConfig { l2_chain_id: Chain::optimism_mainnet(), ..Default::default() },
-            unsafe_signer,
-        );
-
-        // TRICK: Since the decode method recomputes the payload hash, we need to change the unsafe
-        // signer in the handler to ensure that the payload won't be rejected for invalid
-        // signature.
-        let encoded = handler.encode(handler.blocks_v2_topic.clone(), envelope).unwrap();
-        let decoded = OpNetworkPayloadEnvelope::decode_v2(&encoded).unwrap();
-
-        let msg = decoded.payload_hash.signature_message(10);
-        let signer = decoded.signature.recover_address_from_prehash(&msg).unwrap();
-        let (_, unsafe_signer) = tokio::sync::watch::channel(signer);
-        handler.signer_recv = unsafe_signer;
-
-        // Let's try to encode a message.
-        let message = Message {
-            source: None,
-            sequence_number: None,
-            topic: handler.blocks_v2_topic.clone().into(),
-            data: encoded,
-        };
-
-        assert!(matches!(handler.handle(message).0, MessageAcceptance::Accept));
+        let (acceptance, payload) = handler.handle(message(topic, encoded));
+        assert!(matches!(acceptance, MessageAcceptance::Accept));
+        assert!(matches!(payload, Some(OpExecutionPayloadEnvelope::V2(_))));
     }
 
-    /// This payload has a wrong hash so the signature won't be valid.
+    /// A signature over a different payload hash must be rejected before envelope decoding.
     #[test]
     fn test_invalid_decode_payload_hash() {
-        let block = v2_valid_block();
+        let signature = Signature::test_signature();
+        let wrong_message = PayloadHash(B256::ZERO).signature_message(10);
+        let wrong_signer = signature.recover_address_from_prehash(&wrong_message).unwrap();
+        let mut handler = handler_with_signer(wrong_signer);
+        let topic = handler.blocks_v2_topic.clone();
+        let encoded = handler.encode(topic.clone(), v2_envelope(), signature).unwrap();
 
-        let v2 = ExecutionPayloadV2::from_block_slow(&block);
-
-        let payload = OpExecutionPayload::V2(v2);
-        let envelope = OpNetworkPayloadEnvelope {
-            payload,
-            signature: Signature::test_signature(),
-            payload_hash: PayloadHash(B256::ZERO),
-            parent_beacon_block_root: None,
-        };
-
-        let msg = envelope.payload_hash.signature_message(10);
-        let signer = envelope.signature.recover_address_from_prehash(&msg).unwrap();
-        let (_, unsafe_signer) = tokio::sync::watch::channel(signer);
-        let mut handler = BlockHandler::new(
-            RollupConfig { l2_chain_id: Chain::optimism_mainnet(), ..Default::default() },
-            unsafe_signer,
-        );
-
-        // Let's try to encode a message.
-        let message = Message {
-            source: None,
-            sequence_number: None,
-            topic: handler.blocks_v2_topic.clone().into(),
-            data: handler.encode(handler.blocks_v2_topic.clone(), envelope).unwrap(),
-        };
-
-        assert!(matches!(handler.handle(message).0, MessageAcceptance::Reject));
+        assert!(matches!(handler.handle(message(topic, encoded)).0, MessageAcceptance::Reject));
     }
 
-    /// The message contains a wrong version so the payload won't be properly decoded.
+    fn assert_version_mismatch(
+        envelope: OpExecutionPayloadEnvelope,
+        encoded_topic: fn(&BlockHandler) -> IdentTopic,
+        received_topic: fn(&BlockHandler) -> IdentTopic,
+    ) {
+        let mut handler = handler_with_signer(Address::ZERO);
+        let (encoded, signer) =
+            encode_with_test_signature(&handler, encoded_topic(&handler), envelope);
+        handler.signer_recv = tokio::sync::watch::channel(signer).1;
+
+        assert!(matches!(
+            handler.handle(message(received_topic(&handler), encoded)).0,
+            MessageAcceptance::Reject
+        ));
+    }
+
     #[test]
     fn test_invalid_decode_version_mismatch() {
-        let block = v2_valid_block();
-
-        let v2 = ExecutionPayloadV2::from_block_slow(&block);
-
-        let payload = OpExecutionPayload::V2(v2);
-        let envelope = OpNetworkPayloadEnvelope {
-            payload,
-            signature: Signature::test_signature(),
-            payload_hash: PayloadHash(B256::ZERO),
-            parent_beacon_block_root: None,
-        };
-
-        let msg = envelope.payload_hash.signature_message(10);
-        let signer = envelope.signature.recover_address_from_prehash(&msg).unwrap();
-        let (_, unsafe_signer) = tokio::sync::watch::channel(signer);
-        let mut handler = BlockHandler::new(
-            RollupConfig { l2_chain_id: Chain::optimism_mainnet(), ..Default::default() },
-            unsafe_signer,
+        assert_version_mismatch(
+            v2_envelope(),
+            |h| h.blocks_v2_topic.clone(),
+            |h| h.blocks_v1_topic.clone(),
         );
-
-        let encoded = handler.encode(handler.blocks_v2_topic.clone(), envelope).unwrap();
-
-        // Let's try to encode a message.
-        let message = Message {
-            source: None,
-            sequence_number: None,
-            // Version mismatch!
-            topic: handler.blocks_v1_topic.clone().into(),
-            data: encoded,
-        };
-
-        assert!(matches!(handler.handle(message).0, MessageAcceptance::Reject));
     }
 
-    /// The message contains a wrong version so the payload won't be properly decoded.
     #[test]
     fn test_invalid_decode_version_mismatch_v3_with_v2() {
-        let block = v3_valid_block();
-
-        let v3 = ExecutionPayloadV3::from_block_slow(&block);
-
-        let payload = OpExecutionPayload::V3(v3);
-        let envelope = OpNetworkPayloadEnvelope {
-            payload,
-            signature: Signature::test_signature(),
-            payload_hash: PayloadHash(B256::ZERO),
-            parent_beacon_block_root: Some(
-                block.header.parent_beacon_block_root.unwrap_or_default(),
-            ),
-        };
-
-        let msg = envelope.payload_hash.signature_message(10);
-        let signer = envelope.signature.recover_address_from_prehash(&msg).unwrap();
-        let (_, unsafe_signer) = tokio::sync::watch::channel(signer);
-        let mut handler = BlockHandler::new(
-            RollupConfig { l2_chain_id: Chain::optimism_mainnet(), ..Default::default() },
-            unsafe_signer,
+        assert_version_mismatch(
+            v3_envelope(),
+            |h| h.blocks_v3_topic.clone(),
+            |h| h.blocks_v2_topic.clone(),
         );
-
-        let encoded = handler.encode(handler.blocks_v3_topic.clone(), envelope).unwrap();
-
-        // Let's try to encode a message.
-        let message = Message {
-            source: None,
-            sequence_number: None,
-            // Version mismatch!
-            topic: handler.blocks_v2_topic.clone().into(),
-            data: encoded,
-        };
-
-        assert!(matches!(handler.handle(message).0, MessageAcceptance::Reject));
     }
 
-    /// The message contains a wrong version so the payload won't be properly decoded.
     #[test]
     fn test_invalid_decode_version_mismatch_v2_with_v3() {
-        let block = v2_valid_block();
-
-        let v2 = ExecutionPayloadV2::from_block_slow(&block);
-
-        let payload = OpExecutionPayload::V2(v2);
-        let envelope = OpNetworkPayloadEnvelope {
-            payload,
-            signature: Signature::test_signature(),
-            payload_hash: PayloadHash(B256::ZERO),
-            parent_beacon_block_root: Some(
-                block.header.parent_beacon_block_root.unwrap_or_default(),
-            ),
-        };
-
-        let msg = envelope.payload_hash.signature_message(10);
-        let signer = envelope.signature.recover_address_from_prehash(&msg).unwrap();
-        let (_, unsafe_signer) = tokio::sync::watch::channel(signer);
-        let mut handler = BlockHandler::new(
-            RollupConfig { l2_chain_id: Chain::optimism_mainnet(), ..Default::default() },
-            unsafe_signer,
+        assert_version_mismatch(
+            v2_envelope(),
+            |h| h.blocks_v2_topic.clone(),
+            |h| h.blocks_v3_topic.clone(),
         );
-
-        let encoded = handler.encode(handler.blocks_v2_topic.clone(), envelope).unwrap();
-
-        // Let's try to encode a message.
-        let message = Message {
-            source: None,
-            sequence_number: None,
-            // Version mismatch!
-            topic: handler.blocks_v3_topic.clone().into(),
-            data: encoded,
-        };
-
-        assert!(matches!(handler.handle(message).0, MessageAcceptance::Reject));
     }
 
-    /// The message contains a wrong version so the payload won't be properly decoded.
     #[test]
     fn test_invalid_decode_version_mismatch_v4_with_v3() {
-        let block = v4_valid_block();
-
-        let v3 = ExecutionPayloadV3::from_block_slow(&block);
-        let v4 = OpExecutionPayloadV4::from_v3_with_withdrawals_root(
-            v3,
-            block.withdrawals_root.unwrap(),
+        assert_version_mismatch(
+            v4_envelope(),
+            |h| h.blocks_v4_topic.clone(),
+            |h| h.blocks_v3_topic.clone(),
         );
+    }
 
-        let payload = OpExecutionPayload::V4(v4);
-        let envelope = OpNetworkPayloadEnvelope {
-            payload,
-            signature: Signature::test_signature(),
-            payload_hash: PayloadHash(B256::ZERO),
-            parent_beacon_block_root: Some(
-                block.header.parent_beacon_block_root.unwrap_or_default(),
-            ),
-        };
+    fn assert_valid_decode(
+        envelope: OpExecutionPayloadEnvelope,
+        topic: fn(&BlockHandler) -> IdentTopic,
+    ) {
+        let mut handler = handler_with_signer(Address::ZERO);
+        let selected_topic = topic(&handler);
+        let (encoded, signer) =
+            encode_with_test_signature(&handler, selected_topic.clone(), envelope);
+        handler.signer_recv = tokio::sync::watch::channel(signer).1;
 
-        let msg = envelope.payload_hash.signature_message(10);
-        let signer = envelope.signature.recover_address_from_prehash(&msg).unwrap();
-        let (_, unsafe_signer) = tokio::sync::watch::channel(signer);
-        let mut handler = BlockHandler::new(
-            RollupConfig { l2_chain_id: Chain::optimism_mainnet(), ..Default::default() },
-            unsafe_signer,
-        );
-
-        let encoded = handler.encode(handler.blocks_v4_topic.clone(), envelope).unwrap();
-
-        // Let's try to encode a message.
-        let message = Message {
-            source: None,
-            sequence_number: None,
-            // Version mismatch!
-            topic: handler.blocks_v3_topic.clone().into(),
-            data: encoded,
-        };
-
-        assert!(matches!(handler.handle(message).0, MessageAcceptance::Reject));
+        let (acceptance, payload) = handler.handle(message(selected_topic, encoded));
+        assert!(matches!(acceptance, MessageAcceptance::Accept));
+        assert!(payload.is_some());
     }
 
     #[test]
     fn test_valid_decode_v4() {
-        let block = v4_valid_block();
-
-        let v3 = ExecutionPayloadV3::from_block_slow(&block);
-        let v4 = OpExecutionPayloadV4::from_v3_with_withdrawals_root(
-            v3,
-            block.withdrawals_root.unwrap(),
-        );
-
-        let payload = OpExecutionPayload::V4(v4);
-        let envelope = OpNetworkPayloadEnvelope {
-            payload,
-            signature: Signature::test_signature(),
-            payload_hash: PayloadHash(B256::ZERO),
-            parent_beacon_block_root: Some(
-                block.header.parent_beacon_block_root.unwrap_or_default(),
-            ),
-        };
-
-        let msg = envelope.payload_hash.signature_message(10);
-        let signer = envelope.signature.recover_address_from_prehash(&msg).unwrap();
-        let (_, unsafe_signer) = tokio::sync::watch::channel(signer);
-        let mut handler = BlockHandler::new(
-            RollupConfig { l2_chain_id: Chain::optimism_mainnet(), ..Default::default() },
-            unsafe_signer,
-        );
-
-        // TRICK: Since the decode method recomputes the payload hash, we need to change the unsafe
-        // signer in the handler to ensure that the payload won't be rejected for invalid
-        // signature.
-        let encoded = handler.encode(handler.blocks_v4_topic.clone(), envelope).unwrap();
-        let decoded = OpNetworkPayloadEnvelope::decode_v4(&encoded).unwrap();
-
-        let msg = decoded.payload_hash.signature_message(10);
-        let signer = decoded.signature.recover_address_from_prehash(&msg).unwrap();
-        let (_, unsafe_signer) = tokio::sync::watch::channel(signer);
-        handler.signer_recv = unsafe_signer;
-
-        // Let's try to encode a message.
-        let message = Message {
-            source: None,
-            sequence_number: None,
-            topic: handler.blocks_v4_topic.clone().into(),
-            data: encoded,
-        };
-
-        assert!(matches!(handler.handle(message).0, MessageAcceptance::Accept));
+        assert_valid_decode(v4_envelope(), |h| h.blocks_v4_topic.clone());
     }
 
     #[test]
     fn test_valid_decode_v3() {
-        let block = v3_valid_block();
-
-        let v3 = ExecutionPayloadV3::from_block_slow(&block);
-
-        let payload = OpExecutionPayload::V3(v3);
-        let envelope = OpNetworkPayloadEnvelope {
-            payload,
-            signature: Signature::test_signature(),
-            payload_hash: PayloadHash(B256::ZERO),
-            parent_beacon_block_root: Some(
-                block.header.parent_beacon_block_root.unwrap_or_default(),
-            ),
-        };
-
-        let msg = envelope.payload_hash.signature_message(10);
-        let signer = envelope.signature.recover_address_from_prehash(&msg).unwrap();
-        let (_, unsafe_signer) = tokio::sync::watch::channel(signer);
-        let mut handler = BlockHandler::new(
-            RollupConfig { l2_chain_id: Chain::optimism_mainnet(), ..Default::default() },
-            unsafe_signer,
-        );
-
-        // TRICK: Since the decode method recomputes the payload hash, we need to change the unsafe
-        // signer in the handler to ensure that the payload won't be rejected for invalid
-        // signature.
-        let encoded = handler.encode(handler.blocks_v3_topic.clone(), envelope).unwrap();
-        let decoded = OpNetworkPayloadEnvelope::decode_v3(&encoded).unwrap();
-
-        let msg = decoded.payload_hash.signature_message(10);
-        let signer = decoded.signature.recover_address_from_prehash(&msg).unwrap();
-        let (_, unsafe_signer) = tokio::sync::watch::channel(signer);
-        handler.signer_recv = unsafe_signer;
-
-        // Let's try to encode a message.
-        let message = Message {
-            source: None,
-            sequence_number: None,
-            topic: handler.blocks_v3_topic.clone().into(),
-            data: encoded,
-        };
-
-        assert!(matches!(handler.handle(message).0, MessageAcceptance::Accept));
+        assert_valid_decode(v3_envelope(), |h| h.blocks_v3_topic.clone());
     }
 
     #[cfg(feature = "metrics")]
@@ -559,22 +401,12 @@ mod tests {
     fn handle_records_invalid_message_metric_for_decode_error() {
         use metrics_util::debugging::DebuggingRecorder;
 
-        // A v2-encoded payload published on the v1 topic fails `decode_v1` before validation.
-        let v2 = ExecutionPayloadV2::from_block_slow(&v2_valid_block());
-        let envelope = OpNetworkPayloadEnvelope {
-            payload: OpExecutionPayload::V2(v2),
-            signature: Signature::test_signature(),
-            payload_hash: PayloadHash(B256::ZERO),
-            parent_beacon_block_root: None,
-        };
+        // An authenticated V2 payload published on the V1 topic fails typed envelope decoding.
         let mut handler = zero_signer_handler();
-        let encoded = handler.encode(handler.blocks_v2_topic.clone(), envelope).unwrap();
-        let message = Message {
-            source: None,
-            sequence_number: None,
-            topic: handler.blocks_v1_topic.clone().into(),
-            data: encoded,
-        };
+        let (encoded, signer) =
+            encode_with_test_signature(&handler, handler.blocks_v2_topic.clone(), v2_envelope());
+        handler.signer_recv = tokio::sync::watch::channel(signer).1;
+        let message = message(handler.blocks_v1_topic.clone(), encoded);
 
         let recorder = DebuggingRecorder::new();
         let snapshotter = recorder.snapshotter();

--- a/rust/kona/crates/node/gossip/src/lib.rs
+++ b/rust/kona/crates/node/gossip/src/lib.rs
@@ -65,6 +65,8 @@ pub use error::{DialError, GossipDriverBuilderError, HandlerEncodeError, Publish
 mod event;
 pub use event::Event;
 
+mod payload;
+
 mod handler;
 pub use handler::{BlockHandler, Handler};
 

--- a/rust/kona/crates/node/gossip/src/metrics/mod.rs
+++ b/rust/kona/crates/node/gossip/src/metrics/mod.rs
@@ -97,7 +97,7 @@ impl Metrics {
         metrics::describe_gauge!(Self::DIAL_PEER, "Number of peers dialed by the libp2p Swarm");
         metrics::describe_gauge!(
             Self::UNSAFE_BLOCK_PUBLISHED,
-            "Number of OpNetworkPayloadEnvelope gossipped out through the libp2p Swarm"
+            "Number of execution payload envelopes gossiped out through the libp2p swarm"
         );
         metrics::describe_gauge!(
             Self::GOSSIP_PEER_COUNT,

--- a/rust/kona/crates/node/gossip/src/mod.rs
+++ b/rust/kona/crates/node/gossip/src/mod.rs
@@ -34,7 +34,6 @@
 //! - Peer protection mechanisms
 //! - Automatic connection pruning
 //!
-//! [`OpNetworkPayloadEnvelope`]: op_alloy_rpc_types_engine::OpNetworkPayloadEnvelope
 
 mod behaviour;
 pub use behaviour::{Behaviour, BehaviourError};

--- a/rust/kona/crates/node/gossip/src/payload.rs
+++ b/rust/kona/crates/node/gossip/src/payload.rs
@@ -1,0 +1,254 @@
+//! Private wire representation of signed OP Stack gossip payloads.
+
+use crate::HandlerEncodeError;
+use alloy_primitives::{B256, Bytes, Signature};
+use alloy_rpc_types_engine::{ExecutionPayloadV1, ExecutionPayloadV2, ExecutionPayloadV3};
+use op_alloy_rpc_types_engine::{OpExecutionPayloadEnvelope, OpExecutionPayloadV4, PayloadHash};
+use ssz::{Decode, Encode};
+
+/// The execution payload version selected by the gossip topic.
+///
+/// The version is transport metadata and is intentionally kept separate from
+/// [`SignedGossipPayload`], which represents only the decompressed bytes carried by the message.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum GossipPayloadVersion {
+    /// Pre-Canyon payload.
+    V1,
+    /// Canyon payload.
+    V2,
+    /// Ecotone payload.
+    V3,
+    /// Isthmus payload.
+    V4,
+}
+
+/// The exact encoded execution payload envelope bytes authenticated by the block signature.
+///
+/// For V1 and V2 these are the SSZ execution payload bytes. For V3 and V4 these are the parent
+/// beacon block root followed by the SSZ execution payload bytes.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct EncodedExecutionPayloadEnvelope(Bytes);
+
+impl EncodedExecutionPayloadEnvelope {
+    /// Encodes an execution payload envelope for the version selected by its gossip topic.
+    fn encode(
+        envelope: &OpExecutionPayloadEnvelope,
+        version: GossipPayloadVersion,
+    ) -> Result<Self, HandlerEncodeError> {
+        let version_matches = matches!(
+            (envelope, version),
+            (OpExecutionPayloadEnvelope::V1(_), GossipPayloadVersion::V1) |
+                (OpExecutionPayloadEnvelope::V2(_), GossipPayloadVersion::V2) |
+                (OpExecutionPayloadEnvelope::V3 { .. }, GossipPayloadVersion::V3) |
+                (OpExecutionPayloadEnvelope::V4 { .. }, GossipPayloadVersion::V4)
+        );
+        if !version_matches {
+            return Err(HandlerEncodeError::WrongPayloadVersion);
+        }
+
+        Ok(Self(envelope.as_ssz_bytes().into()))
+    }
+
+    /// Decodes these bytes according to the version selected by the gossip topic.
+    pub(crate) fn decode(
+        self,
+        version: GossipPayloadVersion,
+    ) -> Result<OpExecutionPayloadEnvelope, GossipPayloadDecodeError> {
+        let bytes = self.0.as_ref();
+        match version {
+            GossipPayloadVersion::V1 => {
+                Ok(OpExecutionPayloadEnvelope::V1(ExecutionPayloadV1::from_ssz_bytes(bytes)?))
+            }
+            GossipPayloadVersion::V2 => {
+                Ok(OpExecutionPayloadEnvelope::V2(ExecutionPayloadV2::from_ssz_bytes(bytes)?))
+            }
+            GossipPayloadVersion::V3 => {
+                let (parent_beacon_block_root, payload) = decode_parent_beacon_block_root(bytes)?;
+                Ok(OpExecutionPayloadEnvelope::V3 {
+                    payload: ExecutionPayloadV3::from_ssz_bytes(payload)?,
+                    parent_beacon_block_root,
+                })
+            }
+            GossipPayloadVersion::V4 => {
+                let (parent_beacon_block_root, payload) = decode_parent_beacon_block_root(bytes)?;
+                Ok(OpExecutionPayloadEnvelope::V4 {
+                    payload: OpExecutionPayloadV4::from_ssz_bytes(payload)?,
+                    parent_beacon_block_root,
+                })
+            }
+        }
+    }
+
+    /// Returns the hash authenticated by the unsafe block signer.
+    pub(crate) fn payload_hash(&self) -> PayloadHash {
+        PayloadHash::from(self.0.as_ref())
+    }
+}
+
+/// The decompressed bytes carried by an OP Stack block gossip message.
+///
+/// The gossip topic determines how to interpret [`Self::envelope`] and is deliberately not part of
+/// this type because it is not included in the signed payload bytes.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct SignedGossipPayload {
+    signature: Signature,
+    envelope: EncodedExecutionPayloadEnvelope,
+}
+
+impl SignedGossipPayload {
+    /// Decodes the Snappy framing and separates the signature from the exact signed envelope bytes.
+    pub(crate) fn decode_snappy(data: &[u8]) -> Result<Self, GossipPayloadDecodeError> {
+        let decompressed: Bytes = snap::raw::Decoder::new().decompress_vec(data)?.into();
+        if decompressed.len() < 66 {
+            return Err(GossipPayloadDecodeError::InvalidLength);
+        }
+
+        let signature = Signature::try_from(&decompressed[..65])?;
+        Ok(Self { signature, envelope: EncodedExecutionPayloadEnvelope(decompressed.slice(65..)) })
+    }
+
+    /// Constructs a signed payload from a typed envelope for outbound gossip.
+    pub(crate) fn from_envelope(
+        envelope: &OpExecutionPayloadEnvelope,
+        signature: Signature,
+        version: GossipPayloadVersion,
+    ) -> Result<Self, HandlerEncodeError> {
+        Ok(Self {
+            signature,
+            envelope: EncodedExecutionPayloadEnvelope::encode(envelope, version)?,
+        })
+    }
+
+    /// Encodes this signed payload using the Snappy wire framing.
+    pub(crate) fn encode_snappy(&self) -> Result<Vec<u8>, HandlerEncodeError> {
+        let mut data = Vec::with_capacity(65 + self.envelope.0.len());
+        let mut signature = self.signature.as_bytes();
+        signature[64] = self.signature.v() as u8;
+        data.extend_from_slice(&signature);
+        data.extend_from_slice(self.envelope.0.as_ref());
+        Ok(snap::raw::Encoder::new().compress_vec(&data)?)
+    }
+
+    /// Returns the parsed block signature.
+    pub(crate) const fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    /// Returns the hash authenticated by the block signature.
+    pub(crate) fn payload_hash(&self) -> PayloadHash {
+        self.envelope.payload_hash()
+    }
+
+    /// Decodes the signed envelope bytes according to the gossip topic version.
+    pub(crate) fn into_envelope(
+        self,
+        version: GossipPayloadVersion,
+    ) -> Result<OpExecutionPayloadEnvelope, GossipPayloadDecodeError> {
+        self.envelope.decode(version)
+    }
+}
+
+fn decode_parent_beacon_block_root(
+    bytes: &[u8],
+) -> Result<(B256, &[u8]), GossipPayloadDecodeError> {
+    if bytes.len() < B256::len_bytes() {
+        return Err(GossipPayloadDecodeError::InvalidLength);
+    }
+
+    let (root, payload) = bytes.split_at(B256::len_bytes());
+    Ok((B256::from_slice(root), payload))
+}
+
+/// An error encountered while decoding a signed gossip payload.
+#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
+pub(crate) enum GossipPayloadDecodeError {
+    /// The Snappy framing is invalid.
+    #[error("Broken Snappy encoding")]
+    BrokenSnappyEncoding,
+    /// The signature bytes are invalid.
+    #[error("Invalid signature")]
+    InvalidSignature,
+    /// The execution payload SSZ is invalid.
+    #[error("Broken SSZ encoding")]
+    BrokenSszEncoding,
+    /// The signed payload is too short.
+    #[error("Invalid payload length")]
+    InvalidLength,
+}
+
+impl From<snap::Error> for GossipPayloadDecodeError {
+    fn from(_: snap::Error) -> Self {
+        Self::BrokenSnappyEncoding
+    }
+}
+
+impl From<alloy_primitives::SignatureError> for GossipPayloadDecodeError {
+    fn from(_: alloy_primitives::SignatureError) -> Self {
+        Self::InvalidSignature
+    }
+}
+
+impl From<ssz::DecodeError> for GossipPayloadDecodeError {
+    fn from(_: ssz::DecodeError) -> Self {
+        Self::BrokenSszEncoding
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::hex;
+
+    fn assert_roundtrip(data: &[u8], version: GossipPayloadVersion, timestamp: u64) {
+        let signed = SignedGossipPayload::decode_snappy(data).unwrap();
+        let payload_hash = signed.payload_hash();
+        let signature = *signed.signature();
+        let envelope = signed.into_envelope(version).unwrap();
+
+        assert_eq!(envelope.timestamp(), timestamp);
+        assert_eq!(envelope.payload_hash(), payload_hash);
+
+        let encoded = SignedGossipPayload::from_envelope(&envelope, signature, version)
+            .unwrap()
+            .encode_snappy()
+            .unwrap();
+        assert_eq!(encoded, data);
+    }
+
+    #[test]
+    fn roundtrip_v1_golden() {
+        let data = hex::decode("0xbd04f043128457c6ccf35128497167442bcc0f8cce78cda8b366e6a12e526d938d1e4c1046acffffbfc542a7e212bb7d80d3a4b2f84f7b196d935398a24eb84c519789b401000000fe0300fe0300fe0300fe0300fe0300fe0300a203000c4a8fd56621ad04fc0101067601008ce60be0005b220117c32c0f3b394b346c2aa42cfa8157cd41f891aa0bec485a62fc010000").unwrap();
+        assert_roundtrip(&data, GossipPayloadVersion::V1, 1_725_271_882);
+    }
+
+    #[test]
+    fn roundtrip_v2_golden() {
+        let data = hex::decode("0xc104f0433805080eb36c0b130a7cc1dc74c3f721af4e249aa6f61bb89d1557143e971bb738a3f3b98df7c457e74048e9d2d7e5cd82bb45e3760467e2270e9db86d1271a700000000fe0300fe0300fe0300fe0300fe0300fe0300a203000c6b89d46525ad000205067201009cda69cb5b9b73fc4eb2458b37d37f04ff507fe6c9cd2ab704a05ea9dae3cd61760002000000020000").unwrap();
+        assert_roundtrip(&data, GossipPayloadVersion::V2, 1_708_427_627);
+    }
+
+    #[test]
+    fn roundtrip_v3_golden() {
+        let data = hex::decode("0xf104f0434442b9eb38b259f5b23826e6b623e829d2fb878dac70187a1aecf42a3f9bedfd29793d1fcb5822324be0d3e12340a95855553a65d64b83e5579dffb31470df5d010000006a03000412346a1d00fe0100fe0100fe0100fe0100fe0100fe01004201000cc588d465219504100201067601007cfece77b89685f60e3663b6e0faf2de0734674eb91339700c4858c773a8ff921e014401043e0100").unwrap();
+        assert_roundtrip(&data, GossipPayloadVersion::V3, 1_708_427_461);
+    }
+
+    #[test]
+    fn roundtrip_v4_golden() {
+        let data = hex::decode("0x9105f043cee25401b6853202950d1d8a082f31a80c4fef5782c049a731f5d104b1b9b9aa7618605b420438ae98b44c8aaaebd482854473c2ae57c079286bb634bece5210000000006a03000412346a1d00fe0100fe0100fe0100fe0100fe0100fe01004201000c5766d26721950430020106f6010001440104b60100049876").unwrap();
+        assert_roundtrip(&data, GossipPayloadVersion::V4, 1_741_842_007);
+    }
+
+    #[test]
+    fn rejects_topic_version_mismatch_when_encoding() {
+        let data = hex::decode("0xbd04f043128457c6ccf35128497167442bcc0f8cce78cda8b366e6a12e526d938d1e4c1046acffffbfc542a7e212bb7d80d3a4b2f84f7b196d935398a24eb84c519789b401000000fe0300fe0300fe0300fe0300fe0300fe0300a203000c4a8fd56621ad04fc0101067601008ce60be0005b220117c32c0f3b394b346c2aa42cfa8157cd41f891aa0bec485a62fc010000").unwrap();
+        let signed = SignedGossipPayload::decode_snappy(&data).unwrap();
+        let signature = *signed.signature();
+        let envelope = signed.into_envelope(GossipPayloadVersion::V1).unwrap();
+
+        assert!(matches!(
+            SignedGossipPayload::from_envelope(&envelope, signature, GossipPayloadVersion::V2),
+            Err(HandlerEncodeError::WrongPayloadVersion)
+        ));
+    }
+}

--- a/rust/kona/crates/node/rpc/Cargo.toml
+++ b/rust/kona/crates/node/rpc/Cargo.toml
@@ -23,7 +23,6 @@ kona-macros.workspace = true
 kona-genesis = {workspace = true, features = ["serde", "std"]}
 
 # OP Alloy
-op-alloy-consensus.workspace = true
 op-alloy-rpc-types-engine = {workspace = true, features = ["serde", "std"]}
 op-alloy-rpc-types.workspace = true
 

--- a/rust/kona/crates/node/rpc/src/admin.rs
+++ b/rust/kona/crates/node/rpc/src/admin.rs
@@ -2,13 +2,14 @@
 
 use crate::{AdminApiServer, SequencerAdminAPIClient};
 use alloy_primitives::B256;
+use alloy_rpc_types_engine::PayloadError;
 use async_trait::async_trait;
 use core::fmt::Debug;
 use jsonrpsee::{
     core::RpcResult,
     types::{ErrorCode, ErrorObject},
 };
-use op_alloy_rpc_types_engine::OpExecutionPayloadEnvelope;
+use op_alloy_rpc_types_engine::{OpExecutionPayloadEnvelope, OpPayloadError};
 
 /// The query types to the network actor for the admin api.
 #[derive(Debug)]
@@ -64,6 +65,24 @@ where
         payload: OpExecutionPayloadEnvelope,
     ) -> RpcResult<()> {
         kona_macros::inc!(gauge, kona_gossip::Metrics::RPC_CALLS, "method" => "admin_postUnsafePayload");
+
+        payload.check_block_hash().map_err(|err| {
+            tracing::warn!(
+                target: "rpc",
+                %err,
+                "admin_postUnsafePayload: rejecting payload"
+            );
+            let message = match &err {
+                OpPayloadError::Eth(PayloadError::BlockHash { execution, consensus }) => {
+                    format!(
+                        "payload has bad block hash: {consensus}, actual block hash is: {execution}"
+                    )
+                }
+                _ => format!("invalid payload: {err}"),
+            };
+            ErrorObject::owned(ErrorCode::InvalidParams.code(), message, None::<()>)
+        })?;
+
         self.network_sender
             .send(NetworkAdminQuery::PostUnsafePayload { payload })
             .await

--- a/rust/kona/crates/node/service/src/actors/network/actor.rs
+++ b/rust/kona/crates/node/service/src/actors/network/actor.rs
@@ -134,7 +134,7 @@ impl<NetworkEngineClient_: NetworkEngineClient + 'static> NodeActor
                 Ok(())
             }
             Some(block) = self.publish_rx.recv(), if !self.publish_rx.is_closed() => {
-                let timestamp = block.execution_payload.timestamp();
+                let timestamp = block.timestamp();
                 let selector = |handler: &kona_gossip::BlockHandler| {
                     handler.topic(timestamp)
                 };
@@ -149,10 +149,11 @@ impl<NetworkEngineClient_: NetworkEngineClient + 'static> NodeActor
 
                 let payload_hash = block.payload_hash();
                 let signature = signer.sign_block(payload_hash, chain_id, sender_address).await?;
+                let (payload, parent_beacon_block_root) = block.into_parts();
 
                 let payload = OpNetworkPayloadEnvelope {
-                    payload: block.execution_payload,
-                    parent_beacon_block_root: block.parent_beacon_block_root,
+                    payload,
+                    parent_beacon_block_root,
                     signature,
                     payload_hash,
                 };
@@ -169,10 +170,17 @@ impl<NetworkEngineClient_: NetworkEngineClient + 'static> NodeActor
                     return Err(NetworkActorError::ChannelClosed);
                 };
 
-                if let Some(payload) = self.handler.gossip.handle_event(event)
-                    && self.unsafe_block_tx.send(payload.into()).is_err()
-                {
-                    warn!(target: "node::p2p", "Failed to send unsafe block to network handler");
+                if let Some(payload) = self.handler.gossip.handle_event(event) {
+                    match OpExecutionPayloadEnvelope::try_from(payload) {
+                        Ok(payload) => {
+                            if self.unsafe_block_tx.send(payload).is_err() {
+                                warn!(target: "node::p2p", "Failed to send unsafe block to network handler");
+                            }
+                        }
+                        Err(err) => {
+                            warn!(target: "node::p2p", %err, "Validated gossip payload has invalid structure");
+                        }
+                    }
                 }
                 Ok(())
             }
@@ -211,7 +219,6 @@ mod tests {
     use alloy_signer::SignerSync;
     use alloy_signer_local::PrivateKeySigner;
     use arbitrary::Arbitrary;
-    use op_alloy_rpc_types_engine::OpExecutionPayload;
     use rand::Rng;
 
     #[test]
@@ -223,21 +230,15 @@ mod tests {
         let expected_address = pubkey.address();
         const CHAIN_ID: u64 = 1337;
 
-        let block = OpExecutionPayloadEnvelope {
-            execution_payload: OpExecutionPayload::V1(
-                ExecutionPayloadV1::arbitrary(&mut arbitrary::Unstructured::new(&bytes)).unwrap(),
-            ),
-            parent_beacon_block_root: None,
-        };
+        let block = OpExecutionPayloadEnvelope::V1(
+            ExecutionPayloadV1::arbitrary(&mut arbitrary::Unstructured::new(&bytes)).unwrap(),
+        );
 
         let payload_hash = block.payload_hash();
         let signature = pubkey.sign_hash_sync(&payload_hash.signature_message(CHAIN_ID)).unwrap();
-        let payload = OpNetworkPayloadEnvelope {
-            payload: block.execution_payload,
-            parent_beacon_block_root: block.parent_beacon_block_root,
-            signature,
-            payload_hash,
-        };
+        let (payload, parent_beacon_block_root) = block.into_parts();
+        let payload =
+            OpNetworkPayloadEnvelope { payload, parent_beacon_block_root, signature, payload_hash };
         let encoded_payload = payload.encode_v1().unwrap();
 
         let decoded_payload = OpNetworkPayloadEnvelope::decode_v1(&encoded_payload).unwrap();
@@ -257,21 +258,17 @@ mod tests {
         let expected_address = pubkey.address();
         const CHAIN_ID: u64 = 1337;
 
-        let block = OpExecutionPayloadEnvelope {
-            execution_payload: OpExecutionPayload::V3(
-                ExecutionPayloadV3::arbitrary(&mut arbitrary::Unstructured::new(&bytes)).unwrap(),
-            ),
-            parent_beacon_block_root: Some(B256::random()),
+        let block = OpExecutionPayloadEnvelope::V3 {
+            payload: ExecutionPayloadV3::arbitrary(&mut arbitrary::Unstructured::new(&bytes))
+                .unwrap(),
+            parent_beacon_block_root: B256::random(),
         };
 
         let payload_hash = block.payload_hash();
         let signature = pubkey.sign_hash_sync(&payload_hash.signature_message(CHAIN_ID)).unwrap();
-        let payload = OpNetworkPayloadEnvelope {
-            payload: block.execution_payload,
-            parent_beacon_block_root: block.parent_beacon_block_root,
-            signature,
-            payload_hash,
-        };
+        let (payload, parent_beacon_block_root) = block.into_parts();
+        let payload =
+            OpNetworkPayloadEnvelope { payload, parent_beacon_block_root, signature, payload_hash };
         let encoded_payload = payload.encode_v3().unwrap();
 
         let decoded_payload = OpNetworkPayloadEnvelope::decode_v3(&encoded_payload).unwrap();

--- a/rust/kona/crates/node/service/src/actors/network/actor.rs
+++ b/rust/kona/crates/node/service/src/actors/network/actor.rs
@@ -4,7 +4,7 @@ use kona_gossip::P2pRpcRequest;
 use kona_rpc::NetworkAdminQuery;
 use kona_sources::BlockSignerError;
 use libp2p::TransportError;
-use op_alloy_rpc_types_engine::{OpExecutionPayloadEnvelope, OpNetworkPayloadEnvelope};
+use op_alloy_rpc_types_engine::OpExecutionPayloadEnvelope;
 use thiserror::Error;
 use tokio::{
     self, select,
@@ -149,16 +149,8 @@ impl<NetworkEngineClient_: NetworkEngineClient + 'static> NodeActor
 
                 let payload_hash = block.payload_hash();
                 let signature = signer.sign_block(payload_hash, chain_id, sender_address).await?;
-                let (payload, parent_beacon_block_root) = block.into_parts();
 
-                let payload = OpNetworkPayloadEnvelope {
-                    payload,
-                    parent_beacon_block_root,
-                    signature,
-                    payload_hash,
-                };
-
-                match self.handler.gossip.publish(selector, Some(payload)) {
+                match self.handler.gossip.publish(selector, block, signature) {
                     Ok(id) => info!("Published unsafe payload | {:?}", id),
                     Err(e) => warn!("Failed to publish unsafe payload: {:?}", e),
                 }
@@ -170,17 +162,10 @@ impl<NetworkEngineClient_: NetworkEngineClient + 'static> NodeActor
                     return Err(NetworkActorError::ChannelClosed);
                 };
 
-                if let Some(payload) = self.handler.gossip.handle_event(event) {
-                    match OpExecutionPayloadEnvelope::try_from(payload) {
-                        Ok(payload) => {
-                            if self.unsafe_block_tx.send(payload).is_err() {
-                                warn!(target: "node::p2p", "Failed to send unsafe block to network handler");
-                            }
-                        }
-                        Err(err) => {
-                            warn!(target: "node::p2p", %err, "Validated gossip payload has invalid structure");
-                        }
-                    }
+                if let Some(payload) = self.handler.gossip.handle_event(event) &&
+                    self.unsafe_block_tx.send(payload).is_err()
+                {
+                    warn!(target: "node::p2p", "Failed to send unsafe block to network handler");
                 }
                 Ok(())
             }
@@ -222,7 +207,7 @@ mod tests {
     use rand::Rng;
 
     #[test]
-    fn test_payload_signature_roundtrip_v1() {
+    fn test_payload_signature_v1() {
         let mut bytes = [0u8; 4096];
         rand::rng().fill(bytes.as_mut_slice());
 
@@ -235,22 +220,15 @@ mod tests {
         );
 
         let payload_hash = block.payload_hash();
-        let signature = pubkey.sign_hash_sync(&payload_hash.signature_message(CHAIN_ID)).unwrap();
-        let (payload, parent_beacon_block_root) = block.into_parts();
-        let payload =
-            OpNetworkPayloadEnvelope { payload, parent_beacon_block_root, signature, payload_hash };
-        let encoded_payload = payload.encode_v1().unwrap();
-
-        let decoded_payload = OpNetworkPayloadEnvelope::decode_v1(&encoded_payload).unwrap();
-
-        let msg = decoded_payload.payload_hash.signature_message(CHAIN_ID);
-        let msg_signer = decoded_payload.signature.recover_address_from_prehash(&msg).unwrap();
+        let message = payload_hash.signature_message(CHAIN_ID);
+        let signature = pubkey.sign_hash_sync(&message).unwrap();
+        let msg_signer = signature.recover_address_from_prehash(&message).unwrap();
 
         assert_eq!(expected_address, msg_signer);
     }
 
     #[test]
-    fn test_payload_signature_roundtrip_v3() {
+    fn test_payload_signature_v3() {
         let mut bytes = [0u8; 4096];
         rand::rng().fill(bytes.as_mut_slice());
 
@@ -265,16 +243,9 @@ mod tests {
         };
 
         let payload_hash = block.payload_hash();
-        let signature = pubkey.sign_hash_sync(&payload_hash.signature_message(CHAIN_ID)).unwrap();
-        let (payload, parent_beacon_block_root) = block.into_parts();
-        let payload =
-            OpNetworkPayloadEnvelope { payload, parent_beacon_block_root, signature, payload_hash };
-        let encoded_payload = payload.encode_v3().unwrap();
-
-        let decoded_payload = OpNetworkPayloadEnvelope::decode_v3(&encoded_payload).unwrap();
-
-        let msg = decoded_payload.payload_hash.signature_message(CHAIN_ID);
-        let msg_signer = decoded_payload.signature.recover_address_from_prehash(&msg).unwrap();
+        let message = payload_hash.signature_message(CHAIN_ID);
+        let signature = pubkey.sign_hash_sync(&message).unwrap();
+        let msg_signer = signature.recover_address_from_prehash(&message).unwrap();
 
         assert_eq!(expected_address, msg_signer);
     }

--- a/rust/kona/crates/node/service/src/actors/sequencer/actor.rs
+++ b/rust/kona/crates/node/service/src/actors/sequencer/actor.rs
@@ -531,6 +531,7 @@ fn is_seal_task_err_fatal(err: &SealTaskError) -> bool {
         SealTaskError::GetPayloadFailed(_) |
         SealTaskError::HoloceneInvalidFlush |
         SealTaskError::UnsafeHeadChangedSinceBuild => false,
+        SealTaskError::InvalidExecutionPayload(_) |
         SealTaskError::DepositOnlyPayloadFailed |
         SealTaskError::DepositOnlyPayloadReattemptFailed |
         SealTaskError::FromBlock(_) |

--- a/rust/kona/crates/node/service/src/actors/sequencer/actor.rs
+++ b/rust/kona/crates/node/service/src/actors/sequencer/actor.rs
@@ -531,10 +531,8 @@ fn is_seal_task_err_fatal(err: &SealTaskError) -> bool {
         SealTaskError::GetPayloadFailed(_) |
         SealTaskError::HoloceneInvalidFlush |
         SealTaskError::UnsafeHeadChangedSinceBuild => false,
-        SealTaskError::InvalidExecutionPayload(_) |
         SealTaskError::DepositOnlyPayloadFailed |
         SealTaskError::DepositOnlyPayloadReattemptFailed |
-        SealTaskError::FromBlock(_) |
         SealTaskError::MpscSend(_) |
         SealTaskError::ClockWentBackwards => true,
     }

--- a/rust/kona/crates/node/service/tests/actors/generator/block_builder.rs
+++ b/rust/kona/crates/node/service/tests/actors/generator/block_builder.rs
@@ -6,7 +6,7 @@ use alloy_primitives::Bytes;
 use arbitrary::{Arbitrary, Unstructured};
 use libp2p::bytes::BufMut;
 use op_alloy_consensus::OpTxEnvelope;
-use op_alloy_rpc_types_engine::{OpExecutionPayload, OpExecutionPayloadEnvelope};
+use op_alloy_rpc_types_engine::OpExecutionPayloadEnvelope;
 
 use crate::actors::generator::seed::SeedGenerator;
 
@@ -34,14 +34,7 @@ impl SeedGenerator {
             PayloadVersion::V4 => self.v4_valid_block(),
         };
 
-        let (payload, _) = OpExecutionPayload::from_block_slow(&block);
-
-        let parent_beacon_block_root = block.header.parent_beacon_block_root;
-
-        let envelope =
-            OpExecutionPayloadEnvelope { parent_beacon_block_root, execution_payload: payload };
-
-        Ok(envelope)
+        Ok(OpExecutionPayloadEnvelope::from_block_slow(&block)?)
     }
 
     fn valid_block(&mut self) -> Block<OpTxEnvelope> {

--- a/rust/kona/crates/node/service/tests/actors/network/sequencer.rs
+++ b/rust/kona/crates/node/service/tests/actors/network/sequencer.rs
@@ -29,8 +29,7 @@ async fn test_sequencer_network_conn() -> anyhow::Result<()> {
         .await
         .ok_or_else(|| anyhow::anyhow!("No block received"))?;
 
-    assert_eq!(block.parent_beacon_block_root, envelope.parent_beacon_block_root);
-    assert_eq!(block.execution_payload, envelope.execution_payload);
+    assert_eq!(block, envelope);
 
     Ok(())
 }
@@ -74,8 +73,7 @@ async fn test_sequencer_network_propagation() -> anyhow::Result<()> {
         let block =
             network.blocks_rx.recv().await.ok_or_else(|| anyhow::anyhow!("No block received"))?;
 
-        assert_eq!(block.parent_beacon_block_root, envelope.parent_beacon_block_root);
-        assert_eq!(block.execution_payload, envelope.execution_payload);
+        assert_eq!(block, envelope);
     }
 
     Ok(())

--- a/rust/kona/crates/protocol/protocol/src/block.rs
+++ b/rust/kona/crates/protocol/protocol/src/block.rs
@@ -1,20 +1,16 @@
 //! Block Types for Optimism.
 
 use crate::{DecodeError, L1BlockInfoTx};
-use alloc::vec::Vec;
 use alloy_consensus::{Block, Header, Transaction, Typed2718};
 use alloy_eips::{
     BlockNumHash,
     eip2718::{Decodable2718, Eip2718Error},
-    eip7685::EMPTY_REQUESTS_HASH,
 };
 use alloy_primitives::{B256, Bytes, Sealed};
-use alloy_rpc_types_engine::{CancunPayloadFields, PraguePayloadFields};
 use alloy_rpc_types_eth::Block as RpcBlock;
 use derive_more::Display;
 use kona_genesis::ChainGenesis;
-use op_alloy_consensus::{OpBlock, OpTransaction, OpTxEnvelope};
-use op_alloy_rpc_types_engine::{OpExecutionPayload, OpExecutionPayloadSidecar, OpPayloadError};
+use op_alloy_consensus::{OpTransaction, OpTxEnvelope};
 
 /// Block Header Info
 #[derive(Debug, Clone, Display, Copy, Eq, Hash, PartialEq, Default)]
@@ -149,9 +145,6 @@ pub enum FromBlockError {
     /// Failed to decode the [`L1BlockInfoTx`] from the deposit transaction.
     #[error("Failed to decode the L1BlockInfoTx from the deposit transaction: {0}")]
     BlockInfoDecodeError(#[from] DecodeError),
-    /// Failed to convert [`OpExecutionPayload`] to [`OpBlock`].
-    #[error(transparent)]
-    OpPayload(#[from] OpPayloadError),
 }
 
 impl PartialEq<Self> for FromBlockError {
@@ -255,35 +248,6 @@ impl L2BlockInfo {
                 .transpose()?
         };
         Self::from_block_info_and_first_tx(block_info, first_tx.as_ref(), genesis)
-    }
-
-    /// Constructs an [`L2BlockInfo`] From a given [`OpExecutionPayload`] and [`ChainGenesis`].
-    pub fn from_payload_and_genesis(
-        payload: OpExecutionPayload,
-        parent_beacon_block_root: Option<B256>,
-        genesis: &ChainGenesis,
-    ) -> Result<Self, FromBlockError> {
-        let block: OpBlock = match payload {
-            OpExecutionPayload::V4(_) => {
-                let sidecar = OpExecutionPayloadSidecar::v4(
-                    CancunPayloadFields::new(
-                        parent_beacon_block_root.unwrap_or_default(),
-                        Vec::new(),
-                    ),
-                    PraguePayloadFields::new(EMPTY_REQUESTS_HASH),
-                );
-                payload.try_into_block_with_sidecar(&sidecar)?
-            }
-            OpExecutionPayload::V3(_) => {
-                let sidecar = OpExecutionPayloadSidecar::v3(CancunPayloadFields::new(
-                    parent_beacon_block_root.unwrap_or_default(),
-                    Vec::new(),
-                ));
-                payload.try_into_block_with_sidecar(&sidecar)?
-            }
-            _ => payload.try_into_block()?,
-        };
-        Self::from_block_and_genesis(&block, genesis)
     }
 }
 

--- a/rust/op-alloy/crates/rpc-types-engine/Cargo.toml
+++ b/rust/op-alloy/crates/rpc-types-engine/Cargo.toml
@@ -26,7 +26,6 @@ alloy-rlp.workspace = true
 alloy-consensus.workspace = true
 
 # Encoding
-snap = { workspace = true, optional = true }
 ethereum_ssz = { workspace = true, optional = true }
 ethereum_ssz_derive = { workspace = true, optional = true }
 
@@ -50,7 +49,6 @@ alloy-primitives = { workspace = true, features = ["arbitrary", "getrandom"] }
 [features]
 default = ["std", "serde"]
 std = [
-	"dep:snap",
 	"dep:ethereum_ssz",
 	"dep:ethereum_ssz_derive",
 	"alloy-rpc-types-engine/ssz",

--- a/rust/op-alloy/crates/rpc-types-engine/src/envelope.rs
+++ b/rust/op-alloy/crates/rpc-types-engine/src/envelope.rs
@@ -3,39 +3,126 @@
 //! This module uses the `snappy` compression algorithm to decompress the payload.
 //! The license for snappy can be found in the `SNAPPY-LICENSE` at the root of the repository.
 
-use crate::{
-    OpExecutionPayload, OpExecutionPayloadSidecar, OpExecutionPayloadV4, OpFlashblockError,
-    OpFlashblockPayload,
-};
+use crate::{OpExecutionPayload, OpExecutionPayloadSidecar, OpExecutionPayloadV4, OpPayloadError};
 use alloc::vec::Vec;
-use alloy_consensus::{Block, BlockHeader, Sealable, Transaction};
-use alloy_eips::{Encodable2718, eip4895::Withdrawal, eip7685::Requests};
+use alloy_eips::eip7685::Requests;
 use alloy_primitives::{B256, Signature, keccak256};
 use alloy_rpc_types_engine::{
     CancunPayloadFields, ExecutionPayloadInputV2, ExecutionPayloadV1, ExecutionPayloadV2,
     ExecutionPayloadV3, PraguePayloadFields,
 };
 
-/// A thin wrapper around [`OpExecutionPayload`] that includes the parent beacon block root.
+/// A structurally complete OP execution payload envelope.
+///
+/// V3 and V4 envelopes always contain a parent beacon block root, while V1 and V2 envelopes
+/// cannot contain one. Engine API sidecar fields unsupported by OP are validated when converting
+/// from [`OpExecutionData`].
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
-pub struct OpExecutionPayloadEnvelope {
-    /// The parent beacon block root, if any.
-    pub parent_beacon_block_root: Option<B256>,
-    /// The execution payload.
-    pub execution_payload: OpExecutionPayload,
+pub enum OpExecutionPayloadEnvelope {
+    /// A V1 execution payload.
+    V1(ExecutionPayloadV1),
+    /// A V2 execution payload.
+    V2(ExecutionPayloadV2),
+    /// A V3 execution payload and its required parent beacon block root.
+    V3 {
+        /// The execution payload.
+        payload: ExecutionPayloadV3,
+        /// The parent beacon block root.
+        parent_beacon_block_root: B256,
+    },
+    /// A V4 execution payload and its required parent beacon block root.
+    V4 {
+        /// The execution payload.
+        payload: OpExecutionPayloadV4,
+        /// The parent beacon block root.
+        parent_beacon_block_root: B256,
+    },
 }
 
 impl OpExecutionPayloadEnvelope {
-    /// Returns the payload hash over the ssz encoded payload envelope data.
+    /// Constructs an envelope from its wire-level payload and optional parent beacon block root.
+    pub(crate) fn try_from_payload(
+        payload: OpExecutionPayload,
+        parent_beacon_block_root: Option<B256>,
+    ) -> Result<Self, OpPayloadError> {
+        match (payload, parent_beacon_block_root) {
+            (OpExecutionPayload::V1(payload), None) => Ok(Self::V1(payload)),
+            (OpExecutionPayload::V2(payload), None) => Ok(Self::V2(payload)),
+            (OpExecutionPayload::V3(payload), Some(parent_beacon_block_root)) => {
+                Ok(Self::V3 { payload, parent_beacon_block_root })
+            }
+            (OpExecutionPayload::V4(payload), Some(parent_beacon_block_root)) => {
+                Ok(Self::V4 { payload, parent_beacon_block_root })
+            }
+            (OpExecutionPayload::V3(_) | OpExecutionPayload::V4(_), None) => {
+                Err(OpPayloadError::MissingParentBeaconBlockRoot)
+            }
+            (OpExecutionPayload::V1(_) | OpExecutionPayload::V2(_), Some(_)) => {
+                Err(OpPayloadError::UnexpectedParentBeaconBlockRoot)
+            }
+        }
+    }
+
+    /// Consumes the envelope and returns its wire-level payload and parent beacon block root.
+    pub fn into_parts(self) -> (OpExecutionPayload, Option<B256>) {
+        match self {
+            Self::V1(payload) => (OpExecutionPayload::V1(payload), None),
+            Self::V2(payload) => (OpExecutionPayload::V2(payload), None),
+            Self::V3 { payload, parent_beacon_block_root } => {
+                (OpExecutionPayload::V3(payload), Some(parent_beacon_block_root))
+            }
+            Self::V4 { payload, parent_beacon_block_root } => {
+                (OpExecutionPayload::V4(payload), Some(parent_beacon_block_root))
+            }
+        }
+    }
+
+    /// Returns the payload hash over the SSZ-encoded payload envelope data.
     ///
     /// <https://specs.optimism.io/protocol/rollup-node-p2p.html#block-signatures>
     #[cfg(feature = "std")]
     pub fn payload_hash(&self) -> crate::PayloadHash {
         use ssz::Encode;
-        let ssz_bytes = self.as_ssz_bytes();
-        crate::PayloadHash::from(ssz_bytes.as_slice())
+        crate::PayloadHash::from(self.as_ssz_bytes().as_slice())
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for OpExecutionPayloadEnvelope {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+
+        let mut envelope = serializer.serialize_struct("OpExecutionPayloadEnvelope", 2)?;
+        envelope.serialize_field("parentBeaconBlockRoot", &self.parent_beacon_block_root())?;
+        match self {
+            Self::V1(payload) => envelope.serialize_field("executionPayload", payload)?,
+            Self::V2(payload) => envelope.serialize_field("executionPayload", payload)?,
+            Self::V3 { payload, .. } => envelope.serialize_field("executionPayload", payload)?,
+            Self::V4 { payload, .. } => envelope.serialize_field("executionPayload", payload)?,
+        }
+        envelope.end()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for OpExecutionPayloadEnvelope {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(serde::Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct WireEnvelope {
+            parent_beacon_block_root: Option<B256>,
+            execution_payload: OpExecutionPayload,
+        }
+
+        let envelope = WireEnvelope::deserialize(deserializer)?;
+        Self::try_from_payload(envelope.execution_payload, envelope.parent_beacon_block_root)
+            .map_err(serde::de::Error::custom)
     }
 }
 
@@ -46,22 +133,27 @@ impl ssz::Encode for OpExecutionPayloadEnvelope {
     }
 
     fn ssz_append(&self, buf: &mut Vec<u8>) {
-        // Write parent beacon block root only if the payload is not a v1 or v2 payload.
-        // <https://specs.optimism.io/protocol/rollup-node-p2p.html#block-encoding>
-        if !matches!(self.execution_payload, OpExecutionPayload::V1(_) | OpExecutionPayload::V2(_))
-        {
-            buf.extend_from_slice(self.parent_beacon_block_root.unwrap_or_default().as_slice());
+        match self {
+            Self::V1(payload) => payload.ssz_append(buf),
+            Self::V2(payload) => payload.ssz_append(buf),
+            Self::V3 { payload, parent_beacon_block_root } => {
+                buf.extend_from_slice(parent_beacon_block_root.as_slice());
+                payload.ssz_append(buf);
+            }
+            Self::V4 { payload, parent_beacon_block_root } => {
+                buf.extend_from_slice(parent_beacon_block_root.as_slice());
+                payload.ssz_append(buf);
+            }
         }
-
-        // Write payload
-        self.execution_payload.ssz_append(buf);
     }
 
     fn ssz_bytes_len(&self) -> usize {
-        let mut len = 0;
-        len += B256::ssz_fixed_len(); // parent_beacon_block_root is always 32 bytes
-        len += self.execution_payload.ssz_bytes_len();
-        len
+        match self {
+            Self::V1(payload) => payload.ssz_bytes_len(),
+            Self::V2(payload) => payload.ssz_bytes_len(),
+            Self::V3 { payload, .. } => B256::len_bytes() + payload.ssz_bytes_len(),
+            Self::V4 { payload, .. } => B256::len_bytes() + payload.ssz_bytes_len(),
+        }
     }
 }
 
@@ -72,37 +164,45 @@ impl ssz::Decode for OpExecutionPayloadEnvelope {
     }
 
     fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, ssz::DecodeError> {
-        if bytes.len() < B256::ssz_fixed_len() {
+        if let Ok(payload) = OpExecutionPayload::from_ssz_bytes(bytes) {
+            match payload {
+                OpExecutionPayload::V1(payload) => return Ok(Self::V1(payload)),
+                OpExecutionPayload::V2(payload) => return Ok(Self::V2(payload)),
+                OpExecutionPayload::V3(_) | OpExecutionPayload::V4(_) => {}
+            }
+        }
+
+        if bytes.len() < B256::len_bytes() {
             return Err(ssz::DecodeError::InvalidByteLength {
                 len: bytes.len(),
-                expected: B256::ssz_fixed_len(),
+                expected: B256::len_bytes(),
             });
         }
 
-        // Decode parent_beacon_block_root
-        let parent_beacon_block_root = {
-            let root_bytes = &bytes[..B256::ssz_fixed_len()];
-            if root_bytes.iter().all(|&b| b == 0) {
-                None
-            } else {
-                Some(B256::from_slice(root_bytes))
+        let parent_beacon_block_root = B256::from_slice(&bytes[..B256::len_bytes()]);
+        match OpExecutionPayload::from_ssz_bytes(&bytes[B256::len_bytes()..])? {
+            OpExecutionPayload::V3(payload) => Ok(Self::V3 { payload, parent_beacon_block_root }),
+            OpExecutionPayload::V4(payload) => Ok(Self::V4 { payload, parent_beacon_block_root }),
+            OpExecutionPayload::V1(_) | OpExecutionPayload::V2(_) => {
+                Err(ssz::DecodeError::BytesInvalid("parent beacon root on V1/V2 payload".into()))
             }
-        };
-
-        // Decode payload
-        let execution_payload =
-            OpExecutionPayload::from_ssz_bytes(&bytes[B256::ssz_fixed_len()..])?;
-
-        Ok(Self { parent_beacon_block_root, execution_payload })
+        }
     }
 }
 
-impl From<OpNetworkPayloadEnvelope> for OpExecutionPayloadEnvelope {
-    fn from(envelope: OpNetworkPayloadEnvelope) -> Self {
-        Self {
-            execution_payload: envelope.payload,
-            parent_beacon_block_root: envelope.parent_beacon_block_root,
-        }
+impl TryFrom<OpNetworkPayloadEnvelope> for OpExecutionPayloadEnvelope {
+    type Error = OpPayloadError;
+
+    fn try_from(envelope: OpNetworkPayloadEnvelope) -> Result<Self, Self::Error> {
+        Self::try_from_payload(envelope.payload, envelope.parent_beacon_block_root)
+    }
+}
+
+impl TryFrom<&OpNetworkPayloadEnvelope> for OpExecutionPayloadEnvelope {
+    type Error = OpPayloadError;
+
+    fn try_from(envelope: &OpNetworkPayloadEnvelope) -> Result<Self, Self::Error> {
+        Self::try_from_payload(envelope.payload.clone(), envelope.parent_beacon_block_root)
     }
 }
 
@@ -121,160 +221,6 @@ impl OpExecutionData {
     /// Creates new instance of [`OpExecutionData`].
     pub const fn new(payload: OpExecutionPayload, sidecar: OpExecutionPayloadSidecar) -> Self {
         Self { payload, sidecar }
-    }
-
-    /// Conversion from [`alloy_consensus::Block`]. Also returns the [`OpExecutionPayloadSidecar`]
-    /// extracted from the block.
-    ///
-    /// See also [`from_block_unchecked`](OpExecutionPayload::from_block_slow).
-    ///
-    /// Note: This re-calculates the block hash.
-    pub fn from_block_slow<T, H>(block: &Block<T, H>) -> Self
-    where
-        T: Encodable2718 + Transaction,
-        H: BlockHeader + Sealable,
-    {
-        let (payload, sidecar) = OpExecutionPayload::from_block_slow(block);
-
-        Self::new(payload, sidecar)
-    }
-
-    /// Conversion from [`alloy_consensus::Block`]. Also returns the [`OpExecutionPayloadSidecar`]
-    /// extracted from the block.
-    ///
-    /// See also [`OpExecutionPayload::from_block_unchecked`].
-    pub fn from_block_unchecked<T, H>(block_hash: B256, block: &Block<T, H>) -> Self
-    where
-        T: Encodable2718 + Transaction,
-        H: BlockHeader,
-    {
-        let (payload, sidecar) = OpExecutionPayload::from_block_unchecked(block_hash, block);
-
-        Self::new(payload, sidecar)
-    }
-
-    /// Conversion from a vec of [`OpFlashblockPayload`]. Also returns the
-    /// [`OpExecutionPayloadSidecar`] extracted from the payloads.
-    ///
-    /// # Validation
-    ///
-    /// This method performs the following validations:
-    /// - At least one flashblock must be present
-    /// - Indices must be sequential starting from 0
-    /// - First flashblock (index 0) must have a base payload
-    /// - Only the first flashblock may have a base payload
-    ///
-    /// Materializes the latest out-of-band SDM `post_exec_tx` as the trailing transaction.
-    /// The normal execution-payload path validates its type, payload, and position.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if any validation fails.
-    pub fn from_flashblocks(
-        flashblocks: &[OpFlashblockPayload],
-    ) -> Result<Self, OpFlashblockError> {
-        // Validate we have at least one flashblock
-        if flashblocks.is_empty() {
-            return Err(OpFlashblockError::MissingPayload);
-        }
-
-        // Validate indices are sequential starting from 0
-        for (i, fb) in flashblocks.iter().enumerate() {
-            if fb.index as usize != i {
-                return Err(OpFlashblockError::InvalidIndex);
-            }
-        }
-
-        // Validate first flashblock has base and extract it
-        let first = flashblocks.first().unwrap(); // Safe: checked empty above
-        if first.base.is_none() {
-            return Err(OpFlashblockError::MissingBasePayload);
-        }
-
-        // Validate no other flashblocks have base (only first should have it)
-        for fb in flashblocks.iter().skip(1) {
-            if fb.base.is_some() {
-                return Err(OpFlashblockError::UnexpectedBasePayload);
-            }
-        }
-
-        Ok(Self::from_flashblocks_unchecked(flashblocks))
-    }
-
-    /// Conversion from a vec of [`OpFlashblockPayload`] without validation.
-    ///
-    /// This is a faster alternative to [`Self::from_flashblocks`] that skips all validation
-    /// checks. Use this method only when you are certain the input data is valid.
-    ///
-    /// # Safety Requirements
-    ///
-    /// The caller must ensure:
-    /// - At least one flashblock is present
-    /// - Indices are sequential starting from 0
-    /// - First flashblock (index 0) has a base payload
-    /// - Only the first flashblock has a base payload
-    ///
-    /// # Panics
-    ///
-    /// Panics if any of the safety requirements are violated.
-    pub fn from_flashblocks_unchecked(flashblocks: &[OpFlashblockPayload]) -> Self {
-        // Extract base from first flashblock
-        // SAFETY: Caller guarantees at least one flashblock exists with base payload
-        let first = flashblocks.first().expect("flashblocks must not be empty");
-        let base = first.base.as_ref().expect("first flashblock must have base payload");
-
-        // Get the final state from the last flashblock
-        // SAFETY: Caller guarantees at least one flashblock exists
-        let diff = &flashblocks.last().expect("flashblocks must not be empty").diff;
-
-        // Collect all transactions and withdrawals from all flashblocks
-        let (mut transactions, withdrawals) =
-            flashblocks.iter().fold((Vec::new(), Vec::new()), |(mut txs, mut withdrawals), p| {
-                txs.extend(p.diff.transactions.iter().cloned());
-                withdrawals.extend(p.diff.withdrawals.iter().copied());
-                (txs, withdrawals)
-            });
-
-        // Each subblock replaces the out-of-band SDM transaction. Append the latest value once in
-        // the consensus-required trailing position; normal payload validation verifies its bytes.
-        if let Some(post_exec_tx) = diff.post_exec_tx.as_ref() {
-            transactions.push(post_exec_tx.clone());
-        }
-
-        let v3 = ExecutionPayloadV3 {
-            blob_gas_used: diff.blob_gas_used.unwrap_or(0),
-            excess_blob_gas: 0,
-            payload_inner: ExecutionPayloadV2 {
-                withdrawals,
-                payload_inner: ExecutionPayloadV1 {
-                    parent_hash: base.parent_hash,
-                    fee_recipient: base.fee_recipient,
-                    state_root: diff.state_root,
-                    receipts_root: diff.receipts_root,
-                    logs_bloom: diff.logs_bloom,
-                    prev_randao: base.prev_randao,
-                    block_number: base.block_number,
-                    gas_limit: base.gas_limit,
-                    gas_used: diff.gas_used,
-                    timestamp: base.timestamp,
-                    extra_data: base.extra_data.clone(),
-                    base_fee_per_gas: base.base_fee_per_gas,
-                    block_hash: diff.block_hash,
-                    transactions,
-                },
-            },
-        };
-
-        // Before Isthmus hardfork, withdrawals_root was not included.
-        // A zero withdrawals_root indicates a pre-Isthmus flashblock.
-        if diff.withdrawals_root == B256::ZERO {
-            return Self::v3(v3, Vec::new(), base.parent_beacon_block_root);
-        }
-
-        let v4 =
-            OpExecutionPayloadV4 { withdrawals_root: diff.withdrawals_root, payload_inner: v3 };
-
-        Self::v4(v4, Vec::new(), base.parent_beacon_block_root, Default::default())
     }
 
     /// Creates a new instance from args to engine API method `newPayloadV2`.
@@ -317,40 +263,6 @@ impl OpExecutionData {
                 PraguePayloadFields::new(execution_requests),
             ),
         )
-    }
-
-    /// Returns the parent beacon block root, if any.
-    pub fn parent_beacon_block_root(&self) -> Option<B256> {
-        self.sidecar.parent_beacon_block_root()
-    }
-
-    /// Return the withdrawals for the payload or attributes.
-    pub const fn withdrawals(&self) -> Option<&Vec<Withdrawal>> {
-        match &self.payload {
-            OpExecutionPayload::V1(_) => None,
-            OpExecutionPayload::V2(execution_payload_v2) => Some(&execution_payload_v2.withdrawals),
-            OpExecutionPayload::V3(execution_payload_v3) => {
-                Some(execution_payload_v3.withdrawals())
-            }
-            OpExecutionPayload::V4(op_execution_payload_v4) => {
-                Some(op_execution_payload_v4.payload_inner.withdrawals())
-            }
-        }
-    }
-
-    /// Returns the parent hash of the block.
-    pub const fn parent_hash(&self) -> B256 {
-        self.payload.parent_hash()
-    }
-
-    /// Returns the hash of the block.
-    pub const fn block_hash(&self) -> B256 {
-        self.payload.block_hash()
-    }
-
-    /// Returns the number of the block.
-    pub const fn block_number(&self) -> u64 {
-        self.payload.block_number()
     }
 }
 
@@ -640,7 +552,10 @@ impl PayloadHash {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_primitives::{Bytes, b256};
+    use crate::{OpFlashblockError, OpFlashblockPayload, OpPayloadError};
+    use alloy_consensus::Block;
+    use alloy_primitives::{Address, Bloom, Bytes, U256, b256};
+    use alloy_rpc_types_engine::{ExecutionPayloadV1, ExecutionPayloadV2, PayloadError};
 
     #[test]
     #[cfg(feature = "std")]
@@ -666,8 +581,148 @@ mod tests {
 
         let envelope: OpExecutionPayloadEnvelope = serde_json::from_str(envelope_str).unwrap();
         let expected = b256!("9999999999999999999999999999999999999999999999999999999999999999");
-        assert_eq!(envelope.parent_beacon_block_root.unwrap(), expected);
-        let _ = serde_json::to_string(&envelope).unwrap();
+        assert_eq!(envelope.parent_beacon_block_root().unwrap(), expected);
+        assert_eq!(
+            serde_json::to_value(&envelope).unwrap(),
+            serde_json::from_str::<serde_json::Value>(envelope_str).unwrap()
+        );
+
+        let mut missing_root = serde_json::from_str::<serde_json::Value>(envelope_str).unwrap();
+        missing_root.as_object_mut().unwrap().remove("parentBeaconBlockRoot");
+        let err = serde_json::from_value::<OpExecutionPayloadEnvelope>(missing_root).unwrap_err();
+        assert!(err.to_string().contains("missing parent beacon block root"));
+
+        let mut unexpected_root = serde_json::from_str::<serde_json::Value>(envelope_str).unwrap();
+        let payload = unexpected_root["executionPayload"].as_object_mut().unwrap();
+        payload.remove("blobGasUsed");
+        payload.remove("excessBlobGas");
+        payload.remove("withdrawalsRoot");
+        let err =
+            serde_json::from_value::<OpExecutionPayloadEnvelope>(unexpected_root).unwrap_err();
+        assert!(err.to_string().contains("unexpected parent beacon block root"));
+    }
+
+    fn execution_payload_v1(block_hash: B256) -> ExecutionPayloadV1 {
+        ExecutionPayloadV1 {
+            parent_hash: b256!("1111111111111111111111111111111111111111111111111111111111111111"),
+            fee_recipient: Address::repeat_byte(0x22),
+            state_root: b256!("3333333333333333333333333333333333333333333333333333333333333333"),
+            receipts_root: b256!(
+                "4444444444444444444444444444444444444444444444444444444444444444"
+            ),
+            logs_bloom: Bloom::ZERO,
+            prev_randao: b256!("5555555555555555555555555555555555555555555555555555555555555555"),
+            block_number: 1,
+            gas_limit: 30_000_000,
+            gas_used: 21_000,
+            timestamp: 123_456_789,
+            extra_data: Bytes::from_static(&[0x12, 0x34]),
+            base_fee_per_gas: U256::from(1_000_000_000),
+            block_hash,
+            transactions: Vec::new(),
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn test_serde_versioned_root_invariants() {
+        let v2 = OpExecutionPayloadEnvelope::V2(ExecutionPayloadV2 {
+            payload_inner: execution_payload_v1(B256::ZERO),
+            withdrawals: Vec::new(),
+        });
+        let v2_json = serde_json::to_value(&v2).unwrap();
+        assert!(v2_json["parentBeaconBlockRoot"].is_null());
+        assert_eq!(serde_json::from_value::<OpExecutionPayloadEnvelope>(v2_json).unwrap(), v2);
+
+        let v3 = OpExecutionPayloadEnvelope::V3 {
+            payload: ExecutionPayloadV3 {
+                payload_inner: ExecutionPayloadV2 {
+                    payload_inner: execution_payload_v1(B256::ZERO),
+                    withdrawals: Vec::new(),
+                },
+                blob_gas_used: 0,
+                excess_blob_gas: 0,
+            },
+            parent_beacon_block_root: B256::ZERO,
+        };
+        let v3_json = serde_json::to_value(&v3).unwrap();
+        assert_eq!(
+            v3_json["parentBeaconBlockRoot"],
+            serde_json::Value::String(B256::ZERO.to_string())
+        );
+        assert_eq!(serde_json::from_value::<OpExecutionPayloadEnvelope>(v3_json).unwrap(), v3);
+    }
+
+    #[test]
+    fn test_try_into_checked_block() {
+        // Pin hashes produced by op-service's independent ExecutionPayloadEnvelope.CheckBlockHash.
+        // The V3 case uses a present zero beacon root to verify that presence is preserved.
+        let v1_hash = b256!("55e9427d0f33b1e09e76c229aa4d685336ebc151a26820914652439a69e46791");
+        let v2_hash = b256!("de05d55fdc91f15fc85cbf222ab05a586a3b7b6afd1a7abb7f353d3522dfff15");
+        let v3_hash = b256!("f27a826220863770f4c8f5599c19a8dc82b8b2bbbc1bc689cb1b0dab6418886e");
+        let v4_hash = b256!("4034384737b7667a4015c0083ba2262ca3d196cc6fa6c3e763ee0a69ff95e780");
+
+        let cases = [
+            OpExecutionPayloadEnvelope::V1(execution_payload_v1(v1_hash)),
+            OpExecutionPayloadEnvelope::V2(ExecutionPayloadV2 {
+                payload_inner: execution_payload_v1(v2_hash),
+                withdrawals: Vec::new(),
+            }),
+            OpExecutionPayloadEnvelope::V3 {
+                // Presence is required for V3; an explicitly zero root remains distinct from None.
+                parent_beacon_block_root: B256::ZERO,
+                payload: ExecutionPayloadV3 {
+                    payload_inner: ExecutionPayloadV2 {
+                        payload_inner: execution_payload_v1(v3_hash),
+                        withdrawals: Vec::new(),
+                    },
+                    blob_gas_used: 0,
+                    excess_blob_gas: 0,
+                },
+            },
+            OpExecutionPayloadEnvelope::V4 {
+                parent_beacon_block_root: b256!(
+                    "7777777777777777777777777777777777777777777777777777777777777777"
+                ),
+                payload: OpExecutionPayloadV4 {
+                    payload_inner: ExecutionPayloadV3 {
+                        payload_inner: ExecutionPayloadV2 {
+                            payload_inner: execution_payload_v1(v4_hash),
+                            withdrawals: Vec::new(),
+                        },
+                        blob_gas_used: 0,
+                        excess_blob_gas: 0,
+                    },
+                    withdrawals_root: b256!(
+                        "6666666666666666666666666666666666666666666666666666666666666666"
+                    ),
+                },
+            },
+        ];
+
+        for mut envelope in cases {
+            let claimed = envelope.block_hash();
+            assert!(envelope.check_block_hash().is_ok());
+            let block: Block<op_alloy_consensus::OpTxEnvelope> =
+                envelope.clone().try_into_checked_block().unwrap();
+            assert_eq!(block.header.hash_slow(), claimed);
+
+            envelope.as_v1_mut().state_root = B256::ZERO;
+            assert!(matches!(
+                envelope.check_block_hash(),
+                Err(OpPayloadError::Eth(PayloadError::BlockHash {
+                    execution,
+                    consensus,
+                })) if execution != claimed && consensus == claimed
+            ));
+            assert!(matches!(
+                envelope.try_into_checked_block::<op_alloy_consensus::OpTxEnvelope>(),
+                Err(OpPayloadError::Eth(PayloadError::BlockHash {
+                    execution,
+                    consensus,
+                })) if execution != claimed && consensus == claimed
+            ));
+        }
     }
 
     #[test]
@@ -689,6 +744,17 @@ mod tests {
         });
     }
 
+    #[cfg(feature = "std")]
+    fn assert_payload_envelope_roundtrip(network: &OpNetworkPayloadEnvelope) {
+        let envelope = OpExecutionPayloadEnvelope::try_from(network).unwrap();
+        assert_eq!(envelope.payload_hash(), network.payload_hash);
+
+        let encoded = ssz::Encode::as_ssz_bytes(&envelope);
+        let decoded =
+            <OpExecutionPayloadEnvelope as ssz::Decode>::from_ssz_bytes(&encoded).unwrap();
+        assert_eq!(decoded, envelope);
+    }
+
     #[test]
     #[cfg(feature = "std")]
     fn test_roundtrip_encode_envelope_v1() {
@@ -696,6 +762,7 @@ mod tests {
         let data = hex::decode("0xbd04f043128457c6ccf35128497167442bcc0f8cce78cda8b366e6a12e526d938d1e4c1046acffffbfc542a7e212bb7d80d3a4b2f84f7b196d935398a24eb84c519789b401000000fe0300fe0300fe0300fe0300fe0300fe0300a203000c4a8fd56621ad04fc0101067601008ce60be0005b220117c32c0f3b394b346c2aa42cfa8157cd41f891aa0bec485a62fc010000").unwrap();
         let payload_envelop = OpNetworkPayloadEnvelope::decode_v1(&data).unwrap();
         assert_eq!(1725271882, payload_envelop.payload.timestamp());
+        assert_payload_envelope_roundtrip(&payload_envelop);
         let encoded = payload_envelop.encode_v1().unwrap();
         assert_eq!(data, encoded);
     }
@@ -707,6 +774,7 @@ mod tests {
         let data = hex::decode("0xc104f0433805080eb36c0b130a7cc1dc74c3f721af4e249aa6f61bb89d1557143e971bb738a3f3b98df7c457e74048e9d2d7e5cd82bb45e3760467e2270e9db86d1271a700000000fe0300fe0300fe0300fe0300fe0300fe0300a203000c6b89d46525ad000205067201009cda69cb5b9b73fc4eb2458b37d37f04ff507fe6c9cd2ab704a05ea9dae3cd61760002000000020000").unwrap();
         let payload_envelop = OpNetworkPayloadEnvelope::decode_v2(&data).unwrap();
         assert_eq!(1708427627, payload_envelop.payload.timestamp());
+        assert_payload_envelope_roundtrip(&payload_envelop);
         let encoded = payload_envelop.encode_v2().unwrap();
         assert_eq!(data, encoded);
     }
@@ -718,6 +786,7 @@ mod tests {
         let data = hex::decode("0xf104f0434442b9eb38b259f5b23826e6b623e829d2fb878dac70187a1aecf42a3f9bedfd29793d1fcb5822324be0d3e12340a95855553a65d64b83e5579dffb31470df5d010000006a03000412346a1d00fe0100fe0100fe0100fe0100fe0100fe01004201000cc588d465219504100201067601007cfece77b89685f60e3663b6e0faf2de0734674eb91339700c4858c773a8ff921e014401043e0100").unwrap();
         let payload_envelop = OpNetworkPayloadEnvelope::decode_v3(&data).unwrap();
         assert_eq!(1708427461, payload_envelop.payload.timestamp());
+        assert_payload_envelope_roundtrip(&payload_envelop);
         let encoded = payload_envelop.encode_v3().unwrap();
         assert_eq!(data, encoded);
     }
@@ -729,6 +798,7 @@ mod tests {
         let data = hex::decode("0x9105f043cee25401b6853202950d1d8a082f31a80c4fef5782c049a731f5d104b1b9b9aa7618605b420438ae98b44c8aaaebd482854473c2ae57c079286bb634bece5210000000006a03000412346a1d00fe0100fe0100fe0100fe0100fe0100fe01004201000c5766d26721950430020106f6010001440104b60100049876").unwrap();
         let payload_envelop = OpNetworkPayloadEnvelope::decode_v4(&data).unwrap();
         assert_eq!(1741842007, payload_envelop.payload.timestamp());
+        assert_payload_envelope_roundtrip(&payload_envelop);
         let encoded = payload_envelop.encode_v4().unwrap();
         assert_eq!(data, encoded);
     }
@@ -783,7 +853,7 @@ mod tests {
 
     #[test]
     fn test_from_flashblocks_empty_vec() {
-        let result = OpExecutionData::from_flashblocks(&[]);
+        let result = OpExecutionPayloadEnvelope::from_flashblocks(&[]);
         assert!(matches!(result, Err(OpFlashblockError::MissingPayload)));
     }
 
@@ -792,7 +862,7 @@ mod tests {
         let fb1 = create_test_flashblock(0, true, Vec::new(), None);
         let fb2 = create_test_flashblock(2, false, Vec::new(), None); // Skip index 1
 
-        let result = OpExecutionData::from_flashblocks(&[fb1, fb2]);
+        let result = OpExecutionPayloadEnvelope::from_flashblocks(&[fb1, fb2]);
         assert!(matches!(result, Err(OpFlashblockError::InvalidIndex)));
     }
 
@@ -800,7 +870,7 @@ mod tests {
     fn test_from_flashblocks_missing_base_in_first() {
         let fb1 = create_test_flashblock(0, false, Vec::new(), None); // First should have base
 
-        let result = OpExecutionData::from_flashblocks(&[fb1]);
+        let result = OpExecutionPayloadEnvelope::from_flashblocks(&[fb1]);
         assert!(matches!(result, Err(OpFlashblockError::MissingBasePayload)));
     }
 
@@ -809,7 +879,7 @@ mod tests {
         let fb1 = create_test_flashblock(0, true, Vec::new(), None);
         let fb2 = create_test_flashblock(1, true, Vec::new(), None); // Should not have base
 
-        let result = OpExecutionData::from_flashblocks(&[fb1, fb2]);
+        let result = OpExecutionPayloadEnvelope::from_flashblocks(&[fb1, fb2]);
         assert!(matches!(result, Err(OpFlashblockError::UnexpectedBasePayload)));
     }
 
@@ -817,7 +887,7 @@ mod tests {
     fn test_from_flashblocks_single_valid_flashblock() {
         let fb1 = create_test_flashblock(0, true, Vec::new(), None);
 
-        let result = OpExecutionData::from_flashblocks(&[fb1]);
+        let result = OpExecutionPayloadEnvelope::from_flashblocks(&[fb1]);
         assert!(result.is_ok(), "Single valid flashblock should succeed");
     }
 
@@ -827,14 +897,14 @@ mod tests {
         let fb2 = create_test_flashblock(1, false, Vec::new(), None);
         let fb3 = create_test_flashblock(2, false, Vec::new(), None);
 
-        let result = OpExecutionData::from_flashblocks(&[fb1, fb2, fb3]);
+        let result = OpExecutionPayloadEnvelope::from_flashblocks(&[fb1, fb2, fb3]);
         assert!(result.is_ok(), "Multiple valid flashblocks should succeed");
     }
 
     #[test]
     fn test_from_flashblocks_wrong_first_index() {
         let fb1 = create_test_flashblock(1, true, Vec::new(), None); // Should be index 0
-        let result = OpExecutionData::from_flashblocks(&[fb1]);
+        let result = OpExecutionPayloadEnvelope::from_flashblocks(&[fb1]);
         assert!(matches!(result, Err(OpFlashblockError::InvalidIndex)));
     }
 
@@ -843,20 +913,20 @@ mod tests {
         let older = Bytes::from(vec![0x7d, 0x01]);
         let latest = Bytes::from(vec![0x7d, 0x02]);
 
-        let none = OpExecutionData::from_flashblocks(&[
+        let none = OpExecutionPayloadEnvelope::from_flashblocks(&[
             create_test_flashblock(0, true, vec![Bytes::from(vec![0x01])], None),
             create_test_flashblock(1, false, vec![Bytes::from(vec![0x02])], None),
         ])
         .unwrap();
-        assert_eq!(none.payload.transactions().len(), 2, "no 0x7D should be appended");
+        assert_eq!(none.transactions().len(), 2, "no 0x7D should be appended");
 
-        let materialized = OpExecutionData::from_flashblocks(&[
+        let materialized = OpExecutionPayloadEnvelope::from_flashblocks(&[
             create_test_flashblock(0, true, vec![Bytes::from(vec![0x01])], Some(older.clone())),
             create_test_flashblock(1, false, vec![Bytes::from(vec![0x02])], Some(latest.clone())),
             create_test_flashblock(2, false, vec![Bytes::from(vec![0x03])], Some(latest.clone())),
         ])
         .unwrap();
-        let txs = materialized.payload.transactions();
+        let txs = materialized.transactions();
         assert_eq!(txs.len(), 4, "3 user txs + exactly one trailing 0x7D");
         assert_eq!(txs.last(), Some(&latest), "the latest post_exec_tx must be the trailing tx");
         assert!(!txs.iter().any(|t| t == &older), "the superseded post_exec_tx must not appear");
@@ -865,7 +935,7 @@ mod tests {
     #[test]
     fn test_from_subblocks_preserves_empty_post_exec_tx() {
         let empty = Bytes::new();
-        let materialized = OpExecutionData::from_flashblocks(&[create_test_flashblock(
+        let materialized = OpExecutionPayloadEnvelope::from_flashblocks(&[create_test_flashblock(
             0,
             true,
             Vec::new(),
@@ -873,7 +943,7 @@ mod tests {
         )])
         .unwrap();
 
-        assert_eq!(materialized.payload.transactions().last(), Some(&empty));
+        assert_eq!(materialized.transactions().last(), Some(&empty));
     }
 
     // Real-world test case from Unichain Sepolia
@@ -886,36 +956,36 @@ mod tests {
         let raw_sequence = r#"[{"payload_id":"0x03c446f063e3735a","index":0,"base":{"parent_beacon_block_root":"0xf6d335a6b2b4fd8fb539cd51a49769df4d53c31a90c54dd270e54542638ff101","parent_hash":"0x06ff95a9cd23b0328da74a984aa986b2e01d377dab1825f1029e39ece6c4a3ea","fee_recipient":"0x4200000000000000000000000000000000000011","prev_randao":"0x8beee738d20a9d77c5f27e9cb799ebe5b536f0985efad5f7d77ebff47f092c4a","block_number":"0x21e3b52","gas_limit":"0x3938700","timestamp":"0x690be89e","extra_data":"0x00000000320000000c","base_fee_per_gas":"0x33"},"diff":{"state_root":"0xb29a9bcae8cf3ae6d68985fcd70db80b3818cd629c9d5da0bb116451739b2078","receipts_root":"0x91d8ad10740ccfc1bd848fba0e02668d95769c08eeea30f10698692ba86c6159","logs_bloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","gas_used":"0x10994","block_hash":"0xa66f8562a861f906a2438d7d6ba79495640d98d9c6922b9605c54b57f97a345c","transactions":["0x7ef90104a035dd2ec802504a143048c7830f8f570e0d6cf5147217af869939c6b4ba710a3694deaddeaddeaddeaddeaddeaddeaddeaddead00019442000000000000000000000000000000000000158080830f424080b8b0098999be000007d0000dbba0000000000000000800000000690be848000000000092042e000000000000000000000000000000000000000000000000000000000000000900000000000000000000000000000000000000000000000000000000000000010ffd7e2fb2c36e5f27c015872ce733a7b4f3fc0f4ee668d7469c557c48f8250f0000000000000000000000004ab3387810ef500bfe05a49dc53a44c222cbab3e000000000000000000000000","0x02f87e8205158401c8ea9180338255789400000000000000000000000000000000000000008096426c6f636b204e756d6265723a203335353335363938c080a091f83058c881d9ad71c179ce680326501702eb68150d20b2bf7786e388f954a2a0180185d83e503f11bf3c265c1f9296ed8d3d7c04031cd8bb30509ad188ce7bbc"],"withdrawals":[],"withdrawals_root":"0x62ed62e0391b081bf172f287fbbe75e87d8a6c22f1d3b1f1aef4788c134633d2"},"metadata":{"block_number":35535698,"new_account_balances":{},"receipts":{}}},{"payload_id":"0x03c446f063e3735a","index":1,"base":null,"diff":{"state_root":"0xfb1794f74d405b345672c57a5053c6105cc55c8e63f96fb0db5b0260df42413a","receipts_root":"0x1eaaaeb9d43bead7d32b90f1b320589174c63d2fa8f5fd366f841a205b1eb2e0","logs_bloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000004040000000000000000000000000000000000000000000000000000000000000000000000","gas_used":"0x18f7d","block_hash":"0x67b0521ebfcb03d6ce2b6e1bad9c9c66795365f63ad8dc51e1e8f582a5ab7821","transactions":["0x02f86c8205158401c8ea92803382880994f878f0340bf132c28f3211e8b46c569edf81749580843fd553e8c001a0d73ce313aafea312e0b7244767e45f8b05d50305e0f4e4c3c564ddc751666815a02ee015ce2363311823c0b2e96bfb0e8090fd53c6cdd99be8cf343af123036dfc"],"withdrawals":[],"withdrawals_root":"0x62ed62e0391b081bf172f287fbbe75e87d8a6c22f1d3b1f1aef4788c134633d2"},"metadata":{"block_number":35535698,"new_account_balances":{},"receipts":{}}},{"payload_id":"0x03c446f063e3735a","index":2,"base":null,"diff":{"state_root":"0x90dd105c4a2a0dd9ffe994204bfa3e2b4f70f7ea760d5cb9a4263f26a89f91b4","receipts_root":"0x0fff0488aa3732c34018b938839ab2f0caa96018221e4ffaeca011fb06ba288f","logs_bloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000004040000000000000000000000000000000000000000000000000000000000000000000000","gas_used":"0x21566","block_hash":"0x720feb7457110a565b479fafbaa89cc984f5d673846a27d44bbb8cf5200b32fe","transactions":["0x02f86c8205158401c8ea93803382880994f878f0340bf132c28f3211e8b46c569edf81749580843fd553e8c001a0f8cd94080642e116bc772f36a02d002505227aa542e1c13e5129ab40b8b037fba00608318d3895388e39b218bcb275380cebc566e68f26d3d434e32b8b58366cdf"],"withdrawals":[],"withdrawals_root":"0x62ed62e0391b081bf172f287fbbe75e87d8a6c22f1d3b1f1aef4788c134633d2"},"metadata":{"block_number":35535698,"new_account_balances":{},"receipts":{}}},{"payload_id":"0x03c446f063e3735a","index":3,"base":null,"diff":{"state_root":"0x71f8c60fdfdd84cffda3b0b6af7c8ff92195918f4fc2abae750a7306521ac0dc","receipts_root":"0xa62d1d98f56ffb1464a2beb185484253df68208004306e155c0bd1519137afe6","logs_bloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000004040000000000000000000000000000000000000000000000000000000000000000000000","gas_used":"0x29b4f","block_hash":"0x670844e30f7325d4f290ea375e01f7e819afca317fc7db9723e6867a184984fa","transactions":["0x02f86c8205158401c8ea94803382880994f878f0340bf132c28f3211e8b46c569edf81749580843fd553e8c080a04368492ec1d087703aaf6f5fefe4427b3bf382e5cd07133f638bb6701f15fe61a05e28757fbdc7e744118be36d5a1548eb7c009eefcb5dc5c5040e09c2fc6de9d8"],"withdrawals":[],"withdrawals_root":"0x62ed62e0391b081bf172f287fbbe75e87d8a6c22f1d3b1f1aef4788c134633d2"},"metadata":{"block_number":35535698,"new_account_balances":{},"receipts":{}}},{"payload_id":"0x03c446f063e3735a","index":4,"base":null,"diff":{"state_root":"0x5615e4342d231c352438f0ba6a8f0f641459f67961961764b781a909969b28ad","receipts_root":"0x588e1d47b0618d7e935b20c3945cba3b7b8c00141904f79ceed20312ea502e63","logs_bloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000004040000000000000000000000000000000000000000000000000000000000000000000000","gas_used":"0x32138","block_hash":"0xc463a3120c35268f610d969f5608b479332ef10953af77c7a6be806195831196","transactions":["0x02f86c8205158401c8ea95803382880994f878f0340bf132c28f3211e8b46c569edf81749580843fd553e8c080a0802ba6d4f37e3b8de96095bd0b216144f276171d16dc62a004f1a89009af5deea00f0c6250cfd1a062a1bc2bc353a5c227a980cac0f233b7be8932f2192342ec4f"],"withdrawals":[],"withdrawals_root":"0x62ed62e0391b081bf172f287fbbe75e87d8a6c22f1d3b1f1aef4788c134633d2"},"metadata":{"block_number":35535698,"new_account_balances":{},"receipts":{}}}]"#;
 
         let flashblocks: Vec<OpFlashblockPayload> = serde_json::from_str(raw_sequence).unwrap();
-        let execution_data = OpExecutionData::from_flashblocks(&flashblocks).unwrap();
+        let execution_data = OpExecutionPayloadEnvelope::from_flashblocks(&flashblocks).unwrap();
 
         // Validate against expected final block state
         assert_eq!(
-            execution_data.payload.parent_hash(),
+            execution_data.parent_hash(),
             b256!("06ff95a9cd23b0328da74a984aa986b2e01d377dab1825f1029e39ece6c4a3ea")
         );
         assert_eq!(
-            execution_data.payload.block_hash(),
+            execution_data.block_hash(),
             b256!("c463a3120c35268f610d969f5608b479332ef10953af77c7a6be806195831196")
         );
-        assert_eq!(execution_data.payload.block_number(), 0x21E3B52);
-        assert_eq!(execution_data.payload.timestamp(), 0x690be89e);
+        assert_eq!(execution_data.block_number(), 0x21E3B52);
+        assert_eq!(execution_data.timestamp(), 0x690be89e);
         assert_eq!(
-            execution_data.payload.fee_recipient(),
+            execution_data.fee_recipient(),
             address!("4200000000000000000000000000000000000011")
         );
-        assert_eq!(execution_data.payload.gas_limit(), 0x3938700);
-        assert_eq!(execution_data.payload.as_v1().gas_used, 0x32138);
+        assert_eq!(execution_data.gas_limit(), 0x3938700);
+        assert_eq!(execution_data.as_v1().gas_used, 0x32138);
         assert_eq!(
-            execution_data.payload.as_v1().state_root,
+            execution_data.as_v1().state_root,
             b256!("5615e4342d231c352438f0ba6a8f0f641459f67961961764b781a909969b28ad")
         );
         assert_eq!(
-            execution_data.payload.as_v1().receipts_root,
+            execution_data.as_v1().receipts_root,
             b256!("588e1d47b0618d7e935b20c3945cba3b7b8c00141904f79ceed20312ea502e63")
         );
-        assert_eq!(execution_data.payload.transactions().len(), 6);
+        assert_eq!(execution_data.transactions().len(), 6);
         assert_eq!(
-            execution_data.payload.as_v4().unwrap().withdrawals_root,
+            execution_data.as_v4().unwrap().withdrawals_root,
             b256!("62ed62e0391b081bf172f287fbbe75e87d8a6c22f1d3b1f1aef4788c134633d2")
         );
 
@@ -936,38 +1006,38 @@ mod tests {
         let raw_sequence = r#"[{"payload_id":"0x03c33cc62b81edb6","index":0,"base":{"parent_beacon_block_root":"0xf058b1e43890ed5f838bd07e77db06d075d894343d1b31f6099a345b0d8f7d1b","parent_hash":"0x6ffd2714d5af6c412c57db3f664a5a127516573bbd987fd242d06f71ea662741","fee_recipient":"0x4200000000000000000000000000000000000011","prev_randao":"0x9985c1f8ec25b468cbf2b727a8371b4554b7e7adb059c08abf7a7d51d86ceee5","block_number":"0x1fe4052","gas_limit":"0x3938700","timestamp":"0x690fdf84","extra_data":"0x000000003200000004","base_fee_per_gas":"0x34"},"diff":{"state_root":"0x0000000000000000000000000000000000000000000000000000000000000000","receipts_root":"0x1b2fa5e4cbbc1f8c01a7c7204571ebe339dbdfadc666451d8e70d5c10c99830f","logs_bloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","gas_used":"0xb41c","block_hash":"0x87c6775cc427caf4c0ffe0d4b6d76627536f38d77d23f105f9f104ef3e5541c7","transactions":["0x7ef90104a01c055ffd19ea027da4a8aae0a2734c6bf17c3f487d4cc22931d7dbe261409cda94deaddeaddeaddeaddeaddeaddeaddeaddead00019442000000000000000000000000000000000000158080830f424080b8b0098999be0000044d000a118b000000000000000400000000690fde3c00000000009252e3000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000014f1595c3798e3082aa093e433bd5cbd102a11f9619d20e6e821c1a30fb56b12b000000000000000000000000fc56e7272eebbba5bc6c544e159483c4a38f8ba3000000000000000000000000"],"withdrawals":[],"withdrawals_root":"0x77b0fb1616a212bd7cf33d7c28651f19bf6093b2c5f1967e674ec861aeaf9d44"},"metadata":{"block_number":33439826,"new_account_balances":{},"receipts":{}}},{"payload_id":"0x03c33cc62b81edb6","index":1,"diff":{"state_root":"0x0000000000000000000000000000000000000000000000000000000000000000","receipts_root":"0xe38b2090ddfa6ee25b15a8ebcdd7ecc0f1ee9128ec98cb24f47909e29e11832e","logs_bloom":"0x00000000000000000000000020000000040080000000000000020005000000004000000040040000000080000000000000000000000000000002000000000000008000000000000000000000000000014000000000800000000000000000000000000000000000040100000000000000000000000100000000000380008a02000000100000400200000100800000000000000000000004001000200000000000000000000800020000000000400000000000000000008000400801080000000000005000000400000000000000000000000110000000000000000000000000100200021004400010000000010000000400000008002000004080000000000000","gas_used":"0x9d2f2","block_hash":"0x4548d5014de4883cec380838f1b225996fa3c08c176f2f63d98d8c23169fab44","transactions":["0x02f89283014a348202ea830f4275830f427583045dd594a449bc031fa0b815ca14fafd0c5edb75ccd9c80f80a4de0e9a3e000000000000000000000000000000000000000000000001236efcbcbb340000c001a0742ff606597cda39751dd369e66e9978946ce8f4eb578a8d73314535a2df4388a06a6f83c3606c32e1677f62408b8ec69b09a82f499395b26eaefea567deb83843","0x02f9101583014a34830597bd830f4240830f42aa8306aecc9442826e92e6418877459f0920cb058e462ac6a0a480b90fa4dbaa1e6400000000000000000000000000a739e4479c97289801654ec1a52a67077613c000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000691d0e7f4f6ae70adc2708ec4857d3d5ca54a11710c9ac11989b1cb3d3d8d3298a78f6a50000000000000000000000000000000000000000000000000000000000000f200000000000000000000000000000000000000000000000000000000000000e44b653f0c300000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000033bea00000000000000000000000000000000000000000000000000000000000000380000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000030000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000014000000000000000000000000000000000000000000000000000000000000002200000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000004747970650000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000026f6b00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000086f6b2e746f6b656e0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003657468000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000086f6b2e74785f69640000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000046626173653a3078343865643835396232636630633962366261633864373134653162363436313264313232346436643a38343533323a33333433393832323a3333393131333600000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a20000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000090000000000000000000000000000000000000000000000000000000000000120000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000002e000000000000000000000000000000000000000000000000000000000000003e000000000000000000000000000000000000000000000000000000000000004c000000000000000000000000000000000000000000000000000000000000005a000000000000000000000000000000000000000000000000000000000000006a000000000000000000000000000000000000000000000000000000000000007c000000000000000000000000000000000000000000000000000000000000008c00000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000004747970650000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000087769746864726177000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000001977697468647261772e73656e6465722e636861696e5f7569640000000000000000000000000000000000000000000000000000000000000000000000000000046261736500000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000001777697468647261772e73656e6465722e61646472657373000000000000000000000000000000000000000000000000000000000000000000000000000000002a30783438656438353962326366306339623662616338643731346531623634363132643132323464366400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000000e77697468647261772e746f6b656e00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000036574680000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000000f77697468647261772e616d6f756e740000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001431303030303030303030303030303030303030300000000000000000000000000000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000002f77697468647261772e63726f73735f636861696e5f6164647265737365732e302e757365722e636861696e5f756964000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000077365706f6c6961000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000002d77697468647261772e63726f73735f636861696e5f6164647265737365732e302e757365722e6164647265737300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002a307834386564383539623263663063396236626163386437313465316236343631326431323234643664000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000003977697468647261772e63726f73735f636861696e5f6164647265737365732e302e6c696d69742e6c6573735f7468616e5f6f725f657175616c0000000000000000000000000000000000000000000000000000000000000000000000000000143130303030303030303030303030303030303030000000000000000000000000000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000000e77697468647261772e74785f69640000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000046626173653a3078343865643835396232636630633962366261633864373134653162363436313264313232346436643a38343533323a33333433393832323a333339313133360000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000041ffb578b6e9ab1699e4d9cd0078d9f28e7f0ef2136a11596aa7b6d7fe7f896dd353b7b786bf155c924f35d5099f0df90650e74a5858b75673835d24ac6dc8f1e41b00000000000000000000000000000000000000000000000000000000000000c080a09c4f42d262ed1f1bee31461fd10d8d8fbac6e340d9bc2b8035df5faa30f88d4da06d832693c1e28d4f647a6ff08f5d037d08ad2599964a9f3600396efdaec07e4a"],"withdrawals":[],"withdrawals_root":"0x77b0fb1616a212bd7cf33d7c28651f19bf6093b2c5f1967e674ec861aeaf9d44"},"metadata":{"block_number":33439826,"new_account_balances":{},"receipts":{}}},{"payload_id":"0x03c33cc62b81edb6","index":2,"diff":{"state_root":"0x0000000000000000000000000000000000000000000000000000000000000000","receipts_root":"0xda7caba0b5682eda3aed5f47132da84aa2c2757499c23d609aa73dd3a449be1d","logs_bloom":"0x00000000000000000000000020000000040080000000000000020005000000004000000040040000000080000000000000000000000000000002000000000040008000000000000000000000000000014000000800800000000004000000000000000000000400040100000000000000000002800100000000000b80008a02000000100000400200000100800000000000000000000004001000200000000000000000000800020000000000400000000000000000008000440801080200000000005000000400000000000000000000000110000000000008000000000000100200021004400010000000110000000400000008002000004080010000000000","gas_used":"0xd6a91","block_hash":"0x17e106bfeebb2ff0123cf2e1f555e0441ed308773224513dc4ac6257d943e52c","transactions":["0x02f89283014a3482015f830f4275830f427583045dc694a449bc031fa0b815ca14fafd0c5edb75ccd9c80f80a4de0e9a3e000000000000000000000000000000000000000000000000c249fdd327780000c001a098b7dd6d4454a8d31170b5b2d1461bc8a74eed745eddc982232b2c1483cba322a07d3acfe989366b2729aa728ebca7009c15dc908954a9fb5459b75cff1bfd103f"],"withdrawals":[],"withdrawals_root":"0x77b0fb1616a212bd7cf33d7c28651f19bf6093b2c5f1967e674ec861aeaf9d44"},"metadata":{"block_number":33439826,"new_account_balances":{},"receipts":{}}},{"payload_id":"0x03c33cc62b81edb6","index":3,"diff":{"state_root":"0x0000000000000000000000000000000000000000000000000000000000000000","receipts_root":"0xda7caba0b5682eda3aed5f47132da84aa2c2757499c23d609aa73dd3a449be1d","logs_bloom":"0x00000000000000000000000020000000040080000000000000020005000000004000000040040000000080000000000000000000000000000002000000000040008000000000000000000000000000014000000800800000000004000000000000000000000400040100000000000000000002800100000000000b80008a02000000100000400200000100800000000000000000000004001000200000000000000000000800020000000000400000000000000000008000440801080200000000005000000400000000000000000000000110000000000008000000000000100200021004400010000000110000000400000008002000004080010000000000","gas_used":"0xd6a91","block_hash":"0x17e106bfeebb2ff0123cf2e1f555e0441ed308773224513dc4ac6257d943e52c","transactions":[],"withdrawals":[],"withdrawals_root":"0x77b0fb1616a212bd7cf33d7c28651f19bf6093b2c5f1967e674ec861aeaf9d44"},"metadata":{"block_number":33439826,"new_account_balances":{},"receipts":{}}},{"payload_id":"0x03c33cc62b81edb6","index":4,"diff":{"state_root":"0x0000000000000000000000000000000000000000000000000000000000000000","receipts_root":"0xaff50907a173fc423a499319437afffb8abc2071ce36b6f040dc487579a5d4c3","logs_bloom":"0x0002800000000000002000012000040004008000000010000012000500000000480000004004000000918000000000000000000000000000000200821000806000800010000000000000000800000001c000000800800000000004202000000800000000000400040100020100000000000002800100000000000b90008a02000000100000480200000100800010080400000000000004001000224080000000000000008c0002040080000840000000000000000100c000c4080108020000000001500a000400000000000000000000100110000020000008000000000000100a00221004400010000000110100000400100008002100004280010000000000","gas_used":"0x1498a3","block_hash":"0x4764a20ee262986e45d29251db593320bd4bf6de1133de553b6363a5691e7644","transactions":["0x02f89283014a348203af830f4275830f427583045dd594a449bc031fa0b815ca14fafd0c5edb75ccd9c80f80a4de0e9a3e000000000000000000000000000000000000000000000002017a67f731740000c001a04ce59ff67dc25a76f3027441513f916b809f55b29d5de4fecd4aa0136a3a1a4fa02c1b32b3a1600f6bb2365130797238162cbc797843169a4cfb1ebb41465877c7","0x02f8d483014a348309087a830f4240830f42a883030d4094d89f830d7795c10613e4d4769c24c05bf60932c680b864b781777000000000000000000000000022e40d0a0c0bb77b570445fb59d39bcf14790b660000000000000000000000000000000000000000000000004a61b425a5ee98000000000000000000000000000000000000000000000000000006431e74449860c001a002c2402941acdc25bcaae67c62d58f1a942b32723827f77972c74b159b2c174ea04772118ec71bc7fbe0c9f1c9ef90f58927126480ca769d73704365bfbac65db3","0x02f8d483014a348308c06b830f4240830f42a883030d4094d89f830d7795c10613e4d4769c24c05bf60932c680b864b78177700000000000000000000000005643a7772017c8544d3841894c1f7c264cd05ffe0000000000000000000000000000000000000000000000000b035a61b2e8be000000000000000000000000000000000000000000000000000006431e7446c578c001a0ac31a5ad06a3897a0c1a909770badf8cec728abd2daf4d125a551778fa597124a013b1de6f741139d957f299bf22de0a91c1d8a4f2ade6743ddcec89bcc9e8b07d","0x02f8d483014a34830922b1830f4240830f42a883030d4094d89f830d7795c10613e4d4769c24c05bf60932c680b864b7817770000000000000000000000000576831e77af4b5425b39efb23528441b79ee71e20000000000000000000000000000000000000000000000002bed26c4505ca4000000000000000000000000000000000000000000000000000006431e7446f712c080a0c105ef2c930e95694d112028a642399e5a56ce6416f9b8df9ad27baa26244483a064f6e5881fa728b7afaa2e2ddd62c3182789cb247f90b6276c14f8bfc1b4f2cf"],"withdrawals":[],"withdrawals_root":"0x77b0fb1616a212bd7cf33d7c28651f19bf6093b2c5f1967e674ec861aeaf9d44"},"metadata":{"block_number":33439826,"new_account_balances":{},"receipts":{}}},{"payload_id":"0x03c33cc62b81edb6","index":5,"diff":{"state_root":"0x0000000000000000000000000000000000000000000000000000000000000000","receipts_root":"0x6d12b13dcae85ef97ec3756b317ac9d33752bcd231a9323046ecd5a65e8ca8a2","logs_bloom":"0x0002800000000000002000012000040004008000000010000012000500000000480000004004000000918000000000000000000000000100000200821000806000800010000000000000000800000001c000000800800000000004202000000800000000000400040100020100000000000002800100000000004b90008a02000000100000480200000100800010080400000000000004001000224080000000000000008c0002040080000840000000000000000100c000c4080108020000000001500a000400000000000000000000100110004020000008000000000000100a00221004400010000000110100000400100008002100004280010000000000","gas_used":"0x153998","block_hash":"0x810679ccd05f90093eb0e88549d52ad196214f3a4a555cf0b06201f30aa61a2d","transactions":["0x02f8d483014a34830966ae830f4240830f42a883030d4094d89f830d7795c10613e4d4769c24c05bf60932c680b864b781777000000000000000000000000046195a8573f2610bba630bb0bd5c21c064594f3a0000000000000000000000000000000000000000000000002c94bc176f7cb4000000000000000000000000000000000000000000000000000006431e743d37eac080a053f1881c67ad8fa9838d83943afe83b6498dae96a13a019704f25e0df515dbdba05eef8e08269eaafd63ba7e14e13d73e03ec5e7fad5bcdbaaabc124da41e8e32c"],"withdrawals":[],"withdrawals_root":"0x77b0fb1616a212bd7cf33d7c28651f19bf6093b2c5f1967e674ec861aeaf9d44"},"metadata":{"block_number":33439826,"new_account_balances":{},"receipts":{}}},{"payload_id":"0x03c33cc62b81edb6","index":6,"diff":{"state_root":"0x0000000000000000000000000000000000000000000000000000000000000000","receipts_root":"0x1b76e086c31a8a08d1c4a93b868b00238faabd4d52d9e75e55a4abf3a75e65d8","logs_bloom":"0x0002800000000000002000012000048004008000000010000012000500000000480000004004000000918000000000000000000000000100000200821000806000800010000000000000000800000001c008000800800000000004202000000800000000000400040100020100000000000002800100000000004b90008a02000000100000480200000100800010080400000000000004001000224080000000000000008c0002040080000840000000000000000100c000c4080108020000010001500a000400000000000001000000100110004021000008000000000000100a00221004400010000000110100000400100008002100004280010000000001","gas_used":"0x189dc4","block_hash":"0xfdf2cbb452a36c9c4033d1c0bc2b3dd9cee7ba91d0ca5488aa3d9a23b127b79f","transactions":["0x02f89383014a348304e447830f4240830f42a8830226b494cd997aef0b9a1d8c02a16204ccce354844edeeff80a4f7a308060000000000000000000000000000000000000000000000000000000000016636c001a07dc2c0285cd2c53657c87826a698de9ae5bb38e2580657fe1772fc08ab53a9f2a05a183dac1ed51f6aac2eff4add4510fd76d71f9dce59a3536fc00bfbb2ac750c","0x02f8d483014a3483096a27830f4240830f42a883030d4094d89f830d7795c10613e4d4769c24c05bf60932c680b864b7817770000000000000000000000000fde9b0be445930f929705125fe24049093e628e4000000000000000000000000000000000000000000000001517fd24c7f6670000000000000000000000000000000000000000000000000000006431e74408803c080a036f0e0df96ee863041cc41fad376f2f88364225ff6c10c2e492da014d71ab530a03cca82dd065d09a150f75103ea2e1f2867210c604fd82592ec49fae02cadc20a","0x02f8d483014a348309a03d830f4240830f42a883030d4094d89f830d7795c10613e4d4769c24c05bf60932c680b864b781777000000000000000000000000088c7e4701045571734e2147bad80e3d8c56500d300000000000000000000000000000000000000000000000023e284d65ede20000000000000000000000000000000000000000000000000000006431e7441d02ac080a03ee196fff4a614411f9d41431f0b174141ae6f62246df4e54117205bb19c4f64a022f123e006139ae334de3bf7b62c06b72045ba7dc0a508d137bcd056d950da33"],"withdrawals":[],"withdrawals_root":"0x77b0fb1616a212bd7cf33d7c28651f19bf6093b2c5f1967e674ec861aeaf9d44"},"metadata":{"block_number":33439826,"new_account_balances":{},"receipts":{}}},{"payload_id":"0x03c33cc62b81edb6","index":7,"diff":{"state_root":"0x0000000000000000000000000000000000000000000000000000000000000000","receipts_root":"0x065878c1c4d88295544c04fec2e74c9dd8b5d656e196a1b7b09ce8cadbb8f979","logs_bloom":"0x0002800000000010002000052000048004008000000010000012000500000000490000004004000000918000010000000000008000000100040200821000806800800010000000000000000800000001c008000800800000000004202000000804000020000400040100020100000000020002800100000000004b90008a02000000180000480200000100800010080400000000000004011000224080000000000000008c0002040080000840000200000000000100c000c4080108020000012001500a000400000000000001000000100110004021000008000000000000100a00221104400010000000110100000400100008002100004280010000000001","gas_used":"0x1bc281","block_hash":"0xcc9c18ed55c91e97f32353e253c69766cd0d2e0acb0e7f92098d01e1d7761ce3","transactions":["0x02f8d483014a3483091e1f830f4240830f42a883030d4094d89f830d7795c10613e4d4769c24c05bf60932c680b864b7817770000000000000000000000000b501c0a0f800e68d980f5253650d0cf3a69d16c00000000000000000000000000000000000000000000000000b87d57d89ffe7800000000000000000000000000000000000000000000000000006431e7442365fc001a0b276c68f59bcfb78fe7905a720e9418130d5c87d60da4b6d55faf07e1b1724aba03425daae2e51a061a26bedcd89cf6ead44146ac97f831371ec36a0192728d204","0x02f8d483014a3483094dde830f4240830f42a883030d4094d89f830d7795c10613e4d4769c24c05bf60932c680b864b78177700000000000000000000000000097cc7164250c464fea5f9f91d1abec7718814a0000000000000000000000000000000000000000000000004c40d37c20f440000000000000000000000000000000000000000000000000000006431e744372abc001a01f3e58f3baa5e472c08097dafe1e756163c61e7200dc90751f167e796d542f20a02c10596de8b29462c0953a023a8b6c06f74fe77ea66a24598df920d542edab3b","0x02f8d483014a3483094ece830f4240830f42a883030d4094d89f830d7795c10613e4d4769c24c05bf60932c680b864b781777000000000000000000000000083fe74125ec8ffaeee4b2371d7ea17f6ad6f9ba2000000000000000000000000000000000000000000000000f9e4840a6e4938000000000000000000000000000000000000000000000000000006431e744362dec001a066724129c4de96e835cd1377b55541b4582bf4ebcd7c2a3faa4231ade86b14d8a03736bce9203cc0c92878fcc28ee8710961eaddde92bf6a2158c602b4d1bbdbd7","0x02f8d483014a348303750a830f4240830f42a883030d4094d89f830d7795c10613e4d4769c24c05bf60932c680b864b7817770000000000000000000000000414d9179c5d2207a6e0efeb0319b6c556265974600000000000000000000000000000000000000000000000033979a45ffefac000000000000000000000000000000000000000000000000000006431e74442677c001a0682d2489ba1d9666324060a006f0abe06830cecdeed4398169dc9fbf7199eb59a02e971034255d087d02b25f45a7962b31360bbed70e3aa30e69ee8f64dd6afdb4","0x02f8d483014a348308acf2830f4240830f42a883030d4094d89f830d7795c10613e4d4769c24c05bf60932c680b864b781777000000000000000000000000097c152d0fa30c49603e0e3e013e36c4e29bf7fea0000000000000000000000000000000000000000000000001d58bdca2addf5000000000000000000000000000000000000000000000000000006431e744447a9c001a030e423ab3697fe4ccc5ce92232d7a642a8295f489f2e52b3c3ba2f110c828e7ca057fd4d3d0e700734568b0be067deda7927188f6a67f9600bae3d6c75d201fe57"],"withdrawals":[],"withdrawals_root":"0x77b0fb1616a212bd7cf33d7c28651f19bf6093b2c5f1967e674ec861aeaf9d44"},"metadata":{"block_number":33439826,"new_account_balances":{},"receipts":{}}},{"payload_id":"0x03c33cc62b81edb6","index":8,"diff":{"state_root":"0x0000000000000000000000000000000000000000000000000000000000000000","receipts_root":"0x7bf525f832aecc6bf7f7b7e329779640bb4477cb47bf1bde512934c5ed45519b","logs_bloom":"0x0003800000000210002000052000048004008000000010000012000500000000490000004004000000918000010000000000008000000100040200821000806800800010000000000000000800000001c00c000800802000000004202000000804000020000400040100020108000000020002800100000000044b98008a02200000180000480200000100800010080400000000002004011000224080000000000000108c0002040080000844000200000040000100c000c4080108020000012001500a000400000000000001000000104110004021000108000000000000100a00221104400010010000110100000400100008002140004280010000000001","gas_used":"0x213d0b","block_hash":"0x5f9c957cde671b50c5661b328b7f3f8a0e56e194a954d8d7cc4274eb1e014a1e","transactions":["0x02f89283014a34820392830f4275830f427583045dd594a449bc031fa0b815ca14fafd0c5edb75ccd9c80f80a4de0e9a3e000000000000000000000000000000000000000000000002017a67f731740000c001a05c4f86d9218cfab447e6ead7abb27444f7e8d3a185a1fbfb6860a36513c89d93a01d4b9b74f049bfc10feeabcb101a18a14e774e89de35ac246e6452c05e94bc98","0x02f8d483014a348309087a830f4240830f42a883030d4094d89f830d7795c10613e4d4769c24c05bf60932c680b864b781777000000000000000000000000022e40d0a0c0bb77b570445fb59d39bcf14790b660000000000000000000000000000000000000000000000004a61b425a5ee98000000000000000000000000000000000000000000000000000006431e74449860c001a002c2402941acdc25bcaae67c62d58f1a942b32723827f77972c74b159b2c174ea04772118ec71bc7fbe0c9f1c9ef90f58927126480ca769d73704365bfbac65db3","0x02f8d483014a348308c06b830f4240830f42a883030d4094d89f830d7795c10613e4d4769c24c05bf60932c680b864b78177700000000000000000000000005643a7772017c8544d3841894c1f7c264cd05ffe0000000000000000000000000000000000000000000000000b035a61b2e8be000000000000000000000000000000000000000000000000000006431e7446c578c001a0ac31a5ad06a3897a0c1a909770badf8cec728abd2daf4d125a551778fa597124a013b1de6f741139d957f299bf22de0a91c1d8a4f2ade6743ddcec89bcc9e8b07d","0x02f8d483014a34830922b1830f4240830f42a883030d4094d89f830d7795c10613e4d4769c24c05bf60932c680b864b7817770000000000000000000000000576831e77af4b5425b39efb23528441b79ee71e20000000000000000000000000000000000000000000000002bed26c4505ca4000000000000000000000000000000000000000000000000000006431e7446f712c080a0c105ef2c930e95694d112028a642399e5a56ce6416f9b8df9ad27baa26244483a064f6e5881fa728b7afaa2e2ddd62c3182789cb247f90b6276c14f8bfc1b4f2cf"],"withdrawals":[],"withdrawals_root":"0x77b0fb1616a212bd7cf33d7c28651f19bf6093b2c5f1967e674ec861aeaf9d44"},"metadata":{"block_number":33439826,"new_account_balances":{},"receipts":{}}},{"payload_id":"0x03c33cc62b81edb6","index":9,"diff":{"state_root":"0x0000000000000000000000000000000000000000000000000000000000000000","receipts_root":"0xeb419bf069b8bf9738adcb7fad118724a1d4d6a83821bc532983a2949aa0910d","logs_bloom":"0x000380000000021000200005200004800400800000001000001a000500001000490000004004000000918000010000000000008000000100040200821000806800800010000000000000000800000001c00c000800802000000004202000000804000020000400040100020108000000020002800100000000044b98008a02200000180000480200000100800010080400000000002004011000224080000000000000108c0002040080000844000200000040000100c000c4080108020000012001500a000400000000000001000000104110004021000108000000000000100a00221104400010010004110100000400100008002140004280010000000001","gas_used":"0x21de0c","block_hash":"0xb802c08c65bdefdd507fe07634ea29eeaad1859b33ffac2c426dc7b620d22b19","transactions":["0x02f8d483014a3483095beb830f4240830f42a883030d4094d89f830d7795c10613e4d4769c24c05bf60932c680b864b7817770000000000000000000000000f73c129529caa024337c39e467c720cfc45874220000000000000000000000000000000000000000000000000de4f04092790e800000000000000000000000000000000000000000000000000006431e74489081c080a0a100818c4c3ec3b0bced80f81f09fc878b23274266b45e2043956562b6714dcfa023dbcbc4df92ed5817fcc9bcd238a038aad806c69585dc8cf582e6012d012d28"],"withdrawals":[],"withdrawals_root":"0x77b0fb1616a212bd7cf33d7c28651f19bf6093b2c5f1967e674ec861aeaf9d44"},"metadata":{"block_number":33439826,"new_account_balances":{},"receipts":{}}},{"payload_id":"0x03c33cc62b81edb6","index":10,"diff":{"state_root":"0x0000000000000000000000000000000000000000000000000000000000000000","receipts_root":"0xaa280e93aa4a7d3f616ad391404411abbeebe8bc8fb1ed9b3ef4d0a42bf64ccd","logs_bloom":"0x000380000000021000200005200004800400800000001000001a000500001000490000204004000000918000010000000000008000000100040200821020886800800010000000000000000800000001c00c000800802000000004202000000804000020000400040100020108000000020002800100000000044b98008a02200000180000480200000100800010080400000000002004011000224080000000020000108c0002040080000844000200000040000100c000c4080108020000012001500a000400000000000001000000104110004021000108000000000200100a10221104400010010004110100000400100008002140004280010000000001","gas_used":"0x49f43c","block_hash":"0x2b440a266840a96993d85d45d1de1e81f7a859aaac4654dcd5a990ffa2ef947b","transactions":["0x02f90fb583014a34831d4797830f4240830f42a88327fdba94ebaff6d578733e4603b99cbdbb221482f29a78e180b90f4484779f44000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000140000000000000000000000000000000000000000000000000000000000000280000000000000000000000000000000000000000000000000000000000000032000000000000000000000000000000000000000000000000000000000000003c00000000000000000000000000000000000000000000000000000000000000460000000000000000000000000000000000000000000000000000000000000050000000000000000000000000000000000000000000000000000000000000005a0000000000000000000000000000000000000000000000000000000000000064000000000000000000000000000000000000000000000000000000000000006e00000000000000000000000000000000000000000000000000000000000000780000000000000000000000000000000000000000000000000000000000000082000000000000000000000000000000000000000000000000000000000000008c000000000000000000000000000000000000000000000000000000000000009600000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000aa00000000000000000000000000000000000000000000000000000000000000b400000000000000000000000000000000000000000000000000000000000000be00000000000000000000000000000000000000000000000000000000000000c800000000000000000000000000000000000000000000000000000000000000d200000000000000000000000000000000000000000000000000000000000000dc00000000000000000000000000000000000000000000000000000000000000e600000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000053ce75532be4cf5bacb01e018950b5be900eafa59f2431fed6b869799529ab39fe0000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000053ce76343a51197104ee22e37cf9c48a9eb5c99031a25196c2f1264deb5d4d3ff80000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000053ce770a821c08f4e200bf42a148754153d78e977260a213094b521b5625618ec70000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000053ce78bb3bcd3592df48dcd3a6383c8f61d8434b6058f61a587dfb0c37134294420000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000053ce79b35d157e36939c03df12e39599530f615a90e624610d8d023eaf2f8329030000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000053ce7a6370bb580180c882bf7214d1f701529ea455f8567b2be79496c9437a2ce30000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000053ce7bf53208371925c87cacbb0bbfbf330fc8a02818e1d73c56760a9fded7f8c80000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000053ce7cac670fbf544ec6d7360aacecd6e3fb35ea8a6ebef6161c9563a6d16a4a200000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000053ce7d91406552fdfe569345c8561328604a63912a36d21cafa1efed0275ce6b190000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000053ce7e6e0b5ccd73c9cea553a19e7ab6e533bc253f552e6b9145dd5470d2612f8d0000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000053ce7fc72e52aaff88c842a2092b7ce047cf47a8f56da1035142a41b6a59b856420000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000053ce80fcaa166cc2fd1353b40f3071a491cd7ca2746c8943caaa6c024c8df0131f0000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000053ce812aabb780f12ed0c0c5dc6932220d8c5f730c54ee63384fbfe1e7fa90a5090000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000053ce82c1dea3b99a38cf0743f31402eba0d22c4da43e715d37533da9bc5f8ca4ae0000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000053ce835d696b1a6f5089cf9bc4c2c529e181678fa2f2feb745223e7520d885a2260000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000053ce8400f527b7b931ddfe77007be944f58173dfc1c5928eb433ae71e96f61a8420000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000053ce85b6dcd2b462f2d1c72e4b46ea316f9183fb9ea40866724b7eef10211a83390000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000053ce860986c742f73c595e7cf75d5014bdccde828c0fa3891f8a7e77cbaf974e7d0000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000053ce879d5711ffb11c2d9fe9737837f55726ba0609c21d62e2783cc38db59edafa0000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000053ce882976c03e7cf30e96a5a578eff196e4062258f3d859abdf161bcb5fd18356000000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000000c080a0c7ccb6ec845a35639b2905d243be7a6cf2ee1412331d348a4bf65f53ae89cde8a06ecc40e8297c75e86332c2924b96c6bf2334a6d1b1ef803e27c9de692906b138","0x02f8b183014a3481ad830ecd10830ecdaf82b6a994af33add7918f685b2a82c1077bd8c07d220ffa0480b844095ea7b3000000000000000000000000a449bc031fa0b815ca14fafd0c5edb75ccd9c80f00000000000000000000000000000000000000000000000c6a036eb4bc740000c001a0d1877e98821074c02cf20dc84d31d70fbc00027d404fe99f3e887a33082bb6cda016f8a55aea1573b3834180e43d90eb6c4b1ffb321d2a0be8b3aa71eeaed5104a"],"withdrawals":[],"withdrawals_root":"0x77b0fb1616a212bd7cf33d7c28651f19bf6093b2c5f1967e674ec861aeaf9d44"},"metadata":{"block_number":33439826,"new_account_balances":{},"receipts":{}}}]"#;
 
         let flashblocks: Vec<OpFlashblockPayload> = serde_json::from_str(raw_sequence).unwrap();
-        let execution_data = OpExecutionData::from_flashblocks(&flashblocks).unwrap();
+        let execution_data = OpExecutionPayloadEnvelope::from_flashblocks(&flashblocks).unwrap();
 
         // Validate against expected final block state from base payload (index 0)
         assert_eq!(
-            execution_data.payload.parent_hash(),
+            execution_data.parent_hash(),
             b256!("6ffd2714d5af6c412c57db3f664a5a127516573bbd987fd242d06f71ea662741")
         );
-        assert_eq!(execution_data.payload.block_number(), 0x1fe4052);
-        assert_eq!(execution_data.payload.timestamp(), 0x690fdf84);
+        assert_eq!(execution_data.block_number(), 0x1fe4052);
+        assert_eq!(execution_data.timestamp(), 0x690fdf84);
         assert_eq!(
-            execution_data.payload.fee_recipient(),
+            execution_data.fee_recipient(),
             address!("4200000000000000000000000000000000000011")
         );
-        assert_eq!(execution_data.payload.gas_limit(), 0x3938700);
-        assert_eq!(execution_data.payload.as_v1().gas_used, 0x49f43c);
+        assert_eq!(execution_data.gas_limit(), 0x3938700);
+        assert_eq!(execution_data.as_v1().gas_used, 0x49f43c);
 
         // Base skipped state root calculation thus state root is expected to be zeros.
         // And subsequently the last flashblocks' block hash is not the final block's block hash.
         // Real block hash: 0x0c3c3ff081d8a5ea1239bfb8a0593f641154a06b783fa142809880e011cd6a3f
         assert_eq!(
-            execution_data.payload.as_v1().state_root,
+            execution_data.as_v1().state_root,
             b256!("0000000000000000000000000000000000000000000000000000000000000000")
         );
         assert_eq!(
-            execution_data.payload.block_hash(),
+            execution_data.block_hash(),
             // last flashblock block hash
             b256!("2b440a266840a96993d85d45d1de1e81f7a859aaac4654dcd5a990ffa2ef947b")
         );
 
         // Verify receipts root from last flashblock (index 10)
         assert_eq!(
-            execution_data.payload.as_v1().receipts_root,
+            execution_data.as_v1().receipts_root,
             b256!("aa280e93aa4a7d3f616ad391404411abbeebe8bc8fb1ed9b3ef4d0a42bf64ccd")
         );
 
@@ -975,11 +1045,11 @@ mod tests {
         // Index 0: 1, Index 1: 2, Index 2: 1, Index 3: 0, Index 4: 4, Index 5: 1
         // Index 6: 3, Index 7: 5, Index 8: 4, Index 9: 1, Index 10: 2
         // Total: 24 transactions
-        assert_eq!(execution_data.payload.transactions().len(), 24);
+        assert_eq!(execution_data.transactions().len(), 24);
 
         // Verify withdrawals root from last flashblock
         assert_eq!(
-            execution_data.payload.as_v4().unwrap().withdrawals_root,
+            execution_data.as_v4().unwrap().withdrawals_root,
             b256!("77b0fb1616a212bd7cf33d7c28651f19bf6093b2c5f1967e674ec861aeaf9d44")
         );
 

--- a/rust/op-alloy/crates/rpc-types-engine/src/envelope.rs
+++ b/rust/op-alloy/crates/rpc-types-engine/src/envelope.rs
@@ -1,12 +1,11 @@
-//! Optimism execution payload envelope in network format and related types.
-//!
-//! This module uses the `snappy` compression algorithm to decompress the payload.
-//! The license for snappy can be found in the `SNAPPY-LICENSE` at the root of the repository.
+//! Optimism execution payload envelopes and Engine API data types.
 
-use crate::{OpExecutionPayload, OpExecutionPayloadSidecar, OpExecutionPayloadV4, OpPayloadError};
+#[cfg(any(feature = "serde", test))]
+use crate::OpPayloadError;
+use crate::{OpExecutionPayload, OpExecutionPayloadSidecar, OpExecutionPayloadV4};
 use alloc::vec::Vec;
 use alloy_eips::eip7685::Requests;
-use alloy_primitives::{B256, Signature, keccak256};
+use alloy_primitives::{B256, keccak256};
 use alloy_rpc_types_engine::{
     CancunPayloadFields, ExecutionPayloadInputV2, ExecutionPayloadV1, ExecutionPayloadV2,
     ExecutionPayloadV3, PraguePayloadFields,
@@ -41,6 +40,7 @@ pub enum OpExecutionPayloadEnvelope {
 
 impl OpExecutionPayloadEnvelope {
     /// Constructs an envelope from its wire-level payload and optional parent beacon block root.
+    #[cfg(any(feature = "serde", test))]
     pub(crate) fn try_from_payload(
         payload: OpExecutionPayload,
         parent_beacon_block_root: Option<B256>,
@@ -190,22 +190,6 @@ impl ssz::Decode for OpExecutionPayloadEnvelope {
     }
 }
 
-impl TryFrom<OpNetworkPayloadEnvelope> for OpExecutionPayloadEnvelope {
-    type Error = OpPayloadError;
-
-    fn try_from(envelope: OpNetworkPayloadEnvelope) -> Result<Self, Self::Error> {
-        Self::try_from_payload(envelope.payload, envelope.parent_beacon_block_root)
-    }
-}
-
-impl TryFrom<&OpNetworkPayloadEnvelope> for OpExecutionPayloadEnvelope {
-    type Error = OpPayloadError;
-
-    fn try_from(envelope: &OpNetworkPayloadEnvelope) -> Result<Self, Self::Error> {
-        Self::try_from_payload(envelope.payload.clone(), envelope.parent_beacon_block_root)
-    }
-}
-
 /// Struct aggregating [`OpExecutionPayload`] and [`OpExecutionPayloadSidecar`] and encapsulating
 /// complete payload supplied for execution.
 #[derive(Debug, Clone)]
@@ -266,268 +250,7 @@ impl OpExecutionData {
     }
 }
 
-/// Optimism execution payload envelope in network format.
-///
-/// This struct is used to represent payloads that are sent over the Optimism
-/// CL p2p network in a snappy-compressed format.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct OpNetworkPayloadEnvelope {
-    /// The execution payload.
-    pub payload: OpExecutionPayload,
-    /// A signature for the payload.
-    pub signature: Signature,
-    /// The hash of the payload.
-    pub payload_hash: PayloadHash,
-    /// The parent beacon block root.
-    pub parent_beacon_block_root: Option<B256>,
-}
-
-impl OpNetworkPayloadEnvelope {
-    /// Decode a payload envelope from a snappy-compressed byte array.
-    /// The payload version decoded is `ExecutionPayloadV1` from SSZ bytes.
-    #[cfg(feature = "std")]
-    pub fn decode_v1(data: &[u8]) -> Result<Self, PayloadEnvelopeError> {
-        use ssz::Decode;
-        let mut decoder = snap::raw::Decoder::new();
-        let decompressed = decoder.decompress_vec(data)?;
-
-        if decompressed.len() < 66 {
-            return Err(PayloadEnvelopeError::InvalidLength);
-        }
-
-        let sig_data = &decompressed[..65];
-        let block_data = &decompressed[65..];
-
-        let signature = Signature::try_from(sig_data)?;
-        let hash = PayloadHash::from(block_data);
-
-        let payload = OpExecutionPayload::V1(
-            alloy_rpc_types_engine::ExecutionPayloadV1::from_ssz_bytes(block_data)?,
-        );
-
-        Ok(Self { payload, signature, payload_hash: hash, parent_beacon_block_root: None })
-    }
-
-    /// Encodes a payload envelope as a snappy-compressed byte array.
-    #[cfg(feature = "std")]
-    pub fn encode_v1(&self) -> Result<Vec<u8>, PayloadEnvelopeEncodeError> {
-        use ssz::Encode;
-        let execution_payload_v1 = match &self.payload {
-            OpExecutionPayload::V1(execution_payload_v1) => execution_payload_v1,
-            _ => return Err(PayloadEnvelopeEncodeError::WrongVersion),
-        };
-
-        let mut data = Vec::new();
-        let mut sig = self.signature.as_bytes();
-        sig[64] = self.signature.v() as u8;
-        data.extend_from_slice(&sig[..]);
-        let block_data = execution_payload_v1.as_ssz_bytes();
-        data.extend_from_slice(block_data.as_slice());
-
-        Ok(snap::raw::Encoder::new().compress_vec(&data)?)
-    }
-
-    /// Decode a payload envelope from a snappy-compressed byte array.
-    /// The payload version decoded is `ExecutionPayloadV2` from SSZ bytes.
-    #[cfg(feature = "std")]
-    pub fn decode_v2(data: &[u8]) -> Result<Self, PayloadEnvelopeError> {
-        use ssz::Decode;
-        let mut decoder = snap::raw::Decoder::new();
-        let decompressed = decoder.decompress_vec(data)?;
-
-        if decompressed.len() < 66 {
-            return Err(PayloadEnvelopeError::InvalidLength);
-        }
-
-        let sig_data = &decompressed[..65];
-        let block_data = &decompressed[65..];
-
-        let signature = Signature::try_from(sig_data)?;
-        let hash = PayloadHash::from(block_data);
-
-        let payload = OpExecutionPayload::V2(
-            alloy_rpc_types_engine::ExecutionPayloadV2::from_ssz_bytes(block_data)?,
-        );
-
-        Ok(Self { payload, signature, payload_hash: hash, parent_beacon_block_root: None })
-    }
-
-    /// Encodes a payload envelope as a snappy-compressed byte array.
-    #[cfg(feature = "std")]
-    pub fn encode_v2(&self) -> Result<Vec<u8>, PayloadEnvelopeEncodeError> {
-        use ssz::Encode;
-        let execution_payload_v2 = match &self.payload {
-            OpExecutionPayload::V2(execution_payload_v2) => execution_payload_v2,
-            _ => return Err(PayloadEnvelopeEncodeError::WrongVersion),
-        };
-
-        let mut data = Vec::new();
-        let mut sig = self.signature.as_bytes();
-        sig[64] = self.signature.v() as u8;
-        data.extend_from_slice(&sig[..]);
-        let block_data = execution_payload_v2.as_ssz_bytes();
-        data.extend_from_slice(block_data.as_slice());
-
-        Ok(snap::raw::Encoder::new().compress_vec(&data)?)
-    }
-
-    /// Decode a payload envelope from a snappy-compressed byte array.
-    /// The payload version decoded is `ExecutionPayloadV3` from SSZ bytes.
-    #[cfg(feature = "std")]
-    pub fn decode_v3(data: &[u8]) -> Result<Self, PayloadEnvelopeError> {
-        use ssz::Decode;
-        let mut decoder = snap::raw::Decoder::new();
-        let decompressed = decoder.decompress_vec(data)?;
-
-        if decompressed.len() < 98 {
-            return Err(PayloadEnvelopeError::InvalidLength);
-        }
-
-        let sig_data = &decompressed[..65];
-        let parent_beacon_block_root = &decompressed[65..97];
-        let block_data = &decompressed[97..];
-
-        let signature = Signature::try_from(sig_data)?;
-        let parent_beacon_block_root = B256::from_slice(parent_beacon_block_root);
-        let hash = PayloadHash::from(
-            [parent_beacon_block_root.as_slice(), block_data].concat().as_slice(),
-        );
-
-        let payload = OpExecutionPayload::V3(
-            alloy_rpc_types_engine::ExecutionPayloadV3::from_ssz_bytes(block_data)?,
-        );
-
-        Ok(Self {
-            payload,
-            signature,
-            payload_hash: hash,
-            parent_beacon_block_root: Some(parent_beacon_block_root),
-        })
-    }
-
-    /// Encodes a payload envelope as a snappy-compressed byte array.
-    #[cfg(feature = "std")]
-    pub fn encode_v3(&self) -> Result<Vec<u8>, PayloadEnvelopeEncodeError> {
-        use ssz::Encode;
-        let execution_payload_v3 = match &self.payload {
-            OpExecutionPayload::V3(execution_payload_v3) => execution_payload_v3,
-            _ => return Err(PayloadEnvelopeEncodeError::WrongVersion),
-        };
-
-        let mut data = Vec::new();
-        let mut sig = self.signature.as_bytes();
-        sig[64] = self.signature.v() as u8;
-        data.extend_from_slice(&sig[..]);
-        data.extend_from_slice(self.parent_beacon_block_root.as_ref().unwrap().as_slice());
-        let block_data = execution_payload_v3.as_ssz_bytes();
-        data.extend_from_slice(block_data.as_slice());
-
-        Ok(snap::raw::Encoder::new().compress_vec(&data)?)
-    }
-
-    /// Decode a payload envelope from a snappy-compressed byte array.
-    /// The payload version decoded is `ExecutionPayloadV4` from SSZ bytes.
-    #[cfg(feature = "std")]
-    pub fn decode_v4(data: &[u8]) -> Result<Self, PayloadEnvelopeError> {
-        use ssz::Decode;
-        let mut decoder = snap::raw::Decoder::new();
-        let decompressed = decoder.decompress_vec(data)?;
-
-        if decompressed.len() < 98 {
-            return Err(PayloadEnvelopeError::InvalidLength);
-        }
-
-        let sig_data = &decompressed[..65];
-        let parent_beacon_block_root = &decompressed[65..97];
-        let block_data = &decompressed[97..];
-
-        let signature = Signature::try_from(sig_data)?;
-        let parent_beacon_block_root = B256::from_slice(parent_beacon_block_root);
-        let hash = PayloadHash::from(
-            [parent_beacon_block_root.as_slice(), block_data].concat().as_slice(),
-        );
-
-        let payload = OpExecutionPayload::V4(OpExecutionPayloadV4::from_ssz_bytes(block_data)?);
-
-        Ok(Self {
-            payload,
-            signature,
-            payload_hash: hash,
-            parent_beacon_block_root: Some(parent_beacon_block_root),
-        })
-    }
-
-    /// Encodes a payload envelope as a snappy-compressed byte array.
-    #[cfg(feature = "std")]
-    pub fn encode_v4(&self) -> Result<Vec<u8>, PayloadEnvelopeEncodeError> {
-        use ssz::Encode;
-        let execution_payload_v4 = match &self.payload {
-            OpExecutionPayload::V4(execution_payload_v4) => execution_payload_v4,
-            _ => return Err(PayloadEnvelopeEncodeError::WrongVersion),
-        };
-
-        let mut data = Vec::new();
-        let mut sig = self.signature.as_bytes();
-        sig[64] = self.signature.v() as u8;
-        data.extend_from_slice(&sig[..]);
-        data.extend_from_slice(self.parent_beacon_block_root.as_ref().unwrap().as_slice());
-        let block_data = execution_payload_v4.as_ssz_bytes();
-        data.extend_from_slice(block_data.as_slice());
-
-        Ok(snap::raw::Encoder::new().compress_vec(&data)?)
-    }
-}
-
-/// Errors that can occur when encoding a payload envelope.
-#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
-pub enum PayloadEnvelopeEncodeError {
-    /// Wrong versions of the payload.
-    #[error("Wrong version of the payload")]
-    WrongVersion,
-    /// An error occurred during snap encoding.
-    #[error(transparent)]
-    #[cfg(feature = "std")]
-    SnapEncoding(#[from] snap::Error),
-}
-
-/// Errors that can occur when decoding a payload envelope.
-#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
-pub enum PayloadEnvelopeError {
-    /// The snappy encoding is broken.
-    #[error("Broken snappy encoding")]
-    BrokenSnappyEncoding,
-    /// The signature is invalid.
-    #[error("Invalid signature")]
-    InvalidSignature,
-    /// The SSZ encoding is broken.
-    #[error("Broken SSZ encoding")]
-    BrokenSszEncoding,
-    /// The payload envelope is of invalid length.
-    #[error("Invalid length")]
-    InvalidLength,
-}
-
-impl From<alloy_primitives::SignatureError> for PayloadEnvelopeError {
-    fn from(_: alloy_primitives::SignatureError) -> Self {
-        Self::InvalidSignature
-    }
-}
-
-#[cfg(feature = "std")]
-impl From<snap::Error> for PayloadEnvelopeError {
-    fn from(_: snap::Error) -> Self {
-        Self::BrokenSnappyEncoding
-    }
-}
-
-#[cfg(feature = "std")]
-impl From<ssz::DecodeError> for PayloadEnvelopeError {
-    fn from(_: ssz::DecodeError) -> Self {
-        Self::BrokenSszEncoding
-    }
-}
-
-/// Represents the Keccak256 hash of the block
+/// Represents the Keccak-256 hash of an encoded execution payload envelope.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct PayloadHash(pub B256);
@@ -742,65 +465,6 @@ mod tests {
             assert_eq!(hash.0, keccak256(inner.as_slice()));
             Ok(())
         });
-    }
-
-    #[cfg(feature = "std")]
-    fn assert_payload_envelope_roundtrip(network: &OpNetworkPayloadEnvelope) {
-        let envelope = OpExecutionPayloadEnvelope::try_from(network).unwrap();
-        assert_eq!(envelope.payload_hash(), network.payload_hash);
-
-        let encoded = ssz::Encode::as_ssz_bytes(&envelope);
-        let decoded =
-            <OpExecutionPayloadEnvelope as ssz::Decode>::from_ssz_bytes(&encoded).unwrap();
-        assert_eq!(decoded, envelope);
-    }
-
-    #[test]
-    #[cfg(feature = "std")]
-    fn test_roundtrip_encode_envelope_v1() {
-        use alloy_primitives::hex;
-        let data = hex::decode("0xbd04f043128457c6ccf35128497167442bcc0f8cce78cda8b366e6a12e526d938d1e4c1046acffffbfc542a7e212bb7d80d3a4b2f84f7b196d935398a24eb84c519789b401000000fe0300fe0300fe0300fe0300fe0300fe0300a203000c4a8fd56621ad04fc0101067601008ce60be0005b220117c32c0f3b394b346c2aa42cfa8157cd41f891aa0bec485a62fc010000").unwrap();
-        let payload_envelop = OpNetworkPayloadEnvelope::decode_v1(&data).unwrap();
-        assert_eq!(1725271882, payload_envelop.payload.timestamp());
-        assert_payload_envelope_roundtrip(&payload_envelop);
-        let encoded = payload_envelop.encode_v1().unwrap();
-        assert_eq!(data, encoded);
-    }
-
-    #[test]
-    #[cfg(feature = "std")]
-    fn test_roundtrip_encode_envelope_v2() {
-        use alloy_primitives::hex;
-        let data = hex::decode("0xc104f0433805080eb36c0b130a7cc1dc74c3f721af4e249aa6f61bb89d1557143e971bb738a3f3b98df7c457e74048e9d2d7e5cd82bb45e3760467e2270e9db86d1271a700000000fe0300fe0300fe0300fe0300fe0300fe0300a203000c6b89d46525ad000205067201009cda69cb5b9b73fc4eb2458b37d37f04ff507fe6c9cd2ab704a05ea9dae3cd61760002000000020000").unwrap();
-        let payload_envelop = OpNetworkPayloadEnvelope::decode_v2(&data).unwrap();
-        assert_eq!(1708427627, payload_envelop.payload.timestamp());
-        assert_payload_envelope_roundtrip(&payload_envelop);
-        let encoded = payload_envelop.encode_v2().unwrap();
-        assert_eq!(data, encoded);
-    }
-
-    #[test]
-    #[cfg(feature = "std")]
-    fn test_roundtrip_encode_envelope_v3() {
-        use alloy_primitives::hex;
-        let data = hex::decode("0xf104f0434442b9eb38b259f5b23826e6b623e829d2fb878dac70187a1aecf42a3f9bedfd29793d1fcb5822324be0d3e12340a95855553a65d64b83e5579dffb31470df5d010000006a03000412346a1d00fe0100fe0100fe0100fe0100fe0100fe01004201000cc588d465219504100201067601007cfece77b89685f60e3663b6e0faf2de0734674eb91339700c4858c773a8ff921e014401043e0100").unwrap();
-        let payload_envelop = OpNetworkPayloadEnvelope::decode_v3(&data).unwrap();
-        assert_eq!(1708427461, payload_envelop.payload.timestamp());
-        assert_payload_envelope_roundtrip(&payload_envelop);
-        let encoded = payload_envelop.encode_v3().unwrap();
-        assert_eq!(data, encoded);
-    }
-
-    #[test]
-    #[cfg(feature = "std")]
-    fn test_roundtrip_encode_envelope_v4() {
-        use alloy_primitives::hex;
-        let data = hex::decode("0x9105f043cee25401b6853202950d1d8a082f31a80c4fef5782c049a731f5d104b1b9b9aa7618605b420438ae98b44c8aaaebd482854473c2ae57c079286bb634bece5210000000006a03000412346a1d00fe0100fe0100fe0100fe0100fe0100fe01004201000c5766d26721950430020106f6010001440104b60100049876").unwrap();
-        let payload_envelop = OpNetworkPayloadEnvelope::decode_v4(&data).unwrap();
-        assert_eq!(1741842007, payload_envelop.payload.timestamp());
-        assert_payload_envelope_roundtrip(&payload_envelop);
-        let encoded = payload_envelop.encode_v4().unwrap();
-        assert_eq!(data, encoded);
     }
 
     #[cfg(test)]

--- a/rust/op-alloy/crates/rpc-types-engine/src/execution.rs
+++ b/rust/op-alloy/crates/rpc-types-engine/src/execution.rs
@@ -1,0 +1,498 @@
+use crate::{
+    OpExecutionData, OpExecutionPayload, OpExecutionPayloadEnvelope, OpExecutionPayloadV4,
+    OpFlashblockError, OpFlashblockPayload, OpPayloadError,
+};
+use alloc::vec::Vec;
+use alloy_consensus::{Block, BlockHeader, Sealable, Transaction};
+use alloy_eips::{
+    Decodable2718, Encodable2718, Typed2718,
+    eip4895::Withdrawal,
+    eip7685::{EMPTY_REQUESTS_HASH, Requests},
+};
+use alloy_primitives::{B256, Bytes};
+use alloy_rpc_types_engine::{
+    ExecutionPayloadV1, ExecutionPayloadV2, ExecutionPayloadV3, PayloadError,
+};
+
+impl OpExecutionPayloadEnvelope {
+    /// Converts this payload envelope into a block with decoded transactions.
+    pub fn try_into_block<T>(self) -> Result<Block<T>, OpPayloadError>
+    where
+        T: Decodable2718 + Typed2718,
+    {
+        let check_blob_transactions = matches!(&self, Self::V3 { .. } | Self::V4 { .. });
+        let block = self.try_into_block_raw()?.try_map_transactions(|tx| {
+            T::decode_2718_exact(tx.as_ref())
+                .map_err(alloy_rlp::Error::from)
+                .map_err(PayloadError::from)
+        })?;
+        if check_blob_transactions && block.body.has_eip4844_transactions() {
+            return Err(OpPayloadError::BlobTransaction);
+        }
+
+        Ok(block)
+    }
+
+    /// Verifies the claimed block hash using the raw encoded transaction bytes.
+    ///
+    /// This computes the transaction trie root without decoding or validating the transactions.
+    /// Full transaction and execution validation remains the responsibility of the execution
+    /// layer or [`Self::try_into_checked_block`].
+    pub fn check_block_hash(&self) -> Result<(), OpPayloadError> {
+        let consensus = self.block_hash();
+        let block = self.clone().try_into_block_raw()?;
+        let execution = block.header.hash_slow();
+        if execution != consensus {
+            return Err(PayloadError::BlockHash { execution, consensus }.into());
+        }
+
+        Ok(())
+    }
+
+    /// Converts this payload envelope into a block and verifies its claimed block hash.
+    pub fn try_into_checked_block<T>(self) -> Result<Block<T>, OpPayloadError>
+    where
+        T: Decodable2718 + Typed2718,
+    {
+        let consensus = self.block_hash();
+        let block = self.try_into_block()?;
+        let execution = block.header.hash_slow();
+        if execution != consensus {
+            return Err(PayloadError::BlockHash { execution, consensus }.into());
+        }
+
+        Ok(block)
+    }
+
+    /// Converts a block into a payload envelope and recalculates its block hash.
+    pub fn from_block_slow<T, H>(block: &Block<T, H>) -> Result<Self, OpPayloadError>
+    where
+        T: Encodable2718 + Transaction,
+        H: BlockHeader + Sealable,
+    {
+        let (payload, sidecar) = OpExecutionPayload::from_block_slow(block);
+        OpExecutionData::new(payload, sidecar).try_into()
+    }
+
+    /// Converts a block into a payload envelope with the supplied block hash.
+    pub fn from_block_unchecked<T, H>(
+        block_hash: B256,
+        block: &Block<T, H>,
+    ) -> Result<Self, OpPayloadError>
+    where
+        T: Encodable2718 + Transaction,
+        H: BlockHeader,
+    {
+        let (payload, sidecar) = OpExecutionPayload::from_block_unchecked(block_hash, block);
+        OpExecutionData::new(payload, sidecar).try_into()
+    }
+
+    /// Converts a sequence of flashblocks into a payload envelope.
+    pub fn from_flashblocks(
+        flashblocks: &[OpFlashblockPayload],
+    ) -> Result<Self, OpFlashblockError> {
+        if flashblocks.is_empty() {
+            return Err(OpFlashblockError::MissingPayload);
+        }
+        for (i, flashblock) in flashblocks.iter().enumerate() {
+            if flashblock.index as usize != i {
+                return Err(OpFlashblockError::InvalidIndex);
+            }
+        }
+        let first = flashblocks.first().expect("flashblocks must not be empty");
+        if first.base.is_none() {
+            return Err(OpFlashblockError::MissingBasePayload);
+        }
+        if flashblocks.iter().skip(1).any(|flashblock| flashblock.base.is_some()) {
+            return Err(OpFlashblockError::UnexpectedBasePayload);
+        }
+
+        Ok(Self::from_flashblocks_unchecked(flashblocks))
+    }
+
+    /// Converts a sequence of flashblocks into a payload envelope without validation.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the sequence is empty or its first flashblock has no base payload.
+    pub fn from_flashblocks_unchecked(flashblocks: &[OpFlashblockPayload]) -> Self {
+        let first = flashblocks.first().expect("flashblocks must not be empty");
+        let base = first.base.as_ref().expect("first flashblock must have base payload");
+        let diff = &flashblocks.last().expect("flashblocks must not be empty").diff;
+
+        let (mut transactions, withdrawals) = flashblocks.iter().fold(
+            (Vec::new(), Vec::new()),
+            |(mut transactions, mut withdrawals), payload| {
+                transactions.extend(payload.diff.transactions.iter().cloned());
+                withdrawals.extend(payload.diff.withdrawals.iter().copied());
+                (transactions, withdrawals)
+            },
+        );
+
+        if let Some(post_exec_tx) = diff.post_exec_tx.as_ref() {
+            transactions.push(post_exec_tx.clone());
+        }
+
+        let payload = ExecutionPayloadV3 {
+            blob_gas_used: diff.blob_gas_used.unwrap_or(0),
+            excess_blob_gas: 0,
+            payload_inner: ExecutionPayloadV2 {
+                withdrawals,
+                payload_inner: ExecutionPayloadV1 {
+                    parent_hash: base.parent_hash,
+                    fee_recipient: base.fee_recipient,
+                    state_root: diff.state_root,
+                    receipts_root: diff.receipts_root,
+                    logs_bloom: diff.logs_bloom,
+                    prev_randao: base.prev_randao,
+                    block_number: base.block_number,
+                    gas_limit: base.gas_limit,
+                    gas_used: diff.gas_used,
+                    timestamp: base.timestamp,
+                    extra_data: base.extra_data.clone(),
+                    base_fee_per_gas: base.base_fee_per_gas,
+                    block_hash: diff.block_hash,
+                    transactions,
+                },
+            },
+        };
+
+        if diff.withdrawals_root == B256::ZERO {
+            return Self::V3 { payload, parent_beacon_block_root: base.parent_beacon_block_root };
+        }
+
+        Self::V4 {
+            payload: OpExecutionPayloadV4 {
+                withdrawals_root: diff.withdrawals_root,
+                payload_inner: payload,
+            },
+            parent_beacon_block_root: base.parent_beacon_block_root,
+        }
+    }
+
+    /// Converts this payload envelope into a complete block with raw transactions.
+    fn try_into_block_raw(self) -> Result<Block<Bytes>, OpPayloadError> {
+        if self.withdrawals().is_some_and(|withdrawals| !withdrawals.is_empty()) {
+            return Err(OpPayloadError::NonEmptyL1Withdrawals);
+        }
+
+        let block = match self {
+            Self::V1(payload) => payload.into_block_raw()?,
+            Self::V2(payload) => payload.into_block_raw()?,
+            Self::V3 { payload, parent_beacon_block_root } => {
+                let mut block = payload.into_block_raw()?;
+                block.header.parent_beacon_block_root = Some(parent_beacon_block_root);
+                block
+            }
+            Self::V4 { payload, parent_beacon_block_root } => {
+                let mut block = payload.payload_inner.into_block_raw()?;
+                block.header.withdrawals_root = Some(payload.withdrawals_root);
+                block.header.parent_beacon_block_root = Some(parent_beacon_block_root);
+                block.header.requests_hash = Some(EMPTY_REQUESTS_HASH);
+                block
+            }
+        };
+
+        Ok(block)
+    }
+
+    /// Returns the V1 payload fields shared by every payload version.
+    pub const fn as_v1(&self) -> &ExecutionPayloadV1 {
+        match self {
+            Self::V1(payload) => payload,
+            Self::V2(payload) => &payload.payload_inner,
+            Self::V3 { payload, .. } => &payload.payload_inner.payload_inner,
+            Self::V4 { payload, .. } => &payload.payload_inner.payload_inner.payload_inner,
+        }
+    }
+
+    /// Returns the mutable V1 payload fields shared by every payload version.
+    pub const fn as_v1_mut(&mut self) -> &mut ExecutionPayloadV1 {
+        match self {
+            Self::V1(payload) => payload,
+            Self::V2(payload) => &mut payload.payload_inner,
+            Self::V3 { payload, .. } => &mut payload.payload_inner.payload_inner,
+            Self::V4 { payload, .. } => &mut payload.payload_inner.payload_inner.payload_inner,
+        }
+    }
+
+    /// Returns the V4 payload, if present.
+    pub const fn as_v4(&self) -> Option<&OpExecutionPayloadV4> {
+        match self {
+            Self::V4 { payload, .. } => Some(payload),
+            _ => None,
+        }
+    }
+
+    /// Returns the transactions.
+    pub const fn transactions(&self) -> &Vec<alloy_primitives::Bytes> {
+        &self.as_v1().transactions
+    }
+
+    /// Returns the parent beacon block root for V3 and V4 payloads.
+    pub const fn parent_beacon_block_root(&self) -> Option<B256> {
+        match self {
+            Self::V1(_) | Self::V2(_) => None,
+            Self::V3 { parent_beacon_block_root, .. } |
+            Self::V4 { parent_beacon_block_root, .. } => Some(*parent_beacon_block_root),
+        }
+    }
+
+    /// Returns the withdrawals for the payload.
+    pub const fn withdrawals(&self) -> Option<&Vec<Withdrawal>> {
+        match self {
+            Self::V1(_) => None,
+            Self::V2(payload) => Some(&payload.withdrawals),
+            Self::V3 { payload, .. } => Some(payload.withdrawals()),
+            Self::V4 { payload, .. } => Some(payload.payload_inner.withdrawals()),
+        }
+    }
+
+    /// Returns the parent hash.
+    pub const fn parent_hash(&self) -> B256 {
+        self.as_v1().parent_hash
+    }
+
+    /// Returns the claimed block hash.
+    pub const fn block_hash(&self) -> B256 {
+        self.as_v1().block_hash
+    }
+
+    /// Returns the block number.
+    pub const fn block_number(&self) -> u64 {
+        self.as_v1().block_number
+    }
+
+    /// Returns the timestamp.
+    pub const fn timestamp(&self) -> u64 {
+        self.as_v1().timestamp
+    }
+
+    /// Returns the fee recipient.
+    pub const fn fee_recipient(&self) -> alloy_primitives::Address {
+        self.as_v1().fee_recipient
+    }
+
+    /// Returns the gas limit.
+    pub const fn gas_limit(&self) -> u64 {
+        self.as_v1().gas_limit
+    }
+}
+
+impl TryFrom<OpExecutionData> for OpExecutionPayloadEnvelope {
+    type Error = OpPayloadError;
+
+    fn try_from(data: OpExecutionData) -> Result<Self, Self::Error> {
+        let parent_beacon_block_root = data.sidecar.parent_beacon_block_root();
+        let versioned_hashes = data.sidecar.versioned_hashes();
+        let requests_hash = data.sidecar.requests_hash();
+
+        match data.payload {
+            OpExecutionPayload::V1(payload) => {
+                ensure_pre_ecotone_sidecar(parent_beacon_block_root, requests_hash)?;
+                Ok(Self::V1(payload))
+            }
+            OpExecutionPayload::V2(payload) => {
+                ensure_pre_ecotone_sidecar(parent_beacon_block_root, requests_hash)?;
+                Ok(Self::V2(payload))
+            }
+            OpExecutionPayload::V3(payload) => {
+                let parent_beacon_block_root =
+                    parent_beacon_block_root.ok_or(OpPayloadError::MissingParentBeaconBlockRoot)?;
+                ensure_empty_versioned_hashes(versioned_hashes)?;
+                if requests_hash.is_some() {
+                    return Err(OpPayloadError::UnexpectedELRequests);
+                }
+                Ok(Self::V3 { payload, parent_beacon_block_root })
+            }
+            OpExecutionPayload::V4(payload) => {
+                let parent_beacon_block_root =
+                    parent_beacon_block_root.ok_or(OpPayloadError::MissingParentBeaconBlockRoot)?;
+                ensure_empty_versioned_hashes(versioned_hashes)?;
+                let requests_hash = requests_hash.ok_or(OpPayloadError::MissingELRequests)?;
+                if requests_hash != EMPTY_REQUESTS_HASH {
+                    return Err(OpPayloadError::NonEmptyELRequests);
+                }
+                Ok(Self::V4 { payload, parent_beacon_block_root })
+            }
+        }
+    }
+}
+
+impl TryFrom<&OpExecutionData> for OpExecutionPayloadEnvelope {
+    type Error = OpPayloadError;
+
+    fn try_from(data: &OpExecutionData) -> Result<Self, Self::Error> {
+        data.clone().try_into()
+    }
+}
+
+impl From<OpExecutionPayloadEnvelope> for OpExecutionData {
+    fn from(data: OpExecutionPayloadEnvelope) -> Self {
+        match data {
+            OpExecutionPayloadEnvelope::V1(payload) => {
+                Self::new(OpExecutionPayload::V1(payload), Default::default())
+            }
+            OpExecutionPayloadEnvelope::V2(payload) => {
+                Self::new(OpExecutionPayload::V2(payload), Default::default())
+            }
+            OpExecutionPayloadEnvelope::V3 { payload, parent_beacon_block_root } => {
+                Self::v3(payload, Vec::new(), parent_beacon_block_root)
+            }
+            OpExecutionPayloadEnvelope::V4 { payload, parent_beacon_block_root } => {
+                Self::v4(payload, Vec::new(), parent_beacon_block_root, Requests::default())
+            }
+        }
+    }
+}
+
+const fn ensure_pre_ecotone_sidecar(
+    parent_beacon_block_root: Option<B256>,
+    requests_hash: Option<B256>,
+) -> Result<(), OpPayloadError> {
+    if parent_beacon_block_root.is_some() {
+        return Err(OpPayloadError::UnexpectedParentBeaconBlockRoot);
+    }
+    if requests_hash.is_some() {
+        return Err(OpPayloadError::UnexpectedELRequests);
+    }
+    Ok(())
+}
+
+fn ensure_empty_versioned_hashes(
+    versioned_hashes: Option<&Vec<B256>>,
+) -> Result<(), OpPayloadError> {
+    let versioned_hashes = versioned_hashes.ok_or(OpPayloadError::MissingParentBeaconBlockRoot)?;
+    if !versioned_hashes.is_empty() {
+        return Err(OpPayloadError::NonEmptyBlobVersionedHashes);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::OpExecutionPayloadSidecar;
+    use alloy_primitives::Bytes;
+    use alloy_rpc_types_engine::{CancunPayloadFields, PraguePayloadFields};
+    use op_alloy_consensus::OpTxEnvelope;
+
+    fn payload_v1() -> ExecutionPayloadV1 {
+        ExecutionPayloadV1::from_block_unchecked(B256::ZERO, &Block::<OpTxEnvelope>::default())
+    }
+
+    fn payload_v3() -> ExecutionPayloadV3 {
+        ExecutionPayloadV3::from_block_unchecked(B256::ZERO, &Block::<OpTxEnvelope>::default())
+    }
+
+    #[test]
+    fn rejects_missing_v3_parent_beacon_block_root() {
+        let payload = OpExecutionPayload::V3(payload_v3());
+        let data = OpExecutionData::new(payload, OpExecutionPayloadSidecar::default());
+        assert!(matches!(
+            OpExecutionPayloadEnvelope::try_from(data),
+            Err(OpPayloadError::MissingParentBeaconBlockRoot)
+        ));
+
+        assert!(matches!(
+            OpExecutionPayloadEnvelope::try_from_payload(
+                OpExecutionPayload::V3(payload_v3()),
+                None,
+            ),
+            Err(OpPayloadError::MissingParentBeaconBlockRoot)
+        ));
+    }
+
+    #[test]
+    fn distinguishes_present_zero_parent_beacon_block_root() {
+        let data = OpExecutionData::v3(payload_v3(), Vec::new(), B256::ZERO);
+        let envelope = OpExecutionPayloadEnvelope::try_from(data).unwrap();
+        assert!(matches!(
+            envelope,
+            OpExecutionPayloadEnvelope::V3 { parent_beacon_block_root: B256::ZERO, .. }
+        ));
+        assert_eq!(envelope.parent_beacon_block_root(), Some(B256::ZERO));
+
+        let data: OpExecutionData = envelope.clone().into();
+        assert_eq!(data.sidecar.parent_beacon_block_root(), Some(B256::ZERO));
+        assert_eq!(OpExecutionPayloadEnvelope::try_from(data).unwrap(), envelope);
+    }
+
+    #[test]
+    fn rejects_unexpected_v1_parent_beacon_block_root() {
+        let payload = OpExecutionPayload::V1(payload_v1());
+        let sidecar =
+            OpExecutionPayloadSidecar::v3(CancunPayloadFields::new(B256::ZERO, Vec::new()));
+        assert!(matches!(
+            OpExecutionPayloadEnvelope::try_from(OpExecutionData::new(payload, sidecar)),
+            Err(OpPayloadError::UnexpectedParentBeaconBlockRoot)
+        ));
+
+        assert!(matches!(
+            OpExecutionPayloadEnvelope::try_from_payload(
+                OpExecutionPayload::V1(payload_v1()),
+                Some(B256::ZERO),
+            ),
+            Err(OpPayloadError::UnexpectedParentBeaconBlockRoot)
+        ));
+    }
+
+    #[test]
+    fn rejects_non_empty_blob_versioned_hashes() {
+        let data = OpExecutionData::v3(payload_v3(), vec![B256::ZERO], B256::ZERO);
+        assert!(matches!(
+            OpExecutionPayloadEnvelope::try_from(data),
+            Err(OpPayloadError::NonEmptyBlobVersionedHashes)
+        ));
+    }
+
+    #[test]
+    fn rejects_non_empty_execution_requests() {
+        let payload =
+            OpExecutionPayloadV4 { payload_inner: payload_v3(), withdrawals_root: B256::ZERO };
+        let requests = Requests::new(vec![Bytes::from_static(&[0x01, 0x02])]);
+        let data = OpExecutionData::v4(payload, Vec::new(), B256::ZERO, requests);
+        assert!(matches!(
+            OpExecutionPayloadEnvelope::try_from(data),
+            Err(OpPayloadError::NonEmptyELRequests)
+        ));
+    }
+
+    #[test]
+    fn rejects_mismatched_v3_prague_fields() {
+        let payload = OpExecutionPayload::V3(payload_v3());
+        let sidecar = OpExecutionPayloadSidecar::v4(
+            CancunPayloadFields::new(B256::ZERO, Vec::new()),
+            PraguePayloadFields::new(Requests::default()),
+        );
+        assert!(matches!(
+            OpExecutionPayloadEnvelope::try_from(OpExecutionData::new(payload, sidecar)),
+            Err(OpPayloadError::UnexpectedELRequests)
+        ));
+    }
+
+    #[test]
+    fn rejects_v4_without_prague_fields() {
+        let payload = OpExecutionPayload::V4(OpExecutionPayloadV4 {
+            payload_inner: payload_v3(),
+            withdrawals_root: B256::ZERO,
+        });
+        let sidecar =
+            OpExecutionPayloadSidecar::v3(CancunPayloadFields::new(B256::ZERO, Vec::new()));
+        assert!(matches!(
+            OpExecutionPayloadEnvelope::try_from(OpExecutionData::new(payload, sidecar)),
+            Err(OpPayloadError::MissingELRequests)
+        ));
+    }
+
+    #[test]
+    fn check_block_hash_does_not_decode_transactions() {
+        let mut envelope = OpExecutionPayloadEnvelope::V1(payload_v1());
+        envelope.as_v1_mut().transactions = vec![Bytes::from_static(&[0xff])];
+        let block_hash = envelope.clone().try_into_block_raw().unwrap().header.hash_slow();
+        envelope.as_v1_mut().block_hash = block_hash;
+
+        assert!(envelope.check_block_hash().is_ok());
+        assert!(envelope.try_into_block::<OpTxEnvelope>().is_err());
+    }
+}

--- a/rust/op-alloy/crates/rpc-types-engine/src/flashblock/mod.rs
+++ b/rust/op-alloy/crates/rpc-types-engine/src/flashblock/mod.rs
@@ -30,16 +30,16 @@
 //! Convert a sequence of flashblocks to a full execution payload:
 //!
 //! ```rust,ignore
-//! use op_alloy_rpc_types_engine::{OpExecutionData, OpFlashblockPayload};
+//! use op_alloy_rpc_types_engine::{OpFlashblockPayload, OpExecutionPayloadEnvelope};
 //!
 //! let flashblocks: Vec<OpFlashblockPayload> = vec![/* ... */];
-//! let execution_data = OpExecutionData::from_flashblocks(flashblocks)?;
+//! let execution_data = OpExecutionPayloadEnvelope::from_flashblocks(&flashblocks)?;
 //! # Ok::<(), op_alloy_rpc_types_engine::OpFlashblockError>(())
 //! ```
 //!
 //! ## Validation Rules
 //!
-//! The [`OpExecutionData::from_flashblocks`](crate::OpExecutionData::from_flashblocks) method
+//! The [`OpExecutionPayloadEnvelope::from_flashblocks`](crate::OpExecutionPayloadEnvelope::from_flashblocks) method
 //! performs comprehensive validation:
 //!
 //! - Indices must be sequential starting from 0

--- a/rust/op-alloy/crates/rpc-types-engine/src/lib.rs
+++ b/rust/op-alloy/crates/rpc-types-engine/src/lib.rs
@@ -20,6 +20,8 @@ pub use envelope::{
     PayloadEnvelopeEncodeError, PayloadEnvelopeError, PayloadHash,
 };
 
+mod execution;
+
 mod sidecar;
 pub use sidecar::OpExecutionPayloadSidecar;
 

--- a/rust/op-alloy/crates/rpc-types-engine/src/lib.rs
+++ b/rust/op-alloy/crates/rpc-types-engine/src/lib.rs
@@ -15,10 +15,7 @@ mod attributes;
 pub use attributes::OpPayloadAttributes;
 
 mod envelope;
-pub use envelope::{
-    OpExecutionData, OpExecutionPayloadEnvelope, OpNetworkPayloadEnvelope,
-    PayloadEnvelopeEncodeError, PayloadEnvelopeError, PayloadHash,
-};
+pub use envelope::{OpExecutionData, OpExecutionPayloadEnvelope, PayloadHash};
 
 mod execution;
 

--- a/rust/op-alloy/crates/rpc-types-engine/src/payload/error.rs
+++ b/rust/op-alloy/crates/rpc-types-engine/src/payload/error.rs
@@ -17,6 +17,18 @@ pub enum OpPayloadError {
     /// Non-empty list of blob versioned hashes.
     #[error("non-empty blob versioned hashes")]
     NonEmptyBlobVersionedHashes,
+    /// A V3 or V4 payload is missing its parent beacon block root.
+    #[error("missing parent beacon block root")]
+    MissingParentBeaconBlockRoot,
+    /// A V1 or V2 payload unexpectedly includes a parent beacon block root.
+    #[error("unexpected parent beacon block root")]
+    UnexpectedParentBeaconBlockRoot,
+    /// A V4 payload is missing its execution request fields.
+    #[error("missing EL requests")]
+    MissingELRequests,
+    /// A pre-V4 payload unexpectedly includes execution request fields.
+    #[error("unexpected EL requests")]
+    UnexpectedELRequests,
     /// L1 [`PayloadError`] that can also occur on L2.
     #[error(transparent)]
     Eth(#[from] PayloadError),

--- a/rust/op-alloy/crates/rpc-types-engine/src/payload/mod.rs
+++ b/rust/op-alloy/crates/rpc-types-engine/src/payload/mod.rs
@@ -7,13 +7,12 @@ pub mod v4;
 use crate::{OpExecutionPayloadSidecar, OpExecutionPayloadV4};
 use alloc::vec::Vec;
 use alloy_consensus::{Block, BlockHeader, HeaderInfo, Transaction};
-use alloy_eips::{Decodable2718, Encodable2718, Typed2718, eip7685::EMPTY_REQUESTS_HASH};
+use alloy_eips::{Decodable2718, Encodable2718};
 use alloy_primitives::{Address, B256, Bytes, Sealable, U256};
 use alloy_rpc_types_engine::{
     ExecutionPayload, ExecutionPayloadInputV2, ExecutionPayloadV1, ExecutionPayloadV2,
-    ExecutionPayloadV3, PayloadError,
+    ExecutionPayloadV3,
 };
-use error::OpPayloadError;
 
 /// An execution payload, which can be either [`ExecutionPayloadV2`], [`ExecutionPayloadV3`], or
 /// [`OpExecutionPayloadV4`].
@@ -516,170 +515,6 @@ impl OpExecutionPayload {
             mix_hash: Some(self.prev_randao()),
             slot_number: None,
         }
-    }
-
-    /// Converts [`OpExecutionPayload`] to [`Block`] with raw transactions.
-    ///
-    /// Caution: This does not set fields that are not part of the payload and only part of the
-    /// [`OpExecutionPayloadSidecar`]:
-    /// - `parent_beacon_block_root`
-    ///
-    /// See also: [`OpExecutionPayload::into_block_with_sidecar_raw`]
-    pub fn into_block_raw(self) -> Result<Block<alloy_primitives::Bytes>, PayloadError> {
-        match self {
-            Self::V1(payload) => payload.into_block_raw(),
-            Self::V2(payload) => payload.into_block_raw(),
-            Self::V3(payload) => payload.into_block_raw(),
-            Self::V4(payload) => payload.into_block_raw(),
-        }
-    }
-
-    /// Creates a new unsealed block from the given payload and payload sidecar with raw
-    /// transactions.
-    ///
-    /// This sets the `parent_beacon_block_root` and `requests_hash` if present in the sidecar.
-    /// Also validates that L1 withdrawals are empty.
-    ///
-    /// See also: [`OpExecutionPayload::try_into_block_with_sidecar`]
-    pub fn into_block_with_sidecar_raw(
-        self,
-        sidecar: &OpExecutionPayloadSidecar,
-    ) -> Result<Block<alloy_primitives::Bytes>, OpPayloadError> {
-        if let Some(payload) = self.as_v2() &&
-            !payload.withdrawals.is_empty()
-        {
-            return Err(OpPayloadError::NonEmptyL1Withdrawals);
-        }
-
-        let mut block = self.into_block_raw()?;
-
-        if let Some(blobs_hashes) = sidecar.versioned_hashes() &&
-            !blobs_hashes.is_empty()
-        {
-            return Err(OpPayloadError::NonEmptyBlobVersionedHashes);
-        }
-        if let Some(reqs_hash) = sidecar.requests_hash() {
-            if reqs_hash != EMPTY_REQUESTS_HASH {
-                return Err(OpPayloadError::NonEmptyELRequests);
-            }
-            block.header.requests_hash = Some(EMPTY_REQUESTS_HASH)
-        }
-        block.header.parent_beacon_block_root = sidecar.parent_beacon_block_root();
-
-        Ok(block)
-    }
-
-    #[allow(rustdoc::broken_intra_doc_links)]
-    /// Converts [`OpExecutionPayload`] to [`Block`].
-    ///
-    /// Checks that payload doesn't contain:
-    /// - blob transactions
-    /// - L1 withdrawals
-    ///
-    /// Caution: This does not set fields that are not part of the payload and only part of the
-    /// [`OpExecutionPayloadSidecar`]:
-    /// - `parent_beacon_block_root`
-    ///
-    /// See also: [`OpExecutionPayload::try_into_block_with_sidecar`]
-    pub fn try_into_block<T: Decodable2718 + Typed2718>(self) -> Result<Block<T>, OpPayloadError> {
-        self.try_into_block_with(|tx| {
-            T::decode_2718_exact(tx.as_ref())
-                .map_err(alloy_rlp::Error::from)
-                .map_err(PayloadError::from)
-        })
-    }
-
-    #[allow(rustdoc::broken_intra_doc_links)]
-    /// Converts [`OpExecutionPayload`] to [`Block`] with a custom transaction mapper.
-    ///
-    /// Checks that payload doesn't contain:
-    /// - blob transactions
-    /// - L1 withdrawals
-    ///
-    /// Caution: This does not set fields that are not part of the payload and only part of the
-    /// [`OpExecutionPayloadSidecar`]:
-    /// - `parent_beacon_block_root`
-    ///
-    /// See also: [`OpExecutionPayload::try_into_block_with_sidecar_with`]
-    pub fn try_into_block_with<T, F, E>(self, f: F) -> Result<Block<T>, OpPayloadError>
-    where
-        T: Typed2718,
-        F: FnMut(alloy_primitives::Bytes) -> Result<T, E>,
-        E: Into<PayloadError>,
-    {
-        if let Some(payload) = self.as_v2() &&
-            !payload.withdrawals.is_empty()
-        {
-            return Err(OpPayloadError::NonEmptyL1Withdrawals);
-        }
-        let block = match self {
-            Self::V1(payload) => return Ok(payload.try_into_block_with(f)?),
-            Self::V2(payload) => return Ok(payload.try_into_block_with(f)?),
-            Self::V3(payload) => payload.try_into_block_with(f)?,
-            Self::V4(payload) => payload.try_into_block_with(f)?,
-        };
-        if block.body.has_eip4844_transactions() {
-            return Err(OpPayloadError::BlobTransaction);
-        }
-
-        Ok(block)
-    }
-
-    /// Tries to create a new unsealed block from the given payload and payload sidecar.
-    ///
-    /// Additional to checks performed in [`OpExecutionPayload::try_into_block`], which is called
-    /// under the hood, also checks that sidecar doesn't contain:
-    /// - blob versioned hashes
-    /// - execution layer requests
-    ///
-    /// See also docs for
-    /// [`ExecutionPayload::try_into_block_with_sidecar`](alloy_rpc_types_engine::ExecutionPayload::try_into_block_with_sidecar).
-    pub fn try_into_block_with_sidecar<T: Decodable2718 + Typed2718>(
-        self,
-        sidecar: &OpExecutionPayloadSidecar,
-    ) -> Result<Block<T>, OpPayloadError> {
-        self.try_into_block_with_sidecar_with(sidecar, |tx| {
-            T::decode_2718_exact(tx.as_ref())
-                .map_err(alloy_rlp::Error::from)
-                .map_err(PayloadError::from)
-        })
-    }
-
-    /// Tries to create a new unsealed block from the given payload and payload sidecar with a
-    /// custom transaction mapper.
-    ///
-    /// Additional to checks performed in [`OpExecutionPayload::try_into_block_with`], which is
-    /// called under the hood, also checks that sidecar doesn't contain:
-    /// - blob versioned hashes
-    /// - execution layer requests
-    ///
-    /// See also docs for
-    /// [`ExecutionPayload::try_into_block_with_sidecar_with`](alloy_rpc_types_engine::ExecutionPayload::try_into_block_with_sidecar_with).
-    pub fn try_into_block_with_sidecar_with<T, F, E>(
-        self,
-        sidecar: &OpExecutionPayloadSidecar,
-        f: F,
-    ) -> Result<Block<T>, OpPayloadError>
-    where
-        T: Typed2718,
-        F: FnMut(alloy_primitives::Bytes) -> Result<T, E>,
-        E: Into<PayloadError>,
-    {
-        let mut base_payload = self.try_into_block_with(f)?;
-        if let Some(blobs_hashes) = sidecar.versioned_hashes() &&
-            !blobs_hashes.is_empty()
-        {
-            return Err(OpPayloadError::NonEmptyBlobVersionedHashes);
-        }
-        if let Some(reqs_hash) = sidecar.requests_hash() {
-            if reqs_hash != EMPTY_REQUESTS_HASH {
-                return Err(OpPayloadError::NonEmptyELRequests);
-            }
-            base_payload.header.requests_hash = Some(EMPTY_REQUESTS_HASH)
-        }
-        base_payload.header.parent_beacon_block_root = sidecar.parent_beacon_block_root();
-
-        Ok(base_payload)
     }
 
     /// Returns an iterator over the decoded transactions in this payload.

--- a/rust/op-alloy/crates/rpc-types-engine/src/payload/v4.rs
+++ b/rust/op-alloy/crates/rpc-types-engine/src/payload/v4.rs
@@ -1,10 +1,8 @@
 //! Optimism execution payload envelope V3.
 
 use alloc::vec::Vec;
-use alloy_consensus::Block;
-use alloy_eips::Decodable2718;
 use alloy_primitives::{B256, Bytes, U256};
-use alloy_rpc_types_engine::{BlobsBundleV1, ExecutionPayloadV3, PayloadError};
+use alloy_rpc_types_engine::{BlobsBundleV1, ExecutionPayloadV3};
 
 /// The Opstack execution payload for `newPayloadV4` of the engine API introduced with isthmus.
 /// See also <https://specs.optimism.io/protocol/isthmus/exec-engine.html#engine_newpayloadv4-api>
@@ -31,49 +29,6 @@ impl OpExecutionPayloadV4 {
         withdrawals_root: B256,
     ) -> Self {
         Self { withdrawals_root, payload_inner: payload }
-    }
-
-    /// Converts [`OpExecutionPayloadV4`] to [`Block`] with raw transactions.
-    ///
-    /// This performs the same conversion as the underlying V3 payload, but inserts the L2
-    /// withdrawals root and returns raw transaction bytes instead of decoded transactions.
-    pub fn into_block_raw(self) -> Result<Block<Bytes>, PayloadError> {
-        let mut base_block = self.payload_inner.into_block_raw()?;
-
-        // overwrite l1 withdrawals root with l2 withdrawals root
-        base_block.header.withdrawals_root = Some(self.withdrawals_root);
-
-        Ok(base_block)
-    }
-
-    /// Converts [`OpExecutionPayloadV4`] to [`Block`].
-    ///
-    /// This performs the same conversion as the underlying V3 payload, but inserts the L2
-    /// withdrawals root.
-    ///
-    /// See also [`ExecutionPayloadV3::try_into_block`].
-    pub fn try_into_block<T: Decodable2718>(self) -> Result<Block<T>, PayloadError> {
-        let block = self.into_block_raw()?;
-        block.try_map_transactions(|tx| {
-            T::decode_2718_exact(tx.as_ref())
-                .map_err(alloy_rlp::Error::from)
-                .map_err(PayloadError::from)
-        })
-    }
-
-    /// Converts [`OpExecutionPayloadV4`] to [`Block`] with a custom transaction mapper.
-    ///
-    /// This performs the same conversion as the underlying V3 payload, but inserts the L2
-    /// withdrawals root.
-    ///
-    /// See also [`ExecutionPayloadV3::try_into_block_with`].
-    pub fn try_into_block_with<T, F, E>(self, f: F) -> Result<Block<T>, PayloadError>
-    where
-        F: FnMut(Bytes) -> Result<T, E>,
-        E: Into<PayloadError>,
-    {
-        let block = self.into_block_raw()?;
-        block.try_map_transactions(f).map_err(|e| e.into())
     }
 }
 

--- a/rust/op-reth/crates/evm/src/lib.rs
+++ b/rust/op-reth/crates/evm/src/lib.rs
@@ -387,7 +387,7 @@ where
         )?;
 
         Ok(OpBlockExecutionCtx {
-            parent_hash: payload.parent_hash(),
+            parent_hash: payload.payload.parent_hash(),
             // No parent header on this path to detect fork-activation blocks, so the executor's
             // check is skipped; the derivation layer enforces the rule instead.
             no_user_tx_activation_block: false,

--- a/rust/op-reth/crates/flashblocks/src/consensus.rs
+++ b/rust/op-reth/crates/flashblocks/src/consensus.rs
@@ -1,7 +1,7 @@
 use crate::{FlashBlockCompleteSequence, FlashBlockCompleteSequenceRx};
 use alloy_primitives::B256;
 use alloy_rpc_types_engine::PayloadStatusEnum;
-use op_alloy_rpc_types_engine::OpExecutionData;
+use op_alloy_rpc_types_engine::{OpExecutionData, OpExecutionPayloadEnvelope};
 use reth_engine_primitives::ConsensusEngineHandle;
 use reth_optimism_payload_builder::OpPayloadTypes;
 use reth_payload_primitives::{ExecutionPayload, PayloadTypes};
@@ -157,22 +157,22 @@ impl TryFrom<&FlashBlockCompleteSequence> for OpExecutionData {
     type Error = &'static str;
 
     fn try_from(sequence: &FlashBlockCompleteSequence) -> Result<Self, Self::Error> {
-        let mut data = Self::from_flashblocks_unchecked(sequence);
+        let mut data = OpExecutionPayloadEnvelope::from_flashblocks_unchecked(sequence);
 
         // If execution outcome is available, use the computed state_root and block_hash.
         // FlashBlockService computes these when building sequences on top of the local tip.
         if let Some(execution_outcome) = sequence.execution_outcome() {
-            let payload = data.payload.as_v1_mut();
+            let payload = data.as_v1_mut();
             payload.state_root = execution_outcome.state_root;
             payload.block_hash = execution_outcome.block_hash;
         }
 
         // Only proceed if we have a valid state_root (non-zero).
-        if data.payload.as_v1_mut().state_root == B256::ZERO {
+        if data.as_v1().state_root == B256::ZERO {
             return Err("No state_root available for payload");
         }
 
-        Ok(data)
+        Ok(data.into())
     }
 }
 

--- a/rust/op-reth/crates/node/src/engine.rs
+++ b/rust/op-reth/crates/node/src/engine.rs
@@ -1,7 +1,10 @@
 use alloy_consensus::BlockHeader;
 use alloy_primitives::B256;
 use alloy_rpc_types_engine::{ExecutionPayloadEnvelopeV2, ExecutionPayloadV1};
-use op_alloy_rpc_types_engine::{OpExecutionPayloadEnvelopeV3, OpExecutionPayloadEnvelopeV4};
+use op_alloy_rpc_types_engine::{
+    OpExecutionData, OpExecutionPayloadEnvelope, OpExecutionPayloadEnvelopeV3,
+    OpExecutionPayloadEnvelopeV4,
+};
 use reth_consensus::ConsensusError;
 use reth_node_api::{
     BuiltPayload, EngineApiValidator, EngineTypes, InsertBlockErrorKind, NodePrimitives,
@@ -45,9 +48,12 @@ where
         >,
         _bal: Option<alloy_primitives::Bytes>,
     ) -> <T as PayloadTypes>::ExecutionData {
-        OpExecData(op_alloy_rpc_types_engine::OpExecutionData::from_block_unchecked(
-            block.hash(),
-            &block.into_block().into_ethereum_block(),
+        OpExecData(OpExecutionData::from(
+            OpExecutionPayloadEnvelope::from_block_unchecked(
+                block.hash(),
+                &block.into_block().into_ethereum_block(),
+            )
+            .expect("built OP blocks must normalize"),
         ))
     }
 }

--- a/rust/op-reth/crates/payload/src/lib.rs
+++ b/rust/op-reth/crates/payload/src/lib.rs
@@ -15,7 +15,7 @@ pub mod builder;
 pub use builder::{OpPayloadBuilder, PayloadTransactionsWithCommitHook, RethPayloadTransactions};
 pub mod error;
 pub mod payload;
-use op_alloy_rpc_types_engine::OpExecutionData;
+use op_alloy_rpc_types_engine::{OpExecutionData, OpExecutionPayloadEnvelope};
 pub use payload::{
     OpBuiltPayload, OpExecData, OpPayloadAttributes, OpPayloadAttrs, OpPayloadBuilderAttributes,
     payload_id_optimism,
@@ -92,9 +92,12 @@ where
         >,
         _bal: Option<alloy_primitives::Bytes>,
     ) -> Self::ExecutionData {
-        crate::payload::OpExecData::from(OpExecutionData::from_block_unchecked(
-            block.hash(),
-            &block.into_block().into_ethereum_block(),
+        crate::payload::OpExecData::from(OpExecutionData::from(
+            OpExecutionPayloadEnvelope::from_block_unchecked(
+                block.hash(),
+                &block.into_block().into_ethereum_block(),
+            )
+            .expect("built OP blocks must normalize"),
         ))
     }
 }

--- a/rust/op-reth/crates/payload/src/payload.rs
+++ b/rust/op-reth/crates/payload/src/payload.rs
@@ -14,7 +14,8 @@ use alloy_rpc_types_engine::{
 };
 use op_alloy_consensus::{EIP1559ParamError, encode_holocene_extra_data, encode_jovian_extra_data};
 use op_alloy_rpc_types_engine::{
-    OpExecutionPayloadEnvelopeV3, OpExecutionPayloadEnvelopeV4, OpExecutionPayloadV4,
+    OpExecutionPayloadEnvelope, OpExecutionPayloadEnvelopeV3, OpExecutionPayloadEnvelopeV4,
+    OpExecutionPayloadV4,
 };
 use reth_chainspec::EthChainSpec;
 use reth_optimism_evm::OpNextBlockEnvAttributes;
@@ -63,7 +64,7 @@ impl reth_payload_primitives::ExecutionPayload for OpExecData {
     }
 
     fn withdrawals(&self) -> Option<&Vec<alloy_eips::eip4895::Withdrawal>> {
-        self.0.withdrawals()
+        self.0.payload.as_v2().map(|payload| &payload.withdrawals)
     }
 
     fn block_access_list(&self) -> Option<&Bytes> {
@@ -476,7 +477,13 @@ where
     fn from(value: OpBuiltPayload<N>) -> Self {
         let block = Arc::unwrap_or_clone(value.block);
         let hash = block.hash();
-        Self(OpExecutionData::from_block_unchecked(hash, &block.into_block().into_ethereum_block()))
+        Self(OpExecutionData::from(
+            OpExecutionPayloadEnvelope::from_block_unchecked(
+                hash,
+                &block.into_block().into_ethereum_block(),
+            )
+            .expect("built OP blocks must normalize"),
+        ))
     }
 }
 

--- a/rust/op-reth/crates/payload/src/validator.rs
+++ b/rust/op-reth/crates/payload/src/validator.rs
@@ -2,9 +2,8 @@
 
 use alloc::sync::Arc;
 use alloy_consensus::Block;
-use alloy_rpc_types_engine::PayloadError;
 use derive_more::{Constructor, Deref};
-use op_alloy_rpc_types_engine::{OpExecutionData, OpPayloadError};
+use op_alloy_rpc_types_engine::{OpExecutionData, OpExecutionPayloadEnvelope, OpPayloadError};
 use reth_optimism_forks::OpHardforks;
 use reth_payload_validator::{cancun, prague, shanghai};
 use reth_primitives_traits::{Block as _, SealedBlock, SignedTransaction};
@@ -64,17 +63,11 @@ where
     ChainSpec: OpHardforks,
     T: SignedTransaction,
 {
-    let OpExecutionData { payload, sidecar } = payload;
+    let sidecar = payload.sidecar.clone();
+    let payload = OpExecutionPayloadEnvelope::try_from(payload)?;
 
-    let expected_hash = payload.block_hash();
-
-    // First parse the block
-    let sealed_block = payload.try_into_block_with_sidecar(&sidecar)?.seal_slow();
-
-    // Ensure the hash included in the payload matches the block hash
-    if expected_hash != sealed_block.hash() {
-        Err(PayloadError::BlockHash { execution: sealed_block.hash(), consensus: expected_hash })?;
-    }
+    // First parse the block and ensure its hash matches the payload's claim.
+    let sealed_block = payload.try_into_checked_block()?.seal_slow();
 
     shanghai::ensure_well_formed_fields(
         sealed_block.body(),


### PR DESCRIPTION
## Overview

This draft repackages #22280, #22251, #22282, and #22284 into four review-focused commits while simplifying the execution-payload model and the gossip trust boundary.

`OpExecutionPayloadEnvelope` is now the structurally complete internal representation directly. Its V3/V4 variants require a parent beacon block root, while V1/V2 cannot carry one. This avoids introducing a second, isomorphic `OpNormalizedExecutionData` type.

The existing external formats are preserved:

- `admin_postUnsafePayload` and `conductor_commitUnsafePayload` retain the same JSON object shape through custom serde.
- CL P2P payload hashes and Snappy/SSZ encodings remain pinned to existing golden vectors.
- Engine API input remains represented by `OpExecutionData`, which can retain malformed sidecars until its fallible conversion into an envelope.

## Commit structure

1. **`op-alloy: make execution payload envelopes complete`**
   - Changes `OpExecutionPayloadEnvelope` into a V1–V4 enum with required V3/V4 roots.
   - Moves complete block and flashblock reconstruction directly onto the envelope.
   - Adds raw-byte block-hash checking that computes the transaction trie root without decoding transactions.
   - Converts fallibly from Engine API `OpExecutionData`, rejecting mismatched or noncanonical OP sidecars.
   - Converts infallibly back to canonical Engine API data.
   - Migrates Kona and op-reth directly to the complete envelope.

2. **`kona-gossip: authenticate payload bytes before decoding`**
   - Moves the signed P2P wire representation and Snappy codec out of Engine RPC types into a private `kona-gossip` module.
   - Represents the decompressed frame as a typed `Signature` plus exact encoded envelope bytes; the topic-derived version remains external.
   - Hashes and authenticates the exact received bytes before SSZ and transaction decoding.
   - Checks the claimed block hash from raw transaction bytes, matching op-node while leaving transaction validity to the EL.
   - Returns `OpExecutionPayloadEnvelope` from `BlockHandler`, `GossipDriver`, and the complete inbound call stack.
   - Preserves V1–V4 P2P bytes through moved golden-vector tests.

3. **`kona-engine: reuse inserted block info`**
   - Returns the `L2BlockInfo` already constructed by `InsertTask` and reuses it in `SealTask`.
   - Removes duplicate transaction decoding and block-info construction.

4. **`kona-node: validate admin unsafe payload block hashes`**
   - Performs synchronous raw-byte block-hash validation at `admin_postUnsafePayload` without decoding transactions.
   - Returns `InvalidParams` for malformed payloads or hash mismatches.
   - Enables the Kona invalid-CL-P2P-payload acceptance scenario.

## Benefits

- **Eliminates silent root defaulting.** Missing V3/V4 roots can no longer become `B256::ZERO`.
- **Makes structural invariants type-level.** V1/V2 cannot carry a root; V3/V4 always carry one.
- **Uses one complete payload abstraction.** There is no separate normalized type duplicating the envelope's variants and accessors.
- **Authenticates before expensive decoding.** Gossip signatures are checked against exact wire envelope bytes before SSZ decoding. Block hashes are then checked without decoding transactions.
- **Keeps transport details private.** Snappy framing, signature splitting, and topic-version decoding no longer leak through Engine RPC types or past the gossip validation boundary.
- **Validates Engine API boundaries.** Nonempty blob hashes, nonempty execution requests, and mismatched sidecar versions are rejected.
- **Prevents incomplete block reconstruction.** Complete conversion is available only on the complete envelope.
- **Produces canonical outbound sidecars.** Empty OP values and the fixed `EMPTY_REQUESTS_HASH` are synthesized correctly.
- **Preserves execution diversity.** Kona and op-reth continue to perform independent policy, execution, and state validation.

Authoritative execution validation remains in the EL. The synchronous CL check exists to provide immediate admin RPC feedback before asynchronous insertion.

## Tests

- `cargo test -p op-alloy-rpc-types-engine --all-features`
- `cargo test -p kona-engine -p kona-gossip -p kona-rpc -p kona-node-service --all-features -- --skip test_chain_label_metrics`
- `cargo test -p reth-optimism-payload-builder -p reth-optimism-flashblocks --all-features`
- `cargo check -p op-alloy-rpc-types-engine --no-default-features`
- `cargo check -p kona-engine --no-default-features`
- `cargo check -p kona-node --all-features`
- `cargo clippy -p op-alloy-rpc-types-engine -p kona-protocol -p kona-engine -p kona-gossip -p kona-rpc -p kona-node-service -p reth-optimism-evm -p reth-optimism-payload-builder -p reth-optimism-flashblocks -p reth-optimism-node --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p op-alloy-rpc-types-engine -p kona-gossip --all-features --no-deps`
- `cargo build -p op-reth --bin op-reth`
- `DEVSTACK_L2CL_KIND=kona-node DEVSTACK_L2EL_KIND=op-reth go test -parallel=1 -count=1 -run '^TestInvalidPayloadThroughCLP2P$' ./op-acceptance-tests/tests/sync/elsync/gap_elp2p/`

