### PR TITLE
op-alloy: make execution payload envelopes complete

### DIFF
--- a/rust/kona/bin/node/src/commands/net.rs
+++ b/rust/kona/bin/node/src/commands/net.rs
@@ -123,7 +123,7 @@ impl NetCommand {
         loop {
             tokio::select! {
                 Some(payload) = block_rx.recv() => {
-                    info!(target: "net", "Received unsafe payload: {:?}", payload.execution_payload.block_hash());
+                    info!(target: "net", "Received unsafe payload: {:?}", payload.block_hash());
                 }
                 _ = interval.tick(), if !rpc.is_closed() => {
                     let (otx, mut orx) = tokio::sync::oneshot::channel();

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/insert/task.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/insert/task.rs
@@ -4,17 +4,12 @@ use crate::{
     EngineClient, EngineState, EngineTaskExt, InsertTaskError, SynchronizeTask,
     state::EngineSyncStateUpdate,
 };
-use alloy_eips::eip7685::EMPTY_REQUESTS_HASH;
-use alloy_rpc_types_engine::{
-    CancunPayloadFields, ExecutionPayloadInputV2, PayloadStatusEnum, PraguePayloadFields,
-};
+use alloy_rpc_types_engine::{ExecutionPayloadInputV2, PayloadStatusEnum};
 use async_trait::async_trait;
 use kona_genesis::RollupConfig;
 use kona_protocol::L2BlockInfo;
 use op_alloy_consensus::OpBlock;
-use op_alloy_rpc_types_engine::{
-    OpExecutionPayload, OpExecutionPayloadEnvelope, OpExecutionPayloadSidecar,
-};
+use op_alloy_rpc_types_engine::OpExecutionPayloadEnvelope;
 use std::{sync::Arc, time::Instant};
 
 /// The task to insert a payload into the execution engine.
@@ -24,8 +19,8 @@ pub struct InsertTask<EngineClient_: EngineClient> {
     client: Arc<EngineClient_>,
     /// The rollup config.
     rollup_config: Arc<RollupConfig>,
-    /// The network payload envelope.
-    envelope: OpExecutionPayloadEnvelope,
+    /// The complete execution payload envelope.
+    payload: OpExecutionPayloadEnvelope,
     /// If the payload is safe this is true.
     /// A payload is safe if it is derived from a safe block.
     is_payload_safe: bool,
@@ -36,10 +31,10 @@ impl<EngineClient_: EngineClient> InsertTask<EngineClient_> {
     pub const fn new(
         client: Arc<EngineClient_>,
         rollup_config: Arc<RollupConfig>,
-        envelope: OpExecutionPayloadEnvelope,
+        payload: OpExecutionPayloadEnvelope,
         is_attributes_derived: bool,
     ) -> Self {
-        Self { client, rollup_config, envelope, is_payload_safe: is_attributes_derived }
+        Self { client, rollup_config, payload, is_payload_safe: is_attributes_derived }
     }
 
     /// Checks the response of the `engine_newPayload` call.
@@ -59,53 +54,25 @@ impl<EngineClient_: EngineClient> EngineTaskExt for InsertTask<EngineClient_> {
 
         // Insert the new payload.
         // Form the new unsafe block ref from the execution payload.
-        let parent_beacon_block_root = self.envelope.parent_beacon_block_root.unwrap_or_default();
+        let payload = self.payload.clone();
         let insert_time_start = Instant::now();
-        let (response, block): (_, OpBlock) = match self.envelope.execution_payload.clone() {
-            OpExecutionPayload::V1(payload) => (
-                self.client.new_payload_v1(payload).await,
-                self.envelope
-                    .execution_payload
-                    .clone()
-                    .try_into_block()
-                    .map_err(InsertTaskError::FromBlockError)?,
-            ),
-            OpExecutionPayload::V2(payload) => {
+        let response = match payload.clone() {
+            OpExecutionPayloadEnvelope::V1(payload) => self.client.new_payload_v1(payload).await,
+            OpExecutionPayloadEnvelope::V2(payload) => {
                 let payload_input = ExecutionPayloadInputV2 {
                     execution_payload: payload.payload_inner,
                     withdrawals: Some(payload.withdrawals),
                 };
-                (
-                    self.client.new_payload_v2(payload_input).await,
-                    self.envelope
-                        .execution_payload
-                        .clone()
-                        .try_into_block()
-                        .map_err(InsertTaskError::FromBlockError)?,
-                )
+                self.client.new_payload_v2(payload_input).await
             }
-            OpExecutionPayload::V3(payload) => (
-                self.client.new_payload_v3(payload, parent_beacon_block_root).await,
-                self.envelope
-                    .execution_payload
-                    .clone()
-                    .try_into_block_with_sidecar(&OpExecutionPayloadSidecar::v3(
-                        CancunPayloadFields::new(parent_beacon_block_root, vec![]),
-                    ))
-                    .map_err(InsertTaskError::FromBlockError)?,
-            ),
-            OpExecutionPayload::V4(payload) => (
-                self.client.new_payload_v4(payload, parent_beacon_block_root).await,
-                self.envelope
-                    .execution_payload
-                    .clone()
-                    .try_into_block_with_sidecar(&OpExecutionPayloadSidecar::v4(
-                        CancunPayloadFields::new(parent_beacon_block_root, vec![]),
-                        PraguePayloadFields::new(EMPTY_REQUESTS_HASH),
-                    ))
-                    .map_err(InsertTaskError::FromBlockError)?,
-            ),
+            OpExecutionPayloadEnvelope::V3 { payload, parent_beacon_block_root } => {
+                self.client.new_payload_v3(payload, parent_beacon_block_root).await
+            }
+            OpExecutionPayloadEnvelope::V4 { payload, parent_beacon_block_root } => {
+                self.client.new_payload_v4(payload, parent_beacon_block_root).await
+            }
         };
+        let block: OpBlock = payload.try_into_block().map_err(InsertTaskError::FromBlockError)?;
 
         // Check the `engine_newPayload` response.
         let response = match response {

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/seal/error.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/seal/error.rs
@@ -3,7 +3,7 @@
 use crate::{EngineTaskError, InsertTaskError, task_queue::tasks::task::EngineTaskErrorSeverity};
 use alloy_transport::{RpcError, TransportErrorKind};
 use kona_protocol::FromBlockError;
-use op_alloy_rpc_types_engine::OpExecutionPayloadEnvelope;
+use op_alloy_rpc_types_engine::{OpExecutionPayloadEnvelope, OpPayloadError};
 use thiserror::Error;
 use tokio::sync::mpsc;
 
@@ -16,6 +16,9 @@ pub enum SealTaskError {
     /// The get payload call to the engine api failed.
     #[error(transparent)]
     GetPayloadFailed(RpcError<TransportErrorKind>),
+    /// The execution payload could not be converted into a block.
+    #[error(transparent)]
+    InvalidExecutionPayload(#[from] OpPayloadError),
     /// A deposit-only payload failed to import.
     #[error("Deposit-only payload failed to import")]
     DepositOnlyPayloadFailed,
@@ -26,9 +29,8 @@ pub enum SealTaskError {
     /// be flushed post-holocene.
     #[error("Invalid payload, must flush post-holocene")]
     HoloceneInvalidFlush,
-    /// Failed to convert a [`OpExecutionPayload`] to a [`L2BlockInfo`].
+    /// Failed to construct an [`L2BlockInfo`] from the decoded block.
     ///
-    /// [`OpExecutionPayload`]: op_alloy_rpc_types_engine::OpExecutionPayload
     /// [`L2BlockInfo`]: kona_protocol::L2BlockInfo
     #[error(transparent)]
     FromBlock(#[from] FromBlockError),
@@ -54,6 +56,7 @@ impl EngineTaskError for SealTaskError {
             Self::PayloadInsertionFailed(inner) => inner.severity(),
             Self::GetPayloadFailed(_) => EngineTaskErrorSeverity::Temporary,
             Self::HoloceneInvalidFlush => EngineTaskErrorSeverity::Flush,
+            Self::InvalidExecutionPayload(_) |
             Self::DepositOnlyPayloadReattemptFailed |
             Self::DepositOnlyPayloadFailed |
             Self::FromBlock(_) |

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/seal/task.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/seal/task.rs
@@ -10,7 +10,8 @@ use async_trait::async_trait;
 use derive_more::Constructor;
 use kona_genesis::RollupConfig;
 use kona_protocol::{L2BlockInfo, OpAttributesWithParent};
-use op_alloy_rpc_types_engine::{OpExecutionPayload, OpExecutionPayloadEnvelope};
+use op_alloy_consensus::OpBlock;
+use op_alloy_rpc_types_engine::OpExecutionPayloadEnvelope;
 use std::{sync::Arc, time::Instant};
 use tokio::sync::mpsc;
 
@@ -80,9 +81,9 @@ impl<EngineClient_: EngineClient> SealTask<EngineClient_> {
                     SealTaskError::GetPayloadFailed(e)
                 })?;
 
-                OpExecutionPayloadEnvelope {
-                    parent_beacon_block_root: Some(payload.parent_beacon_block_root),
-                    execution_payload: OpExecutionPayload::V4(payload.execution_payload),
+                OpExecutionPayloadEnvelope::V4 {
+                    parent_beacon_block_root: payload.parent_beacon_block_root,
+                    payload: payload.execution_payload,
                 }
             }
             EngineGetPayloadVersion::V4 => {
@@ -91,9 +92,9 @@ impl<EngineClient_: EngineClient> SealTask<EngineClient_> {
                     SealTaskError::GetPayloadFailed(e)
                 })?;
 
-                OpExecutionPayloadEnvelope {
-                    parent_beacon_block_root: Some(payload.parent_beacon_block_root),
-                    execution_payload: OpExecutionPayload::V4(payload.execution_payload),
+                OpExecutionPayloadEnvelope::V4 {
+                    parent_beacon_block_root: payload.parent_beacon_block_root,
+                    payload: payload.execution_payload,
                 }
             }
             EngineGetPayloadVersion::V3 => {
@@ -102,9 +103,9 @@ impl<EngineClient_: EngineClient> SealTask<EngineClient_> {
                     SealTaskError::GetPayloadFailed(e)
                 })?;
 
-                OpExecutionPayloadEnvelope {
-                    parent_beacon_block_root: Some(payload.parent_beacon_block_root),
-                    execution_payload: OpExecutionPayload::V3(payload.execution_payload),
+                OpExecutionPayloadEnvelope::V3 {
+                    parent_beacon_block_root: payload.parent_beacon_block_root,
+                    payload: payload.execution_payload,
                 }
             }
             EngineGetPayloadVersion::V2 => {
@@ -113,13 +114,10 @@ impl<EngineClient_: EngineClient> SealTask<EngineClient_> {
                     SealTaskError::GetPayloadFailed(e)
                 })?;
 
-                OpExecutionPayloadEnvelope {
-                    parent_beacon_block_root: None,
-                    execution_payload: match payload.execution_payload.into_payload() {
-                        ExecutionPayload::V1(payload) => OpExecutionPayload::V1(payload),
-                        ExecutionPayload::V2(payload) => OpExecutionPayload::V2(payload),
-                        _ => unreachable!("the response should be a V1 or V2 payload"),
-                    },
+                match payload.execution_payload.into_payload() {
+                    ExecutionPayload::V1(payload) => OpExecutionPayloadEnvelope::V1(payload),
+                    ExecutionPayload::V2(payload) => OpExecutionPayloadEnvelope::V2(payload),
+                    _ => unreachable!("the response should be a V1 or V2 payload"),
                 }
             }
         };
@@ -138,13 +136,13 @@ impl<EngineClient_: EngineClient> SealTask<EngineClient_> {
     async fn insert_payload(
         &self,
         state: &mut EngineState,
-        new_payload: OpExecutionPayloadEnvelope,
+        payload: OpExecutionPayloadEnvelope,
     ) -> Result<(), SealTaskError> {
         // Insert the new block into the engine.
         match InsertTask::new(
             Arc::clone(&self.engine),
             self.cfg.clone(),
-            new_payload.clone(),
+            payload,
             self.is_attributes_derived,
         )
         .execute(state)
@@ -211,12 +209,9 @@ impl<EngineClient_: EngineClient> SealTask<EngineClient_> {
             .seal_payload(&self.cfg, &self.engine, self.payload_id, self.attributes.clone())
             .await?;
 
-        let new_block_ref = L2BlockInfo::from_payload_and_genesis(
-            new_payload.execution_payload.clone(),
-            self.attributes.attributes().payload_attributes.parent_beacon_block_root,
-            &self.cfg.genesis,
-        )
-        .map_err(SealTaskError::FromBlock)?;
+        let block: OpBlock = new_payload.clone().try_into_block()?;
+        let new_block_ref = L2BlockInfo::from_block_and_genesis(&block, &self.cfg.genesis)
+            .map_err(SealTaskError::FromBlock)?;
 
         // Insert the payload into the engine.
         self.insert_payload(state, new_payload.clone()).await?;

--- a/rust/kona/crates/node/gossip/Cargo.toml
+++ b/rust/kona/crates/node/gossip/Cargo.toml
@@ -24,7 +24,6 @@ kona-disc.workspace = true
 
 # Alloy
 alloy-rlp.workspace = true
-alloy-eips.workspace = true
 alloy-consensus.workspace = true
 alloy-rpc-types-engine.workspace = true
 alloy-primitives = { workspace = true, features = ["k256", "getrandom"] }

--- a/rust/kona/crates/node/gossip/src/block_validity.rs
+++ b/rust/kona/crates/node/gossip/src/block_validity.rs
@@ -3,14 +3,14 @@ use std::time::Instant;
 use std::time::SystemTime;
 
 use alloy_consensus::Block;
-use alloy_eips::eip7685::EMPTY_REQUESTS_HASH;
 use alloy_primitives::{Address, B256};
 use alloy_rpc_types_engine::{ExecutionPayloadV3, PayloadError};
 use kona_genesis::RollupConfig;
 use libp2p::gossipsub::MessageAcceptance;
 use op_alloy_consensus::OpTxEnvelope;
 use op_alloy_rpc_types_engine::{
-    OpExecutionPayload, OpExecutionPayloadV4, OpNetworkPayloadEnvelope, OpPayloadError,
+    OpExecutionPayload, OpExecutionPayloadEnvelope, OpExecutionPayloadV4, OpNetworkPayloadEnvelope,
+    OpPayloadError,
 };
 
 use super::BlockHandler;
@@ -53,8 +53,8 @@ pub enum BlockInvalidError {
     /// Invalid block.
     #[error(transparent)]
     InvalidBlock(#[from] OpPayloadError),
-    /// The block has an invalid parent beacon block root.
-    #[error("Payload is on v3+ topic, but has empty parent beacon root")]
+    /// The block has a parent beacon block root incompatible with its payload version.
+    #[error("Payload has an invalid parent beacon block root")]
     ParentBeaconRoot,
     /// The block has an invalid blob gas used.
     #[error("Payload is on v3+ topic, but has non-zero blob gas used")]
@@ -209,12 +209,15 @@ impl BlockHandler {
 
         // CHECK: Ensure the block hash is valid.
         let expected = envelope.payload.block_hash();
-        let mut block: Block<OpTxEnvelope> = envelope.payload.clone().try_into_block()?;
-        block.header.parent_beacon_block_root = envelope.parent_beacon_block_root;
-        // If isthmus is active, set the requests hash to the empty hash.
-        if self.rollup_config.is_isthmus_active(envelope.payload.timestamp()) {
-            block.header.requests_hash = Some(EMPTY_REQUESTS_HASH);
-        }
+        let execution_data =
+            OpExecutionPayloadEnvelope::try_from(envelope.clone()).map_err(|err| match err {
+                OpPayloadError::MissingParentBeaconBlockRoot |
+                OpPayloadError::UnexpectedParentBeaconBlockRoot => {
+                    BlockInvalidError::ParentBeaconRoot
+                }
+                err => BlockInvalidError::InvalidBlock(err),
+            })?;
+        let block: Block<OpTxEnvelope> = execution_data.try_into_block()?;
         let received = block.header.hash_slow();
         if received != expected {
             return Err(BlockInvalidError::BlockHash { expected, received });
@@ -281,12 +284,11 @@ impl BlockHandler {
         // 3. The block should not have any blob gas used
         // 4. The block should not have any excess blob gas
         // 5. The block should not have any withdrawals root
-        // 6. The block should not have any parent beacon block root (validated because ignored by
-        //    the decoder, this causes a hash mismatch. See tests)
+        // 6. The block should not have any parent beacon block root (checked below)
 
         // Same as v1, except:
         // 1. The block should have an empty withdrawals list. This is checked during the call to
-        //    [`OpExecutionPayload::try_into_block`].
+        //    [`op_alloy_rpc_types_engine::OpExecutionPayloadEnvelope::try_into_block`].
 
         // Same as v2, except:
         // 1. The block should have a zero blob gas used
@@ -324,7 +326,12 @@ impl BlockHandler {
         }
 
         match &envelope.payload {
-            OpExecutionPayload::V1(_) | OpExecutionPayload::V2(_) => Ok(()),
+            OpExecutionPayload::V1(_) | OpExecutionPayload::V2(_) => {
+                if envelope.parent_beacon_block_root.is_some() {
+                    return Err(BlockInvalidError::ParentBeaconRoot);
+                }
+                Ok(())
+            }
             OpExecutionPayload::V3(payload) => {
                 validate_v3(&self.rollup_config, payload, envelope.parent_beacon_block_root)
             }
@@ -341,7 +348,7 @@ pub(crate) mod tests {
     use super::*;
     use alloy_chains::Chain;
     use alloy_consensus::{Block, EMPTY_OMMER_ROOT_HASH};
-    use alloy_eips::{eip2718::Encodable2718, eip4895::Withdrawal};
+    use alloy_eips::{eip2718::Encodable2718, eip4895::Withdrawal, eip7685::EMPTY_REQUESTS_HASH};
     use alloy_primitives::{Address, B256, Bytes, Signature};
     use alloy_rlp::BufMut;
     use alloy_rpc_types_engine::{ExecutionPayloadV1, ExecutionPayloadV2, ExecutionPayloadV3};
@@ -438,7 +445,9 @@ pub(crate) mod tests {
 
     /// Make the block v4 compatible
     pub(crate) fn v4_valid_block() -> Block<OpTxEnvelope> {
-        v3_valid_block()
+        let mut block = v3_valid_block();
+        block.header.requests_hash = Some(EMPTY_REQUESTS_HASH);
+        block
     }
 
     /// Generates a random valid block and ensure it is v1 compatible
@@ -687,9 +696,7 @@ pub(crate) mod tests {
         assert!(matches!(handler.block_valid(&envelope), Err(BlockInvalidError::Signer { .. })));
     }
 
-    /// If we specify a non empty parent beacon block root for blocks with v1/v2 payloads we
-    /// get a hash mismatch error because the decoder enforces that these versions of the execution
-    /// payload don't contain the parent beacon block root.
+    /// V1/V2 payloads reject a parent beacon block root because those versions do not include it.
     #[test]
     fn test_v1_v2_block_invalid_parent_beacon_block_root() {
         let block = v1_valid_block();
@@ -712,7 +719,7 @@ pub(crate) mod tests {
             unsafe_signer,
         );
 
-        assert!(matches!(handler.block_valid(&envelope), Err(BlockInvalidError::BlockHash { .. })));
+        assert!(matches!(handler.block_valid(&envelope), Err(BlockInvalidError::ParentBeaconRoot)));
 
         let block = v2_valid_block();
 
@@ -734,7 +741,7 @@ pub(crate) mod tests {
             unsafe_signer,
         );
 
-        assert!(matches!(handler.block_valid(&envelope), Err(BlockInvalidError::BlockHash { .. })));
+        assert!(matches!(handler.block_valid(&envelope), Err(BlockInvalidError::ParentBeaconRoot)));
     }
 
     #[test]

--- a/rust/kona/crates/node/service/src/actors/network/actor.rs
+++ b/rust/kona/crates/node/service/src/actors/network/actor.rs
@@ -134,7 +134,7 @@ impl<NetworkEngineClient_: NetworkEngineClient + 'static> NodeActor
                 Ok(())
             }
             Some(block) = self.publish_rx.recv(), if !self.publish_rx.is_closed() => {
-                let timestamp = block.execution_payload.timestamp();
+                let timestamp = block.timestamp();
                 let selector = |handler: &kona_gossip::BlockHandler| {
                     handler.topic(timestamp)
                 };
@@ -149,10 +149,11 @@ impl<NetworkEngineClient_: NetworkEngineClient + 'static> NodeActor
 
                 let payload_hash = block.payload_hash();
                 let signature = signer.sign_block(payload_hash, chain_id, sender_address).await?;
+                let (payload, parent_beacon_block_root) = block.into_parts();
 
                 let payload = OpNetworkPayloadEnvelope {
-                    payload: block.execution_payload,
-                    parent_beacon_block_root: block.parent_beacon_block_root,
+                    payload,
+                    parent_beacon_block_root,
                     signature,
                     payload_hash,
                 };
@@ -169,10 +170,17 @@ impl<NetworkEngineClient_: NetworkEngineClient + 'static> NodeActor
                     return Err(NetworkActorError::ChannelClosed);
                 };
 
-                if let Some(payload) = self.handler.gossip.handle_event(event)
-                    && self.unsafe_block_tx.send(payload.into()).is_err()
-                {
-                    warn!(target: "node::p2p", "Failed to send unsafe block to network handler");
+                if let Some(payload) = self.handler.gossip.handle_event(event) {
+                    match OpExecutionPayloadEnvelope::try_from(payload) {
+                        Ok(payload) => {
+                            if self.unsafe_block_tx.send(payload).is_err() {
+                                warn!(target: "node::p2p", "Failed to send unsafe block to network handler");
+                            }
+                        }
+                        Err(err) => {
+                            warn!(target: "node::p2p", %err, "Validated gossip payload has invalid structure");
+                        }
+                    }
                 }
                 Ok(())
             }
@@ -211,7 +219,6 @@ mod tests {
     use alloy_signer::SignerSync;
     use alloy_signer_local::PrivateKeySigner;
     use arbitrary::Arbitrary;
-    use op_alloy_rpc_types_engine::OpExecutionPayload;
     use rand::Rng;
 
     #[test]
@@ -223,21 +230,15 @@ mod tests {
         let expected_address = pubkey.address();
         const CHAIN_ID: u64 = 1337;
 
-        let block = OpExecutionPayloadEnvelope {
-            execution_payload: OpExecutionPayload::V1(
-                ExecutionPayloadV1::arbitrary(&mut arbitrary::Unstructured::new(&bytes)).unwrap(),
-            ),
-            parent_beacon_block_root: None,
-        };
+        let block = OpExecutionPayloadEnvelope::V1(
+            ExecutionPayloadV1::arbitrary(&mut arbitrary::Unstructured::new(&bytes)).unwrap(),
+        );
 
         let payload_hash = block.payload_hash();
         let signature = pubkey.sign_hash_sync(&payload_hash.signature_message(CHAIN_ID)).unwrap();
-        let payload = OpNetworkPayloadEnvelope {
-            payload: block.execution_payload,
-            parent_beacon_block_root: block.parent_beacon_block_root,
-            signature,
-            payload_hash,
-        };
+        let (payload, parent_beacon_block_root) = block.into_parts();
+        let payload =
+            OpNetworkPayloadEnvelope { payload, parent_beacon_block_root, signature, payload_hash };
         let encoded_payload = payload.encode_v1().unwrap();
 
         let decoded_payload = OpNetworkPayloadEnvelope::decode_v1(&encoded_payload).unwrap();
@@ -257,21 +258,17 @@ mod tests {
         let expected_address = pubkey.address();
         const CHAIN_ID: u64 = 1337;
 
-        let block = OpExecutionPayloadEnvelope {
-            execution_payload: OpExecutionPayload::V3(
-                ExecutionPayloadV3::arbitrary(&mut arbitrary::Unstructured::new(&bytes)).unwrap(),
-            ),
-            parent_beacon_block_root: Some(B256::random()),
+        let block = OpExecutionPayloadEnvelope::V3 {
+            payload: ExecutionPayloadV3::arbitrary(&mut arbitrary::Unstructured::new(&bytes))
+                .unwrap(),
+            parent_beacon_block_root: B256::random(),
         };
 
         let payload_hash = block.payload_hash();
         let signature = pubkey.sign_hash_sync(&payload_hash.signature_message(CHAIN_ID)).unwrap();
-        let payload = OpNetworkPayloadEnvelope {
-            payload: block.execution_payload,
-            parent_beacon_block_root: block.parent_beacon_block_root,
-            signature,
-            payload_hash,
-        };
+        let (payload, parent_beacon_block_root) = block.into_parts();
+        let payload =
+            OpNetworkPayloadEnvelope { payload, parent_beacon_block_root, signature, payload_hash };
         let encoded_payload = payload.encode_v3().unwrap();
 
         let decoded_payload = OpNetworkPayloadEnvelope::decode_v3(&encoded_payload).unwrap();

--- a/rust/kona/crates/node/service/src/actors/sequencer/actor.rs
+++ b/rust/kona/crates/node/service/src/actors/sequencer/actor.rs
@@ -531,6 +531,7 @@ fn is_seal_task_err_fatal(err: &SealTaskError) -> bool {
         SealTaskError::GetPayloadFailed(_) |
         SealTaskError::HoloceneInvalidFlush |
         SealTaskError::UnsafeHeadChangedSinceBuild => false,
+        SealTaskError::InvalidExecutionPayload(_) |
         SealTaskError::DepositOnlyPayloadFailed |
         SealTaskError::DepositOnlyPayloadReattemptFailed |
         SealTaskError::FromBlock(_) |

--- a/rust/kona/crates/node/service/tests/actors/generator/block_builder.rs
+++ b/rust/kona/crates/node/service/tests/actors/generator/block_builder.rs
@@ -6,7 +6,7 @@ use alloy_primitives::Bytes;
 use arbitrary::{Arbitrary, Unstructured};
 use libp2p::bytes::BufMut;
 use op_alloy_consensus::OpTxEnvelope;
-use op_alloy_rpc_types_engine::{OpExecutionPayload, OpExecutionPayloadEnvelope};
+use op_alloy_rpc_types_engine::OpExecutionPayloadEnvelope;
 
 use crate::actors::generator::seed::SeedGenerator;
 
@@ -34,14 +34,7 @@ impl SeedGenerator {
             PayloadVersion::V4 => self.v4_valid_block(),
         };
 
-        let (payload, _) = OpExecutionPayload::from_block_slow(&block);
-
-        let parent_beacon_block_root = block.header.parent_beacon_block_root;
-
-        let envelope =
-            OpExecutionPayloadEnvelope { parent_beacon_block_root, execution_payload: payload };
-
-        Ok(envelope)
+        Ok(OpExecutionPayloadEnvelope::from_block_slow(&block)?)
     }
 
     fn valid_block(&mut self) -> Block<OpTxEnvelope> {

--- a/rust/kona/crates/node/service/tests/actors/network/sequencer.rs
+++ b/rust/kona/crates/node/service/tests/actors/network/sequencer.rs
@@ -29,8 +29,7 @@ async fn test_sequencer_network_conn() -> anyhow::Result<()> {
         .await
         .ok_or_else(|| anyhow::anyhow!("No block received"))?;
 
-    assert_eq!(block.parent_beacon_block_root, envelope.parent_beacon_block_root);
-    assert_eq!(block.execution_payload, envelope.execution_payload);
+    assert_eq!(block, envelope);
 
     Ok(())
 }
@@ -74,8 +73,7 @@ async fn test_sequencer_network_propagation() -> anyhow::Result<()> {
         let block =
             network.blocks_rx.recv().await.ok_or_else(|| anyhow::anyhow!("No block received"))?;
 
-        assert_eq!(block.parent_beacon_block_root, envelope.parent_beacon_block_root);
-        assert_eq!(block.execution_payload, envelope.execution_payload);
+        assert_eq!(block, envelope);
     }
 
     Ok(())

--- a/rust/kona/crates/protocol/protocol/src/block.rs
+++ b/rust/kona/crates/protocol/protocol/src/block.rs
@@ -1,20 +1,16 @@
 //! Block Types for Optimism.
 
 use crate::{DecodeError, L1BlockInfoTx};
-use alloc::vec::Vec;
 use alloy_consensus::{Block, Header, Transaction, Typed2718};
 use alloy_eips::{
     BlockNumHash,
     eip2718::{Decodable2718, Eip2718Error},
-    eip7685::EMPTY_REQUESTS_HASH,
 };
 use alloy_primitives::{B256, Bytes, Sealed};
-use alloy_rpc_types_engine::{CancunPayloadFields, PraguePayloadFields};
 use alloy_rpc_types_eth::Block as RpcBlock;
 use derive_more::Display;
 use kona_genesis::ChainGenesis;
-use op_alloy_consensus::{OpBlock, OpTransaction, OpTxEnvelope};
-use op_alloy_rpc_types_engine::{OpExecutionPayload, OpExecutionPayloadSidecar, OpPayloadError};
+use op_alloy_consensus::{OpTransaction, OpTxEnvelope};
 
 /// Block Header Info
 #[derive(Debug, Clone, Display, Copy, Eq, Hash, PartialEq, Default)]
@@ -149,9 +145,6 @@ pub enum FromBlockError {
     /// Failed to decode the [`L1BlockInfoTx`] from the deposit transaction.
     #[error("Failed to decode the L1BlockInfoTx from the deposit transaction: {0}")]
     BlockInfoDecodeError(#[from] DecodeError),
-    /// Failed to convert [`OpExecutionPayload`] to [`OpBlock`].
-    #[error(transparent)]
-    OpPayload(#[from] OpPayloadError),
 }
 
 impl PartialEq<Self> for FromBlockError {
@@ -255,35 +248,6 @@ impl L2BlockInfo {
                 .transpose()?
         };
         Self::from_block_info_and_first_tx(block_info, first_tx.as_ref(), genesis)
-    }
-
-    /// Constructs an [`L2BlockInfo`] From a given [`OpExecutionPayload`] and [`ChainGenesis`].
-    pub fn from_payload_and_genesis(
-        payload: OpExecutionPayload,
-        parent_beacon_block_root: Option<B256>,
-        genesis: &ChainGenesis,
-    ) -> Result<Self, FromBlockError> {
-        let block: OpBlock = match payload {
-            OpExecutionPayload::V4(_) => {
-                let sidecar = OpExecutionPayloadSidecar::v4(
-                    CancunPayloadFields::new(
-                        parent_beacon_block_root.unwrap_or_default(),
-                        Vec::new(),
-                    ),
-                    PraguePayloadFields::new(EMPTY_REQUESTS_HASH),
-                );
-                payload.try_into_block_with_sidecar(&sidecar)?
-            }
-            OpExecutionPayload::V3(_) => {
-                let sidecar = OpExecutionPayloadSidecar::v3(CancunPayloadFields::new(
-                    parent_beacon_block_root.unwrap_or_default(),
-                    Vec::new(),
-                ));
-                payload.try_into_block_with_sidecar(&sidecar)?
-            }
-            _ => payload.try_into_block()?,
-        };
-        Self::from_block_and_genesis(&block, genesis)
     }
 }
 

--- a/rust/op-alloy/crates/rpc-types-engine/src/envelope.rs
+++ b/rust/op-alloy/crates/rpc-types-engine/src/envelope.rs
@@ -626,6 +626,11 @@ mod tests {
     #[test]
     #[cfg(feature = "serde")]
     fn test_serde_versioned_root_invariants() {
+        let v1 = OpExecutionPayloadEnvelope::V1(execution_payload_v1(B256::ZERO));
+        let v1_json = serde_json::to_value(&v1).unwrap();
+        assert!(v1_json["parentBeaconBlockRoot"].is_null());
+        assert_eq!(serde_json::from_value::<OpExecutionPayloadEnvelope>(v1_json).unwrap(), v1);
+
         let v2 = OpExecutionPayloadEnvelope::V2(ExecutionPayloadV2 {
             payload_inner: execution_payload_v1(B256::ZERO),
             withdrawals: Vec::new(),

--- a/rust/op-alloy/crates/rpc-types-engine/src/envelope.rs
+++ b/rust/op-alloy/crates/rpc-types-engine/src/envelope.rs
@@ -17,6 +17,9 @@ use alloy_rpc_types_engine::{
 /// V3 and V4 envelopes always contain a parent beacon block root, while V1 and V2 envelopes
 /// cannot contain one. Engine API sidecar fields unsupported by OP are validated when converting
 /// from [`OpExecutionData`].
+///
+/// The transparent SSZ encoding does not include a version discriminator and is therefore not
+/// self-describing. Decoding requires an externally supplied payload version.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum OpExecutionPayloadEnvelope {
     /// A V1 execution payload.
@@ -153,39 +156,6 @@ impl ssz::Encode for OpExecutionPayloadEnvelope {
             Self::V2(payload) => payload.ssz_bytes_len(),
             Self::V3 { payload, .. } => B256::len_bytes() + payload.ssz_bytes_len(),
             Self::V4 { payload, .. } => B256::len_bytes() + payload.ssz_bytes_len(),
-        }
-    }
-}
-
-#[cfg(feature = "std")]
-impl ssz::Decode for OpExecutionPayloadEnvelope {
-    fn is_ssz_fixed_len() -> bool {
-        false
-    }
-
-    fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, ssz::DecodeError> {
-        if let Ok(payload) = OpExecutionPayload::from_ssz_bytes(bytes) {
-            match payload {
-                OpExecutionPayload::V1(payload) => return Ok(Self::V1(payload)),
-                OpExecutionPayload::V2(payload) => return Ok(Self::V2(payload)),
-                OpExecutionPayload::V3(_) | OpExecutionPayload::V4(_) => {}
-            }
-        }
-
-        if bytes.len() < B256::len_bytes() {
-            return Err(ssz::DecodeError::InvalidByteLength {
-                len: bytes.len(),
-                expected: B256::len_bytes(),
-            });
-        }
-
-        let parent_beacon_block_root = B256::from_slice(&bytes[..B256::len_bytes()]);
-        match OpExecutionPayload::from_ssz_bytes(&bytes[B256::len_bytes()..])? {
-            OpExecutionPayload::V3(payload) => Ok(Self::V3 { payload, parent_beacon_block_root }),
-            OpExecutionPayload::V4(payload) => Ok(Self::V4 { payload, parent_beacon_block_root }),
-            OpExecutionPayload::V1(_) | OpExecutionPayload::V2(_) => {
-                Err(ssz::DecodeError::BytesInvalid("parent beacon root on V1/V2 payload".into()))
-            }
         }
     }
 }
@@ -558,20 +528,6 @@ mod tests {
     use alloy_rpc_types_engine::{ExecutionPayloadV1, ExecutionPayloadV2, PayloadError};
 
     #[test]
-    #[cfg(feature = "std")]
-    fn test_roundtrip_encode_rpc_execution_payload_envelope() {
-        use alloy_primitives::hex;
-        use ssz::{Decode, Encode};
-        let data = hex!(
-            "00000000000000000000000000000000000000000000000000000000000001230000000000000000000000000000000000000000000000000000000000000123000000000000000000000000000000000000045600000000000000000000000000000000000000000000000000000000000007890000000000000000000000000000000000000000000000000000000000000abc0d0e0f000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000111de000000000000004d01000000000000bc010000000000002b02000000000000300200000903000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000088832020000380200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001236666040000009999"
-        );
-
-        let payload = OpExecutionPayloadEnvelope::from_ssz_bytes(&data).unwrap();
-        let serialized = payload.as_ssz_bytes();
-        assert_eq!(data, &serialized[..]);
-    }
-
-    #[test]
     #[cfg(feature = "serde")]
     fn test_serde_roundtrip_op_execution_payload_envelope() {
         let envelope_str = r#"{
@@ -749,15 +705,49 @@ mod tests {
         });
     }
 
+    #[test]
     #[cfg(feature = "std")]
-    fn assert_payload_envelope_roundtrip(network: &OpNetworkPayloadEnvelope) {
+    fn test_ssz_envelope_encoding_requires_external_version() {
+        use ssz::{Decode, Encode};
+
+        let mut payload_v1 = execution_payload_v1(B256::ZERO);
+        payload_v1.extra_data = Bytes::new();
+
+        // With the 32-byte root prefix, the V1 decoder reads these shifted V3 fields as its
+        // extra-data and transactions offsets.
+        payload_v1.block_number = payload_v1.ssz_bytes_len() as u64;
+        let mut payload_v3 = ExecutionPayloadV3 {
+            payload_inner: ExecutionPayloadV2 {
+                payload_inner: payload_v1,
+                withdrawals: Vec::new(),
+            },
+            blob_gas_used: 0,
+            excess_blob_gas: 0,
+        };
+        let encoded_len = B256::len_bytes() + payload_v3.ssz_bytes_len();
+        let mut block_hash = [0; B256::len_bytes()];
+        block_hash[..4].copy_from_slice(&(encoded_len as u32).to_le_bytes());
+        payload_v3.payload_inner.payload_inner.block_hash = B256::from(block_hash);
+        let envelope = OpExecutionPayloadEnvelope::V3 {
+            payload: payload_v3.clone(),
+            parent_beacon_block_root: B256::ZERO,
+        };
+
+        let encoded = envelope.as_ssz_bytes();
+        assert_eq!(encoded.len(), encoded_len);
+
+        // The complete root-prefixed V3 encoding is also structurally valid as a V1 payload.
+        assert!(ExecutionPayloadV1::from_ssz_bytes(&encoded).is_ok());
+        assert_eq!(
+            ExecutionPayloadV3::from_ssz_bytes(&encoded[B256::len_bytes()..]).unwrap(),
+            payload_v3
+        );
+    }
+
+    #[cfg(feature = "std")]
+    fn assert_payload_envelope_encoding(network: &OpNetworkPayloadEnvelope) {
         let envelope = OpExecutionPayloadEnvelope::try_from(network).unwrap();
         assert_eq!(envelope.payload_hash(), network.payload_hash);
-
-        let encoded = ssz::Encode::as_ssz_bytes(&envelope);
-        let decoded =
-            <OpExecutionPayloadEnvelope as ssz::Decode>::from_ssz_bytes(&encoded).unwrap();
-        assert_eq!(decoded, envelope);
     }
 
     #[test]
@@ -767,7 +757,7 @@ mod tests {
         let data = hex::decode("0xbd04f043128457c6ccf35128497167442bcc0f8cce78cda8b366e6a12e526d938d1e4c1046acffffbfc542a7e212bb7d80d3a4b2f84f7b196d935398a24eb84c519789b401000000fe0300fe0300fe0300fe0300fe0300fe0300a203000c4a8fd56621ad04fc0101067601008ce60be0005b220117c32c0f3b394b346c2aa42cfa8157cd41f891aa0bec485a62fc010000").unwrap();
         let payload_envelop = OpNetworkPayloadEnvelope::decode_v1(&data).unwrap();
         assert_eq!(1725271882, payload_envelop.payload.timestamp());
-        assert_payload_envelope_roundtrip(&payload_envelop);
+        assert_payload_envelope_encoding(&payload_envelop);
         let encoded = payload_envelop.encode_v1().unwrap();
         assert_eq!(data, encoded);
     }
@@ -779,7 +769,7 @@ mod tests {
         let data = hex::decode("0xc104f0433805080eb36c0b130a7cc1dc74c3f721af4e249aa6f61bb89d1557143e971bb738a3f3b98df7c457e74048e9d2d7e5cd82bb45e3760467e2270e9db86d1271a700000000fe0300fe0300fe0300fe0300fe0300fe0300a203000c6b89d46525ad000205067201009cda69cb5b9b73fc4eb2458b37d37f04ff507fe6c9cd2ab704a05ea9dae3cd61760002000000020000").unwrap();
         let payload_envelop = OpNetworkPayloadEnvelope::decode_v2(&data).unwrap();
         assert_eq!(1708427627, payload_envelop.payload.timestamp());
-        assert_payload_envelope_roundtrip(&payload_envelop);
+        assert_payload_envelope_encoding(&payload_envelop);
         let encoded = payload_envelop.encode_v2().unwrap();
         assert_eq!(data, encoded);
     }
@@ -791,7 +781,7 @@ mod tests {
         let data = hex::decode("0xf104f0434442b9eb38b259f5b23826e6b623e829d2fb878dac70187a1aecf42a3f9bedfd29793d1fcb5822324be0d3e12340a95855553a65d64b83e5579dffb31470df5d010000006a03000412346a1d00fe0100fe0100fe0100fe0100fe0100fe01004201000cc588d465219504100201067601007cfece77b89685f60e3663b6e0faf2de0734674eb91339700c4858c773a8ff921e014401043e0100").unwrap();
         let payload_envelop = OpNetworkPayloadEnvelope::decode_v3(&data).unwrap();
         assert_eq!(1708427461, payload_envelop.payload.timestamp());
-        assert_payload_envelope_roundtrip(&payload_envelop);
+        assert_payload_envelope_encoding(&payload_envelop);
         let encoded = payload_envelop.encode_v3().unwrap();
         assert_eq!(data, encoded);
     }
@@ -803,7 +793,7 @@ mod tests {
         let data = hex::decode("0x9105f043cee25401b6853202950d1d8a082f31a80c4fef5782c049a731f5d104b1b9b9aa7618605b420438ae98b44c8aaaebd482854473c2ae57c079286bb634bece5210000000006a03000412346a1d00fe0100fe0100fe0100fe0100fe0100fe01004201000c5766d26721950430020106f6010001440104b60100049876").unwrap();
         let payload_envelop = OpNetworkPayloadEnvelope::decode_v4(&data).unwrap();
         assert_eq!(1741842007, payload_envelop.payload.timestamp());
-        assert_payload_envelope_roundtrip(&payload_envelop);
+        assert_payload_envelope_encoding(&payload_envelop);
         let encoded = payload_envelop.encode_v4().unwrap();
         assert_eq!(data, encoded);
     }

--- a/rust/op-alloy/crates/rpc-types-engine/src/envelope.rs
+++ b/rust/op-alloy/crates/rpc-types-engine/src/envelope.rs
@@ -3,39 +3,126 @@
 //! This module uses the `snappy` compression algorithm to decompress the payload.
 //! The license for snappy can be found in the `SNAPPY-LICENSE` at the root of the repository.
 
-use crate::{
-    OpExecutionPayload, OpExecutionPayloadSidecar, OpExecutionPayloadV4, OpFlashblockError,
-    OpFlashblockPayload,
-};
+use crate::{OpExecutionPayload, OpExecutionPayloadSidecar, OpExecutionPayloadV4, OpPayloadError};
 use alloc::vec::Vec;
-use alloy_consensus::{Block, BlockHeader, Sealable, Transaction};
-use alloy_eips::{Encodable2718, eip4895::Withdrawal, eip7685::Requests};
+use alloy_eips::eip7685::Requests;
 use alloy_primitives::{B256, Signature, keccak256};
 use alloy_rpc_types_engine::{
     CancunPayloadFields, ExecutionPayloadInputV2, ExecutionPayloadV1, ExecutionPayloadV2,
     ExecutionPayloadV3, PraguePayloadFields,
 };
 
-/// A thin wrapper around [`OpExecutionPayload`] that includes the parent beacon block root.
+/// A structurally complete OP execution payload envelope.
+///
+/// V3 and V4 envelopes always contain a parent beacon block root, while V1 and V2 envelopes
+/// cannot contain one. Engine API sidecar fields unsupported by OP are validated when converting
+/// from [`OpExecutionData`].
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
-pub struct OpExecutionPayloadEnvelope {
-    /// The parent beacon block root, if any.
-    pub parent_beacon_block_root: Option<B256>,
-    /// The execution payload.
-    pub execution_payload: OpExecutionPayload,
+pub enum OpExecutionPayloadEnvelope {
+    /// A V1 execution payload.
+    V1(ExecutionPayloadV1),
+    /// A V2 execution payload.
+    V2(ExecutionPayloadV2),
+    /// A V3 execution payload and its required parent beacon block root.
+    V3 {
+        /// The execution payload.
+        payload: ExecutionPayloadV3,
+        /// The parent beacon block root.
+        parent_beacon_block_root: B256,
+    },
+    /// A V4 execution payload and its required parent beacon block root.
+    V4 {
+        /// The execution payload.
+        payload: OpExecutionPayloadV4,
+        /// The parent beacon block root.
+        parent_beacon_block_root: B256,
+    },
 }
 
 impl OpExecutionPayloadEnvelope {
-    /// Returns the payload hash over the ssz encoded payload envelope data.
+    /// Constructs an envelope from its wire-level payload and optional parent beacon block root.
+    pub(crate) fn try_from_payload(
+        payload: OpExecutionPayload,
+        parent_beacon_block_root: Option<B256>,
+    ) -> Result<Self, OpPayloadError> {
+        match (payload, parent_beacon_block_root) {
+            (OpExecutionPayload::V1(payload), None) => Ok(Self::V1(payload)),
+            (OpExecutionPayload::V2(payload), None) => Ok(Self::V2(payload)),
+            (OpExecutionPayload::V3(payload), Some(parent_beacon_block_root)) => {
+                Ok(Self::V3 { payload, parent_beacon_block_root })
+            }
+            (OpExecutionPayload::V4(payload), Some(parent_beacon_block_root)) => {
+                Ok(Self::V4 { payload, parent_beacon_block_root })
+            }
+            (OpExecutionPayload::V3(_) | OpExecutionPayload::V4(_), None) => {
+                Err(OpPayloadError::MissingParentBeaconBlockRoot)
+            }
+            (OpExecutionPayload::V1(_) | OpExecutionPayload::V2(_), Some(_)) => {
+                Err(OpPayloadError::UnexpectedParentBeaconBlockRoot)
+            }
+        }
+    }
+
+    /// Consumes the envelope and returns its wire-level payload and parent beacon block root.
+    pub fn into_parts(self) -> (OpExecutionPayload, Option<B256>) {
+        match self {
+            Self::V1(payload) => (OpExecutionPayload::V1(payload), None),
+            Self::V2(payload) => (OpExecutionPayload::V2(payload), None),
+            Self::V3 { payload, parent_beacon_block_root } => {
+                (OpExecutionPayload::V3(payload), Some(parent_beacon_block_root))
+            }
+            Self::V4 { payload, parent_beacon_block_root } => {
+                (OpExecutionPayload::V4(payload), Some(parent_beacon_block_root))
+            }
+        }
+    }
+
+    /// Returns the payload hash over the SSZ-encoded payload envelope data.
     ///
     /// <https://specs.optimism.io/protocol/rollup-node-p2p.html#block-signatures>
     #[cfg(feature = "std")]
     pub fn payload_hash(&self) -> crate::PayloadHash {
         use ssz::Encode;
-        let ssz_bytes = self.as_ssz_bytes();
-        crate::PayloadHash::from(ssz_bytes.as_slice())
+        crate::PayloadHash::from(self.as_ssz_bytes().as_slice())
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for OpExecutionPayloadEnvelope {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+
+        let mut envelope = serializer.serialize_struct("OpExecutionPayloadEnvelope", 2)?;
+        envelope.serialize_field("parentBeaconBlockRoot", &self.parent_beacon_block_root())?;
+        match self {
+            Self::V1(payload) => envelope.serialize_field("executionPayload", payload)?,
+            Self::V2(payload) => envelope.serialize_field("executionPayload", payload)?,
+            Self::V3 { payload, .. } => envelope.serialize_field("executionPayload", payload)?,
+            Self::V4 { payload, .. } => envelope.serialize_field("executionPayload", payload)?,
+        }
+        envelope.end()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for OpExecutionPayloadEnvelope {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(serde::Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct WireEnvelope {
+            parent_beacon_block_root: Option<B256>,
+            execution_payload: OpExecutionPayload,
+        }
+
+        let envelope = WireEnvelope::deserialize(deserializer)?;
+        Self::try_from_payload(envelope.execution_payload, envelope.parent_beacon_block_root)
+            .map_err(serde::de::Error::custom)
     }
 }
 
@@ -46,22 +133,27 @@ impl ssz::Encode for OpExecutionPayloadEnvelope {
     }
 
     fn ssz_append(&self, buf: &mut Vec<u8>) {
-        // Write parent beacon block root only if the payload is not a v1 or v2 payload.
-        // <https://specs.optimism.io/protocol/rollup-node-p2p.html#block-encoding>
-        if !matches!(self.execution_payload, OpExecutionPayload::V1(_) | OpExecutionPayload::V2(_))
-        {
-            buf.extend_from_slice(self.parent_beacon_block_root.unwrap_or_default().as_slice());
+        match self {
+            Self::V1(payload) => payload.ssz_append(buf),
+            Self::V2(payload) => payload.ssz_append(buf),
+            Self::V3 { payload, parent_beacon_block_root } => {
+                buf.extend_from_slice(parent_beacon_block_root.as_slice());
+                payload.ssz_append(buf);
+            }
+            Self::V4 { payload, parent_beacon_block_root } => {
+                buf.extend_from_slice(parent_beacon_block_root.as_slice());
+                payload.ssz_append(buf);
+            }
         }
-
-        // Write payload
-        self.execution_payload.ssz_append(buf);
     }
 
     fn ssz_bytes_len(&self) -> usize {
-        let mut len = 0;
-        len += B256::ssz_fixed_len(); // parent_beacon_block_root is always 32 bytes
-        len += self.execution_payload.ssz_bytes_len();
-        len
+        match self {
+            Self::V1(payload) => payload.ssz_bytes_len(),
+            Self::V2(payload) => payload.ssz_bytes_len(),
+            Self::V3 { payload, .. } => B256::len_bytes() + payload.ssz_bytes_len(),
+            Self::V4 { payload, .. } => B256::len_bytes() + payload.ssz_bytes_len(),
+        }
     }
 }
 
@@ -72,37 +164,45 @@ impl ssz::Decode for OpExecutionPayloadEnvelope {
     }
 
     fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, ssz::DecodeError> {
-        if bytes.len() < B256::ssz_fixed_len() {
+        if let Ok(payload) = OpExecutionPayload::from_ssz_bytes(bytes) {
+            match payload {
+                OpExecutionPayload::V1(payload) => return Ok(Self::V1(payload)),
+                OpExecutionPayload::V2(payload) => return Ok(Self::V2(payload)),
+                OpExecutionPayload::V3(_) | OpExecutionPayload::V4(_) => {}
+            }
+        }
+
+        if bytes.len() < B256::len_bytes() {
             return Err(ssz::DecodeError::InvalidByteLength {
                 len: bytes.len(),
-                expected: B256::ssz_fixed_len(),
+                expected: B256::len_bytes(),
             });
         }
 
-        // Decode parent_beacon_block_root
-        let parent_beacon_block_root = {
-            let root_bytes = &bytes[..B256::ssz_fixed_len()];
-            if root_bytes.iter().all(|&b| b == 0) {
-                None
-            } else {
-                Some(B256::from_slice(root_bytes))
+        let parent_beacon_block_root = B256::from_slice(&bytes[..B256::len_bytes()]);
+        match OpExecutionPayload::from_ssz_bytes(&bytes[B256::len_bytes()..])? {
+            OpExecutionPayload::V3(payload) => Ok(Self::V3 { payload, parent_beacon_block_root }),
+            OpExecutionPayload::V4(payload) => Ok(Self::V4 { payload, parent_beacon_block_root }),
+            OpExecutionPayload::V1(_) | OpExecutionPayload::V2(_) => {
+                Err(ssz::DecodeError::BytesInvalid("parent beacon root on V1/V2 payload".into()))
             }
-        };
-
-        // Decode payload
-        let execution_payload =
-            OpExecutionPayload::from_ssz_bytes(&bytes[B256::ssz_fixed_len()..])?;
-
-        Ok(Self { parent_beacon_block_root, execution_payload })
+        }
     }
 }
 
-impl From<OpNetworkPayloadEnvelope> for OpExecutionPayloadEnvelope {
-    fn from(envelope: OpNetworkPayloadEnvelope) -> Self {
-        Self {
-            execution_payload: envelope.payload,
-            parent_beacon_block_root: envelope.parent_beacon_block_root,
-        }
+impl TryFrom<OpNetworkPayloadEnvelope> for OpExecutionPayloadEnvelope {
+    type Error = OpPayloadError;
+
+    fn try_from(envelope: OpNetworkPayloadEnvelope) -> Result<Self, Self::Error> {
+        Self::try_from_payload(envelope.payload, envelope.parent_beacon_block_root)
+    }
+}
+
+impl TryFrom<&OpNetworkPayloadEnvelope> for OpExecutionPayloadEnvelope {
+    type Error = OpPayloadError;
+
+    fn try_from(envelope: &OpNetworkPayloadEnvelope) -> Result<Self, Self::Error> {
+        Self::try_from_payload(envelope.payload.clone(), envelope.parent_beacon_block_root)
     }
 }
 
@@ -121,160 +221,6 @@ impl OpExecutionData {
     /// Creates new instance of [`OpExecutionData`].
     pub const fn new(payload: OpExecutionPayload, sidecar: OpExecutionPayloadSidecar) -> Self {
         Self { payload, sidecar }
-    }
-
-    /// Conversion from [`alloy_consensus::Block`]. Also returns the [`OpExecutionPayloadSidecar`]
-    /// extracted from the block.
-    ///
-    /// See also [`from_block_unchecked`](OpExecutionPayload::from_block_slow).
-    ///
-    /// Note: This re-calculates the block hash.
-    pub fn from_block_slow<T, H>(block: &Block<T, H>) -> Self
-    where
-        T: Encodable2718 + Transaction,
-        H: BlockHeader + Sealable,
-    {
-        let (payload, sidecar) = OpExecutionPayload::from_block_slow(block);
-
-        Self::new(payload, sidecar)
-    }
-
-    /// Conversion from [`alloy_consensus::Block`]. Also returns the [`OpExecutionPayloadSidecar`]
-    /// extracted from the block.
-    ///
-    /// See also [`OpExecutionPayload::from_block_unchecked`].
-    pub fn from_block_unchecked<T, H>(block_hash: B256, block: &Block<T, H>) -> Self
-    where
-        T: Encodable2718 + Transaction,
-        H: BlockHeader,
-    {
-        let (payload, sidecar) = OpExecutionPayload::from_block_unchecked(block_hash, block);
-
-        Self::new(payload, sidecar)
-    }
-
-    /// Conversion from a vec of [`OpFlashblockPayload`]. Also returns the
-    /// [`OpExecutionPayloadSidecar`] extracted from the payloads.
-    ///
-    /// # Validation
-    ///
-    /// This method performs the following validations:
-    /// - At least one flashblock must be present
-    /// - Indices must be sequential starting from 0
-    /// - First flashblock (index 0) must have a base payload
-    /// - Only the first flashblock may have a base payload
-    ///
-    /// Materializes the latest out-of-band SDM `post_exec_tx` as the trailing transaction.
-    /// The normal execution-payload path validates its type, payload, and position.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if any validation fails.
-    pub fn from_flashblocks(
-        flashblocks: &[OpFlashblockPayload],
-    ) -> Result<Self, OpFlashblockError> {
-        // Validate we have at least one flashblock
-        if flashblocks.is_empty() {
-            return Err(OpFlashblockError::MissingPayload);
-        }
-
-        // Validate indices are sequential starting from 0
-        for (i, fb) in flashblocks.iter().enumerate() {
-            if fb.index as usize != i {
-                return Err(OpFlashblockError::InvalidIndex);
-            }
-        }
-
-        // Validate first flashblock has base and extract it
-        let first = flashblocks.first().unwrap(); // Safe: checked empty above
-        if first.base.is_none() {
-            return Err(OpFlashblockError::MissingBasePayload);
-        }
-
-        // Validate no other flashblocks have base (only first should have it)
-        for fb in flashblocks.iter().skip(1) {
-            if fb.base.is_some() {
-                return Err(OpFlashblockError::UnexpectedBasePayload);
-            }
-        }
-
-        Ok(Self::from_flashblocks_unchecked(flashblocks))
-    }
-
-    /// Conversion from a vec of [`OpFlashblockPayload`] without validation.
-    ///
-    /// This is a faster alternative to [`Self::from_flashblocks`] that skips all validation
-    /// checks. Use this method only when you are certain the input data is valid.
-    ///
-    /// # Safety Requirements
-    ///
-    /// The caller must ensure:
-    /// - At least one flashblock is present
-    /// - Indices are sequential starting from 0
-    /// - First flashblock (index 0) has a base payload
-    /// - Only the first flashblock has a base payload
-    ///
-    /// # Panics
-    ///
-    /// Panics if any of the safety requirements are violated.
-    pub fn from_flashblocks_unchecked(flashblocks: &[OpFlashblockPayload]) -> Self {
-        // Extract base from first flashblock
-        // SAFETY: Caller guarantees at least one flashblock exists with base payload
-        let first = flashblocks.first().expect("flashblocks must not be empty");
-        let base = first.base.as_ref().expect("first flashblock must have base payload");
-
-        // Get the final state from the last flashblock
-        // SAFETY: Caller guarantees at least one flashblock exists
-        let diff = &flashblocks.last().expect("flashblocks must not be empty").diff;
-
-        // Collect all transactions and withdrawals from all flashblocks
-        let (mut transactions, withdrawals) =
-            flashblocks.iter().fold((Vec::new(), Vec::new()), |(mut txs, mut withdrawals), p| {
-                txs.extend(p.diff.transactions.iter().cloned());
-                withdrawals.extend(p.diff.withdrawals.iter().copied());
-                (txs, withdrawals)
-            });
-
-        // Each subblock replaces the out-of-band SDM transaction. Append the latest value once in
-        // the consensus-required trailing position; normal payload validation verifies its bytes.
-        if let Some(post_exec_tx) = diff.post_exec_tx.as_ref() {
-            transactions.push(post_exec_tx.clone());
-        }
-
-        let v3 = ExecutionPayloadV3 {
-            blob_gas_used: diff.blob_gas_used.unwrap_or(0),
-            excess_blob_gas: 0,
-            payload_inner: ExecutionPayloadV2 {
-                withdrawals,
-                payload_inner: ExecutionPayloadV1 {
-                    parent_hash: base.parent_hash,
-                    fee_recipient: base.fee_recipient,
-                    state_root: diff.state_root,
-                    receipts_root: diff.receipts_root,
-                    logs_bloom: diff.logs_bloom,
-                    prev_randao: base.prev_randao,
-                    block_number: base.block_number,
-                    gas_limit: base.gas_limit,
-                    gas_used: diff.gas_used,
-                    timestamp: base.timestamp,
-                    extra_data: base.extra_data.clone(),
-                    base_fee_per_gas: base.base_fee_per_gas,
-                    block_hash: diff.block_hash,
-                    transactions,
-                },
-            },
-        };
-
-        // Before Isthmus hardfork, withdrawals_root was not included.
-        // A zero withdrawals_root indicates a pre-Isthmus flashblock.
-        if diff.withdrawals_root == B256::ZERO {
-            return Self::v3(v3, Vec::new(), base.parent_beacon_block_root);
-        }
-
-        let v4 =
-            OpExecutionPayloadV4 { withdrawals_root: diff.withdrawals_root, payload_inner: v3 };
-
-        Self::v4(v4, Vec::new(), base.parent_beacon_block_root, Default::default())
     }
 
     /// Creates a new instance from args to engine API method `newPayloadV2`.
@@ -317,40 +263,6 @@ impl OpExecutionData {
                 PraguePayloadFields::new(execution_requests),
             ),
         )
-    }
-
-    /// Returns the parent beacon block root, if any.
-    pub fn parent_beacon_block_root(&self) -> Option<B256> {
-        self.sidecar.parent_beacon_block_root()
-    }
-
-    /// Return the withdrawals for the payload or attributes.
-    pub const fn withdrawals(&self) -> Option<&Vec<Withdrawal>> {
-        match &self.payload {
-            OpExecutionPayload::V1(_) => None,
-            OpExecutionPayload::V2(execution_payload_v2) => Some(&execution_payload_v2.withdrawals),
-            OpExecutionPayload::V3(execution_payload_v3) => {
-                Some(execution_payload_v3.withdrawals())
-            }
-            OpExecutionPayload::V4(op_execution_payload_v4) => {
-                Some(op_execution_payload_v4.payload_inner.withdrawals())
-            }
-        }
-    }
-
-    /// Returns the parent hash of the block.
-    pub const fn parent_hash(&self) -> B256 {
-        self.payload.parent_hash()
-    }
-
-    /// Returns the hash of the block.
-    pub const fn block_hash(&self) -> B256 {
-        self.payload.block_hash()
-    }
-
-    /// Returns the number of the block.
-    pub const fn block_number(&self) -> u64 {
-        self.payload.block_number()
     }
 }
 
@@ -640,7 +552,10 @@ impl PayloadHash {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_primitives::{Bytes, b256};
+    use crate::{OpFlashblockError, OpFlashblockPayload, OpPayloadError};
+    use alloy_consensus::Block;
+    use alloy_primitives::{Address, Bloom, Bytes, U256, b256};
+    use alloy_rpc_types_engine::{ExecutionPayloadV1, ExecutionPayloadV2, PayloadError};
 
     #[test]
     #[cfg(feature = "std")]
@@ -666,8 +581,148 @@ mod tests {
 
         let envelope: OpExecutionPayloadEnvelope = serde_json::from_str(envelope_str).unwrap();
         let expected = b256!("9999999999999999999999999999999999999999999999999999999999999999");
-        assert_eq!(envelope.parent_beacon_block_root.unwrap(), expected);
-        let _ = serde_json::to_string(&envelope).unwrap();
+        assert_eq!(envelope.parent_beacon_block_root().unwrap(), expected);
+        assert_eq!(
+            serde_json::to_value(&envelope).unwrap(),
+            serde_json::from_str::<serde_json::Value>(envelope_str).unwrap()
+        );
+
+        let mut missing_root = serde_json::from_str::<serde_json::Value>(envelope_str).unwrap();
+        missing_root.as_object_mut().unwrap().remove("parentBeaconBlockRoot");
+        let err = serde_json::from_value::<OpExecutionPayloadEnvelope>(missing_root).unwrap_err();
+        assert!(err.to_string().contains("missing parent beacon block root"));
+
+        let mut unexpected_root = serde_json::from_str::<serde_json::Value>(envelope_str).unwrap();
+        let payload = unexpected_root["executionPayload"].as_object_mut().unwrap();
+        payload.remove("blobGasUsed");
+        payload.remove("excessBlobGas");
+        payload.remove("withdrawalsRoot");
+        let err =
+            serde_json::from_value::<OpExecutionPayloadEnvelope>(unexpected_root).unwrap_err();
+        assert!(err.to_string().contains("unexpected parent beacon block root"));
+    }
+
+    fn execution_payload_v1(block_hash: B256) -> ExecutionPayloadV1 {
+        ExecutionPayloadV1 {
+            parent_hash: b256!("1111111111111111111111111111111111111111111111111111111111111111"),
+            fee_recipient: Address::repeat_byte(0x22),
+            state_root: b256!("3333333333333333333333333333333333333333333333333333333333333333"),
+            receipts_root: b256!(
+                "4444444444444444444444444444444444444444444444444444444444444444"
+            ),
+            logs_bloom: Bloom::ZERO,
+            prev_randao: b256!("5555555555555555555555555555555555555555555555555555555555555555"),
+            block_number: 1,
+            gas_limit: 30_000_000,
+            gas_used: 21_000,
+            timestamp: 123_456_789,
+            extra_data: Bytes::from_static(&[0x12, 0x34]),
+            base_fee_per_gas: U256::from(1_000_000_000),
+            block_hash,
+            transactions: Vec::new(),
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn test_serde_versioned_root_invariants() {
+        let v2 = OpExecutionPayloadEnvelope::V2(ExecutionPayloadV2 {
+            payload_inner: execution_payload_v1(B256::ZERO),
+            withdrawals: Vec::new(),
+        });
+        let v2_json = serde_json::to_value(&v2).unwrap();
+        assert!(v2_json["parentBeaconBlockRoot"].is_null());
+        assert_eq!(serde_json::from_value::<OpExecutionPayloadEnvelope>(v2_json).unwrap(), v2);
+
+        let v3 = OpExecutionPayloadEnvelope::V3 {
+            payload: ExecutionPayloadV3 {
+                payload_inner: ExecutionPayloadV2 {
+                    payload_inner: execution_payload_v1(B256::ZERO),
+                    withdrawals: Vec::new(),
+                },
+                blob_gas_used: 0,
+                excess_blob_gas: 0,
+            },
+            parent_beacon_block_root: B256::ZERO,
+        };
+        let v3_json = serde_json::to_value(&v3).unwrap();
+        assert_eq!(
+            v3_json["parentBeaconBlockRoot"],
+            serde_json::Value::String(B256::ZERO.to_string())
+        );
+        assert_eq!(serde_json::from_value::<OpExecutionPayloadEnvelope>(v3_json).unwrap(), v3);
+    }
+
+    #[test]
+    fn test_try_into_checked_block() {
+        // Pin hashes produced by op-service's independent ExecutionPayloadEnvelope.CheckBlockHash.
+        // The V3 case uses a present zero beacon root to verify that presence is preserved.
+        let v1_hash = b256!("55e9427d0f33b1e09e76c229aa4d685336ebc151a26820914652439a69e46791");
+        let v2_hash = b256!("de05d55fdc91f15fc85cbf222ab05a586a3b7b6afd1a7abb7f353d3522dfff15");
+        let v3_hash = b256!("f27a826220863770f4c8f5599c19a8dc82b8b2bbbc1bc689cb1b0dab6418886e");
+        let v4_hash = b256!("4034384737b7667a4015c0083ba2262ca3d196cc6fa6c3e763ee0a69ff95e780");
+
+        let cases = [
+            OpExecutionPayloadEnvelope::V1(execution_payload_v1(v1_hash)),
+            OpExecutionPayloadEnvelope::V2(ExecutionPayloadV2 {
+                payload_inner: execution_payload_v1(v2_hash),
+                withdrawals: Vec::new(),
+            }),
+            OpExecutionPayloadEnvelope::V3 {
+                // Presence is required for V3; an explicitly zero root remains distinct from None.
+                parent_beacon_block_root: B256::ZERO,
+                payload: ExecutionPayloadV3 {
+                    payload_inner: ExecutionPayloadV2 {
+                        payload_inner: execution_payload_v1(v3_hash),
+                        withdrawals: Vec::new(),
+                    },
+                    blob_gas_used: 0,
+                    excess_blob_gas: 0,
+                },
+            },
+            OpExecutionPayloadEnvelope::V4 {
+                parent_beacon_block_root: b256!(
+                    "7777777777777777777777777777777777777777777777777777777777777777"
+                ),
+                payload: OpExecutionPayloadV4 {
+                    payload_inner: ExecutionPayloadV3 {
+                        payload_inner: ExecutionPayloadV2 {
+                            payload_inner: execution_payload_v1(v4_hash),
+                            withdrawals: Vec::new(),
+                        },
+                        blob_gas_used: 0,
+                        excess_blob_gas: 0,
+                    },
+                    withdrawals_root: b256!(
+                        "6666666666666666666666666666666666666666666666666666666666666666"
+                    ),
+                },
+            },
+        ];
+
+        for mut envelope in cases {
+            let claimed = envelope.block_hash();
+            assert!(envelope.check_block_hash().is_ok());
+            let block: Block<op_alloy_consensus::OpTxEnvelope> =
+                envelope.clone().try_into_checked_block().unwrap();
+            assert_eq!(block.header.hash_slow(), claimed);
+
+            envelope.as_v1_mut().state_root = B256::ZERO;
+            assert!(matches!(
+                envelope.check_block_hash(),
+                Err(OpPayloadError::Eth(PayloadError::BlockHash {
+                    execution,
+                    consensus,
+                })) if execution != claimed && consensus == claimed
+            ));
+            assert!(matches!(
+                envelope.try_into_checked_block::<op_alloy_consensus::OpTxEnvelope>(),
+                Err(OpPayloadError::Eth(PayloadError::BlockHash {
+                    execution,
+                    consensus,
+                })) if execution != claimed && consensus == claimed
+            ));
+        }
     }
 
     #[test]
@@ -689,6 +744,17 @@ mod tests {
         });
     }
 
+    #[cfg(feature = "std")]
+    fn assert_payload_envelope_roundtrip(network: &OpNetworkPayloadEnvelope) {
+        let envelope = OpExecutionPayloadEnvelope::try_from(network).unwrap();
+        assert_eq!(envelope.payload_hash(), network.payload_hash);
+
+        let encoded = ssz::Encode::as_ssz_bytes(&envelope);
+        let decoded =
+            <OpExecutionPayloadEnvelope as ssz::Decode>::from_ssz_bytes(&encoded).unwrap();
+        assert_eq!(decoded, envelope);
+    }
+
     #[test]
     #[cfg(feature = "std")]
     fn test_roundtrip_encode_envelope_v1() {
@@ -696,6 +762,7 @@ mod tests {
         let data = hex::decode("0xbd04f043128457c6ccf35128497167442bcc0f8cce78cda8b366e6a12e526d938d1e4c1046acffffbfc542a7e212bb7d80d3a4b2f84f7b196d935398a24eb84c519789b401000000fe0300fe0300fe0300fe0300fe0300fe0300a203000c4a8fd56621ad04fc0101067601008ce60be0005b220117c32c0f3b394b346c2aa42cfa8157cd41f891aa0bec485a62fc010000").unwrap();
         let payload_envelop = OpNetworkPayloadEnvelope::decode_v1(&data).unwrap();
         assert_eq!(1725271882, payload_envelop.payload.timestamp());
+        assert_payload_envelope_roundtrip(&payload_envelop);
         let encoded = payload_envelop.encode_v1().unwrap();
         assert_eq!(data, encoded);
     }
@@ -707,6 +774,7 @@ mod tests {
         let data = hex::decode("0xc104f0433805080eb36c0b130a7cc1dc74c3f721af4e249aa6f61bb89d1557143e971bb738a3f3b98df7c457e74048e9d2d7e5cd82bb45e3760467e2270e9db86d1271a700000000fe0300fe0300fe0300fe0300fe0300fe0300a203000c6b89d46525ad000205067201009cda69cb5b9b73fc4eb2458b37d37f04ff507fe6c9cd2ab704a05ea9dae3cd61760002000000020000").unwrap();
         let payload_envelop = OpNetworkPayloadEnvelope::decode_v2(&data).unwrap();
         assert_eq!(1708427627, payload_envelop.payload.timestamp());
+        assert_payload_envelope_roundtrip(&payload_envelop);
         let encoded = payload_envelop.encode_v2().unwrap();
         assert_eq!(data, encoded);
     }
@@ -718,6 +786,7 @@ mod tests {
         let data = hex::decode("0xf104f0434442b9eb38b259f5b23826e6b623e829d2fb878dac70187a1aecf42a3f9bedfd29793d1fcb5822324be0d3e12340a95855553a65d64b83e5579dffb31470df5d010000006a03000412346a1d00fe0100fe0100fe0100fe0100fe0100fe01004201000cc588d465219504100201067601007cfece77b89685f60e3663b6e0faf2de0734674eb91339700c4858c773a8ff921e014401043e0100").unwrap();
         let payload_envelop = OpNetworkPayloadEnvelope::decode_v3(&data).unwrap();
         assert_eq!(1708427461, payload_envelop.payload.timestamp());
+        assert_payload_envelope_roundtrip(&payload_envelop);
         let encoded = payload_envelop.encode_v3().unwrap();
         assert_eq!(data, encoded);
     }
@@ -729,6 +798,7 @@ mod tests {
         let data = hex::decode("0x9105f043cee25401b6853202950d1d8a082f31a80c4fef5782c049a731f5d104b1b9b9aa7618605b420438ae98b44c8aaaebd482854473c2ae57c079286bb634bece5210000000006a03000412346a1d00fe0100fe0100fe0100fe0100fe0100fe01004201000c5766d26721950430020106f6010001440104b60100049876").unwrap();
         let payload_envelop = OpNetworkPayloadEnvelope::decode_v4(&data).unwrap();
         assert_eq!(1741842007, payload_envelop.payload.timestamp());
+        assert_payload_envelope_roundtrip(&payload_envelop);
         let encoded = payload_envelop.encode_v4().unwrap();
         assert_eq!(data, encoded);
     }
@@ -783,7 +853,7 @@ mod tests {
 
     #[test]
     fn test_from_flashblocks_empty_vec() {
-        let result = OpExecutionData::from_flashblocks(&[]);
+        let result = OpExecutionPayloadEnvelope::from_flashblocks(&[]);
         assert!(matches!(result, Err(OpFlashblockError::MissingPayload)));
     }
 
@@ -792,7 +862,7 @@ mod tests {
         let fb1 = create_test_flashblock(0, true, Vec::new(), None);
         let fb2 = create_test_flashblock(2, false, Vec::new(), None); // Skip index 1
 
-        let result = OpExecutionData::from_flashblocks(&[fb1, fb2]);
+        let result = OpExecutionPayloadEnvelope::from_flashblocks(&[fb1, fb2]);
         assert!(matches!(result, Err(OpFlashblockError::InvalidIndex)));
     }
 
@@ -800,7 +870,7 @@ mod tests {
     fn test_from_flashblocks_missing_base_in_first() {
         let fb1 = create_test_flashblock(0, false, Vec::new(), None); // First should have base
 
-        let result = OpExecutionData::from_flashblocks(&[fb1]);
+        let result = OpExecutionPayloadEnvelope::from_flashblocks(&[fb1]);
         assert!(matches!(result, Err(OpFlashblockError::MissingBasePayload)));
     }
 
@@ -809,7 +879,7 @@ mod tests {
         let fb1 = create_test_flashblock(0, true, Vec::new(), None);
         let fb2 = create_test_flashblock(1, true, Vec::new(), None); // Should not have base
 
-        let result = OpExecutionData::from_flashblocks(&[fb1, fb2]);
+        let result = OpExecutionPayloadEnvelope::from_flashblocks(&[fb1, fb2]);
         assert!(matches!(result, Err(OpFlashblockError::UnexpectedBasePayload)));
     }
 
@@ -817,7 +887,7 @@ mod tests {
     fn test_from_flashblocks_single_valid_flashblock() {
         let fb1 = create_test_flashblock(0, true, Vec::new(), None);
 
-        let result = OpExecutionData::from_flashblocks(&[fb1]);
+        let result = OpExecutionPayloadEnvelope::from_flashblocks(&[fb1]);
         assert!(result.is_ok(), "Single valid flashblock should succeed");
     }
 
@@ -827,14 +897,14 @@ mod tests {
         let fb2 = create_test_flashblock(1, false, Vec::new(), None);
         let fb3 = create_test_flashblock(2, false, Vec::new(), None);
 
-        let result = OpExecutionData::from_flashblocks(&[fb1, fb2, fb3]);
+        let result = OpExecutionPayloadEnvelope::from_flashblocks(&[fb1, fb2, fb3]);
         assert!(result.is_ok(), "Multiple valid flashblocks should succeed");
     }
 
     #[test]
     fn test_from_flashblocks_wrong_first_index() {
         let fb1 = create_test_flashblock(1, true, Vec::new(), None); // Should be index 0
-        let result = OpExecutionData::from_flashblocks(&[fb1]);
+        let result = OpExecutionPayloadEnvelope::from_flashblocks(&[fb1]);
         assert!(matches!(result, Err(OpFlashblockError::InvalidIndex)));
     }
 
@@ -843,20 +913,20 @@ mod tests {
         let older = Bytes::from(vec![0x7d, 0x01]);
         let latest = Bytes::from(vec![0x7d, 0x02]);
 
-        let none = OpExecutionData::from_flashblocks(&[
+        let none = OpExecutionPayloadEnvelope::from_flashblocks(&[
             create_test_flashblock(0, true, vec![Bytes::from(vec![0x01])], None),
             create_test_flashblock(1, false, vec![Bytes::from(vec![0x02])], None),
         ])
         .unwrap();
-        assert_eq!(none.payload.transactions().len(), 2, "no 0x7D should be appended");
+        assert_eq!(none.transactions().len(), 2, "no 0x7D should be appended");
 
-        let materialized = OpExecutionData::from_flashblocks(&[
+        let materialized = OpExecutionPayloadEnvelope::from_flashblocks(&[
             create_test_flashblock(0, true, vec![Bytes::from(vec![0x01])], Some(older.clone())),
             create_test_flashblock(1, false, vec![Bytes::from(vec![0x02])], Some(latest.clone())),
             create_test_flashblock(2, false, vec![Bytes::from(vec![0x03])], Some(latest.clone())),
         ])
         .unwrap();
-        let txs = materialized.payload.transactions();
+        let txs = materialized.transactions();
         assert_eq!(txs.len(), 4, "3 user txs + exactly one trailing 0x7D");
         assert_eq!(txs.last(), Some(&latest), "the latest post_exec_tx must be the trailing tx");
         assert!(!txs.iter().any(|t| t == &older), "the superseded post_exec_tx must not appear");
@@ -865,7 +935,7 @@ mod tests {
     #[test]
     fn test_from_subblocks_preserves_empty_post_exec_tx() {
         let empty = Bytes::new();
-        let materialized = OpExecutionData::from_flashblocks(&[create_test_flashblock(
+        let materialized = OpExecutionPayloadEnvelope::from_flashblocks(&[create_test_flashblock(
             0,
             true,
             Vec::new(),
@@ -873,7 +943,7 @@ mod tests {
         )])
         .unwrap();
 
-        assert_eq!(materialized.payload.transactions().last(), Some(&empty));
+        assert_eq!(materialized.transactions().last(), Some(&empty));
     }
 
     // Real-world test case from Unichain Sepolia
@@ -886,36 +956,36 @@ mod tests {
         let raw_sequence = r#"[{"payload_id":"0x03c446f063e3735a","index":0,"base":{"parent_beacon_block_root":"0xf6d335a6b2b4fd8fb539cd51a49769df4d53c31a90c54dd270e54542638ff101","parent_hash":"0x06ff95a9cd23b0328da74a984aa986b2e01d377dab1825f1029e39ece6c4a3ea","fee_recipient":"0x4200000000000000000000000000000000000011","prev_randao":"0x8beee738d20a9d77c5f27e9cb799ebe5b536f0985efad5f7d77ebff47f092c4a","block_number":"0x21e3b52","gas_limit":"0x3938700","timestamp":"0x690be89e","extra_data":"0x00000000320000000c","base_fee_per_gas":"0x33"},"diff":{"state_root":"0xb29a9bcae8cf3ae6d68985fcd70db80b3818cd629c9d5da0bb116451739b2078","receipts_root":"0x91d8ad10740ccfc1bd848fba0e02668d95769c08eeea30f10698692ba86c6159","logs_bloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","gas_used":"0x10994","block_hash":"0xa66f8562a861f906a2438d7d6ba79495640d98d9c6922b9605c54b57f97a345c","transactions":["0x7ef90104a035dd2ec802504a143048c7830f8f570e0d6cf5147217af869939c6b4ba710a3694deaddeaddeaddeaddeaddeaddeaddeaddead00019442000000000000000000000000000000000000158080830f424080b8b0098999be000007d0000dbba0000000000000000800000000690be848000000000092042e000000000000000000000000000000000000000000000000000000000000000900000000000000000000000000000000000000000000000000000000000000010ffd7e2fb2c36e5f27c015872ce733a7b4f3fc0f4ee668d7469c557c48f8250f0000000000000000000000004ab3387810ef500bfe05a49dc53a44c222cbab3e000000000000000000000000","0x02f87e8205158401c8ea9180338255789400000000000000000000000000000000000000008096426c6f636b204e756d6265723a203335353335363938c080a091f83058c881d9ad71c179ce680326501702eb68150d20b2bf7786e388f954a2a0180185d83e503f11bf3c265c1f9296ed8d3d7c04031cd8bb30509ad188ce7bbc"],"withdrawals":[],"withdrawals_root":"0x62ed62e0391b081bf172f287fbbe75e87d8a6c22f1d3b1f1aef4788c134633d2"},"metadata":{"block_number":35535698,"new_account_balances":{},"receipts":{}}},{"payload_id":"0x03c446f063e3735a","index":1,"base":null,"diff":{"state_root":"0xfb1794f74d405b345672c57a5053c6105cc55c8e63f96fb0db5b0260df42413a","receipts_root":"0x1eaaaeb9d43bead7d32b90f1b320589174c63d2fa8f5fd366f841a205b1eb2e0","logs_bloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000004040000000000000000000000000000000000000000000000000000000000000000000000","gas_used":"0x18f7d","block_hash":"0x67b0521ebfcb03d6ce2b6e1bad9c9c66795365f63ad8dc51e1e8f582a5ab7821","transactions":["0x02f86c8205158401c8ea92803382880994f878f0340bf132c28f3211e8b46c569edf81749580843fd553e8c001a0d73ce313aafea312e0b7244767e45f8b05d50305e0f4e4c3c564ddc751666815a02ee015ce2363311823c0b2e96bfb0e8090fd53c6cdd99be8cf343af123036dfc"],"withdrawals":[],"withdrawals_root":"0x62ed62e0391b081bf172f287fbbe75e87d8a6c22f1d3b1f1aef4788c134633d2"},"metadata":{"block_number":35535698,"new_account_balances":{},"receipts":{}}},{"payload_id":"0x03c446f063e3735a","index":2,"base":null,"diff":{"state_root":"0x90dd105c4a2a0dd9ffe994204bfa3e2b4f70f7ea760d5cb9a4263f26a89f91b4","receipts_root":"0x0fff0488aa3732c34018b938839ab2f0caa96018221e4ffaeca011fb06ba288f","logs_bloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000004040000000000000000000000000000000000000000000000000000000000000000000000","gas_used":"0x21566","block_hash":"0x720feb7457110a565b479fafbaa89cc984f5d673846a27d44bbb8cf5200b32fe","transactions":["0x02f86c8205158401c8ea93803382880994f878f0340bf132c28f3211e8b46c569edf81749580843fd553e8c001a0f8cd94080642e116bc772f36a02d002505227aa542e1c13e5129ab40b8b037fba00608318d3895388e39b218bcb275380cebc566e68f26d3d434e32b8b58366cdf"],"withdrawals":[],"withdrawals_root":"0x62ed62e0391b081bf172f287fbbe75e87d8a6c22f1d3b1f1aef4788c134633d2"},"metadata":{"block_number":35535698,"new_account_balances":{},"receipts":{}}},{"payload_id":"0x03c446f063e3735a","index":3,"base":null,"diff":{"state_root":"0x71f8c60fdfdd84cffda3b0b6af7c8ff92195918f4fc2abae750a7306521ac0dc","receipts_root":"0xa62d1d98f56ffb1464a2beb185484253df68208004306e155c0bd1519137afe6","logs_bloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000004040000000000000000000000000000000000000000000000000000000000000000000000","gas_used":"0x29b4f","block_hash":"0x670844e30f7325d4f290ea375e01f7e819afca317fc7db9723e6867a184984fa","transactions":["0x02f86c8205158401c8ea94803382880994f878f0340bf132c28f3211e8b46c569edf81749580843fd553e8c080a04368492ec1d087703aaf6f5fefe4427b3bf382e5cd07133f638bb6701f15fe61a05e28757fbdc7e744118be36d5a1548eb7c009eefcb5dc5c5040e09c2fc6de9d8"],"withdrawals":[],"withdrawals_root":"0x62ed62e0391b081bf172f287fbbe75e87d8a6c22f1d3b1f1aef4788c134633d2"},"metadata":{"block_number":35535698,"new_account_balances":{},"receipts":{}}},{"payload_id":"0x03c446f063e3735a","index":4,"base":null,"diff":{"state_root":"0x5615e4342d231c352438f0ba6a8f0f641459f67961961764b781a909969b28ad","receipts_root":"0x588e1d47b0618d7e935b20c3945cba3b7b8c00141904f79ceed20312ea502e63","logs_bloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000004040000000000000000000000000000000000000000000000000000000000000000000000","gas_used":"0x32138","block_hash":"0xc463a3120c35268f610d969f5608b479332ef10953af77c7a6be806195831196","transactions":["0x02f86c8205158401c8ea95803382880994f878f0340bf132c28f3211e8b46c569edf81749580843fd553e8c080a0802ba6d4f37e3b8de96095bd0b216144f276171d16dc62a004f1a89009af5deea00f0c6250cfd1a062a1bc2bc353a5c227a980cac0f233b7be8932f2192342ec4f"],"withdrawals":[],"withdrawals_root":"0x62ed62e0391b081bf172f287fbbe75e87d8a6c22f1d3b1f1aef4788c134633d2"},"metadata":{"block_number":35535698,"new_account_balances":{},"receipts":{}}}]"#;
 
         let flashblocks: Vec<OpFlashblockPayload> = serde_json::from_str(raw_sequence).unwrap();
-        let execution_data = OpExecutionData::from_flashblocks(&flashblocks).unwrap();
+        let execution_data = OpExecutionPayloadEnvelope::from_flashblocks(&flashblocks).unwrap();
 
         // Validate against expected final block state
         assert_eq!(
-            execution_data.payload.parent_hash(),
+            execution_data.parent_hash(),
             b256!("06ff95a9cd23b0328da74a984aa986b2e01d377dab1825f1029e39ece6c4a3ea")
         );
         assert_eq!(
-            execution_data.payload.block_hash(),
+            execution_data.block_hash(),
             b256!("c463a3120c35268f610d969f5608b479332ef10953af77c7a6be806195831196")
         );
-        assert_eq!(execution_data.payload.block_number(), 0x21E3B52);
-        assert_eq!(execution_data.payload.timestamp(), 0x690be89e);
+        assert_eq!(execution_data.block_number(), 0x21E3B52);
+        assert_eq!(execution_data.timestamp(), 0x690be89e);
         assert_eq!(
-            execution_data.payload.fee_recipient(),
+            execution_data.fee_recipient(),
             address!("4200000000000000000000000000000000000011")
         );
-        assert_eq!(execution_data.payload.gas_limit(), 0x3938700);
-        assert_eq!(execution_data.payload.as_v1().gas_used, 0x32138);
+        assert_eq!(execution_data.gas_limit(), 0x3938700);
+        assert_eq!(execution_data.as_v1().gas_used, 0x32138);
         assert_eq!(
-            execution_data.payload.as_v1().state_root,
+            execution_data.as_v1().state_root,
             b256!("5615e4342d231c352438f0ba6a8f0f641459f67961961764b781a909969b28ad")
         );
         assert_eq!(
-            execution_data.payload.as_v1().receipts_root,
+            execution_data.as_v1().receipts_root,
             b256!("588e1d47b0618d7e935b20c3945cba3b7b8c00141904f79ceed20312ea502e63")
         );
-        assert_eq!(execution_data.payload.transactions().len(), 6);
+        assert_eq!(execution_data.transactions().len(), 6);
         assert_eq!(
-            execution_data.payload.as_v4().unwrap().withdrawals_root,
+            execution_data.as_v4().unwrap().withdrawals_root,
             b256!("62ed62e0391b081bf172f287fbbe75e87d8a6c22f1d3b1f1aef4788c134633d2")
         );
 
@@ -936,38 +1006,38 @@ mod tests {
         let raw_sequence = r#"[{"payload_id":"0x03c33cc62b81edb6","index":0,"base":{"parent_beacon_block_root":"0xf058b1e43890ed5f838bd07e77db06d075d894343d1b31f6099a345b0d8f7d1b","parent_hash":"0x6ffd2714d5af6c412c57db3f664a5a127516573bbd987fd242d06f71ea662741","fee_recipient":"0x4200000000000000000000000000000000000011","prev_randao":"0x9985c1f8ec25b468cbf2b727a8371b4554b7e7adb059c08abf7a7d51d86ceee5","block_number":"0x1fe4052","gas_limit":"0x3938700","timestamp":"0x690fdf84","extra_data":"0x000000003200000004","base_fee_per_gas":"0x34"},"diff":{"state_root":"0x0000000000000000000000000000000000000000000000000000000000000000","receipts_root":"0x1b2fa5e4cbbc1f8c01a7c7204571ebe339dbdfadc666451d8e70d5c10c99830f","logs_bloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","gas_used":"0xb41c","block_hash":"0x87c6775cc427caf4c0ffe0d4b6d76627536f38d77d23f105f9f104ef3e5541c7","transactions":["0x7ef90104a01c055ffd19ea027da4a8aae0a2734c6bf17c3f487d4cc22931d7dbe261409cda94deaddeaddeaddeaddeaddeaddeaddeaddead00019442000000000000000000000000000000000000158080830f424080b8b0098999be0000044d000a118b000000000000000400000000690fde3c00000000009252e3000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000014f1595c3798e3082aa093e433bd5cbd102a11f9619d20e6e821c1a30fb56b12b000000000000000000000000fc56e7272eebbba5bc6c544e159483c4a38f8ba3000000000000000000000000"],"withdrawals":[],"withdrawals_root":"0x77b0fb1616a212bd7cf33d7c28651f19bf6093b2c5f1967e674ec861aeaf9d44"},"metadata":{"block_number":33439826,"new_account_balances":{},"receipts":{}}},{"payload_id":"0x03c33cc62b81edb6","index":1,"diff":{"state_root":"0x0000000000000000000000000000000000000000000000000000000000000000","receipts_root":"0xe38b2090ddfa6ee25b15a8ebcdd7ecc0f1ee9128ec98cb24f47909e29e11832e","logs_bloom":"0x00000000000000000000000020000000040080000000000000020005000000004000000040040000000080000000000000000000000000000002000000000000008000000000000000000000000000014000000000800000000000000000000000000000000000040100000000000000000000000100000000000380008a02000000100000400200000100800000000000000000000004001000200000000000000000000800020000000000400000000000000000008000400801080000000000005000000400000000000000000000000110000000000000000000000000100200021004400010000000010000000400000008002000004080000000000000","gas_used":"0x9d2f2","block_hash":"0x4548d5014de4883cec380838f1b225996fa3c08c176f2f63d98d8c23169fab44","transactions":["0x02f89283014a348202ea830f4275830f427583045dd594a449bc031fa0b815ca14fafd0c5edb75ccd9c80f80a4de0e9a3e000000000000000000000000000000000000000000000001236efcbcbb340000c001a0742ff606597cda39751dd369e66e9978946ce8f4eb578a8d73314535a2df4388a06a6f83c3606c32e1677f62408b8ec69b09a82f499395b26eaefea567deb83843","0x02f9101583014a34830597bd830f4240830f42aa8306aecc9442826e92e6418877459f0920cb058e462ac6a0a480b90fa4dbaa1e6400000000000000000000000000a739e4479c97289801654ec1a52a67077613c000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000691d0e7f4f6ae70adc2708ec4857d3d5ca54a11710c9ac11989b1cb3d3d8d3298a78f6a50000000000000000000000000000000000000000000000000000000000000f200000000000000000000000000000000000000000000000000000000000000e44b653f0c300000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000033bea00000000000000000000000000000000000000000000000000000000000000380000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000030000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000014000000000000000000000000000000000000000000000000000000000000002200000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000004747970650000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000026f6b00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000086f6b2e746f6b656e0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003657468000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000086f6b2e74785f69640000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000046626173653a3078343865643835396232636630633962366261633864373134653162363436313264313232346436643a38343533323a33333433393832323a3333393131333600000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a20000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000090000000000000000000000000000000000000000000000000000000000000120000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000002e000000000000000000000000000000000000000000000000000000000000003e000000000000000000000000000000000000000000000000000000000000004c000000000000000000000000000000000000000000000000000000000000005a000000000000000000000000000000000000000000000000000000000000006a000000000000000000000000000000000000000000000000000000000000007c000000000000000000000000000000000000000000000000000000000000008c00000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000004747970650000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000087769746864726177000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000001977697468647261772e73656e6465722e636861696e5f7569640000000000000000000000000000000000000000000000000000000000000000000000000000046261736500000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000001777697468647261772e73656e6465722e61646472657373000000000000000000000000000000000000000000000000000000000000000000000000000000002a30783438656438353962326366306339623662616338643731346531623634363132643132323464366400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000000e77697468647261772e746f6b656e00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000036574680000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000000f77697468647261772e616d6f756e740000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001431303030303030303030303030303030303030300000000000000000000000000000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000002f77697468647261772e63726f73735f636861696e5f6164647265737365732e302e757365722e636861696e5f756964000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000077365706f6c6961000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000002d77697468647261772e63726f73735f636861696e5f6164647265737365732e302e757365722e6164647265737300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002a307834386564383539623263663063396236626163386437313465316236343631326431323234643664000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000003977697468647261772e63726f73735f636861696e5f6164647265737365732e302e6c696d69742e6c6573735f7468616e5f6f725f657175616c0000000000000000000000000000000000000000000000000000000000000000000000000000143130303030303030303030303030303030303030000000000000000000000000000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000000e77697468647261772e74785f69640000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000046626173653a3078343865643835396232636630633962366261633864373134653162363436313264313232346436643a38343533323a33333433393832323a333339313133360000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000041ffb578b6e9ab1699e4d9cd0078d9f28e7f0ef2136a11596aa7b6d7fe7f896dd353b7b786bf155c924f35d5099f0df90650e74a5858b75673835d24ac6dc8f1e41b00000000000000000000000000000000000000000000000000000000000000c080a09c4f42d262ed1f1bee31461fd10d8d8fbac6e340d9bc2b8035df5faa30f88d4da06d832693c1e28d4f647a6ff08f5d037d08ad2599964a9f3600396efdaec07e4a"],"withdrawals":[],"withdrawals_root":"0x77b0fb1616a212bd7cf33d7c28651f19bf6093b2c5f1967e674ec861aeaf9d44"},"metadata":{"block_number":33439826,"new_account_balances":{},"receipts":{}}},{"payload_id":"0x03c33cc62b81edb6","index":2,"diff":{"state_root":"0x0000000000000000000000000000000000000000000000000000000000000000","receipts_root":"0xda7caba0b5682eda3aed5f47132da84aa2c2757499c23d609aa73dd3a449be1d","logs_bloom":"0x00000000000000000000000020000000040080000000000000020005000000004000000040040000000080000000000000000000000000000002000000000040008000000000000000000000000000014000000800800000000004000000000000000000000400040100000000000000000002800100000000000b80008a02000000100000400200000100800000000000000000000004001000200000000000000000000800020000000000400000000000000000008000440801080200000000005000000400000000000000000000000110000000000008000000000000100200021004400010000000110000000400000008002000004080010000000000","gas_used":"0xd6a91","block_hash":"0x17e106bfeebb2ff0123cf2e1f555e0441ed308773224513dc4ac6257d943e52c","transactions":["0x02f89283014a3482015f830f4275830f427583045dc694a449bc031fa0b815ca14fafd0c5edb75ccd9c80f80a4de0e9a3e000000000000000000000000000000000000000000000000c249fdd327780000c001a098b7dd6d4454a8d31170b5b2d1461bc8a74eed745eddc982232b2c1483cba322a07d3acfe989366b2729aa728ebca7009c15dc908954a9fb5459b75cff1bfd103f"],"withdrawals":[],"withdrawals_root":"0x77b0fb1616a212bd7cf33d7c28651f19bf6093b2c5f1967e674ec861aeaf9d44"},"metadata":{"block_number":33439826,"new_account_balances":{},"receipts":{}}},{"payload_id":"0x03c33cc62b81edb6","index":3,"diff":{"state_root":"0x0000000000000000000000000000000000000000000000000000000000000000","receipts_root":"0xda7caba0b5682eda3aed5f47132da84aa2c2757499c23d609aa73dd3a449be1d","logs_bloom":"0x00000000000000000000000020000000040080000000000000020005000000004000000040040000000080000000000000000000000000000002000000000040008000000000000000000000000000014000000800800000000004000000000000000000000400040100000000000000000002800100000000000b80008a02000000100000400200000100800000000000000000000004001000200000000000000000000800020000000000400000000000000000008000440801080200000000005000000400000000000000000000000110000000000008000000000000100200021004400010000000110000000400000008002000004080010000000000","gas_used":"0xd6a91","block_hash":"0x17e106bfeebb2ff0123cf2e1f555e0441ed308773224513dc4ac6257d943e52c","transactions":[],"withdrawals":[],"withdrawals_root":"0x77b0fb1616a212bd7cf33d7c28651f19bf6093b2c5f1967e674ec861aeaf9d44"},"metadata":{"block_number":33439826,"new_account_balances":{},"receipts":{}}},{"payload_id":"0x03c33cc62b81edb6","index":4,"diff":{"state_root":"0x0000000000000000000000000000000000000000000000000000000000000000","receipts_root":"0xaff50907a173fc423a499319437afffb8abc2071ce36b6f040dc487579a5d4c3","logs_bloom":"0x0002800000000000002000012000040004008000000010000012000500000000480000004004000000918000000000000000000000000000000200821000806000800010000000000000000800000001c000000800800000000004202000000800000000000400040100020100000000000002800100000000000b90008a02000000100000480200000100800010080400000000000004001000224080000000000000008c0002040080000840000000000000000100c000c4080108020000000001500a000400000000000000000000100110000020000008000000000000100a00221004400010000000110100000400100008002100004280010000000000","gas_used":"0x1498a3","block_hash":"0x4764a20ee262986e45d29251db593320bd4bf6de1133de553b6363a5691e7644","transactions":["0x02f89283014a348203af830f4275830f427583045dd594a449bc031fa0b815ca14fafd0c5edb75ccd9c80f80a4de0e9a3e000000000000000000000000000000000000000000000002017a67f731740000c001a04ce59ff67dc25a76f3027441513f916b809f55b29d5de4fecd4aa0136a3a1a4fa02c1b32b3a1600f6bb2365130797238162cbc797843169a4cfb1ebb41465877c7","0x02f8d483014a348309087a830f4240830f42a883030d4094d89f830d7795c10613e4d4769c24c05bf60932c680b864b781777000000000000000000000000022e40d0a0c0bb77b570445fb59d39bcf14790b660000000000000000000000000000000000000000000000004a61b425a5ee98000000000000000000000000000000000000000000000000000006431e74449860c001a002c2402941acdc25bcaae67c62d58f1a942b32723827f77972c74b159b2c174ea04772118ec71bc7fbe0c9f1c9ef90f58927126480ca769d73704365bfbac65db3","0x02f8d483014a348308c06b830f4240830f42a883030d4094d89f830d7795c10613e4d4769c24c05bf60932c680b864b78177700000000000000000000000005643a7772017c8544d3841894c1f7c264cd05ffe0000000000000000000000000000000000000000000000000b035a61b2e8be000000000000000000000000000000000000000000000000000006431e7446c578c001a0ac31a5ad06a3897a0c1a909770badf8cec728abd2daf4d125a551778fa597124a013b1de6f741139d957f299bf22de0a91c1d8a4f2ade6743ddcec89bcc9e8b07d","0x02f8d483014a34830922b1830f4240830f42a883030d4094d89f830d7795c10613e4d4769c24c05bf60932c680b864b7817770000000000000000000000000576831e77af4b5425b39efb23528441b79ee71e20000000000000000000000000000000000000000000000002bed26c4505ca4000000000000000000000000000000000000000000000000000006431e7446f712c080a0c105ef2c930e95694d112028a642399e5a56ce6416f9b8df9ad27baa26244483a064f6e5881fa728b7afaa2e2ddd62c3182789cb247f90b6276c14f8bfc1b4f2cf"],"withdrawals":[],"withdrawals_root":"0x77b0fb1616a212bd7cf33d7c28651f19bf6093b2c5f1967e674ec861aeaf9d44"},"metadata":{"block_number":33439826,"new_account_balances":{},"receipts":{}}},{"payload_id":"0x03c33cc62b81edb6","index":5,"diff":{"state_root":"0x0000000000000000000000000000000000000000000000000000000000000000","receipts_root":"0x6d12b13dcae85ef97ec3756b317ac9d33752bcd231a9323046ecd5a65e8ca8a2","logs_bloom":"0x0002800000000000002000012000040004008000000010000012000500000000480000004004000000918000000000000000000000000100000200821000806000800010000000000000000800000001c000000800800000000004202000000800000000000400040100020100000000000002800100000000004b90008a02000000100000480200000100800010080400000000000004001000224080000000000000008c0002040080000840000000000000000100c000c4080108020000000001500a000400000000000000000000100110004020000008000000000000100a00221004400010000000110100000400100008002100004280010000000000","gas_used":"0x153998","block_hash":"0x810679ccd05f90093eb0e88549d52ad196214f3a4a555cf0b06201f30aa61a2d","transactions":["0x02f8d483014a34830966ae830f4240830f42a883030d4094d89f830d7795c10613e4d4769c24c05bf60932c680b864b781777000000000000000000000000046195a8573f2610bba630bb0bd5c21c064594f3a0000000000000000000000000000000000000000000000002c94bc176f7cb4000000000000000000000000000000000000000000000000000006431e743d37eac080a053f1881c67ad8fa9838d83943afe83b6498dae96a13a019704f25e0df515dbdba05eef8e08269eaafd63ba7e14e13d73e03ec5e7fad5bcdbaaabc124da41e8e32c"],"withdrawals":[],"withdrawals_root":"0x77b0fb1616a212bd7cf33d7c28651f19bf6093b2c5f1967e674ec861aeaf9d44"},"metadata":{"block_number":33439826,"new_account_balances":{},"receipts":{}}},{"payload_id":"0x03c33cc62b81edb6","index":6,"diff":{"state_root":"0x0000000000000000000000000000000000000000000000000000000000000000","receipts_root":"0x1b76e086c31a8a08d1c4a93b868b00238faabd4d52d9e75e55a4abf3a75e65d8","logs_bloom":"0x0002800000000000002000012000048004008000000010000012000500000000480000004004000000918000000000000000000000000100000200821000806000800010000000000000000800000001c008000800800000000004202000000800000000000400040100020100000000000002800100000000004b90008a02000000100000480200000100800010080400000000000004001000224080000000000000008c0002040080000840000000000000000100c000c4080108020000010001500a000400000000000001000000100110004021000008000000000000100a00221004400010000000110100000400100008002100004280010000000001","gas_used":"0x189dc4","block_hash":"0xfdf2cbb452a36c9c4033d1c0bc2b3dd9cee7ba91d0ca5488aa3d9a23b127b79f","transactions":["0x02f89383014a348304e447830f4240830f42a8830226b494cd997aef0b9a1d8c02a16204ccce354844edeeff80a4f7a308060000000000000000000000000000000000000000000000000000000000016636c001a07dc2c0285cd2c53657c87826a698de9ae5bb38e2580657fe1772fc08ab53a9f2a05a183dac1ed51f6aac2eff4add4510fd76d71f9dce59a3536fc00bfbb2ac750c","0x02f8d483014a3483096a27830f4240830f42a883030d4094d89f830d7795c10613e4d4769c24c05bf60932c680b864b7817770000000000000000000000000fde9b0be445930f929705125fe24049093e628e4000000000000000000000000000000000000000000000001517fd24c7f6670000000000000000000000000000000000000000000000000000006431e74408803c080a036f0e0df96ee863041cc41fad376f2f88364225ff6c10c2e492da014d71ab530a03cca82dd065d09a150f75103ea2e1f2867210c604fd82592ec49fae02cadc20a","0x02f8d483014a348309a03d830f4240830f42a883030d4094d89f830d7795c10613e4d4769c24c05bf60932c680b864b781777000000000000000000000000088c7e4701045571734e2147bad80e3d8c56500d300000000000000000000000000000000000000000000000023e284d65ede20000000000000000000000000000000000000000000000000000006431e7441d02ac080a03ee196fff4a614411f9d41431f0b174141ae6f62246df4e54117205bb19c4f64a022f123e006139ae334de3bf7b62c06b72045ba7dc0a508d137bcd056d950da33"],"withdrawals":[],"withdrawals_root":"0x77b0fb1616a212bd7cf33d7c28651f19bf6093b2c5f1967e674ec861aeaf9d44"},"metadata":{"block_number":33439826,"new_account_balances":{},"receipts":{}}},{"payload_id":"0x03c33cc62b81edb6","index":7,"diff":{"state_root":"0x0000000000000000000000000000000000000000000000000000000000000000","receipts_root":"0x065878c1c4d88295544c04fec2e74c9dd8b5d656e196a1b7b09ce8cadbb8f979","logs_bloom":"0x0002800000000010002000052000048004008000000010000012000500000000490000004004000000918000010000000000008000000100040200821000806800800010000000000000000800000001c008000800800000000004202000000804000020000400040100020100000000020002800100000000004b90008a02000000180000480200000100800010080400000000000004011000224080000000000000008c0002040080000840000200000000000100c000c4080108020000012001500a000400000000000001000000100110004021000008000000000000100a00221104400010000000110100000400100008002100004280010000000001","gas_used":"0x1bc281","block_hash":"0xcc9c18ed55c91e97f32353e253c69766cd0d2e0acb0e7f92098d01e1d7761ce3","transactions":["0x02f8d483014a3483091e1f830f4240830f42a883030d4094d89f830d7795c10613e4d4769c24c05bf60932c680b864b7817770000000000000000000000000b501c0a0f800e68d980f5253650d0cf3a69d16c00000000000000000000000000000000000000000000000000b87d57d89ffe7800000000000000000000000000000000000000000000000000006431e7442365fc001a0b276c68f59bcfb78fe7905a720e9418130d5c87d60da4b6d55faf07e1b1724aba03425daae2e51a061a26bedcd89cf6ead44146ac97f831371ec36a0192728d204","0x02f8d483014a3483094dde830f4240830f42a883030d4094d89f830d7795c10613e4d4769c24c05bf60932c680b864b78177700000000000000000000000000097cc7164250c464fea5f9f91d1abec7718814a0000000000000000000000000000000000000000000000004c40d37c20f440000000000000000000000000000000000000000000000000000006431e744372abc001a01f3e58f3baa5e472c08097dafe1e756163c61e7200dc90751f167e796d542f20a02c10596de8b29462c0953a023a8b6c06f74fe77ea66a24598df920d542edab3b","0x02f8d483014a3483094ece830f4240830f42a883030d4094d89f830d7795c10613e4d4769c24c05bf60932c680b864b781777000000000000000000000000083fe74125ec8ffaeee4b2371d7ea17f6ad6f9ba2000000000000000000000000000000000000000000000000f9e4840a6e4938000000000000000000000000000000000000000000000000000006431e744362dec001a066724129c4de96e835cd1377b55541b4582bf4ebcd7c2a3faa4231ade86b14d8a03736bce9203cc0c92878fcc28ee8710961eaddde92bf6a2158c602b4d1bbdbd7","0x02f8d483014a348303750a830f4240830f42a883030d4094d89f830d7795c10613e4d4769c24c05bf60932c680b864b7817770000000000000000000000000414d9179c5d2207a6e0efeb0319b6c556265974600000000000000000000000000000000000000000000000033979a45ffefac000000000000000000000000000000000000000000000000000006431e74442677c001a0682d2489ba1d9666324060a006f0abe06830cecdeed4398169dc9fbf7199eb59a02e971034255d087d02b25f45a7962b31360bbed70e3aa30e69ee8f64dd6afdb4","0x02f8d483014a348308acf2830f4240830f42a883030d4094d89f830d7795c10613e4d4769c24c05bf60932c680b864b781777000000000000000000000000097c152d0fa30c49603e0e3e013e36c4e29bf7fea0000000000000000000000000000000000000000000000001d58bdca2addf5000000000000000000000000000000000000000000000000000006431e744447a9c001a030e423ab3697fe4ccc5ce92232d7a642a8295f489f2e52b3c3ba2f110c828e7ca057fd4d3d0e700734568b0be067deda7927188f6a67f9600bae3d6c75d201fe57"],"withdrawals":[],"withdrawals_root":"0x77b0fb1616a212bd7cf33d7c28651f19bf6093b2c5f1967e674ec861aeaf9d44"},"metadata":{"block_number":33439826,"new_account_balances":{},"receipts":{}}},{"payload_id":"0x03c33cc62b81edb6","index":8,"diff":{"state_root":"0x0000000000000000000000000000000000000000000000000000000000000000","receipts_root":"0x7bf525f832aecc6bf7f7b7e329779640bb4477cb47bf1bde512934c5ed45519b","logs_bloom":"0x0003800000000210002000052000048004008000000010000012000500000000490000004004000000918000010000000000008000000100040200821000806800800010000000000000000800000001c00c000800802000000004202000000804000020000400040100020108000000020002800100000000044b98008a02200000180000480200000100800010080400000000002004011000224080000000000000108c0002040080000844000200000040000100c000c4080108020000012001500a000400000000000001000000104110004021000108000000000000100a00221104400010010000110100000400100008002140004280010000000001","gas_used":"0x213d0b","block_hash":"0x5f9c957cde671b50c5661b328b7f3f8a0e56e194a954d8d7cc4274eb1e014a1e","transactions":["0x02f89283014a34820392830f4275830f427583045dd594a449bc031fa0b815ca14fafd0c5edb75ccd9c80f80a4de0e9a3e000000000000000000000000000000000000000000000002017a67f731740000c001a05c4f86d9218cfab447e6ead7abb27444f7e8d3a185a1fbfb6860a36513c89d93a01d4b9b74f049bfc10feeabcb101a18a14e774e89de35ac246e6452c05e94bc98","0x02f8d483014a348309087a830f4240830f42a883030d4094d89f830d7795c10613e4d4769c24c05bf60932c680b864b781777000000000000000000000000022e40d0a0c0bb77b570445fb59d39bcf14790b660000000000000000000000000000000000000000000000004a61b425a5ee98000000000000000000000000000000000000000000000000000006431e74449860c001a002c2402941acdc25bcaae67c62d58f1a942b32723827f77972c74b159b2c174ea04772118ec71bc7fbe0c9f1c9ef90f58927126480ca769d73704365bfbac65db3","0x02f8d483014a348308c06b830f4240830f42a883030d4094d89f830d7795c10613e4d4769c24c05bf60932c680b864b78177700000000000000000000000005643a7772017c8544d3841894c1f7c264cd05ffe0000000000000000000000000000000000000000000000000b035a61b2e8be000000000000000000000000000000000000000000000000000006431e7446c578c001a0ac31a5ad06a3897a0c1a909770badf8cec728abd2daf4d125a551778fa597124a013b1de6f741139d957f299bf22de0a91c1d8a4f2ade6743ddcec89bcc9e8b07d","0x02f8d483014a34830922b1830f4240830f42a883030d4094d89f830d7795c10613e4d4769c24c05bf60932c680b864b7817770000000000000000000000000576831e77af4b5425b39efb23528441b79ee71e20000000000000000000000000000000000000000000000002bed26c4505ca4000000000000000000000000000000000000000000000000000006431e7446f712c080a0c105ef2c930e95694d112028a642399e5a56ce6416f9b8df9ad27baa26244483a064f6e5881fa728b7afaa2e2ddd62c3182789cb247f90b6276c14f8bfc1b4f2cf"],"withdrawals":[],"withdrawals_root":"0x77b0fb1616a212bd7cf33d7c28651f19bf6093b2c5f1967e674ec861aeaf9d44"},"metadata":{"block_number":33439826,"new_account_balances":{},"receipts":{}}},{"payload_id":"0x03c33cc62b81edb6","index":9,"diff":{"state_root":"0x0000000000000000000000000000000000000000000000000000000000000000","receipts_root":"0xeb419bf069b8bf9738adcb7fad118724a1d4d6a83821bc532983a2949aa0910d","logs_bloom":"0x000380000000021000200005200004800400800000001000001a000500001000490000004004000000918000010000000000008000000100040200821000806800800010000000000000000800000001c00c000800802000000004202000000804000020000400040100020108000000020002800100000000044b98008a02200000180000480200000100800010080400000000002004011000224080000000000000108c0002040080000844000200000040000100c000c4080108020000012001500a000400000000000001000000104110004021000108000000000000100a00221104400010010004110100000400100008002140004280010000000001","gas_used":"0x21de0c","block_hash":"0xb802c08c65bdefdd507fe07634ea29eeaad1859b33ffac2c426dc7b620d22b19","transactions":["0x02f8d483014a3483095beb830f4240830f42a883030d4094d89f830d7795c10613e4d4769c24c05bf60932c680b864b7817770000000000000000000000000f73c129529caa024337c39e467c720cfc45874220000000000000000000000000000000000000000000000000de4f04092790e800000000000000000000000000000000000000000000000000006431e74489081c080a0a100818c4c3ec3b0bced80f81f09fc878b23274266b45e2043956562b6714dcfa023dbcbc4df92ed5817fcc9bcd238a038aad806c69585dc8cf582e6012d012d28"],"withdrawals":[],"withdrawals_root":"0x77b0fb1616a212bd7cf33d7c28651f19bf6093b2c5f1967e674ec861aeaf9d44"},"metadata":{"block_number":33439826,"new_account_balances":{},"receipts":{}}},{"payload_id":"0x03c33cc62b81edb6","index":10,"diff":{"state_root":"0x0000000000000000000000000000000000000000000000000000000000000000","receipts_root":"0xaa280e93aa4a7d3f616ad391404411abbeebe8bc8fb1ed9b3ef4d0a42bf64ccd","logs_bloom":"0x000380000000021000200005200004800400800000001000001a000500001000490000204004000000918000010000000000008000000100040200821020886800800010000000000000000800000001c00c000800802000000004202000000804000020000400040100020108000000020002800100000000044b98008a02200000180000480200000100800010080400000000002004011000224080000000020000108c0002040080000844000200000040000100c000c4080108020000012001500a000400000000000001000000104110004021000108000000000200100a10221104400010010004110100000400100008002140004280010000000001","gas_used":"0x49f43c","block_hash":"0x2b440a266840a96993d85d45d1de1e81f7a859aaac4654dcd5a990ffa2ef947b","transactions":["0x02f90fb583014a34831d4797830f4240830f42a88327fdba94ebaff6d578733e4603b99cbdbb221482f29a78e180b90f4484779f44000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000140000000000000000000000000000000000000000000000000000000000000280000000000000000000000000000000000000000000000000000000000000032000000000000000000000000000000000000000000000000000000000000003c00000000000000000000000000000000000000000000000000000000000000460000000000000000000000000000000000000000000000000000000000000050000000000000000000000000000000000000000000000000000000000000005a0000000000000000000000000000000000000000000000000000000000000064000000000000000000000000000000000000000000000000000000000000006e00000000000000000000000000000000000000000000000000000000000000780000000000000000000000000000000000000000000000000000000000000082000000000000000000000000000000000000000000000000000000000000008c000000000000000000000000000000000000000000000000000000000000009600000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000aa00000000000000000000000000000000000000000000000000000000000000b400000000000000000000000000000000000000000000000000000000000000be00000000000000000000000000000000000000000000000000000000000000c800000000000000000000000000000000000000000000000000000000000000d200000000000000000000000000000000000000000000000000000000000000dc00000000000000000000000000000000000000000000000000000000000000e600000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000053ce75532be4cf5bacb01e018950b5be900eafa59f2431fed6b869799529ab39fe0000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000053ce76343a51197104ee22e37cf9c48a9eb5c99031a25196c2f1264deb5d4d3ff80000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000053ce770a821c08f4e200bf42a148754153d78e977260a213094b521b5625618ec70000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000053ce78bb3bcd3592df48dcd3a6383c8f61d8434b6058f61a587dfb0c37134294420000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000053ce79b35d157e36939c03df12e39599530f615a90e624610d8d023eaf2f8329030000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000053ce7a6370bb580180c882bf7214d1f701529ea455f8567b2be79496c9437a2ce30000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000053ce7bf53208371925c87cacbb0bbfbf330fc8a02818e1d73c56760a9fded7f8c80000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000053ce7cac670fbf544ec6d7360aacecd6e3fb35ea8a6ebef6161c9563a6d16a4a200000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000053ce7d91406552fdfe569345c8561328604a63912a36d21cafa1efed0275ce6b190000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000053ce7e6e0b5ccd73c9cea553a19e7ab6e533bc253f552e6b9145dd5470d2612f8d0000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000053ce7fc72e52aaff88c842a2092b7ce047cf47a8f56da1035142a41b6a59b856420000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000053ce80fcaa166cc2fd1353b40f3071a491cd7ca2746c8943caaa6c024c8df0131f0000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000053ce812aabb780f12ed0c0c5dc6932220d8c5f730c54ee63384fbfe1e7fa90a5090000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000053ce82c1dea3b99a38cf0743f31402eba0d22c4da43e715d37533da9bc5f8ca4ae0000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000053ce835d696b1a6f5089cf9bc4c2c529e181678fa2f2feb745223e7520d885a2260000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000053ce8400f527b7b931ddfe77007be944f58173dfc1c5928eb433ae71e96f61a8420000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000053ce85b6dcd2b462f2d1c72e4b46ea316f9183fb9ea40866724b7eef10211a83390000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000053ce860986c742f73c595e7cf75d5014bdccde828c0fa3891f8a7e77cbaf974e7d0000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000053ce879d5711ffb11c2d9fe9737837f55726ba0609c21d62e2783cc38db59edafa0000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000053ce882976c03e7cf30e96a5a578eff196e4062258f3d859abdf161bcb5fd18356000000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000000c080a0c7ccb6ec845a35639b2905d243be7a6cf2ee1412331d348a4bf65f53ae89cde8a06ecc40e8297c75e86332c2924b96c6bf2334a6d1b1ef803e27c9de692906b138","0x02f8b183014a3481ad830ecd10830ecdaf82b6a994af33add7918f685b2a82c1077bd8c07d220ffa0480b844095ea7b3000000000000000000000000a449bc031fa0b815ca14fafd0c5edb75ccd9c80f00000000000000000000000000000000000000000000000c6a036eb4bc740000c001a0d1877e98821074c02cf20dc84d31d70fbc00027d404fe99f3e887a33082bb6cda016f8a55aea1573b3834180e43d90eb6c4b1ffb321d2a0be8b3aa71eeaed5104a"],"withdrawals":[],"withdrawals_root":"0x77b0fb1616a212bd7cf33d7c28651f19bf6093b2c5f1967e674ec861aeaf9d44"},"metadata":{"block_number":33439826,"new_account_balances":{},"receipts":{}}}]"#;
 
         let flashblocks: Vec<OpFlashblockPayload> = serde_json::from_str(raw_sequence).unwrap();
-        let execution_data = OpExecutionData::from_flashblocks(&flashblocks).unwrap();
+        let execution_data = OpExecutionPayloadEnvelope::from_flashblocks(&flashblocks).unwrap();
 
         // Validate against expected final block state from base payload (index 0)
         assert_eq!(
-            execution_data.payload.parent_hash(),
+            execution_data.parent_hash(),
             b256!("6ffd2714d5af6c412c57db3f664a5a127516573bbd987fd242d06f71ea662741")
         );
-        assert_eq!(execution_data.payload.block_number(), 0x1fe4052);
-        assert_eq!(execution_data.payload.timestamp(), 0x690fdf84);
+        assert_eq!(execution_data.block_number(), 0x1fe4052);
+        assert_eq!(execution_data.timestamp(), 0x690fdf84);
         assert_eq!(
-            execution_data.payload.fee_recipient(),
+            execution_data.fee_recipient(),
             address!("4200000000000000000000000000000000000011")
         );
-        assert_eq!(execution_data.payload.gas_limit(), 0x3938700);
-        assert_eq!(execution_data.payload.as_v1().gas_used, 0x49f43c);
+        assert_eq!(execution_data.gas_limit(), 0x3938700);
+        assert_eq!(execution_data.as_v1().gas_used, 0x49f43c);
 
         // Base skipped state root calculation thus state root is expected to be zeros.
         // And subsequently the last flashblocks' block hash is not the final block's block hash.
         // Real block hash: 0x0c3c3ff081d8a5ea1239bfb8a0593f641154a06b783fa142809880e011cd6a3f
         assert_eq!(
-            execution_data.payload.as_v1().state_root,
+            execution_data.as_v1().state_root,
             b256!("0000000000000000000000000000000000000000000000000000000000000000")
         );
         assert_eq!(
-            execution_data.payload.block_hash(),
+            execution_data.block_hash(),
             // last flashblock block hash
             b256!("2b440a266840a96993d85d45d1de1e81f7a859aaac4654dcd5a990ffa2ef947b")
         );
 
         // Verify receipts root from last flashblock (index 10)
         assert_eq!(
-            execution_data.payload.as_v1().receipts_root,
+            execution_data.as_v1().receipts_root,
             b256!("aa280e93aa4a7d3f616ad391404411abbeebe8bc8fb1ed9b3ef4d0a42bf64ccd")
         );
 
@@ -975,11 +1045,11 @@ mod tests {
         // Index 0: 1, Index 1: 2, Index 2: 1, Index 3: 0, Index 4: 4, Index 5: 1
         // Index 6: 3, Index 7: 5, Index 8: 4, Index 9: 1, Index 10: 2
         // Total: 24 transactions
-        assert_eq!(execution_data.payload.transactions().len(), 24);
+        assert_eq!(execution_data.transactions().len(), 24);
 
         // Verify withdrawals root from last flashblock
         assert_eq!(
-            execution_data.payload.as_v4().unwrap().withdrawals_root,
+            execution_data.as_v4().unwrap().withdrawals_root,
             b256!("77b0fb1616a212bd7cf33d7c28651f19bf6093b2c5f1967e674ec861aeaf9d44")
         );
 

--- a/rust/op-alloy/crates/rpc-types-engine/src/execution.rs
+++ b/rust/op-alloy/crates/rpc-types-engine/src/execution.rs
@@ -1,0 +1,498 @@
+use crate::{
+    OpExecutionData, OpExecutionPayload, OpExecutionPayloadEnvelope, OpExecutionPayloadV4,
+    OpFlashblockError, OpFlashblockPayload, OpPayloadError,
+};
+use alloc::vec::Vec;
+use alloy_consensus::{Block, BlockHeader, Sealable, Transaction};
+use alloy_eips::{
+    Decodable2718, Encodable2718, Typed2718,
+    eip4895::Withdrawal,
+    eip7685::{EMPTY_REQUESTS_HASH, Requests},
+};
+use alloy_primitives::{B256, Bytes};
+use alloy_rpc_types_engine::{
+    ExecutionPayloadV1, ExecutionPayloadV2, ExecutionPayloadV3, PayloadError,
+};
+
+impl OpExecutionPayloadEnvelope {
+    /// Converts this payload envelope into a block with decoded transactions.
+    pub fn try_into_block<T>(self) -> Result<Block<T>, OpPayloadError>
+    where
+        T: Decodable2718 + Typed2718,
+    {
+        let check_blob_transactions = matches!(&self, Self::V3 { .. } | Self::V4 { .. });
+        let block = self.try_into_block_raw()?.try_map_transactions(|tx| {
+            T::decode_2718_exact(tx.as_ref())
+                .map_err(alloy_rlp::Error::from)
+                .map_err(PayloadError::from)
+        })?;
+        if check_blob_transactions && block.body.has_eip4844_transactions() {
+            return Err(OpPayloadError::BlobTransaction);
+        }
+
+        Ok(block)
+    }
+
+    /// Verifies the claimed block hash using the raw encoded transaction bytes.
+    ///
+    /// This computes the transaction trie root without decoding or validating the transactions.
+    /// Full transaction and execution validation remains the responsibility of the execution
+    /// layer or [`Self::try_into_checked_block`].
+    pub fn check_block_hash(&self) -> Result<(), OpPayloadError> {
+        let consensus = self.block_hash();
+        let block = self.clone().try_into_block_raw()?;
+        let execution = block.header.hash_slow();
+        if execution != consensus {
+            return Err(PayloadError::BlockHash { execution, consensus }.into());
+        }
+
+        Ok(())
+    }
+
+    /// Converts this payload envelope into a block and verifies its claimed block hash.
+    pub fn try_into_checked_block<T>(self) -> Result<Block<T>, OpPayloadError>
+    where
+        T: Decodable2718 + Typed2718,
+    {
+        let consensus = self.block_hash();
+        let block = self.try_into_block()?;
+        let execution = block.header.hash_slow();
+        if execution != consensus {
+            return Err(PayloadError::BlockHash { execution, consensus }.into());
+        }
+
+        Ok(block)
+    }
+
+    /// Converts a block into a payload envelope and recalculates its block hash.
+    pub fn from_block_slow<T, H>(block: &Block<T, H>) -> Result<Self, OpPayloadError>
+    where
+        T: Encodable2718 + Transaction,
+        H: BlockHeader + Sealable,
+    {
+        let (payload, sidecar) = OpExecutionPayload::from_block_slow(block);
+        OpExecutionData::new(payload, sidecar).try_into()
+    }
+
+    /// Converts a block into a payload envelope with the supplied block hash.
+    pub fn from_block_unchecked<T, H>(
+        block_hash: B256,
+        block: &Block<T, H>,
+    ) -> Result<Self, OpPayloadError>
+    where
+        T: Encodable2718 + Transaction,
+        H: BlockHeader,
+    {
+        let (payload, sidecar) = OpExecutionPayload::from_block_unchecked(block_hash, block);
+        OpExecutionData::new(payload, sidecar).try_into()
+    }
+
+    /// Converts a sequence of flashblocks into a payload envelope.
+    pub fn from_flashblocks(
+        flashblocks: &[OpFlashblockPayload],
+    ) -> Result<Self, OpFlashblockError> {
+        if flashblocks.is_empty() {
+            return Err(OpFlashblockError::MissingPayload);
+        }
+        for (i, flashblock) in flashblocks.iter().enumerate() {
+            if flashblock.index as usize != i {
+                return Err(OpFlashblockError::InvalidIndex);
+            }
+        }
+        let first = flashblocks.first().expect("flashblocks must not be empty");
+        if first.base.is_none() {
+            return Err(OpFlashblockError::MissingBasePayload);
+        }
+        if flashblocks.iter().skip(1).any(|flashblock| flashblock.base.is_some()) {
+            return Err(OpFlashblockError::UnexpectedBasePayload);
+        }
+
+        Ok(Self::from_flashblocks_unchecked(flashblocks))
+    }
+
+    /// Converts a sequence of flashblocks into a payload envelope without validation.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the sequence is empty or its first flashblock has no base payload.
+    pub fn from_flashblocks_unchecked(flashblocks: &[OpFlashblockPayload]) -> Self {
+        let first = flashblocks.first().expect("flashblocks must not be empty");
+        let base = first.base.as_ref().expect("first flashblock must have base payload");
+        let diff = &flashblocks.last().expect("flashblocks must not be empty").diff;
+
+        let (mut transactions, withdrawals) = flashblocks.iter().fold(
+            (Vec::new(), Vec::new()),
+            |(mut transactions, mut withdrawals), payload| {
+                transactions.extend(payload.diff.transactions.iter().cloned());
+                withdrawals.extend(payload.diff.withdrawals.iter().copied());
+                (transactions, withdrawals)
+            },
+        );
+
+        if let Some(post_exec_tx) = diff.post_exec_tx.as_ref() {
+            transactions.push(post_exec_tx.clone());
+        }
+
+        let payload = ExecutionPayloadV3 {
+            blob_gas_used: diff.blob_gas_used.unwrap_or(0),
+            excess_blob_gas: 0,
+            payload_inner: ExecutionPayloadV2 {
+                withdrawals,
+                payload_inner: ExecutionPayloadV1 {
+                    parent_hash: base.parent_hash,
+                    fee_recipient: base.fee_recipient,
+                    state_root: diff.state_root,
+                    receipts_root: diff.receipts_root,
+                    logs_bloom: diff.logs_bloom,
+                    prev_randao: base.prev_randao,
+                    block_number: base.block_number,
+                    gas_limit: base.gas_limit,
+                    gas_used: diff.gas_used,
+                    timestamp: base.timestamp,
+                    extra_data: base.extra_data.clone(),
+                    base_fee_per_gas: base.base_fee_per_gas,
+                    block_hash: diff.block_hash,
+                    transactions,
+                },
+            },
+        };
+
+        if diff.withdrawals_root == B256::ZERO {
+            return Self::V3 { payload, parent_beacon_block_root: base.parent_beacon_block_root };
+        }
+
+        Self::V4 {
+            payload: OpExecutionPayloadV4 {
+                withdrawals_root: diff.withdrawals_root,
+                payload_inner: payload,
+            },
+            parent_beacon_block_root: base.parent_beacon_block_root,
+        }
+    }
+
+    /// Converts this payload envelope into a complete block with raw transactions.
+    fn try_into_block_raw(self) -> Result<Block<Bytes>, OpPayloadError> {
+        if self.withdrawals().is_some_and(|withdrawals| !withdrawals.is_empty()) {
+            return Err(OpPayloadError::NonEmptyL1Withdrawals);
+        }
+
+        let block = match self {
+            Self::V1(payload) => payload.into_block_raw()?,
+            Self::V2(payload) => payload.into_block_raw()?,
+            Self::V3 { payload, parent_beacon_block_root } => {
+                let mut block = payload.into_block_raw()?;
+                block.header.parent_beacon_block_root = Some(parent_beacon_block_root);
+                block
+            }
+            Self::V4 { payload, parent_beacon_block_root } => {
+                let mut block = payload.payload_inner.into_block_raw()?;
+                block.header.withdrawals_root = Some(payload.withdrawals_root);
+                block.header.parent_beacon_block_root = Some(parent_beacon_block_root);
+                block.header.requests_hash = Some(EMPTY_REQUESTS_HASH);
+                block
+            }
+        };
+
+        Ok(block)
+    }
+
+    /// Returns the V1 payload fields shared by every payload version.
+    pub const fn as_v1(&self) -> &ExecutionPayloadV1 {
+        match self {
+            Self::V1(payload) => payload,
+            Self::V2(payload) => &payload.payload_inner,
+            Self::V3 { payload, .. } => &payload.payload_inner.payload_inner,
+            Self::V4 { payload, .. } => &payload.payload_inner.payload_inner.payload_inner,
+        }
+    }
+
+    /// Returns the mutable V1 payload fields shared by every payload version.
+    pub const fn as_v1_mut(&mut self) -> &mut ExecutionPayloadV1 {
+        match self {
+            Self::V1(payload) => payload,
+            Self::V2(payload) => &mut payload.payload_inner,
+            Self::V3 { payload, .. } => &mut payload.payload_inner.payload_inner,
+            Self::V4 { payload, .. } => &mut payload.payload_inner.payload_inner.payload_inner,
+        }
+    }
+
+    /// Returns the V4 payload, if present.
+    pub const fn as_v4(&self) -> Option<&OpExecutionPayloadV4> {
+        match self {
+            Self::V4 { payload, .. } => Some(payload),
+            _ => None,
+        }
+    }
+
+    /// Returns the transactions.
+    pub const fn transactions(&self) -> &Vec<alloy_primitives::Bytes> {
+        &self.as_v1().transactions
+    }
+
+    /// Returns the parent beacon block root for V3 and V4 payloads.
+    pub const fn parent_beacon_block_root(&self) -> Option<B256> {
+        match self {
+            Self::V1(_) | Self::V2(_) => None,
+            Self::V3 { parent_beacon_block_root, .. } |
+            Self::V4 { parent_beacon_block_root, .. } => Some(*parent_beacon_block_root),
+        }
+    }
+
+    /// Returns the withdrawals for the payload.
+    pub const fn withdrawals(&self) -> Option<&Vec<Withdrawal>> {
+        match self {
+            Self::V1(_) => None,
+            Self::V2(payload) => Some(&payload.withdrawals),
+            Self::V3 { payload, .. } => Some(payload.withdrawals()),
+            Self::V4 { payload, .. } => Some(payload.payload_inner.withdrawals()),
+        }
+    }
+
+    /// Returns the parent hash.
+    pub const fn parent_hash(&self) -> B256 {
+        self.as_v1().parent_hash
+    }
+
+    /// Returns the claimed block hash.
+    pub const fn block_hash(&self) -> B256 {
+        self.as_v1().block_hash
+    }
+
+    /// Returns the block number.
+    pub const fn block_number(&self) -> u64 {
+        self.as_v1().block_number
+    }
+
+    /// Returns the timestamp.
+    pub const fn timestamp(&self) -> u64 {
+        self.as_v1().timestamp
+    }
+
+    /// Returns the fee recipient.
+    pub const fn fee_recipient(&self) -> alloy_primitives::Address {
+        self.as_v1().fee_recipient
+    }
+
+    /// Returns the gas limit.
+    pub const fn gas_limit(&self) -> u64 {
+        self.as_v1().gas_limit
+    }
+}
+
+impl TryFrom<OpExecutionData> for OpExecutionPayloadEnvelope {
+    type Error = OpPayloadError;
+
+    fn try_from(data: OpExecutionData) -> Result<Self, Self::Error> {
+        let parent_beacon_block_root = data.sidecar.parent_beacon_block_root();
+        let versioned_hashes = data.sidecar.versioned_hashes();
+        let requests_hash = data.sidecar.requests_hash();
+
+        match data.payload {
+            OpExecutionPayload::V1(payload) => {
+                ensure_pre_ecotone_sidecar(parent_beacon_block_root, requests_hash)?;
+                Ok(Self::V1(payload))
+            }
+            OpExecutionPayload::V2(payload) => {
+                ensure_pre_ecotone_sidecar(parent_beacon_block_root, requests_hash)?;
+                Ok(Self::V2(payload))
+            }
+            OpExecutionPayload::V3(payload) => {
+                let parent_beacon_block_root =
+                    parent_beacon_block_root.ok_or(OpPayloadError::MissingParentBeaconBlockRoot)?;
+                ensure_empty_versioned_hashes(versioned_hashes)?;
+                if requests_hash.is_some() {
+                    return Err(OpPayloadError::UnexpectedELRequests);
+                }
+                Ok(Self::V3 { payload, parent_beacon_block_root })
+            }
+            OpExecutionPayload::V4(payload) => {
+                let parent_beacon_block_root =
+                    parent_beacon_block_root.ok_or(OpPayloadError::MissingParentBeaconBlockRoot)?;
+                ensure_empty_versioned_hashes(versioned_hashes)?;
+                let requests_hash = requests_hash.ok_or(OpPayloadError::MissingELRequests)?;
+                if requests_hash != EMPTY_REQUESTS_HASH {
+                    return Err(OpPayloadError::NonEmptyELRequests);
+                }
+                Ok(Self::V4 { payload, parent_beacon_block_root })
+            }
+        }
+    }
+}
+
+impl TryFrom<&OpExecutionData> for OpExecutionPayloadEnvelope {
+    type Error = OpPayloadError;
+
+    fn try_from(data: &OpExecutionData) -> Result<Self, Self::Error> {
+        data.clone().try_into()
+    }
+}
+
+impl From<OpExecutionPayloadEnvelope> for OpExecutionData {
+    fn from(data: OpExecutionPayloadEnvelope) -> Self {
+        match data {
+            OpExecutionPayloadEnvelope::V1(payload) => {
+                Self::new(OpExecutionPayload::V1(payload), Default::default())
+            }
+            OpExecutionPayloadEnvelope::V2(payload) => {
+                Self::new(OpExecutionPayload::V2(payload), Default::default())
+            }
+            OpExecutionPayloadEnvelope::V3 { payload, parent_beacon_block_root } => {
+                Self::v3(payload, Vec::new(), parent_beacon_block_root)
+            }
+            OpExecutionPayloadEnvelope::V4 { payload, parent_beacon_block_root } => {
+                Self::v4(payload, Vec::new(), parent_beacon_block_root, Requests::default())
+            }
+        }
+    }
+}
+
+const fn ensure_pre_ecotone_sidecar(
+    parent_beacon_block_root: Option<B256>,
+    requests_hash: Option<B256>,
+) -> Result<(), OpPayloadError> {
+    if parent_beacon_block_root.is_some() {
+        return Err(OpPayloadError::UnexpectedParentBeaconBlockRoot);
+    }
+    if requests_hash.is_some() {
+        return Err(OpPayloadError::UnexpectedELRequests);
+    }
+    Ok(())
+}
+
+fn ensure_empty_versioned_hashes(
+    versioned_hashes: Option<&Vec<B256>>,
+) -> Result<(), OpPayloadError> {
+    let versioned_hashes = versioned_hashes.ok_or(OpPayloadError::MissingParentBeaconBlockRoot)?;
+    if !versioned_hashes.is_empty() {
+        return Err(OpPayloadError::NonEmptyBlobVersionedHashes);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::OpExecutionPayloadSidecar;
+    use alloy_primitives::Bytes;
+    use alloy_rpc_types_engine::{CancunPayloadFields, PraguePayloadFields};
+    use op_alloy_consensus::OpTxEnvelope;
+
+    fn payload_v1() -> ExecutionPayloadV1 {
+        ExecutionPayloadV1::from_block_unchecked(B256::ZERO, &Block::<OpTxEnvelope>::default())
+    }
+
+    fn payload_v3() -> ExecutionPayloadV3 {
+        ExecutionPayloadV3::from_block_unchecked(B256::ZERO, &Block::<OpTxEnvelope>::default())
+    }
+
+    #[test]
+    fn rejects_missing_v3_parent_beacon_block_root() {
+        let payload = OpExecutionPayload::V3(payload_v3());
+        let data = OpExecutionData::new(payload, OpExecutionPayloadSidecar::default());
+        assert!(matches!(
+            OpExecutionPayloadEnvelope::try_from(data),
+            Err(OpPayloadError::MissingParentBeaconBlockRoot)
+        ));
+
+        assert!(matches!(
+            OpExecutionPayloadEnvelope::try_from_payload(
+                OpExecutionPayload::V3(payload_v3()),
+                None,
+            ),
+            Err(OpPayloadError::MissingParentBeaconBlockRoot)
+        ));
+    }
+
+    #[test]
+    fn distinguishes_present_zero_parent_beacon_block_root() {
+        let data = OpExecutionData::v3(payload_v3(), Vec::new(), B256::ZERO);
+        let envelope = OpExecutionPayloadEnvelope::try_from(data).unwrap();
+        assert!(matches!(
+            envelope,
+            OpExecutionPayloadEnvelope::V3 { parent_beacon_block_root: B256::ZERO, .. }
+        ));
+        assert_eq!(envelope.parent_beacon_block_root(), Some(B256::ZERO));
+
+        let data: OpExecutionData = envelope.clone().into();
+        assert_eq!(data.sidecar.parent_beacon_block_root(), Some(B256::ZERO));
+        assert_eq!(OpExecutionPayloadEnvelope::try_from(data).unwrap(), envelope);
+    }
+
+    #[test]
+    fn rejects_unexpected_v1_parent_beacon_block_root() {
+        let payload = OpExecutionPayload::V1(payload_v1());
+        let sidecar =
+            OpExecutionPayloadSidecar::v3(CancunPayloadFields::new(B256::ZERO, Vec::new()));
+        assert!(matches!(
+            OpExecutionPayloadEnvelope::try_from(OpExecutionData::new(payload, sidecar)),
+            Err(OpPayloadError::UnexpectedParentBeaconBlockRoot)
+        ));
+
+        assert!(matches!(
+            OpExecutionPayloadEnvelope::try_from_payload(
+                OpExecutionPayload::V1(payload_v1()),
+                Some(B256::ZERO),
+            ),
+            Err(OpPayloadError::UnexpectedParentBeaconBlockRoot)
+        ));
+    }
+
+    #[test]
+    fn rejects_non_empty_blob_versioned_hashes() {
+        let data = OpExecutionData::v3(payload_v3(), vec![B256::ZERO], B256::ZERO);
+        assert!(matches!(
+            OpExecutionPayloadEnvelope::try_from(data),
+            Err(OpPayloadError::NonEmptyBlobVersionedHashes)
+        ));
+    }
+
+    #[test]
+    fn rejects_non_empty_execution_requests() {
+        let payload =
+            OpExecutionPayloadV4 { payload_inner: payload_v3(), withdrawals_root: B256::ZERO };
+        let requests = Requests::new(vec![Bytes::from_static(&[0x01, 0x02])]);
+        let data = OpExecutionData::v4(payload, Vec::new(), B256::ZERO, requests);
+        assert!(matches!(
+            OpExecutionPayloadEnvelope::try_from(data),
+            Err(OpPayloadError::NonEmptyELRequests)
+        ));
+    }
+
+    #[test]
+    fn rejects_mismatched_v3_prague_fields() {
+        let payload = OpExecutionPayload::V3(payload_v3());
+        let sidecar = OpExecutionPayloadSidecar::v4(
+            CancunPayloadFields::new(B256::ZERO, Vec::new()),
+            PraguePayloadFields::new(Requests::default()),
+        );
+        assert!(matches!(
+            OpExecutionPayloadEnvelope::try_from(OpExecutionData::new(payload, sidecar)),
+            Err(OpPayloadError::UnexpectedELRequests)
+        ));
+    }
+
+    #[test]
+    fn rejects_v4_without_prague_fields() {
+        let payload = OpExecutionPayload::V4(OpExecutionPayloadV4 {
+            payload_inner: payload_v3(),
+            withdrawals_root: B256::ZERO,
+        });
+        let sidecar =
+            OpExecutionPayloadSidecar::v3(CancunPayloadFields::new(B256::ZERO, Vec::new()));
+        assert!(matches!(
+            OpExecutionPayloadEnvelope::try_from(OpExecutionData::new(payload, sidecar)),
+            Err(OpPayloadError::MissingELRequests)
+        ));
+    }
+
+    #[test]
+    fn check_block_hash_does_not_decode_transactions() {
+        let mut envelope = OpExecutionPayloadEnvelope::V1(payload_v1());
+        envelope.as_v1_mut().transactions = vec![Bytes::from_static(&[0xff])];
+        let block_hash = envelope.clone().try_into_block_raw().unwrap().header.hash_slow();
+        envelope.as_v1_mut().block_hash = block_hash;
+
+        assert!(envelope.check_block_hash().is_ok());
+        assert!(envelope.try_into_block::<OpTxEnvelope>().is_err());
+    }
+}

--- a/rust/op-alloy/crates/rpc-types-engine/src/flashblock/mod.rs
+++ b/rust/op-alloy/crates/rpc-types-engine/src/flashblock/mod.rs
@@ -30,16 +30,16 @@
 //! Convert a sequence of flashblocks to a full execution payload:
 //!
 //! ```rust,ignore
-//! use op_alloy_rpc_types_engine::{OpExecutionData, OpFlashblockPayload};
+//! use op_alloy_rpc_types_engine::{OpFlashblockPayload, OpExecutionPayloadEnvelope};
 //!
 //! let flashblocks: Vec<OpFlashblockPayload> = vec![/* ... */];
-//! let execution_data = OpExecutionData::from_flashblocks(flashblocks)?;
+//! let execution_data = OpExecutionPayloadEnvelope::from_flashblocks(&flashblocks)?;
 //! # Ok::<(), op_alloy_rpc_types_engine::OpFlashblockError>(())
 //! ```
 //!
 //! ## Validation Rules
 //!
-//! The [`OpExecutionData::from_flashblocks`](crate::OpExecutionData::from_flashblocks) method
+//! The [`OpExecutionPayloadEnvelope::from_flashblocks`](crate::OpExecutionPayloadEnvelope::from_flashblocks) method
 //! performs comprehensive validation:
 //!
 //! - Indices must be sequential starting from 0

--- a/rust/op-alloy/crates/rpc-types-engine/src/lib.rs
+++ b/rust/op-alloy/crates/rpc-types-engine/src/lib.rs
@@ -20,6 +20,8 @@ pub use envelope::{
     PayloadEnvelopeEncodeError, PayloadEnvelopeError, PayloadHash,
 };
 
+mod execution;
+
 mod sidecar;
 pub use sidecar::OpExecutionPayloadSidecar;
 

--- a/rust/op-alloy/crates/rpc-types-engine/src/payload/error.rs
+++ b/rust/op-alloy/crates/rpc-types-engine/src/payload/error.rs
@@ -17,6 +17,18 @@ pub enum OpPayloadError {
     /// Non-empty list of blob versioned hashes.
     #[error("non-empty blob versioned hashes")]
     NonEmptyBlobVersionedHashes,
+    /// A V3 or V4 payload is missing its parent beacon block root.
+    #[error("missing parent beacon block root")]
+    MissingParentBeaconBlockRoot,
+    /// A V1 or V2 payload unexpectedly includes a parent beacon block root.
+    #[error("unexpected parent beacon block root")]
+    UnexpectedParentBeaconBlockRoot,
+    /// A V4 payload is missing its execution request fields.
+    #[error("missing EL requests")]
+    MissingELRequests,
+    /// A pre-V4 payload unexpectedly includes execution request fields.
+    #[error("unexpected EL requests")]
+    UnexpectedELRequests,
     /// L1 [`PayloadError`] that can also occur on L2.
     #[error(transparent)]
     Eth(#[from] PayloadError),

--- a/rust/op-alloy/crates/rpc-types-engine/src/payload/mod.rs
+++ b/rust/op-alloy/crates/rpc-types-engine/src/payload/mod.rs
@@ -18,9 +18,11 @@ use alloy_rpc_types_engine::{
 ///
 /// V1 through V3 use the corresponding Alloy execution payload types. V4 uses the OP-specific
 /// Isthmus payload, which adds a withdrawals root and differs from Alloy's execution payload V4.
+/// Its transparent SSZ encoding does not include a version discriminator, so decoding requires an
+/// externally supplied payload version.
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
-#[cfg_attr(feature = "std", derive(ssz_derive::Encode, ssz_derive::Decode))]
+#[cfg_attr(feature = "std", derive(ssz_derive::Encode))]
 #[cfg_attr(feature = "std", ssz(enum_behaviour = "transparent"))]
 #[cfg_attr(feature = "serde", serde(untagged))]
 pub enum OpExecutionPayload {

--- a/rust/op-alloy/crates/rpc-types-engine/src/payload/mod.rs
+++ b/rust/op-alloy/crates/rpc-types-engine/src/payload/mod.rs
@@ -7,13 +7,12 @@ pub mod v4;
 use crate::{OpExecutionPayloadSidecar, OpExecutionPayloadV4};
 use alloc::vec::Vec;
 use alloy_consensus::{Block, BlockHeader, HeaderInfo, Transaction};
-use alloy_eips::{Decodable2718, Encodable2718, Typed2718, eip7685::EMPTY_REQUESTS_HASH};
+use alloy_eips::{Decodable2718, Encodable2718};
 use alloy_primitives::{Address, B256, Bytes, Sealable, U256};
 use alloy_rpc_types_engine::{
     ExecutionPayload, ExecutionPayloadInputV2, ExecutionPayloadV1, ExecutionPayloadV2,
-    ExecutionPayloadV3, PayloadError,
+    ExecutionPayloadV3,
 };
-use error::OpPayloadError;
 
 /// An execution payload, which can be either [`ExecutionPayloadV2`], [`ExecutionPayloadV3`], or
 /// [`OpExecutionPayloadV4`].
@@ -516,170 +515,6 @@ impl OpExecutionPayload {
             mix_hash: Some(self.prev_randao()),
             slot_number: None,
         }
-    }
-
-    /// Converts [`OpExecutionPayload`] to [`Block`] with raw transactions.
-    ///
-    /// Caution: This does not set fields that are not part of the payload and only part of the
-    /// [`OpExecutionPayloadSidecar`]:
-    /// - `parent_beacon_block_root`
-    ///
-    /// See also: [`OpExecutionPayload::into_block_with_sidecar_raw`]
-    pub fn into_block_raw(self) -> Result<Block<alloy_primitives::Bytes>, PayloadError> {
-        match self {
-            Self::V1(payload) => payload.into_block_raw(),
-            Self::V2(payload) => payload.into_block_raw(),
-            Self::V3(payload) => payload.into_block_raw(),
-            Self::V4(payload) => payload.into_block_raw(),
-        }
-    }
-
-    /// Creates a new unsealed block from the given payload and payload sidecar with raw
-    /// transactions.
-    ///
-    /// This sets the `parent_beacon_block_root` and `requests_hash` if present in the sidecar.
-    /// Also validates that L1 withdrawals are empty.
-    ///
-    /// See also: [`OpExecutionPayload::try_into_block_with_sidecar`]
-    pub fn into_block_with_sidecar_raw(
-        self,
-        sidecar: &OpExecutionPayloadSidecar,
-    ) -> Result<Block<alloy_primitives::Bytes>, OpPayloadError> {
-        if let Some(payload) = self.as_v2() &&
-            !payload.withdrawals.is_empty()
-        {
-            return Err(OpPayloadError::NonEmptyL1Withdrawals);
-        }
-
-        let mut block = self.into_block_raw()?;
-
-        if let Some(blobs_hashes) = sidecar.versioned_hashes() &&
-            !blobs_hashes.is_empty()
-        {
-            return Err(OpPayloadError::NonEmptyBlobVersionedHashes);
-        }
-        if let Some(reqs_hash) = sidecar.requests_hash() {
-            if reqs_hash != EMPTY_REQUESTS_HASH {
-                return Err(OpPayloadError::NonEmptyELRequests);
-            }
-            block.header.requests_hash = Some(EMPTY_REQUESTS_HASH)
-        }
-        block.header.parent_beacon_block_root = sidecar.parent_beacon_block_root();
-
-        Ok(block)
-    }
-
-    #[allow(rustdoc::broken_intra_doc_links)]
-    /// Converts [`OpExecutionPayload`] to [`Block`].
-    ///
-    /// Checks that payload doesn't contain:
-    /// - blob transactions
-    /// - L1 withdrawals
-    ///
-    /// Caution: This does not set fields that are not part of the payload and only part of the
-    /// [`OpExecutionPayloadSidecar`]:
-    /// - `parent_beacon_block_root`
-    ///
-    /// See also: [`OpExecutionPayload::try_into_block_with_sidecar`]
-    pub fn try_into_block<T: Decodable2718 + Typed2718>(self) -> Result<Block<T>, OpPayloadError> {
-        self.try_into_block_with(|tx| {
-            T::decode_2718_exact(tx.as_ref())
-                .map_err(alloy_rlp::Error::from)
-                .map_err(PayloadError::from)
-        })
-    }
-
-    #[allow(rustdoc::broken_intra_doc_links)]
-    /// Converts [`OpExecutionPayload`] to [`Block`] with a custom transaction mapper.
-    ///
-    /// Checks that payload doesn't contain:
-    /// - blob transactions
-    /// - L1 withdrawals
-    ///
-    /// Caution: This does not set fields that are not part of the payload and only part of the
-    /// [`OpExecutionPayloadSidecar`]:
-    /// - `parent_beacon_block_root`
-    ///
-    /// See also: [`OpExecutionPayload::try_into_block_with_sidecar_with`]
-    pub fn try_into_block_with<T, F, E>(self, f: F) -> Result<Block<T>, OpPayloadError>
-    where
-        T: Typed2718,
-        F: FnMut(alloy_primitives::Bytes) -> Result<T, E>,
-        E: Into<PayloadError>,
-    {
-        if let Some(payload) = self.as_v2() &&
-            !payload.withdrawals.is_empty()
-        {
-            return Err(OpPayloadError::NonEmptyL1Withdrawals);
-        }
-        let block = match self {
-            Self::V1(payload) => return Ok(payload.try_into_block_with(f)?),
-            Self::V2(payload) => return Ok(payload.try_into_block_with(f)?),
-            Self::V3(payload) => payload.try_into_block_with(f)?,
-            Self::V4(payload) => payload.try_into_block_with(f)?,
-        };
-        if block.body.has_eip4844_transactions() {
-            return Err(OpPayloadError::BlobTransaction);
-        }
-
-        Ok(block)
-    }
-
-    /// Tries to create a new unsealed block from the given payload and payload sidecar.
-    ///
-    /// Additional to checks performed in [`OpExecutionPayload::try_into_block`], which is called
-    /// under the hood, also checks that sidecar doesn't contain:
-    /// - blob versioned hashes
-    /// - execution layer requests
-    ///
-    /// See also docs for
-    /// [`ExecutionPayload::try_into_block_with_sidecar`](alloy_rpc_types_engine::ExecutionPayload::try_into_block_with_sidecar).
-    pub fn try_into_block_with_sidecar<T: Decodable2718 + Typed2718>(
-        self,
-        sidecar: &OpExecutionPayloadSidecar,
-    ) -> Result<Block<T>, OpPayloadError> {
-        self.try_into_block_with_sidecar_with(sidecar, |tx| {
-            T::decode_2718_exact(tx.as_ref())
-                .map_err(alloy_rlp::Error::from)
-                .map_err(PayloadError::from)
-        })
-    }
-
-    /// Tries to create a new unsealed block from the given payload and payload sidecar with a
-    /// custom transaction mapper.
-    ///
-    /// Additional to checks performed in [`OpExecutionPayload::try_into_block_with`], which is
-    /// called under the hood, also checks that sidecar doesn't contain:
-    /// - blob versioned hashes
-    /// - execution layer requests
-    ///
-    /// See also docs for
-    /// [`ExecutionPayload::try_into_block_with_sidecar_with`](alloy_rpc_types_engine::ExecutionPayload::try_into_block_with_sidecar_with).
-    pub fn try_into_block_with_sidecar_with<T, F, E>(
-        self,
-        sidecar: &OpExecutionPayloadSidecar,
-        f: F,
-    ) -> Result<Block<T>, OpPayloadError>
-    where
-        T: Typed2718,
-        F: FnMut(alloy_primitives::Bytes) -> Result<T, E>,
-        E: Into<PayloadError>,
-    {
-        let mut base_payload = self.try_into_block_with(f)?;
-        if let Some(blobs_hashes) = sidecar.versioned_hashes() &&
-            !blobs_hashes.is_empty()
-        {
-            return Err(OpPayloadError::NonEmptyBlobVersionedHashes);
-        }
-        if let Some(reqs_hash) = sidecar.requests_hash() {
-            if reqs_hash != EMPTY_REQUESTS_HASH {
-                return Err(OpPayloadError::NonEmptyELRequests);
-            }
-            base_payload.header.requests_hash = Some(EMPTY_REQUESTS_HASH)
-        }
-        base_payload.header.parent_beacon_block_root = sidecar.parent_beacon_block_root();
-
-        Ok(base_payload)
     }
 
     /// Returns an iterator over the decoded transactions in this payload.

--- a/rust/op-alloy/crates/rpc-types-engine/src/payload/mod.rs
+++ b/rust/op-alloy/crates/rpc-types-engine/src/payload/mod.rs
@@ -14,21 +14,23 @@ use alloy_rpc_types_engine::{
     ExecutionPayloadV3,
 };
 
-/// An execution payload, which can be either [`ExecutionPayloadV2`], [`ExecutionPayloadV3`], or
-/// [`OpExecutionPayloadV4`].
+/// A versioned OP execution payload.
+///
+/// V1 through V3 use the corresponding Alloy execution payload types. V4 uses the OP-specific
+/// Isthmus payload, which adds a withdrawals root and differs from Alloy's execution payload V4.
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[cfg_attr(feature = "std", derive(ssz_derive::Encode, ssz_derive::Decode))]
 #[cfg_attr(feature = "std", ssz(enum_behaviour = "transparent"))]
 #[cfg_attr(feature = "serde", serde(untagged))]
 pub enum OpExecutionPayload {
-    /// V1 payload
+    /// Pre-Canyon execution payload.
     V1(ExecutionPayloadV1),
-    /// V2 payload
+    /// Canyon execution payload.
     V2(ExecutionPayloadV2),
-    /// V3 payload
+    /// Ecotone execution payload.
     V3(ExecutionPayloadV3),
-    /// V4 payload
+    /// OP-specific Isthmus execution payload.
     V4(OpExecutionPayloadV4),
 }
 
@@ -223,17 +225,23 @@ impl<'de> serde::Deserialize<'de> for OpExecutionPayload {
                         .ok_or_else(|| serde::de::Error::missing_field("transactions"))?,
                 };
 
-                // Ensure `withdrawals` is present before proceeding
-                let withdrawals =
-                    withdrawals.ok_or_else(|| serde::de::Error::missing_field("withdrawals"))?;
+                // Match Alloy's V1 through V3 field-based decoding, with the OP-specific
+                // withdrawals root as the V4 discriminator.
+                let Some(withdrawals) = withdrawals else {
+                    return if blob_gas_used.is_none() &&
+                        excess_blob_gas.is_none() &&
+                        withdrawals_root.is_none()
+                    {
+                        Ok(OpExecutionPayload::V1(v1))
+                    } else {
+                        Err(serde::de::Error::custom("invalid enum variant"))
+                    };
+                };
 
-                // Construct base V2 payload
                 let payload_v2 = ExecutionPayloadV2 { payload_inner: v1, withdrawals };
 
-                // Ensure `blob_gas_used` and `excess_blob_gas` are either both present or both
-                // absent
                 match (blob_gas_used, excess_blob_gas) {
-                    // If both are present, create V3
+                    // Both blob gas fields distinguish V3 from V2.
                     (Some(blob_gas_used), Some(excess_blob_gas)) => {
                         let payload_v3 = ExecutionPayloadV3 {
                             payload_inner: payload_v2,
@@ -241,7 +249,7 @@ impl<'de> serde::Deserialize<'de> for OpExecutionPayload {
                             excess_blob_gas,
                         };
 
-                        // If `withdrawals_root` is present, wrap into V4; otherwise, return V3
+                        // The withdrawals root distinguishes the OP-specific V4 from V3.
                         if let Some(withdrawals_root) = withdrawals_root {
                             Ok(OpExecutionPayload::V4(OpExecutionPayloadV4 {
                                 payload_inner: payload_v3,
@@ -251,11 +259,14 @@ impl<'de> serde::Deserialize<'de> for OpExecutionPayload {
                             Ok(OpExecutionPayload::V3(payload_v3))
                         }
                     }
-                    // If one is missing, reject as invalid
+                    // An incomplete V3 payload is invalid.
                     (Some(_), None) | (None, Some(_)) => {
                         Err(serde::de::Error::custom("invalid enum variant"))
                     }
-                    // If neither are present, return V2
+                    // A withdrawals root without the V3 fields is also invalid.
+                    (None, None) if withdrawals_root.is_some() => {
+                        Err(serde::de::Error::custom("invalid enum variant"))
+                    }
                     (None, None) => Ok(OpExecutionPayload::V2(payload_v2)),
                 }
             }
@@ -590,6 +601,43 @@ impl OpExecutionPayload {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn serde_payload_input_enum_v1() {
+        let payload = OpExecutionPayload::V1(ExecutionPayloadV1::from_block_unchecked(
+            B256::ZERO,
+            &Block::<op_alloy_consensus::OpTxEnvelope>::default(),
+        ));
+        let mut json = serde_json::to_value(&payload).unwrap();
+
+        assert!(json.get("withdrawals").is_none());
+        assert_eq!(serde_json::from_value::<OpExecutionPayload>(json.clone()).unwrap(), payload);
+
+        // Later-fork fields without withdrawals must not be silently discarded as a V1 payload.
+        json["withdrawalsRoot"] = serde_json::Value::String(B256::ZERO.to_string());
+        assert!(serde_json::from_value::<OpExecutionPayload>(json).is_err());
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn serde_payload_input_enum_rejects_v2_with_withdrawals_root() {
+        let payload = OpExecutionPayload::V2(ExecutionPayloadV2 {
+            payload_inner: ExecutionPayloadV1::from_block_unchecked(
+                B256::ZERO,
+                &Block::<op_alloy_consensus::OpTxEnvelope>::default(),
+            ),
+            withdrawals: Vec::new(),
+        });
+        let mut json = serde_json::to_value(&payload).unwrap();
+
+        assert!(json.get("withdrawals").is_some());
+        assert!(json.get("blobGasUsed").is_none());
+        assert!(json.get("excessBlobGas").is_none());
+
+        json["withdrawalsRoot"] = serde_json::Value::String(B256::ZERO.to_string());
+        assert!(serde_json::from_value::<OpExecutionPayload>(json).is_err());
+    }
 
     #[test]
     #[cfg(feature = "serde")]

--- a/rust/op-alloy/crates/rpc-types-engine/src/payload/v4.rs
+++ b/rust/op-alloy/crates/rpc-types-engine/src/payload/v4.rs
@@ -1,10 +1,8 @@
 //! Optimism execution payload envelope V3.
 
 use alloc::vec::Vec;
-use alloy_consensus::Block;
-use alloy_eips::Decodable2718;
 use alloy_primitives::{B256, Bytes, U256};
-use alloy_rpc_types_engine::{BlobsBundleV1, ExecutionPayloadV3, PayloadError};
+use alloy_rpc_types_engine::{BlobsBundleV1, ExecutionPayloadV3};
 
 /// The Opstack execution payload for `newPayloadV4` of the engine API introduced with isthmus.
 /// See also <https://specs.optimism.io/protocol/isthmus/exec-engine.html#engine_newpayloadv4-api>
@@ -31,49 +29,6 @@ impl OpExecutionPayloadV4 {
         withdrawals_root: B256,
     ) -> Self {
         Self { withdrawals_root, payload_inner: payload }
-    }
-
-    /// Converts [`OpExecutionPayloadV4`] to [`Block`] with raw transactions.
-    ///
-    /// This performs the same conversion as the underlying V3 payload, but inserts the L2
-    /// withdrawals root and returns raw transaction bytes instead of decoded transactions.
-    pub fn into_block_raw(self) -> Result<Block<Bytes>, PayloadError> {
-        let mut base_block = self.payload_inner.into_block_raw()?;
-
-        // overwrite l1 withdrawals root with l2 withdrawals root
-        base_block.header.withdrawals_root = Some(self.withdrawals_root);
-
-        Ok(base_block)
-    }
-
-    /// Converts [`OpExecutionPayloadV4`] to [`Block`].
-    ///
-    /// This performs the same conversion as the underlying V3 payload, but inserts the L2
-    /// withdrawals root.
-    ///
-    /// See also [`ExecutionPayloadV3::try_into_block`].
-    pub fn try_into_block<T: Decodable2718>(self) -> Result<Block<T>, PayloadError> {
-        let block = self.into_block_raw()?;
-        block.try_map_transactions(|tx| {
-            T::decode_2718_exact(tx.as_ref())
-                .map_err(alloy_rlp::Error::from)
-                .map_err(PayloadError::from)
-        })
-    }
-
-    /// Converts [`OpExecutionPayloadV4`] to [`Block`] with a custom transaction mapper.
-    ///
-    /// This performs the same conversion as the underlying V3 payload, but inserts the L2
-    /// withdrawals root.
-    ///
-    /// See also [`ExecutionPayloadV3::try_into_block_with`].
-    pub fn try_into_block_with<T, F, E>(self, f: F) -> Result<Block<T>, PayloadError>
-    where
-        F: FnMut(Bytes) -> Result<T, E>,
-        E: Into<PayloadError>,
-    {
-        let block = self.into_block_raw()?;
-        block.try_map_transactions(f).map_err(|e| e.into())
     }
 }
 

--- a/rust/op-reth/crates/evm/src/lib.rs
+++ b/rust/op-reth/crates/evm/src/lib.rs
@@ -395,7 +395,7 @@ where
         )?;
 
         Ok(OpBlockExecutionCtx {
-            parent_hash: payload.parent_hash(),
+            parent_hash: payload.payload.parent_hash(),
             // No parent header on this path to detect fork-activation blocks, so the executor's
             // check is skipped; the derivation layer enforces the rule instead.
             no_user_tx_activation_block: false,

--- a/rust/op-reth/crates/flashblocks/src/consensus.rs
+++ b/rust/op-reth/crates/flashblocks/src/consensus.rs
@@ -1,7 +1,7 @@
 use crate::{FlashBlockCompleteSequence, FlashBlockCompleteSequenceRx};
 use alloy_primitives::B256;
 use alloy_rpc_types_engine::PayloadStatusEnum;
-use op_alloy_rpc_types_engine::OpExecutionData;
+use op_alloy_rpc_types_engine::{OpExecutionData, OpExecutionPayloadEnvelope};
 use reth_engine_primitives::ConsensusEngineHandle;
 use reth_optimism_payload_builder::OpPayloadTypes;
 use reth_payload_primitives::{ExecutionPayload, PayloadTypes};
@@ -157,22 +157,22 @@ impl TryFrom<&FlashBlockCompleteSequence> for OpExecutionData {
     type Error = &'static str;
 
     fn try_from(sequence: &FlashBlockCompleteSequence) -> Result<Self, Self::Error> {
-        let mut data = Self::from_flashblocks_unchecked(sequence);
+        let mut data = OpExecutionPayloadEnvelope::from_flashblocks_unchecked(sequence);
 
         // If execution outcome is available, use the computed state_root and block_hash.
         // FlashBlockService computes these when building sequences on top of the local tip.
         if let Some(execution_outcome) = sequence.execution_outcome() {
-            let payload = data.payload.as_v1_mut();
+            let payload = data.as_v1_mut();
             payload.state_root = execution_outcome.state_root;
             payload.block_hash = execution_outcome.block_hash;
         }
 
         // Only proceed if we have a valid state_root (non-zero).
-        if data.payload.as_v1_mut().state_root == B256::ZERO {
+        if data.as_v1().state_root == B256::ZERO {
             return Err("No state_root available for payload");
         }
 
-        Ok(data)
+        Ok(data.into())
     }
 }
 

--- a/rust/op-reth/crates/node/src/engine.rs
+++ b/rust/op-reth/crates/node/src/engine.rs
@@ -1,7 +1,10 @@
 use alloy_consensus::BlockHeader;
 use alloy_primitives::B256;
 use alloy_rpc_types_engine::{ExecutionPayloadEnvelopeV2, ExecutionPayloadV1};
-use op_alloy_rpc_types_engine::{OpExecutionPayloadEnvelopeV3, OpExecutionPayloadEnvelopeV4};
+use op_alloy_rpc_types_engine::{
+    OpExecutionData, OpExecutionPayloadEnvelope, OpExecutionPayloadEnvelopeV3,
+    OpExecutionPayloadEnvelopeV4,
+};
 use reth_consensus::ConsensusError;
 use reth_node_api::{
     BuiltPayload, EngineApiValidator, EngineTypes, InsertBlockErrorKind, NodePrimitives,
@@ -45,9 +48,12 @@ where
         >,
         _bal: Option<alloy_primitives::Bytes>,
     ) -> <T as PayloadTypes>::ExecutionData {
-        OpExecData(op_alloy_rpc_types_engine::OpExecutionData::from_block_unchecked(
-            block.hash(),
-            &block.into_block().into_ethereum_block(),
+        OpExecData(OpExecutionData::from(
+            OpExecutionPayloadEnvelope::from_block_unchecked(
+                block.hash(),
+                &block.into_block().into_ethereum_block(),
+            )
+            .expect("built OP blocks must normalize"),
         ))
     }
 }

--- a/rust/op-reth/crates/payload/src/lib.rs
+++ b/rust/op-reth/crates/payload/src/lib.rs
@@ -17,7 +17,7 @@ pub use builder::{
 };
 pub mod error;
 pub mod payload;
-use op_alloy_rpc_types_engine::OpExecutionData;
+use op_alloy_rpc_types_engine::{OpExecutionData, OpExecutionPayloadEnvelope};
 pub use payload::{
     OpBuiltPayload, OpExecData, OpPayloadAttributes, OpPayloadAttrs, OpPayloadBuilderAttributes,
     payload_id_optimism,
@@ -94,9 +94,12 @@ where
         >,
         _bal: Option<alloy_primitives::Bytes>,
     ) -> Self::ExecutionData {
-        crate::payload::OpExecData::from(OpExecutionData::from_block_unchecked(
-            block.hash(),
-            &block.into_block().into_ethereum_block(),
+        crate::payload::OpExecData::from(OpExecutionData::from(
+            OpExecutionPayloadEnvelope::from_block_unchecked(
+                block.hash(),
+                &block.into_block().into_ethereum_block(),
+            )
+            .expect("built OP blocks must normalize"),
         ))
     }
 }

--- a/rust/op-reth/crates/payload/src/payload.rs
+++ b/rust/op-reth/crates/payload/src/payload.rs
@@ -14,7 +14,8 @@ use alloy_rpc_types_engine::{
 };
 use op_alloy_consensus::{EIP1559ParamError, encode_holocene_extra_data, encode_jovian_extra_data};
 use op_alloy_rpc_types_engine::{
-    OpExecutionPayloadEnvelopeV3, OpExecutionPayloadEnvelopeV4, OpExecutionPayloadV4,
+    OpExecutionPayloadEnvelope, OpExecutionPayloadEnvelopeV3, OpExecutionPayloadEnvelopeV4,
+    OpExecutionPayloadV4,
 };
 use reth_chainspec::EthChainSpec;
 use reth_optimism_evm::OpNextBlockEnvAttributes;
@@ -63,7 +64,7 @@ impl reth_payload_primitives::ExecutionPayload for OpExecData {
     }
 
     fn withdrawals(&self) -> Option<&Vec<alloy_eips::eip4895::Withdrawal>> {
-        self.0.withdrawals()
+        self.0.payload.as_v2().map(|payload| &payload.withdrawals)
     }
 
     fn block_access_list(&self) -> Option<&Bytes> {
@@ -476,7 +477,13 @@ where
     fn from(value: OpBuiltPayload<N>) -> Self {
         let block = Arc::unwrap_or_clone(value.block);
         let hash = block.hash();
-        Self(OpExecutionData::from_block_unchecked(hash, &block.into_block().into_ethereum_block()))
+        Self(OpExecutionData::from(
+            OpExecutionPayloadEnvelope::from_block_unchecked(
+                hash,
+                &block.into_block().into_ethereum_block(),
+            )
+            .expect("built OP blocks must normalize"),
+        ))
     }
 }
 

--- a/rust/op-reth/crates/payload/src/validator.rs
+++ b/rust/op-reth/crates/payload/src/validator.rs
@@ -2,9 +2,8 @@
 
 use alloc::sync::Arc;
 use alloy_consensus::Block;
-use alloy_rpc_types_engine::PayloadError;
 use derive_more::{Constructor, Deref};
-use op_alloy_rpc_types_engine::{OpExecutionData, OpPayloadError};
+use op_alloy_rpc_types_engine::{OpExecutionData, OpExecutionPayloadEnvelope, OpPayloadError};
 use reth_optimism_forks::OpHardforks;
 use reth_payload_validator::{cancun, prague, shanghai};
 use reth_primitives_traits::{Block as _, SealedBlock, SignedTransaction};
@@ -64,17 +63,11 @@ where
     ChainSpec: OpHardforks,
     T: SignedTransaction,
 {
-    let OpExecutionData { payload, sidecar } = payload;
+    let sidecar = payload.sidecar.clone();
+    let payload = OpExecutionPayloadEnvelope::try_from(payload)?;
 
-    let expected_hash = payload.block_hash();
-
-    // First parse the block
-    let sealed_block = payload.try_into_block_with_sidecar(&sidecar)?.seal_slow();
-
-    // Ensure the hash included in the payload matches the block hash
-    if expected_hash != sealed_block.hash() {
-        Err(PayloadError::BlockHash { execution: sealed_block.hash(), consensus: expected_hash })?;
-    }
+    // First parse the block and ensure its hash matches the payload's claim.
+    let sealed_block = payload.try_into_checked_block()?.seal_slow();
 
     shanghai::ensure_well_formed_fields(
         sealed_block.body(),


### PR DESCRIPTION
## Summary

- Introduce `OpExecutionPayloadEnvelope` as the complete V1–V4 execution payload abstraction.
- Encode fork invariants structurally: V1/V2 cannot carry a parent beacon block root, while V3/V4 require one.
- Centralize complete block and flashblock reconstruction on the envelope.
- Keep `OpExecutionData` as the fallible Engine API boundary and reject malformed sidecar combinations.
- Add raw-byte block-hash checking without decoding transactions.
- Migrate Kona and op-reth conversion paths to the shared envelope while preserving independent EL execution validation.
- Preserve existing external JSON and P2P/SSZ formats.

## Stack

This is the base PR for three independent follow-ups. Once this PR is merged, each follow-up can be reviewed and merged independently:

- #22305 — gossip authentication
- #22306 — inserted block-info reuse
- #22307 — admin unsafe-payload hash validation

## Testing

- `cargo +nightly-2026-02-20 fmt --all -- --check`
- `cargo +nightly-2026-02-20 fmt --manifest-path kona/sp1/programs/Cargo.toml --all -- --check`
- Targeted tests for op-alloy RPC types, Kona protocol/engine/gossip/RPC/service, and op-reth payload/flashblocks
- Clippy with `--all-targets --all-features -- -D warnings` across affected Kona, op-alloy, and op-reth crates
