### PR TITLE
op-node: register l2.follow.source.rpc-timeout flag

### DIFF
--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -489,6 +489,7 @@ var optionalFlags = []cli.Flag{
 	L2EngineKind,
 	L2EngineRpcTimeout,
 	L2FollowSource,
+	L2FollowSourceRpcTimeout,
 	InteropDependencySet,
 	IgnoreMissingPectraBlobSchedule,
 	ExperimentalOPStackAPI,


### PR DESCRIPTION
L2FollowSourceRpcTimeout (--l2.follow.source.rpc-timeout / OP_NODE_L2_FOLLOW_SOURCE_RPC_TIMEOUT) was declared in op-node/flags/flags.go but never added to optionalFlags, so urfave/cli never registered it: it was absent from op-node --help, passing it failed as an unknown flag, and ctx.Duration in NewL2FollowSourceConfig returned 0 rather than the declared 10s default.

This adds the flag to optionalFlags.

No behavior change at default: the 0 flowed into client.WithCallTimeout(0), and applyOptions treats zero as unset (falling back to 10s), so the effective per-call timeout was already 10s. After this change the flag and env var actually take effect and appear in --help.

Verified with go build ./..., go test ./flags/..., go test ./op-supernode/flags/... and go vet ./op-node/flags/....