### PR TITLE
kona-node: simplify gossip

### DIFF
--- a/docs/public-docs/node-operators/kona-node/design/p2p.mdx
+++ b/docs/public-docs/node-operators/kona-node/design/p2p.mdx
@@ -106,9 +106,9 @@ The [libp2p Swarm][swarm] listens on a specified
 
 As mentioned in [the previous section](#gossip), L2 blocks
 are published as payloads through the [libp2p Swarm][swarm],
-which is done using the `GossipDriver`. The actual payload
-type that is published is an [`OpNetworkPayloadEnvelope`][env],
-which is well documented in the [OP Stack P2P Specs][p2p-specs].
+which is done using the `GossipDriver`. The `GossipDriver` accepts an `OpExecutionPayloadEnvelope` and its
+signature, then privately encodes them in the wire format documented
+in the [OP Stack P2P Specs][p2p-specs].
 
 L2 blocks published through the `GossipDriver` are published on
 a "topic". The topic is used by the gossipsub protocol to publish
@@ -124,8 +124,9 @@ snappy compressed, they need to be decompressed and then decoded
 for the correct [block topic][block-topic] those messages are
 published on.
 
-Only once the [`OpNetworkPayloadEnvelope`][env] is successfully
-decoded for the corresponding block topic, is the block validated.
+After decompression, kona separates the signature from the exact encoded
+envelope bytes. It authenticates those bytes before decoding the envelope
+according to the corresponding block topic and validating the block contents.
 
 <Info>
 
@@ -136,13 +137,14 @@ Block validity in kona follows the [OP Stack block validation specs][validation]
 As of writing these docs, block validation follows a few rules.
 
 - The timestamp is between 60 seconds in the past and at most 5 seconds in the future.
-- The block hash is valid. This is checked by transforming the payload into a block
-  and then hashing the block header to produce the payload hash.
+- The block signature authenticates the exact encoded envelope bytes.
+- The block hash is valid. This is checked by computing the transaction trie root directly from
+  the encoded transaction bytes and hashing the reconstructed header. Transaction decoding and
+  execution remain the execution layer's responsibility.
 - The contents of the payload envelope are correct for its version. Since different
   versions introduce new contents to the payload from hardforks, the
   forwards-compatible payload envelope cannot have fields with content that don't exist
   for previous versions.
-- The block signature is valid.
 
 
 ### Node Identification
@@ -160,8 +162,6 @@ TODO
 [block-topic]: https://specs.optimism.io/protocol/rollup-node-p2p.html#gossip-topics
 
 [multiaddr]: https://docs.rs/libp2p/0.56.0/libp2p/struct.Multiaddr.html
-
-[env]: https://docs.rs/op-alloy-rpc-types-engine/latest/op_alloy_rpc_types_engine/struct.OpNetworkPayloadEnvelope.html
 
 [swarm]: https://docs.rs/libp2p/latest/libp2p/struct.Swarm.html
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -7040,6 +7040,7 @@ dependencies = [
  "arbitrary",
  "derive_more 2.1.1",
  "discv5 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethereum_ssz",
  "futures",
  "ipnet",
  "kona-disc",
@@ -9451,7 +9452,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "snap",
  "thiserror 2.0.18",
 ]
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -7043,6 +7043,7 @@ dependencies = [
  "ethereum_ssz",
  "futures",
  "ipnet",
+ "k256",
  "kona-disc",
  "kona-genesis",
  "kona-macros",

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/insert/task.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/insert/task.rs
@@ -72,7 +72,6 @@ impl<EngineClient_: EngineClient> EngineTaskExt for InsertTask<EngineClient_> {
                 self.client.new_payload_v4(payload, parent_beacon_block_root).await
             }
         };
-        let block: OpBlock = payload.try_into_block().map_err(InsertTaskError::FromBlockError)?;
 
         // Check the `engine_newPayload` response.
         let response = match response {
@@ -87,6 +86,7 @@ impl<EngineClient_: EngineClient> EngineTaskExt for InsertTask<EngineClient_> {
         }
         let insert_duration = insert_time_start.elapsed();
 
+        let block: OpBlock = payload.try_into_block().map_err(InsertTaskError::FromBlockError)?;
         let new_unsafe_ref =
             L2BlockInfo::from_block_and_genesis(&block, &self.rollup_config.genesis)
                 .map_err(InsertTaskError::L2BlockInfoConstruction)?;

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/task.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/task.rs
@@ -8,6 +8,7 @@ use crate::{
     InsertTaskError,
     task_queue::{SealTask, SealTaskError},
 };
+use alloy_rpc_types_engine::PayloadStatusEnum;
 use async_trait::async_trait;
 use derive_more::Display;
 use std::cmp::Ordering;
@@ -92,7 +93,7 @@ impl EngineTaskError for EngineTaskErrors {
 /// [`Engine`]: crate::Engine
 #[derive(Debug, Clone)]
 pub enum EngineTask<EngineClient_: EngineClient> {
-    /// Inserts a payload into the execution engine.
+    /// Inserts an unsafe payload into the execution engine.
     Insert(Box<InsertTask<EngineClient_>>),
     /// Begins building a new block with the given attributes, producing a new payload ID.
     Build(Box<BuildTask<EngineClient_>>),
@@ -110,9 +111,17 @@ impl<EngineClient_: EngineClient> EngineTask<EngineClient_> {
     /// Executes the task without consuming it.
     async fn execute_inner(&self, state: &mut EngineState) -> Result<(), EngineTaskErrors> {
         match self {
-            Self::Insert(task) => {
-                task.execute(state).await?;
-            }
+            Self::Insert(task) => match task.execute(state).await {
+                // INVALID is terminal for an externally sourced unsafe payload. Drop it so the
+                // queue can process competing or subsequent payloads instead of retrying forever.
+                Err(InsertTaskError::UnexpectedPayloadStatus(
+                    status @ PayloadStatusEnum::Invalid { .. },
+                )) => {
+                    warn!(target: "engine", %status, "Dropping invalid unsafe payload");
+                }
+                Err(err) => return Err(err.into()),
+                Ok(_) => {}
+            },
             Self::Seal(task) => task.execute(state).await?,
             Self::Consolidate(task) => task.execute(state).await?,
             Self::Finalize(task) => task.execute(state).await?,
@@ -238,5 +247,44 @@ impl<EngineClient_: EngineClient> EngineTaskExt for EngineTask<EngineClient_> {
         kona_macros::inc!(counter, crate::Metrics::ENGINE_TASK_SUCCESS, self.task_metrics_label());
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::MockEngineClient;
+    use alloy_consensus::Block;
+    use alloy_primitives::Bytes;
+    use alloy_rpc_types_engine::{ExecutionPayloadV1, PayloadStatus};
+    use kona_genesis::RollupConfig;
+    use op_alloy_consensus::OpTxEnvelope;
+    use op_alloy_rpc_types_engine::OpExecutionPayloadEnvelope;
+    use std::{sync::Arc, time::Duration};
+
+    #[tokio::test]
+    async fn invalid_unsafe_payload_completes_without_retry() {
+        let config = Arc::new(RollupConfig::default());
+        let client = Arc::new(
+            MockEngineClient::builder()
+                .with_config(config.clone())
+                .with_new_payload_v1_response(PayloadStatus::from_status(
+                    PayloadStatusEnum::Invalid { validation_error: "invalid transaction".into() },
+                ))
+                .build(),
+        );
+        let mut payload = ExecutionPayloadV1::from_block_slow(&Block::<OpTxEnvelope>::default());
+        payload.transactions = vec![Bytes::from_static(&[0xff])];
+        let task = EngineTask::Insert(Box::new(InsertTask::new(
+            client,
+            config,
+            OpExecutionPayloadEnvelope::V1(payload),
+            false,
+        )));
+
+        tokio::time::timeout(Duration::from_secs(1), task.execute(&mut EngineState::default()))
+            .await
+            .expect("invalid unsafe payload task should not retry")
+            .unwrap();
     }
 }

--- a/rust/kona/crates/node/gossip/Cargo.toml
+++ b/rust/kona/crates/node/gossip/Cargo.toml
@@ -24,16 +24,17 @@ kona-disc.workspace = true
 
 # Alloy
 alloy-rlp.workspace = true
-alloy-consensus.workspace = true
 alloy-rpc-types-engine.workspace = true
 alloy-primitives = { workspace = true, features = ["k256", "getrandom"] }
 
 # Op Alloy
-op-alloy-consensus = { workspace = true, features = ["k256"] }
 op-alloy-rpc-types-engine = { workspace = true, features = ["std", "serde"] }
 
-# Networking
+# Encoding
+ethereum_ssz.workspace = true
 snap.workspace = true
+
+# Networking
 futures.workspace = true
 libp2p-stream.workspace = true
 discv5 = { workspace = true, features = ["libp2p"] }

--- a/rust/kona/crates/node/gossip/Cargo.toml
+++ b/rust/kona/crates/node/gossip/Cargo.toml
@@ -26,6 +26,7 @@ kona-disc.workspace = true
 alloy-rlp.workspace = true
 alloy-rpc-types-engine.workspace = true
 alloy-primitives = { workspace = true, features = ["k256", "getrandom"] }
+k256.workspace = true
 
 # Op Alloy
 op-alloy-rpc-types-engine = { workspace = true, features = ["std", "serde"] }

--- a/rust/kona/crates/node/gossip/src/block_validity.rs
+++ b/rust/kona/crates/node/gossip/src/block_validity.rs
@@ -2,20 +2,16 @@
 use std::time::Instant;
 use std::time::SystemTime;
 
-use alloy_consensus::Block;
 use alloy_primitives::{Address, B256};
 use alloy_rpc_types_engine::{ExecutionPayloadV3, PayloadError};
 use kona_genesis::RollupConfig;
 use libp2p::gossipsub::MessageAcceptance;
-use op_alloy_consensus::OpTxEnvelope;
-use op_alloy_rpc_types_engine::{
-    OpExecutionPayload, OpExecutionPayloadEnvelope, OpExecutionPayloadV4, OpNetworkPayloadEnvelope,
-    OpPayloadError,
-};
+use op_alloy_rpc_types_engine::{OpExecutionPayloadEnvelope, OpExecutionPayloadV4, OpPayloadError};
 
 use super::BlockHandler;
 #[cfg(feature = "metrics")]
 use crate::Metrics;
+use crate::payload::SignedGossipPayload;
 
 /// Error that can occur when validating a block.
 #[derive(Debug, thiserror::Error)]
@@ -53,9 +49,6 @@ pub enum BlockInvalidError {
     /// Invalid block.
     #[error(transparent)]
     InvalidBlock(#[from] OpPayloadError),
-    /// The block has a parent beacon block root incompatible with its payload version.
-    #[error("Payload has an invalid parent beacon block root")]
-    ParentBeaconRoot,
     /// The block has an invalid blob gas used.
     #[error("Payload is on v3+ topic, but has non-zero blob gas used")]
     BlobGasUsed,
@@ -105,6 +98,30 @@ impl BlockHandler {
     /// <https://specs.optimism.io/protocol/rollup-node-p2p.html#block-validation>
     const MAX_BLOCKS_TO_KEEP: usize = 5;
 
+    /// Validates that the signature authenticates the exact encoded envelope bytes and was
+    /// produced by the configured unsafe block signer.
+    pub(crate) fn validate_signature(
+        &self,
+        payload: &SignedGossipPayload,
+    ) -> Result<(), BlockInvalidError> {
+        let message = payload.payload_hash().signature_message(self.rollup_config.l2_chain_id.id());
+        let expected = *self.signer_recv.borrow();
+        let received = match payload.signature().recover_address_from_prehash(&message) {
+            Ok(received) => received,
+            Err(_) => {
+                #[cfg(feature = "metrics")]
+                kona_macros::inc!(counter, Metrics::BLOCK_VALIDATION_FAILED, "reason" => "invalid_signature");
+                return Err(BlockInvalidError::Signature);
+            }
+        };
+        if received != expected {
+            #[cfg(feature = "metrics")]
+            kona_macros::inc!(counter, Metrics::BLOCK_VALIDATION_FAILED, "reason" => "invalid_signer");
+            return Err(BlockInvalidError::Signer { expected, received });
+        }
+        Ok(())
+    }
+
     /// Determines if a block is valid.
     ///
     /// We validate the block according to the rules defined here:
@@ -114,24 +131,20 @@ impl BlockHandler {
     /// in the handle).
     pub fn block_valid(
         &mut self,
-        envelope: &OpNetworkPayloadEnvelope,
+        envelope: &OpExecutionPayloadEnvelope,
     ) -> Result<(), BlockInvalidError> {
         // Start timing for the validation duration
         #[cfg(feature = "metrics")]
         let validation_start = Instant::now();
 
-        // Record total validation attempts
-        #[cfg(feature = "metrics")]
-        kona_macros::inc!(counter, Metrics::BLOCK_VALIDATION_TOTAL);
-
         // Record block version distribution
         #[cfg(feature = "metrics")]
         {
-            let version = match &envelope.payload {
-                OpExecutionPayload::V1(_) => "v1",
-                OpExecutionPayload::V2(_) => "v2",
-                OpExecutionPayload::V3(_) => "v3",
-                OpExecutionPayload::V4(_) => "v4",
+            let version = match envelope {
+                OpExecutionPayloadEnvelope::V1(_) => "v1",
+                OpExecutionPayloadEnvelope::V2(_) => "v2",
+                OpExecutionPayloadEnvelope::V3 { .. } => "v3",
+                OpExecutionPayloadEnvelope::V4 { .. } => "v4",
             };
             kona_macros::inc!(counter, Metrics::BLOCK_VERSION, "version" => version);
         }
@@ -173,7 +186,6 @@ impl BlockHandler {
                         BlockInvalidError::BlockSeen { .. } => "block_seen",
                         BlockInvalidError::InvalidBlock(_) |
                         BlockInvalidError::BaseFeePerGasOverflow(_) => "invalid_block",
-                        BlockInvalidError::ParentBeaconRoot => "parent_beacon_root",
                         BlockInvalidError::BlobGasUsed => "blob_gas_used",
                         BlockInvalidError::ExcessBlobGas => "excess_blob_gas",
                         BlockInvalidError::WithdrawalsRoot => "withdrawals_root",
@@ -189,80 +201,49 @@ impl BlockHandler {
     /// Internal validation logic extracted for cleaner metrics instrumentation.
     fn validate_block_internal(
         &mut self,
-        envelope: &OpNetworkPayloadEnvelope,
+        envelope: &OpExecutionPayloadEnvelope,
     ) -> Result<(), BlockInvalidError> {
         let current_timestamp =
             SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap().as_secs();
 
         // The timestamp is at most 5 seconds in the future.
-        let is_future = envelope.payload.timestamp() > current_timestamp + 5;
+        let is_future = envelope.timestamp() > current_timestamp + 5;
         // The timestamp is at most 60 seconds in the past.
-        let is_past = envelope.payload.timestamp() < current_timestamp - 60;
+        let is_past = envelope.timestamp() < current_timestamp - 60;
 
         // CHECK: The timestamp is not too far in the future or past.
         if is_future || is_past {
             return Err(BlockInvalidError::Timestamp {
                 current: current_timestamp,
-                received: envelope.payload.timestamp(),
+                received: envelope.timestamp(),
             });
         }
 
-        // CHECK: Ensure the block hash is valid.
-        let expected = envelope.payload.block_hash();
-        let execution_data =
-            OpExecutionPayloadEnvelope::try_from(envelope.clone()).map_err(|err| match err {
-                OpPayloadError::MissingParentBeaconBlockRoot |
-                OpPayloadError::UnexpectedParentBeaconBlockRoot => {
-                    BlockInvalidError::ParentBeaconRoot
-                }
-                err => BlockInvalidError::InvalidBlock(err),
-            })?;
-        let block: Block<OpTxEnvelope> = execution_data.try_into_block()?;
-        let received = block.header.hash_slow();
-        if received != expected {
-            return Err(BlockInvalidError::BlockHash { expected, received });
-        }
+        // CHECK: Ensure the block hash is valid without decoding the transactions.
+        envelope.check_block_hash().map_err(|err| match err {
+            OpPayloadError::Eth(PayloadError::BlockHash { execution, consensus }) => {
+                BlockInvalidError::BlockHash { expected: consensus, received: execution }
+            }
+            err => BlockInvalidError::InvalidBlock(err),
+        })?;
 
         // CHECK: The payload is valid for the specific version of this block.
         self.validate_version_specific_payload(envelope)?;
 
-        if let Some(seen_hashes_at_height) =
-            self.seen_hashes.get_mut(&envelope.payload.block_number())
-        {
+        if let Some(seen_hashes_at_height) = self.seen_hashes.get_mut(&envelope.block_number()) {
             // CHECK: If more than [`Self::MAX_BLOCKS_TO_KEEP`] different blocks have been received
             // for the same height, reject the block.
             if seen_hashes_at_height.len() > Self::MAX_BLOCKS_TO_KEEP {
-                return Err(BlockInvalidError::TooManyBlocks {
-                    height: envelope.payload.block_number(),
-                });
+                return Err(BlockInvalidError::TooManyBlocks { height: envelope.block_number() });
             }
 
             // CHECK: If the block has already been seen, ignore it.
-            if seen_hashes_at_height.contains(&envelope.payload.block_hash()) {
-                return Err(BlockInvalidError::BlockSeen {
-                    block_hash: envelope.payload.block_hash(),
-                });
+            if seen_hashes_at_height.contains(&envelope.block_hash()) {
+                return Err(BlockInvalidError::BlockSeen { block_hash: envelope.block_hash() });
             }
         }
 
-        // CHECK: The signature is valid.
-        let msg = envelope.payload_hash.signature_message(self.rollup_config.l2_chain_id.id());
-        let block_signer = *self.signer_recv.borrow();
-
-        // The block has a valid signature.
-        let Ok(msg_signer) = envelope.signature.recover_address_from_prehash(&msg) else {
-            return Err(BlockInvalidError::Signature);
-        };
-
-        // The block is signed by the expected signer (the unsafe block signer).
-        if msg_signer != block_signer {
-            return Err(BlockInvalidError::Signer { expected: block_signer, received: msg_signer });
-        }
-
-        self.seen_hashes
-            .entry(envelope.payload.block_number())
-            .or_default()
-            .insert(envelope.payload.block_hash());
+        self.seen_hashes.entry(envelope.block_number()).or_default().insert(envelope.block_hash());
 
         // Mark the block as seen.
         if self.seen_hashes.len() >= Self::SEEN_HASH_CACHE_SIZE {
@@ -275,7 +256,7 @@ impl BlockHandler {
     /// Validate version specific contents of the payload.
     fn validate_version_specific_payload(
         &self,
-        envelope: &OpNetworkPayloadEnvelope,
+        envelope: &OpExecutionPayloadEnvelope,
     ) -> Result<(), BlockInvalidError> {
         // Validation for v1 payloads are mostly ensured by type-safety, by decoding the
         // payload to the ExecutionPayloadV1 type:
@@ -284,20 +265,19 @@ impl BlockHandler {
         // 3. The block should not have any blob gas used
         // 4. The block should not have any excess blob gas
         // 5. The block should not have any withdrawals root
-        // 6. The block should not have any parent beacon block root (checked below)
+        // 6. The block cannot have a parent beacon block root by construction
 
         // Same as v1, except:
-        // 1. The block should have an empty withdrawals list. This is checked during the call to
-        //    [`op_alloy_rpc_types_engine::OpExecutionPayloadEnvelope::try_into_block`].
+        // 1. The block should have an empty withdrawals list. This is checked during block
+        //    reconstruction.
 
         // Same as v2, except:
         // 1. The block should have a zero blob gas used
         // 2. The block should have a zero excess blob gas
-        // 3. The block should have a non empty parent beacon block root
+        // 3. The block has a parent beacon block root by construction
         fn validate_v3(
             rollup_config: &RollupConfig,
             block: &ExecutionPayloadV3,
-            parent_beacon_block_root: Option<B256>,
         ) -> Result<(), BlockInvalidError> {
             // If Jovian is not active, the blob gas used should be zero.
             if !rollup_config.is_jovian_active(block.timestamp()) && block.blob_gas_used != 0 {
@@ -308,10 +288,6 @@ impl BlockHandler {
                 return Err(BlockInvalidError::ExcessBlobGas);
             }
 
-            if parent_beacon_block_root.is_none() {
-                return Err(BlockInvalidError::ParentBeaconRoot);
-            }
-
             Ok(())
         }
 
@@ -320,23 +296,17 @@ impl BlockHandler {
         fn validate_v4(
             rollup_config: &RollupConfig,
             block: &OpExecutionPayloadV4,
-            parent_beacon_block_root: Option<B256>,
         ) -> Result<(), BlockInvalidError> {
-            validate_v3(rollup_config, &block.payload_inner, parent_beacon_block_root)
+            validate_v3(rollup_config, &block.payload_inner)
         }
 
-        match &envelope.payload {
-            OpExecutionPayload::V1(_) | OpExecutionPayload::V2(_) => {
-                if envelope.parent_beacon_block_root.is_some() {
-                    return Err(BlockInvalidError::ParentBeaconRoot);
-                }
-                Ok(())
+        match envelope {
+            OpExecutionPayloadEnvelope::V1(_) | OpExecutionPayloadEnvelope::V2(_) => Ok(()),
+            OpExecutionPayloadEnvelope::V3 { payload, .. } => {
+                validate_v3(&self.rollup_config, payload)
             }
-            OpExecutionPayload::V3(payload) => {
-                validate_v3(&self.rollup_config, payload, envelope.parent_beacon_block_root)
-            }
-            OpExecutionPayload::V4(payload) => {
-                validate_v4(&self.rollup_config, payload, envelope.parent_beacon_block_root)
+            OpExecutionPayloadEnvelope::V4 { payload, .. } => {
+                validate_v4(&self.rollup_config, payload)
             }
         }
     }
@@ -355,7 +325,9 @@ pub(crate) mod tests {
     use arbitrary::{Arbitrary, Unstructured};
     use kona_genesis::RollupConfig;
     use op_alloy_consensus::OpTxEnvelope;
-    use op_alloy_rpc_types_engine::{OpExecutionPayload, OpExecutionPayloadV4, PayloadHash};
+    use op_alloy_rpc_types_engine::OpExecutionPayloadV4;
+
+    use crate::payload::GossipPayloadVersion;
 
     fn valid_block() -> Block<OpTxEnvelope> {
         // Simulate some random data
@@ -450,137 +422,114 @@ pub(crate) mod tests {
         block
     }
 
-    /// Generates a random valid block and ensure it is v1 compatible
-    #[test]
-    fn test_block_valid() {
-        let block = v1_valid_block();
-
-        let v1 = ExecutionPayloadV1::from_block_slow(&block);
-
-        let payload = OpExecutionPayload::V1(v1);
-        let envelope = OpNetworkPayloadEnvelope {
-            payload,
-            signature: Signature::test_signature(),
-            payload_hash: PayloadHash(B256::ZERO),
-            parent_beacon_block_root: None,
-        };
-
-        let msg = envelope.payload_hash.signature_message(10);
-        let signer = envelope.signature.recover_address_from_prehash(&msg).unwrap();
-        let (_, unsafe_signer) = tokio::sync::watch::channel(signer);
-        let mut handler = BlockHandler::new(
+    fn handler() -> BlockHandler {
+        let (_, unsafe_signer) = tokio::sync::watch::channel(Address::ZERO);
+        BlockHandler::new(
             RollupConfig { l2_chain_id: Chain::optimism_mainnet(), ..Default::default() },
             unsafe_signer,
-        );
-
-        assert!(handler.block_valid(&envelope).is_ok());
+        )
     }
 
-    /// Generates a random block with an invalid timestamp and ensure it is rejected
+    fn v1_envelope(block: &Block<OpTxEnvelope>) -> OpExecutionPayloadEnvelope {
+        OpExecutionPayloadEnvelope::V1(ExecutionPayloadV1::from_block_slow(block))
+    }
+
+    fn v2_envelope(block: &Block<OpTxEnvelope>) -> OpExecutionPayloadEnvelope {
+        OpExecutionPayloadEnvelope::V2(ExecutionPayloadV2::from_block_slow(block))
+    }
+
+    fn v3_envelope(block: &Block<OpTxEnvelope>) -> OpExecutionPayloadEnvelope {
+        OpExecutionPayloadEnvelope::V3 {
+            payload: ExecutionPayloadV3::from_block_slow(block),
+            parent_beacon_block_root: block.header.parent_beacon_block_root.unwrap(),
+        }
+    }
+
+    fn v4_envelope(block: &Block<OpTxEnvelope>) -> OpExecutionPayloadEnvelope {
+        OpExecutionPayloadEnvelope::V4 {
+            payload: OpExecutionPayloadV4::from_v3_with_withdrawals_root(
+                ExecutionPayloadV3::from_block_slow(block),
+                block.withdrawals_root.unwrap(),
+            ),
+            parent_beacon_block_root: block.header.parent_beacon_block_root.unwrap(),
+        }
+    }
+
+    fn signed_payload(
+        envelope: &OpExecutionPayloadEnvelope,
+        signature: Signature,
+    ) -> SignedGossipPayload {
+        let version = match envelope {
+            OpExecutionPayloadEnvelope::V1(_) => GossipPayloadVersion::V1,
+            OpExecutionPayloadEnvelope::V2(_) => GossipPayloadVersion::V2,
+            OpExecutionPayloadEnvelope::V3 { .. } => GossipPayloadVersion::V3,
+            OpExecutionPayloadEnvelope::V4 { .. } => GossipPayloadVersion::V4,
+        };
+        SignedGossipPayload::from_envelope(envelope, signature, version).unwrap()
+    }
+
+    /// Generates a random valid block and ensures it is V1 compatible.
+    #[test]
+    fn test_block_valid() {
+        let envelope = v1_envelope(&v1_valid_block());
+        assert!(handler().block_valid(&envelope).is_ok());
+    }
+
     #[test]
     fn test_block_invalid_timestamp_early() {
         let mut block = v1_valid_block();
-
         block.header.timestamp -= 61;
+        let envelope = v1_envelope(&block);
 
-        let v1 = ExecutionPayloadV1::from_block_slow(&block);
-
-        let payload = OpExecutionPayload::V1(v1);
-        let envelope = OpNetworkPayloadEnvelope {
-            payload,
-            signature: Signature::test_signature(),
-            payload_hash: PayloadHash(B256::ZERO),
-            parent_beacon_block_root: None,
-        };
-
-        let msg = envelope.payload_hash.signature_message(10);
-        let signer = envelope.signature.recover_address_from_prehash(&msg).unwrap();
-        let (_, unsafe_signer) = tokio::sync::watch::channel(signer);
-        let mut handler = BlockHandler::new(
-            RollupConfig { l2_chain_id: Chain::optimism_mainnet(), ..Default::default() },
-            unsafe_signer,
-        );
-
-        assert!(matches!(handler.block_valid(&envelope), Err(BlockInvalidError::Timestamp { .. })));
+        assert!(matches!(
+            handler().block_valid(&envelope),
+            Err(BlockInvalidError::Timestamp { .. })
+        ));
     }
 
-    /// Generates a random block with an invalid timestamp and ensure it is rejected
     #[test]
     fn test_block_invalid_timestamp_too_far() {
         let mut block = v1_valid_block();
-
         block.header.timestamp += 6;
+        let envelope = v1_envelope(&block);
 
-        let v1 = ExecutionPayloadV1::from_block_slow(&block);
-
-        let payload = OpExecutionPayload::V1(v1);
-        let envelope = OpNetworkPayloadEnvelope {
-            payload,
-            signature: Signature::test_signature(),
-            payload_hash: PayloadHash(B256::ZERO),
-            parent_beacon_block_root: None,
-        };
-
-        let msg = envelope.payload_hash.signature_message(10);
-        let signer = envelope.signature.recover_address_from_prehash(&msg).unwrap();
-        let (_, unsafe_signer) = tokio::sync::watch::channel(signer);
-        let mut handler = BlockHandler::new(
-            RollupConfig { l2_chain_id: Chain::optimism_mainnet(), ..Default::default() },
-            unsafe_signer,
-        );
-
-        assert!(matches!(handler.block_valid(&envelope), Err(BlockInvalidError::Timestamp { .. })));
+        assert!(matches!(
+            handler().block_valid(&envelope),
+            Err(BlockInvalidError::Timestamp { .. })
+        ));
     }
 
-    /// Generates a random block with an invalid hash and ensure it is rejected
     #[test]
     fn test_block_invalid_hash() {
         let block = v1_valid_block();
+        let mut payload = ExecutionPayloadV1::from_block_slow(&block);
+        payload.block_hash = B256::ZERO;
+        let envelope = OpExecutionPayloadEnvelope::V1(payload);
 
-        let mut v1 = ExecutionPayloadV1::from_block_slow(&block);
+        assert!(matches!(
+            handler().block_valid(&envelope),
+            Err(BlockInvalidError::BlockHash { .. })
+        ));
+    }
 
-        v1.block_hash = B256::ZERO;
-
-        let payload = OpExecutionPayload::V1(v1);
-        let envelope = OpNetworkPayloadEnvelope {
-            payload,
-            signature: Signature::test_signature(),
-            payload_hash: PayloadHash(B256::ZERO),
-            parent_beacon_block_root: None,
+    #[test]
+    fn test_block_hash_validation_does_not_decode_transactions() {
+        let mut envelope = v1_envelope(&v1_valid_block());
+        envelope.as_v1_mut().transactions = vec![Bytes::from_static(&[0xff])];
+        let block_hash = match envelope.check_block_hash() {
+            Err(OpPayloadError::Eth(PayloadError::BlockHash { execution, .. })) => execution,
+            result => panic!("expected block hash mismatch, got {result:?}"),
         };
+        envelope.as_v1_mut().block_hash = block_hash;
 
-        let msg = envelope.payload_hash.signature_message(10);
-        let signer = envelope.signature.recover_address_from_prehash(&msg).unwrap();
-        let (_, unsafe_signer) = tokio::sync::watch::channel(signer);
-        let mut handler = BlockHandler::new(
-            RollupConfig { l2_chain_id: Chain::optimism_mainnet(), ..Default::default() },
-            unsafe_signer,
-        );
-
-        assert!(matches!(handler.block_valid(&envelope), Err(BlockInvalidError::BlockHash { .. })));
+        assert!(handler().block_valid(&envelope).is_ok());
+        assert!(envelope.try_into_block::<OpTxEnvelope>().is_err());
     }
 
     #[test]
     fn test_cannot_validate_same_block_twice() {
-        let block = v1_valid_block();
-
-        let v1 = ExecutionPayloadV1::from_block_slow(&block);
-
-        let payload = OpExecutionPayload::V1(v1);
-        let envelope = OpNetworkPayloadEnvelope {
-            payload,
-            signature: Signature::test_signature(),
-            payload_hash: PayloadHash(B256::ZERO),
-            parent_beacon_block_root: None,
-        };
-
-        let msg = envelope.payload_hash.signature_message(10);
-        let signer = envelope.signature.recover_address_from_prehash(&msg).unwrap();
-        let (_, unsafe_signer) = tokio::sync::watch::channel(signer);
-        let mut handler = BlockHandler::new(
-            RollupConfig { l2_chain_id: Chain::optimism_mainnet(), ..Default::default() },
-            unsafe_signer,
-        );
+        let envelope = v1_envelope(&v1_valid_block());
+        let mut handler = handler();
 
         assert!(handler.block_valid(&envelope).is_ok());
         assert!(matches!(handler.block_valid(&envelope), Err(BlockInvalidError::BlockSeen { .. })));
@@ -589,277 +538,99 @@ pub(crate) mod tests {
     #[test]
     fn test_cannot_have_too_many_blocks_for_the_same_height() {
         let first_block = v1_valid_block();
-
         let initial_height = first_block.header.number;
-
-        let v1 = ExecutionPayloadV1::from_block_slow(&first_block);
-
-        let payload = OpExecutionPayload::V1(v1);
-        let envelope = OpNetworkPayloadEnvelope {
-            payload,
-            signature: Signature::test_signature(),
-            payload_hash: PayloadHash(B256::ZERO),
-            parent_beacon_block_root: None,
-        };
-
-        let msg = envelope.payload_hash.signature_message(10);
-        let signer = envelope.signature.recover_address_from_prehash(&msg).unwrap();
-        let (_, unsafe_signer) = tokio::sync::watch::channel(signer);
-        let mut handler = BlockHandler::new(
-            RollupConfig { l2_chain_id: Chain::optimism_mainnet(), ..Default::default() },
-            unsafe_signer,
-        );
-
-        assert!(handler.block_valid(&envelope).is_ok());
+        let first = v1_envelope(&first_block);
+        let mut handler = handler();
+        assert!(handler.block_valid(&first).is_ok());
 
         let next_payloads = (0..=BlockHandler::MAX_BLOCKS_TO_KEEP)
             .map(|_| {
                 let mut block = v1_valid_block();
-                // The blocks have the same height
                 block.header.number = initial_height;
-
-                let v1 = ExecutionPayloadV1::from_block_slow(&block);
-
-                let payload = OpExecutionPayload::V1(v1);
-                OpNetworkPayloadEnvelope {
-                    payload,
-                    signature: Signature::test_signature(),
-                    payload_hash: PayloadHash(B256::ZERO),
-                    parent_beacon_block_root: None,
-                }
+                v1_envelope(&block)
             })
             .collect::<Vec<_>>();
 
         for envelope in &next_payloads[..next_payloads.len() - 1] {
             assert!(handler.block_valid(envelope).is_ok());
         }
-
-        // The last envelope should fail
         assert!(matches!(
             handler.block_valid(next_payloads.last().unwrap()),
             Err(BlockInvalidError::TooManyBlocks { .. })
         ));
     }
 
-    /// Blocks with invalid signatures should be rejected.
     #[test]
     fn test_invalid_signature() {
-        let block = v1_valid_block();
-
-        let v1 = ExecutionPayloadV1::from_block_slow(&block);
-
-        let payload = OpExecutionPayload::V1(v1);
-        let mut envelope = OpNetworkPayloadEnvelope {
-            payload,
-            signature: Signature::test_signature(),
-            payload_hash: PayloadHash(B256::ZERO),
-            parent_beacon_block_root: None,
-        };
-
-        let msg = envelope.payload_hash.signature_message(10);
-        let signer = envelope.signature.recover_address_from_prehash(&msg).unwrap();
+        let envelope = v1_envelope(&v1_valid_block());
+        let signature = Signature::test_signature();
+        let valid = signed_payload(&envelope, signature);
+        let message = valid.payload_hash().signature_message(10);
+        let signer = signature.recover_address_from_prehash(&message).unwrap();
         let (_, unsafe_signer) = tokio::sync::watch::channel(signer);
-        let mut handler = BlockHandler::new(
+        let handler = BlockHandler::new(
             RollupConfig { l2_chain_id: Chain::optimism_mainnet(), ..Default::default() },
             unsafe_signer,
         );
 
-        let mut signature_bytes = envelope.signature.as_bytes();
+        let mut signature_bytes = signature.as_bytes();
         signature_bytes[0] = !signature_bytes[0];
-        envelope.signature = Signature::from_raw_array(&signature_bytes).unwrap();
-
-        assert!(handler.seen_hashes.is_empty());
-        assert!(matches!(handler.block_valid(&envelope), Err(BlockInvalidError::Signature)));
+        let invalid =
+            signed_payload(&envelope, Signature::from_raw_array(&signature_bytes).unwrap());
+        assert!(matches!(
+            handler.validate_signature(&invalid),
+            Err(BlockInvalidError::Signature | BlockInvalidError::Signer { .. })
+        ));
     }
 
-    /// Blocks with invalid signers should be rejected.
     #[test]
     fn test_invalid_signer() {
-        let block = v1_valid_block();
-
-        let v1 = ExecutionPayloadV1::from_block_slow(&block);
-
-        let payload = OpExecutionPayload::V1(v1);
-        let envelope = OpNetworkPayloadEnvelope {
-            payload,
-            signature: Signature::test_signature(),
-            payload_hash: PayloadHash(B256::ZERO),
-            parent_beacon_block_root: None,
-        };
-
-        let (_, unsafe_signer) = tokio::sync::watch::channel(Address::default());
-        let mut handler = BlockHandler::new(
-            RollupConfig { l2_chain_id: Chain::optimism_mainnet(), ..Default::default() },
-            unsafe_signer,
-        );
-
-        assert!(matches!(handler.block_valid(&envelope), Err(BlockInvalidError::Signer { .. })));
-    }
-
-    /// V1/V2 payloads reject a parent beacon block root because those versions do not include it.
-    #[test]
-    fn test_v1_v2_block_invalid_parent_beacon_block_root() {
-        let block = v1_valid_block();
-
-        let v1 = ExecutionPayloadV1::from_block_slow(&block);
-
-        let payload = OpExecutionPayload::V1(v1);
-        let envelope = OpNetworkPayloadEnvelope {
-            payload,
-            signature: Signature::test_signature(),
-            payload_hash: PayloadHash(B256::ZERO),
-            parent_beacon_block_root: Some(B256::ZERO),
-        };
-
-        let msg = envelope.payload_hash.signature_message(10);
-        let signer = envelope.signature.recover_address_from_prehash(&msg).unwrap();
-        let (_, unsafe_signer) = tokio::sync::watch::channel(signer);
-        let mut handler = BlockHandler::new(
-            RollupConfig { l2_chain_id: Chain::optimism_mainnet(), ..Default::default() },
-            unsafe_signer,
-        );
-
-        assert!(matches!(handler.block_valid(&envelope), Err(BlockInvalidError::ParentBeaconRoot)));
-
-        let block = v2_valid_block();
-
-        let v2 = ExecutionPayloadV2::from_block_slow(&block);
-
-        let payload = OpExecutionPayload::V2(v2);
-        let envelope = OpNetworkPayloadEnvelope {
-            payload,
-            signature: Signature::test_signature(),
-            payload_hash: PayloadHash(B256::ZERO),
-            parent_beacon_block_root: Some(B256::ZERO),
-        };
-
-        let msg = envelope.payload_hash.signature_message(10);
-        let signer = envelope.signature.recover_address_from_prehash(&msg).unwrap();
-        let (_, unsafe_signer) = tokio::sync::watch::channel(signer);
-        let mut handler = BlockHandler::new(
-            RollupConfig { l2_chain_id: Chain::optimism_mainnet(), ..Default::default() },
-            unsafe_signer,
-        );
-
-        assert!(matches!(handler.block_valid(&envelope), Err(BlockInvalidError::ParentBeaconRoot)));
+        let envelope = v1_envelope(&v1_valid_block());
+        let signed = signed_payload(&envelope, Signature::test_signature());
+        assert!(matches!(
+            handler().validate_signature(&signed),
+            Err(BlockInvalidError::Signer { .. })
+        ));
     }
 
     #[test]
     fn test_v2_block() {
-        let block = v2_valid_block();
-
-        let v2 = ExecutionPayloadV2::from_block_slow(&block);
-
-        let payload = OpExecutionPayload::V2(v2);
-        let envelope = OpNetworkPayloadEnvelope {
-            payload,
-            signature: Signature::test_signature(),
-            payload_hash: PayloadHash(B256::ZERO),
-            parent_beacon_block_root: None,
-        };
-
-        let msg = envelope.payload_hash.signature_message(10);
-        let signer = envelope.signature.recover_address_from_prehash(&msg).unwrap();
-        let (_, unsafe_signer) = tokio::sync::watch::channel(signer);
-        let mut handler = BlockHandler::new(
-            RollupConfig { l2_chain_id: Chain::optimism_mainnet(), ..Default::default() },
-            unsafe_signer,
-        );
-
-        assert!(handler.block_valid(&envelope).is_ok());
+        let envelope = v2_envelope(&v2_valid_block());
+        assert!(handler().block_valid(&envelope).is_ok());
     }
 
     #[test]
     fn test_v2_non_empty_withdrawals() {
         let mut block = v2_valid_block();
         block.body.withdrawals = Some(vec![Withdrawal::default()].into());
-        let withdrawals_root = alloy_consensus::proofs::calculate_withdrawals_root(
+        block.header.withdrawals_root = Some(alloy_consensus::proofs::calculate_withdrawals_root(
             &block.body.withdrawals.clone().unwrap_or_default(),
-        );
-        block.header.withdrawals_root = Some(withdrawals_root);
-
-        let v2 = ExecutionPayloadV2::from_block_slow(&block);
-
-        let payload = OpExecutionPayload::V2(v2);
-        let envelope = OpNetworkPayloadEnvelope {
-            payload,
-            signature: Signature::test_signature(),
-            payload_hash: PayloadHash(B256::ZERO),
-            parent_beacon_block_root: None,
-        };
-
-        let msg = envelope.payload_hash.signature_message(10);
-        let signer = envelope.signature.recover_address_from_prehash(&msg).unwrap();
-        let (_, unsafe_signer) = tokio::sync::watch::channel(signer);
-        let mut handler = BlockHandler::new(
-            RollupConfig { l2_chain_id: Chain::optimism_mainnet(), ..Default::default() },
-            unsafe_signer,
-        );
+        ));
+        let envelope = v2_envelope(&block);
 
         assert!(matches!(
-            handler.block_valid(&envelope),
+            handler().block_valid(&envelope),
             Err(BlockInvalidError::InvalidBlock(OpPayloadError::NonEmptyL1Withdrawals))
         ));
     }
 
     #[test]
     fn test_v3_block() {
-        let block = v3_valid_block();
-
-        let v3 = ExecutionPayloadV3::from_block_slow(&block);
-
-        let payload = OpExecutionPayload::V3(v3);
-        let envelope = OpNetworkPayloadEnvelope {
-            payload,
-            signature: Signature::test_signature(),
-            payload_hash: PayloadHash(B256::ZERO),
-            parent_beacon_block_root: Some(
-                block.header.parent_beacon_block_root.unwrap_or_default(),
-            ),
-        };
-
-        let msg = envelope.payload_hash.signature_message(10);
-        let signer = envelope.signature.recover_address_from_prehash(&msg).unwrap();
-        let (_, unsafe_signer) = tokio::sync::watch::channel(signer);
-        let mut handler = BlockHandler::new(
-            RollupConfig { l2_chain_id: Chain::optimism_mainnet(), ..Default::default() },
-            unsafe_signer,
-        );
-
-        assert!(handler.block_valid(&envelope).is_ok());
+        let envelope = v3_envelope(&v3_valid_block());
+        assert!(handler().block_valid(&envelope).is_ok());
     }
 
     #[test]
     fn test_v3_non_empty_withdrawals() {
         let mut block = v3_valid_block();
         block.body.withdrawals = Some(vec![Withdrawal::default()].into());
-        let withdrawals_root = alloy_consensus::proofs::calculate_withdrawals_root(
+        block.header.withdrawals_root = Some(alloy_consensus::proofs::calculate_withdrawals_root(
             &block.body.withdrawals.clone().unwrap_or_default(),
-        );
-        block.header.withdrawals_root = Some(withdrawals_root);
-
-        let v3 = ExecutionPayloadV3::from_block_slow(&block);
-
-        let payload = OpExecutionPayload::V3(v3);
-        let envelope = OpNetworkPayloadEnvelope {
-            payload,
-            signature: Signature::test_signature(),
-            payload_hash: PayloadHash(B256::ZERO),
-            parent_beacon_block_root: Some(
-                block.header.parent_beacon_block_root.unwrap_or_default(),
-            ),
-        };
-
-        let msg = envelope.payload_hash.signature_message(10);
-        let signer = envelope.signature.recover_address_from_prehash(&msg).unwrap();
-        let (_, unsafe_signer) = tokio::sync::watch::channel(signer);
-        let mut handler = BlockHandler::new(
-            RollupConfig { l2_chain_id: Chain::optimism_mainnet(), ..Default::default() },
-            unsafe_signer,
-        );
+        ));
+        let envelope = v3_envelope(&block);
 
         assert!(matches!(
-            handler.block_valid(&envelope),
+            handler().block_valid(&envelope),
             Err(BlockInvalidError::InvalidBlock(OpPayloadError::NonEmptyL1Withdrawals))
         ));
     }
@@ -868,150 +639,39 @@ pub(crate) mod tests {
     fn test_v3_gas_params() {
         let mut block = v3_valid_block();
         block.header.blob_gas_used = Some(1);
-
-        let v3 = ExecutionPayloadV3::from_block_slow(&block);
-
-        let payload = OpExecutionPayload::V3(v3);
-        let envelope = OpNetworkPayloadEnvelope {
-            payload,
-            signature: Signature::test_signature(),
-            payload_hash: PayloadHash(B256::ZERO),
-            parent_beacon_block_root: Some(
-                block.header.parent_beacon_block_root.unwrap_or_default(),
-            ),
-        };
-
-        let msg = envelope.payload_hash.signature_message(10);
-        let signer = envelope.signature.recover_address_from_prehash(&msg).unwrap();
-        let (_, unsafe_signer) = tokio::sync::watch::channel(signer);
-        let mut handler = BlockHandler::new(
-            RollupConfig { l2_chain_id: Chain::optimism_mainnet(), ..Default::default() },
-            unsafe_signer,
-        );
-
-        assert!(matches!(handler.block_valid(&envelope), Err(BlockInvalidError::BlobGasUsed)));
+        let envelope = v3_envelope(&block);
+        assert!(matches!(handler().block_valid(&envelope), Err(BlockInvalidError::BlobGasUsed)));
 
         block.header.blob_gas_used = Some(0);
         block.header.excess_blob_gas = Some(1);
-
-        let v3 = ExecutionPayloadV3::from_block_slow(&block);
-
-        let payload = OpExecutionPayload::V3(v3);
-        let envelope = OpNetworkPayloadEnvelope {
-            payload,
-            signature: Signature::test_signature(),
-            payload_hash: PayloadHash(B256::ZERO),
-            parent_beacon_block_root: Some(
-                block.header.parent_beacon_block_root.unwrap_or_default(),
-            ),
-        };
-
-        assert!(matches!(handler.block_valid(&envelope), Err(BlockInvalidError::ExcessBlobGas)));
+        let envelope = v3_envelope(&block);
+        assert!(matches!(handler().block_valid(&envelope), Err(BlockInvalidError::ExcessBlobGas)));
     }
 
     #[test]
     fn test_v4_block() {
-        let block = v4_valid_block();
-
-        let v3 = ExecutionPayloadV3::from_block_slow(&block);
-        let v4 = OpExecutionPayloadV4::from_v3_with_withdrawals_root(
-            v3,
-            block.withdrawals_root.unwrap(),
-        );
-
-        let payload = OpExecutionPayload::V4(v4);
-        let envelope = OpNetworkPayloadEnvelope {
-            payload,
-            signature: Signature::test_signature(),
-            payload_hash: PayloadHash(B256::ZERO),
-            parent_beacon_block_root: Some(
-                block.header.parent_beacon_block_root.unwrap_or_default(),
-            ),
-        };
-
-        let msg = envelope.payload_hash.signature_message(10);
-        let signer = envelope.signature.recover_address_from_prehash(&msg).unwrap();
-        let (_, unsafe_signer) = tokio::sync::watch::channel(signer);
-        let mut handler = BlockHandler::new(
-            RollupConfig { l2_chain_id: Chain::optimism_mainnet(), ..Default::default() },
-            unsafe_signer,
-        );
-
-        assert!(handler.block_valid(&envelope).is_ok());
+        let envelope = v4_envelope(&v4_valid_block());
+        assert!(handler().block_valid(&envelope).is_ok());
     }
 
     #[test]
     #[cfg(feature = "metrics")]
     fn test_metrics_instrumentation() {
-        // This test verifies that metrics code compiles and doesn't panic
-        // The actual metric values would require a metrics registry setup in a real test
-        // environment
-
         use crate::Metrics;
-
-        // Initialize metrics (this should not panic)
         Metrics::init();
 
-        let block = v1_valid_block();
-        let v1 = ExecutionPayloadV1::from_block_slow(&block);
-        let payload = OpExecutionPayload::V1(v1);
-        let envelope = OpNetworkPayloadEnvelope {
-            payload,
-            signature: Signature::test_signature(),
-            payload_hash: PayloadHash(B256::ZERO),
-            parent_beacon_block_root: None,
-        };
-
-        let msg = envelope.payload_hash.signature_message(10);
-        let signer = envelope.signature.recover_address_from_prehash(&msg).unwrap();
-        let (_, unsafe_signer) = tokio::sync::watch::channel(signer);
-        let mut handler = BlockHandler::new(
-            RollupConfig { l2_chain_id: Chain::optimism_mainnet(), ..Default::default() },
-            unsafe_signer,
-        );
-
-        // Test successful validation metrics
+        let envelope = v1_envelope(&v1_valid_block());
+        let mut handler = handler();
         assert!(handler.block_valid(&envelope).is_ok());
 
-        // Test failed validation metrics
         let mut invalid_block = v1_valid_block();
-        invalid_block.header.timestamp = 0; // Invalid timestamp
-
-        let v1_invalid = ExecutionPayloadV1::from_block_slow(&invalid_block);
-        let payload_invalid = OpExecutionPayload::V1(v1_invalid);
-        let envelope_invalid = OpNetworkPayloadEnvelope {
-            payload: payload_invalid,
-            signature: Signature::test_signature(),
-            payload_hash: PayloadHash(B256::ZERO),
-            parent_beacon_block_root: None,
-        };
-
-        // This should increment failure metrics
-        assert!(handler.block_valid(&envelope_invalid).is_err());
+        invalid_block.header.timestamp = 0;
+        assert!(handler.block_valid(&v1_envelope(&invalid_block)).is_err());
     }
 
     #[test]
     fn test_metrics_feature_gating() {
-        // Verify the code compiles and runs without panics even when metrics feature is disabled
-        let block = v1_valid_block();
-        let v1 = ExecutionPayloadV1::from_block_slow(&block);
-        let payload = OpExecutionPayload::V1(v1);
-        let envelope = OpNetworkPayloadEnvelope {
-            payload,
-            signature: Signature::test_signature(),
-            payload_hash: PayloadHash(B256::ZERO),
-            parent_beacon_block_root: None,
-        };
-
-        let msg = envelope.payload_hash.signature_message(10);
-        let signer = envelope.signature.recover_address_from_prehash(&msg).unwrap();
-        let (_, unsafe_signer) = tokio::sync::watch::channel(signer);
-        let mut handler = BlockHandler::new(
-            RollupConfig { l2_chain_id: Chain::optimism_mainnet(), ..Default::default() },
-            unsafe_signer,
-        );
-
-        // Should work regardless of metrics feature
-        assert!(handler.block_valid(&envelope).is_ok());
+        let envelope = v1_envelope(&v1_valid_block());
+        assert!(handler().block_valid(&envelope).is_ok());
     }
 }

--- a/rust/kona/crates/node/gossip/src/block_validity.rs
+++ b/rust/kona/crates/node/gossip/src/block_validity.rs
@@ -106,7 +106,7 @@ impl BlockHandler {
     ) -> Result<(), BlockInvalidError> {
         let message = payload.payload_hash().signature_message(self.rollup_config.l2_chain_id.id());
         let expected = *self.signer_recv.borrow();
-        let received = match payload.signature().recover_address_from_prehash(&message) {
+        let received = match payload.recover_signer(&message) {
             Ok(received) => received,
             Err(_) => {
                 #[cfg(feature = "metrics")]

--- a/rust/kona/crates/node/gossip/src/driver.rs
+++ b/rust/kona/crates/node/gossip/src/driver.rs
@@ -1,6 +1,6 @@
 //! Consensus-layer gossipsub driver for Optimism.
 
-use alloy_primitives::{Address, hex};
+use alloy_primitives::{Address, Signature, hex};
 use derive_more::Debug;
 use discv5::Enr;
 use futures::{AsyncReadExt, AsyncWriteExt, stream::StreamExt};
@@ -13,7 +13,7 @@ use libp2p::{
 };
 use libp2p_identity::Keypair;
 use libp2p_stream::IncomingStreams;
-use op_alloy_rpc_types_engine::OpNetworkPayloadEnvelope;
+use op_alloy_rpc_types_engine::OpExecutionPayloadEnvelope;
 use std::{
     collections::HashMap,
     sync::Arc,
@@ -116,17 +116,15 @@ where
     pub fn publish(
         &mut self,
         selector: impl FnOnce(&BlockHandler) -> IdentTopic,
-        payload: Option<OpNetworkPayloadEnvelope>,
-    ) -> Result<Option<MessageId>, PublishError> {
-        let Some(payload) = payload else {
-            return Ok(None);
-        };
+        payload: OpExecutionPayloadEnvelope,
+        signature: Signature,
+    ) -> Result<MessageId, PublishError> {
         let topic = selector(&self.handler);
         let topic_hash = topic.hash();
-        let data = self.handler.encode(topic, payload)?;
+        let data = self.handler.encode(topic, payload, signature)?;
         let id = self.swarm.behaviour_mut().gossipsub.publish(topic_hash, data)?;
         kona_macros::inc!(gauge, crate::Metrics::UNSAFE_BLOCK_PUBLISHED);
-        Ok(Some(id))
+        Ok(id)
     }
 
     /// Handles the sync request/response protocol.
@@ -284,7 +282,7 @@ where
         }
     }
 
-    fn handle_gossip_event(&mut self, event: Event) -> Option<OpNetworkPayloadEnvelope> {
+    fn handle_gossip_event(&mut self, event: Event) -> Option<OpExecutionPayloadEnvelope> {
         match event {
             Event::Gossipsub(e) => return self.handle_gossipsub_event(*e),
             Event::Ping(libp2p::ping::Event { peer, result, .. }) => {
@@ -344,7 +342,7 @@ where
     fn handle_gossipsub_event(
         &mut self,
         event: libp2p::gossipsub::Event,
-    ) -> Option<OpNetworkPayloadEnvelope> {
+    ) -> Option<OpExecutionPayloadEnvelope> {
         match event {
             libp2p::gossipsub::Event::Message {
                 propagation_source: src,
@@ -384,7 +382,7 @@ where
     }
 
     /// Handles the [`SwarmEvent<Event>`].
-    pub fn handle_event(&mut self, event: SwarmEvent<Event>) -> Option<OpNetworkPayloadEnvelope> {
+    pub fn handle_event(&mut self, event: SwarmEvent<Event>) -> Option<OpExecutionPayloadEnvelope> {
         match event {
             SwarmEvent::Behaviour(behavior_event) => {
                 return self.handle_gossip_event(behavior_event);

--- a/rust/kona/crates/node/gossip/src/error.rs
+++ b/rust/kona/crates/node/gossip/src/error.rs
@@ -33,12 +33,13 @@ pub enum PublishError {
 /// occurring when converting OP Stack data structures to network format.
 #[derive(Debug, Error)]
 pub enum HandlerEncodeError {
-    /// Failed to encode the OP Stack payload envelope.
-    ///
-    /// This error indicates issues with serializing the OP Stack network payload
-    /// structure, which contains the consensus data being gossiped.
-    #[error("Failed to encode payload: {0}")]
-    PayloadEncodeError(#[from] op_alloy_rpc_types_engine::PayloadEnvelopeEncodeError),
+    /// The execution payload version does not match the gossip topic.
+    #[error("Payload version does not match gossip topic")]
+    WrongPayloadVersion,
+
+    /// Failed to Snappy-compress the signed payload.
+    #[error("Failed to compress payload: {0}")]
+    SnapEncoding(#[from] snap::Error),
 
     /// Attempted to publish to an unknown or unsubscribed topic.
     ///

--- a/rust/kona/crates/node/gossip/src/handler.rs
+++ b/rust/kona/crates/node/gossip/src/handler.rs
@@ -250,7 +250,6 @@ mod tests {
         assert!(matches!(payload, Some(OpExecutionPayloadEnvelope::V2(_))));
     }
 
-    /// A signature over a different payload hash must be rejected before envelope decoding.
     #[test]
     fn test_invalid_decode_payload_hash() {
         let signature = Signature::test_signature();

--- a/rust/kona/crates/node/gossip/src/handler.rs
+++ b/rust/kona/crates/node/gossip/src/handler.rs
@@ -1,10 +1,14 @@
 //! Block Handler
 
-use crate::{HandlerEncodeError, config::snappy_decompressed_len_within_bound};
-use alloy_primitives::{Address, B256};
+use crate::{
+    HandlerEncodeError,
+    config::snappy_decompressed_len_within_bound,
+    payload::{GossipPayloadVersion, SignedGossipPayload},
+};
+use alloy_primitives::{Address, B256, Signature};
 use kona_genesis::RollupConfig;
 use libp2p::gossipsub::{IdentTopic, Message, MessageAcceptance, TopicHash};
-use op_alloy_rpc_types_engine::OpNetworkPayloadEnvelope;
+use op_alloy_rpc_types_engine::OpExecutionPayloadEnvelope;
 use std::collections::{BTreeMap, HashSet};
 use tokio::sync::watch::Receiver;
 
@@ -16,7 +20,7 @@ use tokio::sync::watch::Receiver;
 pub trait Handler: Send {
     /// Manages validation and further processing of messages
     /// This is a stateful method, because the handler needs to keep track of seen hashes.
-    fn handle(&mut self, msg: Message) -> (MessageAcceptance, Option<OpNetworkPayloadEnvelope>);
+    fn handle(&mut self, msg: Message) -> (MessageAcceptance, Option<OpExecutionPayloadEnvelope>);
 
     /// Specifies which topics the handler is interested in
     fn topics(&self) -> Vec<TopicHash>;
@@ -43,53 +47,60 @@ pub struct BlockHandler {
 }
 
 impl Handler for BlockHandler {
-    /// Checks validity of a [`OpNetworkPayloadEnvelope`] received over P2P gossip.
-    /// If valid, sends the [`OpNetworkPayloadEnvelope`] to the block update channel.
-    fn handle(&mut self, msg: Message) -> (MessageAcceptance, Option<OpNetworkPayloadEnvelope>) {
-        // Reject frames whose snappy header declares a decompressed size over MAX_GOSSIP_SIZE
-        // before decoding. `OpNetworkPayloadEnvelope::decode_v*` otherwise pre-allocates a
-        // buffer of the declared length (up to ~4 GiB) from a tiny frame. Mirrors op-node's
-        // gossip topic validator, which rejects `outLen > maxGossipSize` before decompressing.
+    /// Authenticates and validates a signed execution payload received over P2P gossip.
+    fn handle(&mut self, msg: Message) -> (MessageAcceptance, Option<OpExecutionPayloadEnvelope>) {
+        // Reject frames whose Snappy header declares a decompressed size over MAX_GOSSIP_SIZE
+        // before decoding. The decoder would otherwise pre-allocate the declared length (up to
+        // roughly 4 GiB) from a tiny frame. This mirrors op-node's gossip topic validator.
         if snappy_decompressed_len_within_bound(&msg.data).is_none() {
-            // The snappy header declares a length that is unreadable or over MAX_GOSSIP_SIZE. Count
-            // for alerting and debug-log for investigation, but never warn: unauthenticated remote
-            // input must not be able to spam warnings just by being invalid.
             kona_macros::inc!(counter, crate::Metrics::INVALID_MESSAGE, "reason" => "invalid_snappy_length");
-            debug!(target: "gossip", len = msg.data.len(), "Rejecting snappy frame with invalid declared length before decode");
+            debug!(target: "gossip", len = msg.data.len(), "Rejecting Snappy frame with invalid declared length before decode");
             return (MessageAcceptance::Reject, None);
         }
 
-        let decoded = if msg.topic == self.blocks_v1_topic.hash() {
-            OpNetworkPayloadEnvelope::decode_v1(&msg.data)
-        } else if msg.topic == self.blocks_v2_topic.hash() {
-            OpNetworkPayloadEnvelope::decode_v2(&msg.data)
-        } else if msg.topic == self.blocks_v3_topic.hash() {
-            OpNetworkPayloadEnvelope::decode_v3(&msg.data)
-        } else if msg.topic == self.blocks_v4_topic.hash() {
-            OpNetworkPayloadEnvelope::decode_v4(&msg.data)
-        } else {
-            // Unreachable in practice (the driver only dispatches known block topics), but count
-            // and debug-log it rather than warn if that ever changes.
+        let Some(version) = self.payload_version(&msg.topic) else {
+            // Unreachable in practice because the driver dispatches only known block topics.
             kona_macros::inc!(counter, crate::Metrics::INVALID_MESSAGE, "reason" => "unknown_topic");
             debug!(target: "gossip", topic = ?msg.topic, "Received block with unknown topic");
             return (MessageAcceptance::Reject, None);
         };
 
-        match decoded {
-            Ok(envelope) => match self.block_valid(&envelope) {
-                Ok(()) => (MessageAcceptance::Accept, Some(envelope)),
-                Err(err) => {
-                    // Already metered by BLOCK_VALIDATION_FAILED; debug-log for investigation
-                    // without letting invalid remote blocks spam warnings.
-                    debug!(target: "gossip", ?err, hash = ?envelope.payload_hash, "Received invalid block");
-                    (err.into(), None)
-                }
-            },
+        let signed = match SignedGossipPayload::decode_snappy(&msg.data) {
+            Ok(signed) => signed,
             Err(err) => {
-                // Undecodable payload from unauthenticated input: count and debug-log, don't warn.
                 kona_macros::inc!(counter, crate::Metrics::INVALID_MESSAGE, "reason" => "decode_error");
-                debug!(target: "gossip", ?err, "Failed to decode block");
-                (MessageAcceptance::Reject, None)
+                debug!(target: "gossip", ?err, "Failed to decode signed gossip payload");
+                return (MessageAcceptance::Reject, None);
+            }
+        };
+        let payload_hash = signed.payload_hash();
+        #[cfg(feature = "metrics")]
+        kona_macros::inc!(counter, crate::Metrics::BLOCK_VALIDATION_TOTAL);
+
+        // Authenticate the exact envelope bytes before decoding the SSZ payload and transactions.
+        if let Err(err) = self.validate_signature(&signed) {
+            debug!(target: "gossip", ?err, hash = ?payload_hash, "Received unauthenticated block");
+            return (err.into(), None);
+        }
+
+        let envelope = match signed.into_envelope(version) {
+            Ok(envelope) => envelope,
+            Err(err) => {
+                kona_macros::inc!(counter, crate::Metrics::INVALID_MESSAGE, "reason" => "decode_error");
+                #[cfg(feature = "metrics")]
+                kona_macros::inc!(counter, crate::Metrics::BLOCK_VALIDATION_FAILED, "reason" => "invalid_block");
+                debug!(target: "gossip", ?err, hash = ?payload_hash, "Failed to decode authenticated execution payload");
+                return (MessageAcceptance::Reject, None);
+            }
+        };
+
+        match self.block_valid(&envelope) {
+            Ok(()) => (MessageAcceptance::Accept, Some(envelope)),
+            Err(err) => {
+                // Already metered by BLOCK_VALIDATION_FAILED; debug-log for investigation without
+                // letting invalid remote blocks spam warnings.
+                debug!(target: "gossip", ?err, hash = ?payload_hash, "Received invalid block");
+                (err.into(), None)
             }
         }
     }
@@ -137,21 +148,33 @@ impl BlockHandler {
         }
     }
 
-    /// Encodes a [`OpNetworkPayloadEnvelope`] into a byte array
-    /// based on the specified topic.
+    /// Encodes an execution payload and signature for the specified gossip topic.
     pub fn encode(
         &self,
         topic: IdentTopic,
-        envelope: OpNetworkPayloadEnvelope,
+        envelope: OpExecutionPayloadEnvelope,
+        signature: Signature,
     ) -> Result<Vec<u8>, HandlerEncodeError> {
-        let encoded = match topic.hash() {
-            hash if hash == self.blocks_v1_topic.hash() => envelope.encode_v1()?,
-            hash if hash == self.blocks_v2_topic.hash() => envelope.encode_v2()?,
-            hash if hash == self.blocks_v3_topic.hash() => envelope.encode_v3()?,
-            hash if hash == self.blocks_v4_topic.hash() => envelope.encode_v4()?,
-            hash => return Err(HandlerEncodeError::UnknownTopic(hash)),
-        };
-        Ok(encoded)
+        let topic_hash = topic.hash();
+        let version = self
+            .payload_version(&topic_hash)
+            .ok_or(HandlerEncodeError::UnknownTopic(topic_hash))?;
+        SignedGossipPayload::from_envelope(&envelope, signature, version)?.encode_snappy()
+    }
+
+    /// Returns the payload version selected by a gossip topic.
+    fn payload_version(&self, topic: &TopicHash) -> Option<GossipPayloadVersion> {
+        if topic == &self.blocks_v1_topic.hash() {
+            Some(GossipPayloadVersion::V1)
+        } else if topic == &self.blocks_v2_topic.hash() {
+            Some(GossipPayloadVersion::V2)
+        } else if topic == &self.blocks_v3_topic.hash() {
+            Some(GossipPayloadVersion::V3)
+        } else if topic == &self.blocks_v4_topic.hash() {
+            Some(GossipPayloadVersion::V4)
+        } else {
+            None
+        }
     }
 }
 
@@ -159,343 +182,162 @@ impl BlockHandler {
 mod tests {
     use alloy_chains::Chain;
     use alloy_rpc_types_engine::{ExecutionPayloadV2, ExecutionPayloadV3};
-    use op_alloy_rpc_types_engine::{OpExecutionPayload, OpExecutionPayloadV4, PayloadHash};
+    use op_alloy_rpc_types_engine::{
+        OpExecutionPayloadEnvelope, OpExecutionPayloadV4, PayloadHash,
+    };
 
     use crate::{v2_valid_block, v3_valid_block, v4_valid_block};
 
     use super::*;
-    use alloy_primitives::{B256, Signature};
+    use alloy_primitives::{Address, B256, Signature};
+
+    fn encode_with_test_signature(
+        handler: &BlockHandler,
+        topic: IdentTopic,
+        envelope: OpExecutionPayloadEnvelope,
+    ) -> (Vec<u8>, Address) {
+        let signature = Signature::test_signature();
+        let message = envelope.payload_hash().signature_message(10);
+        let signer = signature.recover_address_from_prehash(&message).unwrap();
+        let encoded = handler.encode(topic, envelope, signature).unwrap();
+        (encoded, signer)
+    }
+
+    fn message(topic: IdentTopic, data: Vec<u8>) -> Message {
+        Message { source: None, sequence_number: None, topic: topic.into(), data }
+    }
+
+    fn v2_envelope() -> OpExecutionPayloadEnvelope {
+        OpExecutionPayloadEnvelope::V2(ExecutionPayloadV2::from_block_slow(&v2_valid_block()))
+    }
+
+    fn v3_envelope() -> OpExecutionPayloadEnvelope {
+        let block = v3_valid_block();
+        OpExecutionPayloadEnvelope::V3 {
+            payload: ExecutionPayloadV3::from_block_slow(&block),
+            parent_beacon_block_root: block.header.parent_beacon_block_root.unwrap(),
+        }
+    }
+
+    fn v4_envelope() -> OpExecutionPayloadEnvelope {
+        let block = v4_valid_block();
+        OpExecutionPayloadEnvelope::V4 {
+            payload: OpExecutionPayloadV4::from_v3_with_withdrawals_root(
+                ExecutionPayloadV3::from_block_slow(&block),
+                block.withdrawals_root.unwrap(),
+            ),
+            parent_beacon_block_root: block.header.parent_beacon_block_root.unwrap(),
+        }
+    }
+
+    fn handler_with_signer(signer: Address) -> BlockHandler {
+        let (_, unsafe_signer) = tokio::sync::watch::channel(signer);
+        BlockHandler::new(
+            RollupConfig { l2_chain_id: Chain::optimism_mainnet(), ..Default::default() },
+            unsafe_signer,
+        )
+    }
 
     #[test]
     fn test_valid_decode() {
-        let block = v2_valid_block();
+        let mut handler = handler_with_signer(Address::ZERO);
+        let topic = handler.blocks_v2_topic.clone();
+        let (encoded, signer) = encode_with_test_signature(&handler, topic.clone(), v2_envelope());
+        handler.signer_recv = tokio::sync::watch::channel(signer).1;
 
-        let v2 = ExecutionPayloadV2::from_block_slow(&block);
-
-        let payload = OpExecutionPayload::V2(v2);
-        let envelope = OpNetworkPayloadEnvelope {
-            payload,
-            signature: Signature::test_signature(),
-            payload_hash: PayloadHash(B256::ZERO),
-            parent_beacon_block_root: None,
-        };
-
-        let msg = envelope.payload_hash.signature_message(10);
-        let signer = envelope.signature.recover_address_from_prehash(&msg).unwrap();
-        let (_, unsafe_signer) = tokio::sync::watch::channel(signer);
-        let mut handler = BlockHandler::new(
-            RollupConfig { l2_chain_id: Chain::optimism_mainnet(), ..Default::default() },
-            unsafe_signer,
-        );
-
-        // TRICK: Since the decode method recomputes the payload hash, we need to change the unsafe
-        // signer in the handler to ensure that the payload won't be rejected for invalid
-        // signature.
-        let encoded = handler.encode(handler.blocks_v2_topic.clone(), envelope).unwrap();
-        let decoded = OpNetworkPayloadEnvelope::decode_v2(&encoded).unwrap();
-
-        let msg = decoded.payload_hash.signature_message(10);
-        let signer = decoded.signature.recover_address_from_prehash(&msg).unwrap();
-        let (_, unsafe_signer) = tokio::sync::watch::channel(signer);
-        handler.signer_recv = unsafe_signer;
-
-        // Let's try to encode a message.
-        let message = Message {
-            source: None,
-            sequence_number: None,
-            topic: handler.blocks_v2_topic.clone().into(),
-            data: encoded,
-        };
-
-        assert!(matches!(handler.handle(message).0, MessageAcceptance::Accept));
+        let (acceptance, payload) = handler.handle(message(topic, encoded));
+        assert!(matches!(acceptance, MessageAcceptance::Accept));
+        assert!(matches!(payload, Some(OpExecutionPayloadEnvelope::V2(_))));
     }
 
-    /// This payload has a wrong hash so the signature won't be valid.
+    /// A signature over a different payload hash must be rejected before envelope decoding.
     #[test]
     fn test_invalid_decode_payload_hash() {
-        let block = v2_valid_block();
+        let signature = Signature::test_signature();
+        let wrong_message = PayloadHash(B256::ZERO).signature_message(10);
+        let wrong_signer = signature.recover_address_from_prehash(&wrong_message).unwrap();
+        let mut handler = handler_with_signer(wrong_signer);
+        let topic = handler.blocks_v2_topic.clone();
+        let encoded = handler.encode(topic.clone(), v2_envelope(), signature).unwrap();
 
-        let v2 = ExecutionPayloadV2::from_block_slow(&block);
-
-        let payload = OpExecutionPayload::V2(v2);
-        let envelope = OpNetworkPayloadEnvelope {
-            payload,
-            signature: Signature::test_signature(),
-            payload_hash: PayloadHash(B256::ZERO),
-            parent_beacon_block_root: None,
-        };
-
-        let msg = envelope.payload_hash.signature_message(10);
-        let signer = envelope.signature.recover_address_from_prehash(&msg).unwrap();
-        let (_, unsafe_signer) = tokio::sync::watch::channel(signer);
-        let mut handler = BlockHandler::new(
-            RollupConfig { l2_chain_id: Chain::optimism_mainnet(), ..Default::default() },
-            unsafe_signer,
-        );
-
-        // Let's try to encode a message.
-        let message = Message {
-            source: None,
-            sequence_number: None,
-            topic: handler.blocks_v2_topic.clone().into(),
-            data: handler.encode(handler.blocks_v2_topic.clone(), envelope).unwrap(),
-        };
-
-        assert!(matches!(handler.handle(message).0, MessageAcceptance::Reject));
+        assert!(matches!(handler.handle(message(topic, encoded)).0, MessageAcceptance::Reject));
     }
 
-    /// The message contains a wrong version so the payload won't be properly decoded.
+    fn assert_version_mismatch(
+        envelope: OpExecutionPayloadEnvelope,
+        encoded_topic: fn(&BlockHandler) -> IdentTopic,
+        received_topic: fn(&BlockHandler) -> IdentTopic,
+    ) {
+        let mut handler = handler_with_signer(Address::ZERO);
+        let (encoded, signer) =
+            encode_with_test_signature(&handler, encoded_topic(&handler), envelope);
+        handler.signer_recv = tokio::sync::watch::channel(signer).1;
+
+        assert!(matches!(
+            handler.handle(message(received_topic(&handler), encoded)).0,
+            MessageAcceptance::Reject
+        ));
+    }
+
     #[test]
     fn test_invalid_decode_version_mismatch() {
-        let block = v2_valid_block();
-
-        let v2 = ExecutionPayloadV2::from_block_slow(&block);
-
-        let payload = OpExecutionPayload::V2(v2);
-        let envelope = OpNetworkPayloadEnvelope {
-            payload,
-            signature: Signature::test_signature(),
-            payload_hash: PayloadHash(B256::ZERO),
-            parent_beacon_block_root: None,
-        };
-
-        let msg = envelope.payload_hash.signature_message(10);
-        let signer = envelope.signature.recover_address_from_prehash(&msg).unwrap();
-        let (_, unsafe_signer) = tokio::sync::watch::channel(signer);
-        let mut handler = BlockHandler::new(
-            RollupConfig { l2_chain_id: Chain::optimism_mainnet(), ..Default::default() },
-            unsafe_signer,
+        assert_version_mismatch(
+            v2_envelope(),
+            |h| h.blocks_v2_topic.clone(),
+            |h| h.blocks_v1_topic.clone(),
         );
-
-        let encoded = handler.encode(handler.blocks_v2_topic.clone(), envelope).unwrap();
-
-        // Let's try to encode a message.
-        let message = Message {
-            source: None,
-            sequence_number: None,
-            // Version mismatch!
-            topic: handler.blocks_v1_topic.clone().into(),
-            data: encoded,
-        };
-
-        assert!(matches!(handler.handle(message).0, MessageAcceptance::Reject));
     }
 
-    /// The message contains a wrong version so the payload won't be properly decoded.
     #[test]
     fn test_invalid_decode_version_mismatch_v3_with_v2() {
-        let block = v3_valid_block();
-
-        let v3 = ExecutionPayloadV3::from_block_slow(&block);
-
-        let payload = OpExecutionPayload::V3(v3);
-        let envelope = OpNetworkPayloadEnvelope {
-            payload,
-            signature: Signature::test_signature(),
-            payload_hash: PayloadHash(B256::ZERO),
-            parent_beacon_block_root: Some(
-                block.header.parent_beacon_block_root.unwrap_or_default(),
-            ),
-        };
-
-        let msg = envelope.payload_hash.signature_message(10);
-        let signer = envelope.signature.recover_address_from_prehash(&msg).unwrap();
-        let (_, unsafe_signer) = tokio::sync::watch::channel(signer);
-        let mut handler = BlockHandler::new(
-            RollupConfig { l2_chain_id: Chain::optimism_mainnet(), ..Default::default() },
-            unsafe_signer,
+        assert_version_mismatch(
+            v3_envelope(),
+            |h| h.blocks_v3_topic.clone(),
+            |h| h.blocks_v2_topic.clone(),
         );
-
-        let encoded = handler.encode(handler.blocks_v3_topic.clone(), envelope).unwrap();
-
-        // Let's try to encode a message.
-        let message = Message {
-            source: None,
-            sequence_number: None,
-            // Version mismatch!
-            topic: handler.blocks_v2_topic.clone().into(),
-            data: encoded,
-        };
-
-        assert!(matches!(handler.handle(message).0, MessageAcceptance::Reject));
     }
 
-    /// The message contains a wrong version so the payload won't be properly decoded.
     #[test]
     fn test_invalid_decode_version_mismatch_v2_with_v3() {
-        let block = v2_valid_block();
-
-        let v2 = ExecutionPayloadV2::from_block_slow(&block);
-
-        let payload = OpExecutionPayload::V2(v2);
-        let envelope = OpNetworkPayloadEnvelope {
-            payload,
-            signature: Signature::test_signature(),
-            payload_hash: PayloadHash(B256::ZERO),
-            parent_beacon_block_root: Some(
-                block.header.parent_beacon_block_root.unwrap_or_default(),
-            ),
-        };
-
-        let msg = envelope.payload_hash.signature_message(10);
-        let signer = envelope.signature.recover_address_from_prehash(&msg).unwrap();
-        let (_, unsafe_signer) = tokio::sync::watch::channel(signer);
-        let mut handler = BlockHandler::new(
-            RollupConfig { l2_chain_id: Chain::optimism_mainnet(), ..Default::default() },
-            unsafe_signer,
+        assert_version_mismatch(
+            v2_envelope(),
+            |h| h.blocks_v2_topic.clone(),
+            |h| h.blocks_v3_topic.clone(),
         );
-
-        let encoded = handler.encode(handler.blocks_v2_topic.clone(), envelope).unwrap();
-
-        // Let's try to encode a message.
-        let message = Message {
-            source: None,
-            sequence_number: None,
-            // Version mismatch!
-            topic: handler.blocks_v3_topic.clone().into(),
-            data: encoded,
-        };
-
-        assert!(matches!(handler.handle(message).0, MessageAcceptance::Reject));
     }
 
-    /// The message contains a wrong version so the payload won't be properly decoded.
     #[test]
     fn test_invalid_decode_version_mismatch_v4_with_v3() {
-        let block = v4_valid_block();
-
-        let v3 = ExecutionPayloadV3::from_block_slow(&block);
-        let v4 = OpExecutionPayloadV4::from_v3_with_withdrawals_root(
-            v3,
-            block.withdrawals_root.unwrap(),
+        assert_version_mismatch(
+            v4_envelope(),
+            |h| h.blocks_v4_topic.clone(),
+            |h| h.blocks_v3_topic.clone(),
         );
+    }
 
-        let payload = OpExecutionPayload::V4(v4);
-        let envelope = OpNetworkPayloadEnvelope {
-            payload,
-            signature: Signature::test_signature(),
-            payload_hash: PayloadHash(B256::ZERO),
-            parent_beacon_block_root: Some(
-                block.header.parent_beacon_block_root.unwrap_or_default(),
-            ),
-        };
+    fn assert_valid_decode(
+        envelope: OpExecutionPayloadEnvelope,
+        topic: fn(&BlockHandler) -> IdentTopic,
+    ) {
+        let mut handler = handler_with_signer(Address::ZERO);
+        let selected_topic = topic(&handler);
+        let (encoded, signer) =
+            encode_with_test_signature(&handler, selected_topic.clone(), envelope);
+        handler.signer_recv = tokio::sync::watch::channel(signer).1;
 
-        let msg = envelope.payload_hash.signature_message(10);
-        let signer = envelope.signature.recover_address_from_prehash(&msg).unwrap();
-        let (_, unsafe_signer) = tokio::sync::watch::channel(signer);
-        let mut handler = BlockHandler::new(
-            RollupConfig { l2_chain_id: Chain::optimism_mainnet(), ..Default::default() },
-            unsafe_signer,
-        );
-
-        let encoded = handler.encode(handler.blocks_v4_topic.clone(), envelope).unwrap();
-
-        // Let's try to encode a message.
-        let message = Message {
-            source: None,
-            sequence_number: None,
-            // Version mismatch!
-            topic: handler.blocks_v3_topic.clone().into(),
-            data: encoded,
-        };
-
-        assert!(matches!(handler.handle(message).0, MessageAcceptance::Reject));
+        let (acceptance, payload) = handler.handle(message(selected_topic, encoded));
+        assert!(matches!(acceptance, MessageAcceptance::Accept));
+        assert!(payload.is_some());
     }
 
     #[test]
     fn test_valid_decode_v4() {
-        let block = v4_valid_block();
-
-        let v3 = ExecutionPayloadV3::from_block_slow(&block);
-        let v4 = OpExecutionPayloadV4::from_v3_with_withdrawals_root(
-            v3,
-            block.withdrawals_root.unwrap(),
-        );
-
-        let payload = OpExecutionPayload::V4(v4);
-        let envelope = OpNetworkPayloadEnvelope {
-            payload,
-            signature: Signature::test_signature(),
-            payload_hash: PayloadHash(B256::ZERO),
-            parent_beacon_block_root: Some(
-                block.header.parent_beacon_block_root.unwrap_or_default(),
-            ),
-        };
-
-        let msg = envelope.payload_hash.signature_message(10);
-        let signer = envelope.signature.recover_address_from_prehash(&msg).unwrap();
-        let (_, unsafe_signer) = tokio::sync::watch::channel(signer);
-        let mut handler = BlockHandler::new(
-            RollupConfig { l2_chain_id: Chain::optimism_mainnet(), ..Default::default() },
-            unsafe_signer,
-        );
-
-        // TRICK: Since the decode method recomputes the payload hash, we need to change the unsafe
-        // signer in the handler to ensure that the payload won't be rejected for invalid
-        // signature.
-        let encoded = handler.encode(handler.blocks_v4_topic.clone(), envelope).unwrap();
-        let decoded = OpNetworkPayloadEnvelope::decode_v4(&encoded).unwrap();
-
-        let msg = decoded.payload_hash.signature_message(10);
-        let signer = decoded.signature.recover_address_from_prehash(&msg).unwrap();
-        let (_, unsafe_signer) = tokio::sync::watch::channel(signer);
-        handler.signer_recv = unsafe_signer;
-
-        // Let's try to encode a message.
-        let message = Message {
-            source: None,
-            sequence_number: None,
-            topic: handler.blocks_v4_topic.clone().into(),
-            data: encoded,
-        };
-
-        assert!(matches!(handler.handle(message).0, MessageAcceptance::Accept));
+        assert_valid_decode(v4_envelope(), |h| h.blocks_v4_topic.clone());
     }
 
     #[test]
     fn test_valid_decode_v3() {
-        let block = v3_valid_block();
-
-        let v3 = ExecutionPayloadV3::from_block_slow(&block);
-
-        let payload = OpExecutionPayload::V3(v3);
-        let envelope = OpNetworkPayloadEnvelope {
-            payload,
-            signature: Signature::test_signature(),
-            payload_hash: PayloadHash(B256::ZERO),
-            parent_beacon_block_root: Some(
-                block.header.parent_beacon_block_root.unwrap_or_default(),
-            ),
-        };
-
-        let msg = envelope.payload_hash.signature_message(10);
-        let signer = envelope.signature.recover_address_from_prehash(&msg).unwrap();
-        let (_, unsafe_signer) = tokio::sync::watch::channel(signer);
-        let mut handler = BlockHandler::new(
-            RollupConfig { l2_chain_id: Chain::optimism_mainnet(), ..Default::default() },
-            unsafe_signer,
-        );
-
-        // TRICK: Since the decode method recomputes the payload hash, we need to change the unsafe
-        // signer in the handler to ensure that the payload won't be rejected for invalid
-        // signature.
-        let encoded = handler.encode(handler.blocks_v3_topic.clone(), envelope).unwrap();
-        let decoded = OpNetworkPayloadEnvelope::decode_v3(&encoded).unwrap();
-
-        let msg = decoded.payload_hash.signature_message(10);
-        let signer = decoded.signature.recover_address_from_prehash(&msg).unwrap();
-        let (_, unsafe_signer) = tokio::sync::watch::channel(signer);
-        handler.signer_recv = unsafe_signer;
-
-        // Let's try to encode a message.
-        let message = Message {
-            source: None,
-            sequence_number: None,
-            topic: handler.blocks_v3_topic.clone().into(),
-            data: encoded,
-        };
-
-        assert!(matches!(handler.handle(message).0, MessageAcceptance::Accept));
+        assert_valid_decode(v3_envelope(), |h| h.blocks_v3_topic.clone());
     }
 
     #[cfg(feature = "metrics")]
@@ -559,22 +401,12 @@ mod tests {
     fn handle_records_invalid_message_metric_for_decode_error() {
         use metrics_util::debugging::DebuggingRecorder;
 
-        // A v2-encoded payload published on the v1 topic fails `decode_v1` before validation.
-        let v2 = ExecutionPayloadV2::from_block_slow(&v2_valid_block());
-        let envelope = OpNetworkPayloadEnvelope {
-            payload: OpExecutionPayload::V2(v2),
-            signature: Signature::test_signature(),
-            payload_hash: PayloadHash(B256::ZERO),
-            parent_beacon_block_root: None,
-        };
+        // An authenticated V2 payload published on the V1 topic fails typed envelope decoding.
         let mut handler = zero_signer_handler();
-        let encoded = handler.encode(handler.blocks_v2_topic.clone(), envelope).unwrap();
-        let message = Message {
-            source: None,
-            sequence_number: None,
-            topic: handler.blocks_v1_topic.clone().into(),
-            data: encoded,
-        };
+        let (encoded, signer) =
+            encode_with_test_signature(&handler, handler.blocks_v2_topic.clone(), v2_envelope());
+        handler.signer_recv = tokio::sync::watch::channel(signer).1;
+        let message = message(handler.blocks_v1_topic.clone(), encoded);
 
         let recorder = DebuggingRecorder::new();
         let snapshotter = recorder.snapshotter();

--- a/rust/kona/crates/node/gossip/src/lib.rs
+++ b/rust/kona/crates/node/gossip/src/lib.rs
@@ -65,6 +65,8 @@ pub use error::{DialError, GossipDriverBuilderError, HandlerEncodeError, Publish
 mod event;
 pub use event::Event;
 
+mod payload;
+
 mod handler;
 pub use handler::{BlockHandler, Handler};
 

--- a/rust/kona/crates/node/gossip/src/metrics/mod.rs
+++ b/rust/kona/crates/node/gossip/src/metrics/mod.rs
@@ -97,7 +97,7 @@ impl Metrics {
         metrics::describe_gauge!(Self::DIAL_PEER, "Number of peers dialed by the libp2p Swarm");
         metrics::describe_gauge!(
             Self::UNSAFE_BLOCK_PUBLISHED,
-            "Number of OpNetworkPayloadEnvelope gossipped out through the libp2p Swarm"
+            "Number of execution payload envelopes gossiped out through the libp2p swarm"
         );
         metrics::describe_gauge!(
             Self::GOSSIP_PEER_COUNT,

--- a/rust/kona/crates/node/gossip/src/mod.rs
+++ b/rust/kona/crates/node/gossip/src/mod.rs
@@ -34,7 +34,6 @@
 //! - Peer protection mechanisms
 //! - Automatic connection pruning
 //!
-//! [`OpNetworkPayloadEnvelope`]: op_alloy_rpc_types_engine::OpNetworkPayloadEnvelope
 
 mod behaviour;
 pub use behaviour::{Behaviour, BehaviourError};

--- a/rust/kona/crates/node/gossip/src/payload.rs
+++ b/rust/kona/crates/node/gossip/src/payload.rs
@@ -1,0 +1,254 @@
+//! Private wire representation of signed OP Stack gossip payloads.
+
+use crate::HandlerEncodeError;
+use alloy_primitives::{B256, Bytes, Signature};
+use alloy_rpc_types_engine::{ExecutionPayloadV1, ExecutionPayloadV2, ExecutionPayloadV3};
+use op_alloy_rpc_types_engine::{OpExecutionPayloadEnvelope, OpExecutionPayloadV4, PayloadHash};
+use ssz::{Decode, Encode};
+
+/// The execution payload version selected by the gossip topic.
+///
+/// The version is transport metadata and is intentionally kept separate from
+/// [`SignedGossipPayload`], which represents only the decompressed bytes carried by the message.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum GossipPayloadVersion {
+    /// Pre-Canyon payload.
+    V1,
+    /// Canyon payload.
+    V2,
+    /// Ecotone payload.
+    V3,
+    /// Isthmus payload.
+    V4,
+}
+
+/// The exact encoded execution payload envelope bytes authenticated by the block signature.
+///
+/// For V1 and V2 these are the SSZ execution payload bytes. For V3 and V4 these are the parent
+/// beacon block root followed by the SSZ execution payload bytes.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct EncodedExecutionPayloadEnvelope(Bytes);
+
+impl EncodedExecutionPayloadEnvelope {
+    /// Encodes an execution payload envelope for the version selected by its gossip topic.
+    fn encode(
+        envelope: &OpExecutionPayloadEnvelope,
+        version: GossipPayloadVersion,
+    ) -> Result<Self, HandlerEncodeError> {
+        let version_matches = matches!(
+            (envelope, version),
+            (OpExecutionPayloadEnvelope::V1(_), GossipPayloadVersion::V1) |
+                (OpExecutionPayloadEnvelope::V2(_), GossipPayloadVersion::V2) |
+                (OpExecutionPayloadEnvelope::V3 { .. }, GossipPayloadVersion::V3) |
+                (OpExecutionPayloadEnvelope::V4 { .. }, GossipPayloadVersion::V4)
+        );
+        if !version_matches {
+            return Err(HandlerEncodeError::WrongPayloadVersion);
+        }
+
+        Ok(Self(envelope.as_ssz_bytes().into()))
+    }
+
+    /// Decodes these bytes according to the version selected by the gossip topic.
+    pub(crate) fn decode(
+        self,
+        version: GossipPayloadVersion,
+    ) -> Result<OpExecutionPayloadEnvelope, GossipPayloadDecodeError> {
+        let bytes = self.0.as_ref();
+        match version {
+            GossipPayloadVersion::V1 => {
+                Ok(OpExecutionPayloadEnvelope::V1(ExecutionPayloadV1::from_ssz_bytes(bytes)?))
+            }
+            GossipPayloadVersion::V2 => {
+                Ok(OpExecutionPayloadEnvelope::V2(ExecutionPayloadV2::from_ssz_bytes(bytes)?))
+            }
+            GossipPayloadVersion::V3 => {
+                let (parent_beacon_block_root, payload) = decode_parent_beacon_block_root(bytes)?;
+                Ok(OpExecutionPayloadEnvelope::V3 {
+                    payload: ExecutionPayloadV3::from_ssz_bytes(payload)?,
+                    parent_beacon_block_root,
+                })
+            }
+            GossipPayloadVersion::V4 => {
+                let (parent_beacon_block_root, payload) = decode_parent_beacon_block_root(bytes)?;
+                Ok(OpExecutionPayloadEnvelope::V4 {
+                    payload: OpExecutionPayloadV4::from_ssz_bytes(payload)?,
+                    parent_beacon_block_root,
+                })
+            }
+        }
+    }
+
+    /// Returns the hash authenticated by the unsafe block signer.
+    pub(crate) fn payload_hash(&self) -> PayloadHash {
+        PayloadHash::from(self.0.as_ref())
+    }
+}
+
+/// The decompressed bytes carried by an OP Stack block gossip message.
+///
+/// The gossip topic determines how to interpret [`Self::envelope`] and is deliberately not part of
+/// this type because it is not included in the signed payload bytes.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct SignedGossipPayload {
+    signature: Signature,
+    envelope: EncodedExecutionPayloadEnvelope,
+}
+
+impl SignedGossipPayload {
+    /// Decodes the Snappy framing and separates the signature from the exact signed envelope bytes.
+    pub(crate) fn decode_snappy(data: &[u8]) -> Result<Self, GossipPayloadDecodeError> {
+        let decompressed: Bytes = snap::raw::Decoder::new().decompress_vec(data)?.into();
+        if decompressed.len() < 66 {
+            return Err(GossipPayloadDecodeError::InvalidLength);
+        }
+
+        let signature = Signature::try_from(&decompressed[..65])?;
+        Ok(Self { signature, envelope: EncodedExecutionPayloadEnvelope(decompressed.slice(65..)) })
+    }
+
+    /// Constructs a signed payload from a typed envelope for outbound gossip.
+    pub(crate) fn from_envelope(
+        envelope: &OpExecutionPayloadEnvelope,
+        signature: Signature,
+        version: GossipPayloadVersion,
+    ) -> Result<Self, HandlerEncodeError> {
+        Ok(Self {
+            signature,
+            envelope: EncodedExecutionPayloadEnvelope::encode(envelope, version)?,
+        })
+    }
+
+    /// Encodes this signed payload using the Snappy wire framing.
+    pub(crate) fn encode_snappy(&self) -> Result<Vec<u8>, HandlerEncodeError> {
+        let mut data = Vec::with_capacity(65 + self.envelope.0.len());
+        let mut signature = self.signature.as_bytes();
+        signature[64] = self.signature.v() as u8;
+        data.extend_from_slice(&signature);
+        data.extend_from_slice(self.envelope.0.as_ref());
+        Ok(snap::raw::Encoder::new().compress_vec(&data)?)
+    }
+
+    /// Returns the parsed block signature.
+    pub(crate) const fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    /// Returns the hash authenticated by the block signature.
+    pub(crate) fn payload_hash(&self) -> PayloadHash {
+        self.envelope.payload_hash()
+    }
+
+    /// Decodes the signed envelope bytes according to the gossip topic version.
+    pub(crate) fn into_envelope(
+        self,
+        version: GossipPayloadVersion,
+    ) -> Result<OpExecutionPayloadEnvelope, GossipPayloadDecodeError> {
+        self.envelope.decode(version)
+    }
+}
+
+fn decode_parent_beacon_block_root(
+    bytes: &[u8],
+) -> Result<(B256, &[u8]), GossipPayloadDecodeError> {
+    if bytes.len() < B256::len_bytes() {
+        return Err(GossipPayloadDecodeError::InvalidLength);
+    }
+
+    let (root, payload) = bytes.split_at(B256::len_bytes());
+    Ok((B256::from_slice(root), payload))
+}
+
+/// An error encountered while decoding a signed gossip payload.
+#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
+pub(crate) enum GossipPayloadDecodeError {
+    /// The Snappy framing is invalid.
+    #[error("Broken Snappy encoding")]
+    BrokenSnappyEncoding,
+    /// The signature bytes are invalid.
+    #[error("Invalid signature")]
+    InvalidSignature,
+    /// The execution payload SSZ is invalid.
+    #[error("Broken SSZ encoding")]
+    BrokenSszEncoding,
+    /// The signed payload is too short.
+    #[error("Invalid payload length")]
+    InvalidLength,
+}
+
+impl From<snap::Error> for GossipPayloadDecodeError {
+    fn from(_: snap::Error) -> Self {
+        Self::BrokenSnappyEncoding
+    }
+}
+
+impl From<alloy_primitives::SignatureError> for GossipPayloadDecodeError {
+    fn from(_: alloy_primitives::SignatureError) -> Self {
+        Self::InvalidSignature
+    }
+}
+
+impl From<ssz::DecodeError> for GossipPayloadDecodeError {
+    fn from(_: ssz::DecodeError) -> Self {
+        Self::BrokenSszEncoding
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::hex;
+
+    fn assert_roundtrip(data: &[u8], version: GossipPayloadVersion, timestamp: u64) {
+        let signed = SignedGossipPayload::decode_snappy(data).unwrap();
+        let payload_hash = signed.payload_hash();
+        let signature = *signed.signature();
+        let envelope = signed.into_envelope(version).unwrap();
+
+        assert_eq!(envelope.timestamp(), timestamp);
+        assert_eq!(envelope.payload_hash(), payload_hash);
+
+        let encoded = SignedGossipPayload::from_envelope(&envelope, signature, version)
+            .unwrap()
+            .encode_snappy()
+            .unwrap();
+        assert_eq!(encoded, data);
+    }
+
+    #[test]
+    fn roundtrip_v1_golden() {
+        let data = hex::decode("0xbd04f043128457c6ccf35128497167442bcc0f8cce78cda8b366e6a12e526d938d1e4c1046acffffbfc542a7e212bb7d80d3a4b2f84f7b196d935398a24eb84c519789b401000000fe0300fe0300fe0300fe0300fe0300fe0300a203000c4a8fd56621ad04fc0101067601008ce60be0005b220117c32c0f3b394b346c2aa42cfa8157cd41f891aa0bec485a62fc010000").unwrap();
+        assert_roundtrip(&data, GossipPayloadVersion::V1, 1_725_271_882);
+    }
+
+    #[test]
+    fn roundtrip_v2_golden() {
+        let data = hex::decode("0xc104f0433805080eb36c0b130a7cc1dc74c3f721af4e249aa6f61bb89d1557143e971bb738a3f3b98df7c457e74048e9d2d7e5cd82bb45e3760467e2270e9db86d1271a700000000fe0300fe0300fe0300fe0300fe0300fe0300a203000c6b89d46525ad000205067201009cda69cb5b9b73fc4eb2458b37d37f04ff507fe6c9cd2ab704a05ea9dae3cd61760002000000020000").unwrap();
+        assert_roundtrip(&data, GossipPayloadVersion::V2, 1_708_427_627);
+    }
+
+    #[test]
+    fn roundtrip_v3_golden() {
+        let data = hex::decode("0xf104f0434442b9eb38b259f5b23826e6b623e829d2fb878dac70187a1aecf42a3f9bedfd29793d1fcb5822324be0d3e12340a95855553a65d64b83e5579dffb31470df5d010000006a03000412346a1d00fe0100fe0100fe0100fe0100fe0100fe01004201000cc588d465219504100201067601007cfece77b89685f60e3663b6e0faf2de0734674eb91339700c4858c773a8ff921e014401043e0100").unwrap();
+        assert_roundtrip(&data, GossipPayloadVersion::V3, 1_708_427_461);
+    }
+
+    #[test]
+    fn roundtrip_v4_golden() {
+        let data = hex::decode("0x9105f043cee25401b6853202950d1d8a082f31a80c4fef5782c049a731f5d104b1b9b9aa7618605b420438ae98b44c8aaaebd482854473c2ae57c079286bb634bece5210000000006a03000412346a1d00fe0100fe0100fe0100fe0100fe0100fe01004201000c5766d26721950430020106f6010001440104b60100049876").unwrap();
+        assert_roundtrip(&data, GossipPayloadVersion::V4, 1_741_842_007);
+    }
+
+    #[test]
+    fn rejects_topic_version_mismatch_when_encoding() {
+        let data = hex::decode("0xbd04f043128457c6ccf35128497167442bcc0f8cce78cda8b366e6a12e526d938d1e4c1046acffffbfc542a7e212bb7d80d3a4b2f84f7b196d935398a24eb84c519789b401000000fe0300fe0300fe0300fe0300fe0300fe0300a203000c4a8fd56621ad04fc0101067601008ce60be0005b220117c32c0f3b394b346c2aa42cfa8157cd41f891aa0bec485a62fc010000").unwrap();
+        let signed = SignedGossipPayload::decode_snappy(&data).unwrap();
+        let signature = *signed.signature();
+        let envelope = signed.into_envelope(GossipPayloadVersion::V1).unwrap();
+
+        assert!(matches!(
+            SignedGossipPayload::from_envelope(&envelope, signature, GossipPayloadVersion::V2),
+            Err(HandlerEncodeError::WrongPayloadVersion)
+        ));
+    }
+}

--- a/rust/kona/crates/node/gossip/src/payload.rs
+++ b/rust/kona/crates/node/gossip/src/payload.rs
@@ -1,8 +1,9 @@
 //! Private wire representation of signed OP Stack gossip payloads.
 
 use crate::HandlerEncodeError;
-use alloy_primitives::{B256, Bytes, Signature};
+use alloy_primitives::{Address, B256, Bytes, Signature};
 use alloy_rpc_types_engine::{ExecutionPayloadV1, ExecutionPayloadV2, ExecutionPayloadV3};
+use k256::ecdsa::{RecoveryId, Signature as K256Signature, VerifyingKey};
 use op_alloy_rpc_types_engine::{OpExecutionPayloadEnvelope, OpExecutionPayloadV4, PayloadHash};
 use ssz::{Decode, Encode};
 
@@ -85,13 +86,52 @@ impl EncodedExecutionPayloadEnvelope {
     }
 }
 
+/// A compact secp256k1 signature as encoded on the gossip wire.
+///
+/// The final byte is a recovery ID in `0..=3`, not an Ethereum transaction-style `v` value.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct GossipSignature([u8; 65]);
+
+impl GossipSignature {
+    /// Parses a compact signature without normalizing its raw recovery ID.
+    fn decode(bytes: &[u8]) -> Result<Self, GossipPayloadDecodeError> {
+        let bytes: [u8; 65] =
+            bytes.try_into().map_err(|_| GossipPayloadDecodeError::InvalidSignature)?;
+        if RecoveryId::from_byte(bytes[64]).is_none() {
+            return Err(GossipPayloadDecodeError::InvalidSignature);
+        }
+        Ok(Self(bytes))
+    }
+
+    /// Converts an Alloy signature to its canonical compact wire encoding.
+    fn from_alloy(signature: Signature) -> Self {
+        let mut bytes = signature.as_bytes();
+        bytes[64] = signature.v() as u8;
+        Self(bytes)
+    }
+
+    /// Recovers the address that signed `prehash` using the full two-bit recovery ID.
+    fn recover_address_from_prehash(&self, prehash: &B256) -> Result<Address, k256::ecdsa::Error> {
+        let signature = K256Signature::try_from(&self.0[..64])?;
+        let recovery_id = RecoveryId::try_from(self.0[64])?;
+        let public_key =
+            VerifyingKey::recover_from_prehash(prehash.as_slice(), &signature, recovery_id)?;
+        Ok(Address::from_public_key(&public_key))
+    }
+
+    /// Returns the exact compact signature bytes.
+    const fn as_bytes(&self) -> &[u8; 65] {
+        &self.0
+    }
+}
+
 /// The decompressed bytes carried by an OP Stack block gossip message.
 ///
 /// The gossip topic determines how to interpret [`Self::envelope`] and is deliberately not part of
 /// this type because it is not included in the signed payload bytes.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct SignedGossipPayload {
-    signature: Signature,
+    signature: GossipSignature,
     envelope: EncodedExecutionPayloadEnvelope,
 }
 
@@ -103,7 +143,7 @@ impl SignedGossipPayload {
             return Err(GossipPayloadDecodeError::InvalidLength);
         }
 
-        let signature = Signature::try_from(&decompressed[..65])?;
+        let signature = GossipSignature::decode(&decompressed[..65])?;
         Ok(Self { signature, envelope: EncodedExecutionPayloadEnvelope(decompressed.slice(65..)) })
     }
 
@@ -114,7 +154,7 @@ impl SignedGossipPayload {
         version: GossipPayloadVersion,
     ) -> Result<Self, HandlerEncodeError> {
         Ok(Self {
-            signature,
+            signature: GossipSignature::from_alloy(signature),
             envelope: EncodedExecutionPayloadEnvelope::encode(envelope, version)?,
         })
     }
@@ -122,16 +162,14 @@ impl SignedGossipPayload {
     /// Encodes this signed payload using the Snappy wire framing.
     pub(crate) fn encode_snappy(&self) -> Result<Vec<u8>, HandlerEncodeError> {
         let mut data = Vec::with_capacity(65 + self.envelope.0.len());
-        let mut signature = self.signature.as_bytes();
-        signature[64] = self.signature.v() as u8;
-        data.extend_from_slice(&signature);
+        data.extend_from_slice(self.signature.as_bytes());
         data.extend_from_slice(self.envelope.0.as_ref());
         Ok(snap::raw::Encoder::new().compress_vec(&data)?)
     }
 
-    /// Returns the parsed block signature.
-    pub(crate) const fn signature(&self) -> &Signature {
-        &self.signature
+    /// Recovers the address that signed the provided prehash.
+    pub(crate) fn recover_signer(&self, prehash: &B256) -> Result<Address, k256::ecdsa::Error> {
+        self.signature.recover_address_from_prehash(prehash)
     }
 
     /// Returns the hash authenticated by the block signature.
@@ -182,12 +220,6 @@ impl From<snap::Error> for GossipPayloadDecodeError {
     }
 }
 
-impl From<alloy_primitives::SignatureError> for GossipPayloadDecodeError {
-    fn from(_: alloy_primitives::SignatureError) -> Self {
-        Self::InvalidSignature
-    }
-}
-
 impl From<ssz::DecodeError> for GossipPayloadDecodeError {
     fn from(_: ssz::DecodeError) -> Self {
         Self::BrokenSszEncoding
@@ -202,7 +234,7 @@ mod tests {
     fn assert_roundtrip(data: &[u8], version: GossipPayloadVersion, timestamp: u64) {
         let signed = SignedGossipPayload::decode_snappy(data).unwrap();
         let payload_hash = signed.payload_hash();
-        let signature = *signed.signature();
+        let signature = Signature::try_from(signed.signature.as_bytes().as_slice()).unwrap();
         let envelope = signed.into_envelope(version).unwrap();
 
         assert_eq!(envelope.timestamp(), timestamp);
@@ -213,6 +245,24 @@ mod tests {
             .encode_snappy()
             .unwrap();
         assert_eq!(encoded, data);
+    }
+
+    #[test]
+    fn enforces_compact_recovery_id_range() {
+        for recovery_id in 0..=u8::MAX {
+            let mut decompressed = vec![0; 66];
+            decompressed[64] = recovery_id;
+            let encoded = snap::raw::Encoder::new().compress_vec(&decompressed).unwrap();
+            let decoded = SignedGossipPayload::decode_snappy(&encoded);
+
+            if recovery_id < 4 {
+                let signed = decoded.unwrap();
+                assert_eq!(signed.signature.as_bytes()[64], recovery_id);
+                assert_eq!(signed.encode_snappy().unwrap(), encoded);
+            } else {
+                assert_eq!(decoded.unwrap_err(), GossipPayloadDecodeError::InvalidSignature);
+            }
+        }
     }
 
     #[test]
@@ -243,7 +293,7 @@ mod tests {
     fn rejects_topic_version_mismatch_when_encoding() {
         let data = hex::decode("0xbd04f043128457c6ccf35128497167442bcc0f8cce78cda8b366e6a12e526d938d1e4c1046acffffbfc542a7e212bb7d80d3a4b2f84f7b196d935398a24eb84c519789b401000000fe0300fe0300fe0300fe0300fe0300fe0300a203000c4a8fd56621ad04fc0101067601008ce60be0005b220117c32c0f3b394b346c2aa42cfa8157cd41f891aa0bec485a62fc010000").unwrap();
         let signed = SignedGossipPayload::decode_snappy(&data).unwrap();
-        let signature = *signed.signature();
+        let signature = Signature::try_from(signed.signature.as_bytes().as_slice()).unwrap();
         let envelope = signed.into_envelope(GossipPayloadVersion::V1).unwrap();
 
         assert!(matches!(

--- a/rust/kona/crates/node/service/src/actors/network/actor.rs
+++ b/rust/kona/crates/node/service/src/actors/network/actor.rs
@@ -4,7 +4,7 @@ use kona_gossip::P2pRpcRequest;
 use kona_rpc::NetworkAdminQuery;
 use kona_sources::BlockSignerError;
 use libp2p::TransportError;
-use op_alloy_rpc_types_engine::{OpExecutionPayloadEnvelope, OpNetworkPayloadEnvelope};
+use op_alloy_rpc_types_engine::OpExecutionPayloadEnvelope;
 use thiserror::Error;
 use tokio::{
     self, select,
@@ -149,16 +149,8 @@ impl<NetworkEngineClient_: NetworkEngineClient + 'static> NodeActor
 
                 let payload_hash = block.payload_hash();
                 let signature = signer.sign_block(payload_hash, chain_id, sender_address).await?;
-                let (payload, parent_beacon_block_root) = block.into_parts();
 
-                let payload = OpNetworkPayloadEnvelope {
-                    payload,
-                    parent_beacon_block_root,
-                    signature,
-                    payload_hash,
-                };
-
-                match self.handler.gossip.publish(selector, Some(payload)) {
+                match self.handler.gossip.publish(selector, block, signature) {
                     Ok(id) => info!("Published unsafe payload | {:?}", id),
                     Err(e) => warn!("Failed to publish unsafe payload: {:?}", e),
                 }
@@ -170,17 +162,10 @@ impl<NetworkEngineClient_: NetworkEngineClient + 'static> NodeActor
                     return Err(NetworkActorError::ChannelClosed);
                 };
 
-                if let Some(payload) = self.handler.gossip.handle_event(event) {
-                    match OpExecutionPayloadEnvelope::try_from(payload) {
-                        Ok(payload) => {
-                            if self.unsafe_block_tx.send(payload).is_err() {
-                                warn!(target: "node::p2p", "Failed to send unsafe block to network handler");
-                            }
-                        }
-                        Err(err) => {
-                            warn!(target: "node::p2p", %err, "Validated gossip payload has invalid structure");
-                        }
-                    }
+                if let Some(payload) = self.handler.gossip.handle_event(event) &&
+                    self.unsafe_block_tx.send(payload).is_err()
+                {
+                    warn!(target: "node::p2p", "Failed to send unsafe block to network handler");
                 }
                 Ok(())
             }
@@ -222,7 +207,7 @@ mod tests {
     use rand::Rng;
 
     #[test]
-    fn test_payload_signature_roundtrip_v1() {
+    fn test_payload_signature_v1() {
         let mut bytes = [0u8; 4096];
         rand::rng().fill(bytes.as_mut_slice());
 
@@ -235,22 +220,15 @@ mod tests {
         );
 
         let payload_hash = block.payload_hash();
-        let signature = pubkey.sign_hash_sync(&payload_hash.signature_message(CHAIN_ID)).unwrap();
-        let (payload, parent_beacon_block_root) = block.into_parts();
-        let payload =
-            OpNetworkPayloadEnvelope { payload, parent_beacon_block_root, signature, payload_hash };
-        let encoded_payload = payload.encode_v1().unwrap();
-
-        let decoded_payload = OpNetworkPayloadEnvelope::decode_v1(&encoded_payload).unwrap();
-
-        let msg = decoded_payload.payload_hash.signature_message(CHAIN_ID);
-        let msg_signer = decoded_payload.signature.recover_address_from_prehash(&msg).unwrap();
+        let message = payload_hash.signature_message(CHAIN_ID);
+        let signature = pubkey.sign_hash_sync(&message).unwrap();
+        let msg_signer = signature.recover_address_from_prehash(&message).unwrap();
 
         assert_eq!(expected_address, msg_signer);
     }
 
     #[test]
-    fn test_payload_signature_roundtrip_v3() {
+    fn test_payload_signature_v3() {
         let mut bytes = [0u8; 4096];
         rand::rng().fill(bytes.as_mut_slice());
 
@@ -265,16 +243,9 @@ mod tests {
         };
 
         let payload_hash = block.payload_hash();
-        let signature = pubkey.sign_hash_sync(&payload_hash.signature_message(CHAIN_ID)).unwrap();
-        let (payload, parent_beacon_block_root) = block.into_parts();
-        let payload =
-            OpNetworkPayloadEnvelope { payload, parent_beacon_block_root, signature, payload_hash };
-        let encoded_payload = payload.encode_v3().unwrap();
-
-        let decoded_payload = OpNetworkPayloadEnvelope::decode_v3(&encoded_payload).unwrap();
-
-        let msg = decoded_payload.payload_hash.signature_message(CHAIN_ID);
-        let msg_signer = decoded_payload.signature.recover_address_from_prehash(&msg).unwrap();
+        let message = payload_hash.signature_message(CHAIN_ID);
+        let signature = pubkey.sign_hash_sync(&message).unwrap();
+        let msg_signer = signature.recover_address_from_prehash(&message).unwrap();
 
         assert_eq!(expected_address, msg_signer);
     }

--- a/rust/op-alloy/crates/rpc-types-engine/Cargo.toml
+++ b/rust/op-alloy/crates/rpc-types-engine/Cargo.toml
@@ -26,7 +26,6 @@ alloy-rlp.workspace = true
 alloy-consensus.workspace = true
 
 # Encoding
-snap = { workspace = true, optional = true }
 ethereum_ssz = { workspace = true, optional = true }
 ethereum_ssz_derive = { workspace = true, optional = true }
 
@@ -50,7 +49,6 @@ alloy-primitives = { workspace = true, features = ["arbitrary", "getrandom"] }
 [features]
 default = ["std", "serde"]
 std = [
-	"dep:snap",
 	"dep:ethereum_ssz",
 	"dep:ethereum_ssz_derive",
 	"alloy-rpc-types-engine/ssz",

--- a/rust/op-alloy/crates/rpc-types-engine/src/envelope.rs
+++ b/rust/op-alloy/crates/rpc-types-engine/src/envelope.rs
@@ -1,12 +1,11 @@
-//! Optimism execution payload envelope in network format and related types.
-//!
-//! This module uses the `snappy` compression algorithm to decompress the payload.
-//! The license for snappy can be found in the `SNAPPY-LICENSE` at the root of the repository.
+//! Optimism execution payload envelopes and Engine API data types.
 
-use crate::{OpExecutionPayload, OpExecutionPayloadSidecar, OpExecutionPayloadV4, OpPayloadError};
+#[cfg(any(feature = "serde", test))]
+use crate::OpPayloadError;
+use crate::{OpExecutionPayload, OpExecutionPayloadSidecar, OpExecutionPayloadV4};
 use alloc::vec::Vec;
 use alloy_eips::eip7685::Requests;
-use alloy_primitives::{B256, Signature, keccak256};
+use alloy_primitives::{B256, keccak256};
 use alloy_rpc_types_engine::{
     CancunPayloadFields, ExecutionPayloadInputV2, ExecutionPayloadV1, ExecutionPayloadV2,
     ExecutionPayloadV3, PraguePayloadFields,
@@ -44,6 +43,7 @@ pub enum OpExecutionPayloadEnvelope {
 
 impl OpExecutionPayloadEnvelope {
     /// Constructs an envelope from its wire-level payload and optional parent beacon block root.
+    #[cfg(any(feature = "serde", test))]
     pub(crate) fn try_from_payload(
         payload: OpExecutionPayload,
         parent_beacon_block_root: Option<B256>,
@@ -160,22 +160,6 @@ impl ssz::Encode for OpExecutionPayloadEnvelope {
     }
 }
 
-impl TryFrom<OpNetworkPayloadEnvelope> for OpExecutionPayloadEnvelope {
-    type Error = OpPayloadError;
-
-    fn try_from(envelope: OpNetworkPayloadEnvelope) -> Result<Self, Self::Error> {
-        Self::try_from_payload(envelope.payload, envelope.parent_beacon_block_root)
-    }
-}
-
-impl TryFrom<&OpNetworkPayloadEnvelope> for OpExecutionPayloadEnvelope {
-    type Error = OpPayloadError;
-
-    fn try_from(envelope: &OpNetworkPayloadEnvelope) -> Result<Self, Self::Error> {
-        Self::try_from_payload(envelope.payload.clone(), envelope.parent_beacon_block_root)
-    }
-}
-
 /// Struct aggregating [`OpExecutionPayload`] and [`OpExecutionPayloadSidecar`] and encapsulating
 /// complete payload supplied for execution.
 #[derive(Debug, Clone)]
@@ -236,268 +220,7 @@ impl OpExecutionData {
     }
 }
 
-/// Optimism execution payload envelope in network format.
-///
-/// This struct is used to represent payloads that are sent over the Optimism
-/// CL p2p network in a snappy-compressed format.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct OpNetworkPayloadEnvelope {
-    /// The execution payload.
-    pub payload: OpExecutionPayload,
-    /// A signature for the payload.
-    pub signature: Signature,
-    /// The hash of the payload.
-    pub payload_hash: PayloadHash,
-    /// The parent beacon block root.
-    pub parent_beacon_block_root: Option<B256>,
-}
-
-impl OpNetworkPayloadEnvelope {
-    /// Decode a payload envelope from a snappy-compressed byte array.
-    /// The payload version decoded is `ExecutionPayloadV1` from SSZ bytes.
-    #[cfg(feature = "std")]
-    pub fn decode_v1(data: &[u8]) -> Result<Self, PayloadEnvelopeError> {
-        use ssz::Decode;
-        let mut decoder = snap::raw::Decoder::new();
-        let decompressed = decoder.decompress_vec(data)?;
-
-        if decompressed.len() < 66 {
-            return Err(PayloadEnvelopeError::InvalidLength);
-        }
-
-        let sig_data = &decompressed[..65];
-        let block_data = &decompressed[65..];
-
-        let signature = Signature::try_from(sig_data)?;
-        let hash = PayloadHash::from(block_data);
-
-        let payload = OpExecutionPayload::V1(
-            alloy_rpc_types_engine::ExecutionPayloadV1::from_ssz_bytes(block_data)?,
-        );
-
-        Ok(Self { payload, signature, payload_hash: hash, parent_beacon_block_root: None })
-    }
-
-    /// Encodes a payload envelope as a snappy-compressed byte array.
-    #[cfg(feature = "std")]
-    pub fn encode_v1(&self) -> Result<Vec<u8>, PayloadEnvelopeEncodeError> {
-        use ssz::Encode;
-        let execution_payload_v1 = match &self.payload {
-            OpExecutionPayload::V1(execution_payload_v1) => execution_payload_v1,
-            _ => return Err(PayloadEnvelopeEncodeError::WrongVersion),
-        };
-
-        let mut data = Vec::new();
-        let mut sig = self.signature.as_bytes();
-        sig[64] = self.signature.v() as u8;
-        data.extend_from_slice(&sig[..]);
-        let block_data = execution_payload_v1.as_ssz_bytes();
-        data.extend_from_slice(block_data.as_slice());
-
-        Ok(snap::raw::Encoder::new().compress_vec(&data)?)
-    }
-
-    /// Decode a payload envelope from a snappy-compressed byte array.
-    /// The payload version decoded is `ExecutionPayloadV2` from SSZ bytes.
-    #[cfg(feature = "std")]
-    pub fn decode_v2(data: &[u8]) -> Result<Self, PayloadEnvelopeError> {
-        use ssz::Decode;
-        let mut decoder = snap::raw::Decoder::new();
-        let decompressed = decoder.decompress_vec(data)?;
-
-        if decompressed.len() < 66 {
-            return Err(PayloadEnvelopeError::InvalidLength);
-        }
-
-        let sig_data = &decompressed[..65];
-        let block_data = &decompressed[65..];
-
-        let signature = Signature::try_from(sig_data)?;
-        let hash = PayloadHash::from(block_data);
-
-        let payload = OpExecutionPayload::V2(
-            alloy_rpc_types_engine::ExecutionPayloadV2::from_ssz_bytes(block_data)?,
-        );
-
-        Ok(Self { payload, signature, payload_hash: hash, parent_beacon_block_root: None })
-    }
-
-    /// Encodes a payload envelope as a snappy-compressed byte array.
-    #[cfg(feature = "std")]
-    pub fn encode_v2(&self) -> Result<Vec<u8>, PayloadEnvelopeEncodeError> {
-        use ssz::Encode;
-        let execution_payload_v2 = match &self.payload {
-            OpExecutionPayload::V2(execution_payload_v2) => execution_payload_v2,
-            _ => return Err(PayloadEnvelopeEncodeError::WrongVersion),
-        };
-
-        let mut data = Vec::new();
-        let mut sig = self.signature.as_bytes();
-        sig[64] = self.signature.v() as u8;
-        data.extend_from_slice(&sig[..]);
-        let block_data = execution_payload_v2.as_ssz_bytes();
-        data.extend_from_slice(block_data.as_slice());
-
-        Ok(snap::raw::Encoder::new().compress_vec(&data)?)
-    }
-
-    /// Decode a payload envelope from a snappy-compressed byte array.
-    /// The payload version decoded is `ExecutionPayloadV3` from SSZ bytes.
-    #[cfg(feature = "std")]
-    pub fn decode_v3(data: &[u8]) -> Result<Self, PayloadEnvelopeError> {
-        use ssz::Decode;
-        let mut decoder = snap::raw::Decoder::new();
-        let decompressed = decoder.decompress_vec(data)?;
-
-        if decompressed.len() < 98 {
-            return Err(PayloadEnvelopeError::InvalidLength);
-        }
-
-        let sig_data = &decompressed[..65];
-        let parent_beacon_block_root = &decompressed[65..97];
-        let block_data = &decompressed[97..];
-
-        let signature = Signature::try_from(sig_data)?;
-        let parent_beacon_block_root = B256::from_slice(parent_beacon_block_root);
-        let hash = PayloadHash::from(
-            [parent_beacon_block_root.as_slice(), block_data].concat().as_slice(),
-        );
-
-        let payload = OpExecutionPayload::V3(
-            alloy_rpc_types_engine::ExecutionPayloadV3::from_ssz_bytes(block_data)?,
-        );
-
-        Ok(Self {
-            payload,
-            signature,
-            payload_hash: hash,
-            parent_beacon_block_root: Some(parent_beacon_block_root),
-        })
-    }
-
-    /// Encodes a payload envelope as a snappy-compressed byte array.
-    #[cfg(feature = "std")]
-    pub fn encode_v3(&self) -> Result<Vec<u8>, PayloadEnvelopeEncodeError> {
-        use ssz::Encode;
-        let execution_payload_v3 = match &self.payload {
-            OpExecutionPayload::V3(execution_payload_v3) => execution_payload_v3,
-            _ => return Err(PayloadEnvelopeEncodeError::WrongVersion),
-        };
-
-        let mut data = Vec::new();
-        let mut sig = self.signature.as_bytes();
-        sig[64] = self.signature.v() as u8;
-        data.extend_from_slice(&sig[..]);
-        data.extend_from_slice(self.parent_beacon_block_root.as_ref().unwrap().as_slice());
-        let block_data = execution_payload_v3.as_ssz_bytes();
-        data.extend_from_slice(block_data.as_slice());
-
-        Ok(snap::raw::Encoder::new().compress_vec(&data)?)
-    }
-
-    /// Decode a payload envelope from a snappy-compressed byte array.
-    /// The payload version decoded is `ExecutionPayloadV4` from SSZ bytes.
-    #[cfg(feature = "std")]
-    pub fn decode_v4(data: &[u8]) -> Result<Self, PayloadEnvelopeError> {
-        use ssz::Decode;
-        let mut decoder = snap::raw::Decoder::new();
-        let decompressed = decoder.decompress_vec(data)?;
-
-        if decompressed.len() < 98 {
-            return Err(PayloadEnvelopeError::InvalidLength);
-        }
-
-        let sig_data = &decompressed[..65];
-        let parent_beacon_block_root = &decompressed[65..97];
-        let block_data = &decompressed[97..];
-
-        let signature = Signature::try_from(sig_data)?;
-        let parent_beacon_block_root = B256::from_slice(parent_beacon_block_root);
-        let hash = PayloadHash::from(
-            [parent_beacon_block_root.as_slice(), block_data].concat().as_slice(),
-        );
-
-        let payload = OpExecutionPayload::V4(OpExecutionPayloadV4::from_ssz_bytes(block_data)?);
-
-        Ok(Self {
-            payload,
-            signature,
-            payload_hash: hash,
-            parent_beacon_block_root: Some(parent_beacon_block_root),
-        })
-    }
-
-    /// Encodes a payload envelope as a snappy-compressed byte array.
-    #[cfg(feature = "std")]
-    pub fn encode_v4(&self) -> Result<Vec<u8>, PayloadEnvelopeEncodeError> {
-        use ssz::Encode;
-        let execution_payload_v4 = match &self.payload {
-            OpExecutionPayload::V4(execution_payload_v4) => execution_payload_v4,
-            _ => return Err(PayloadEnvelopeEncodeError::WrongVersion),
-        };
-
-        let mut data = Vec::new();
-        let mut sig = self.signature.as_bytes();
-        sig[64] = self.signature.v() as u8;
-        data.extend_from_slice(&sig[..]);
-        data.extend_from_slice(self.parent_beacon_block_root.as_ref().unwrap().as_slice());
-        let block_data = execution_payload_v4.as_ssz_bytes();
-        data.extend_from_slice(block_data.as_slice());
-
-        Ok(snap::raw::Encoder::new().compress_vec(&data)?)
-    }
-}
-
-/// Errors that can occur when encoding a payload envelope.
-#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
-pub enum PayloadEnvelopeEncodeError {
-    /// Wrong versions of the payload.
-    #[error("Wrong version of the payload")]
-    WrongVersion,
-    /// An error occurred during snap encoding.
-    #[error(transparent)]
-    #[cfg(feature = "std")]
-    SnapEncoding(#[from] snap::Error),
-}
-
-/// Errors that can occur when decoding a payload envelope.
-#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
-pub enum PayloadEnvelopeError {
-    /// The snappy encoding is broken.
-    #[error("Broken snappy encoding")]
-    BrokenSnappyEncoding,
-    /// The signature is invalid.
-    #[error("Invalid signature")]
-    InvalidSignature,
-    /// The SSZ encoding is broken.
-    #[error("Broken SSZ encoding")]
-    BrokenSszEncoding,
-    /// The payload envelope is of invalid length.
-    #[error("Invalid length")]
-    InvalidLength,
-}
-
-impl From<alloy_primitives::SignatureError> for PayloadEnvelopeError {
-    fn from(_: alloy_primitives::SignatureError) -> Self {
-        Self::InvalidSignature
-    }
-}
-
-#[cfg(feature = "std")]
-impl From<snap::Error> for PayloadEnvelopeError {
-    fn from(_: snap::Error) -> Self {
-        Self::BrokenSnappyEncoding
-    }
-}
-
-#[cfg(feature = "std")]
-impl From<ssz::DecodeError> for PayloadEnvelopeError {
-    fn from(_: ssz::DecodeError) -> Self {
-        Self::BrokenSszEncoding
-    }
-}
-
-/// Represents the Keccak256 hash of the block
+/// Represents the Keccak-256 hash of an encoded execution payload envelope.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct PayloadHash(pub B256);
@@ -742,60 +465,6 @@ mod tests {
             ExecutionPayloadV3::from_ssz_bytes(&encoded[B256::len_bytes()..]).unwrap(),
             payload_v3
         );
-    }
-
-    #[cfg(feature = "std")]
-    fn assert_payload_envelope_encoding(network: &OpNetworkPayloadEnvelope) {
-        let envelope = OpExecutionPayloadEnvelope::try_from(network).unwrap();
-        assert_eq!(envelope.payload_hash(), network.payload_hash);
-    }
-
-    #[test]
-    #[cfg(feature = "std")]
-    fn test_roundtrip_encode_envelope_v1() {
-        use alloy_primitives::hex;
-        let data = hex::decode("0xbd04f043128457c6ccf35128497167442bcc0f8cce78cda8b366e6a12e526d938d1e4c1046acffffbfc542a7e212bb7d80d3a4b2f84f7b196d935398a24eb84c519789b401000000fe0300fe0300fe0300fe0300fe0300fe0300a203000c4a8fd56621ad04fc0101067601008ce60be0005b220117c32c0f3b394b346c2aa42cfa8157cd41f891aa0bec485a62fc010000").unwrap();
-        let payload_envelop = OpNetworkPayloadEnvelope::decode_v1(&data).unwrap();
-        assert_eq!(1725271882, payload_envelop.payload.timestamp());
-        assert_payload_envelope_encoding(&payload_envelop);
-        let encoded = payload_envelop.encode_v1().unwrap();
-        assert_eq!(data, encoded);
-    }
-
-    #[test]
-    #[cfg(feature = "std")]
-    fn test_roundtrip_encode_envelope_v2() {
-        use alloy_primitives::hex;
-        let data = hex::decode("0xc104f0433805080eb36c0b130a7cc1dc74c3f721af4e249aa6f61bb89d1557143e971bb738a3f3b98df7c457e74048e9d2d7e5cd82bb45e3760467e2270e9db86d1271a700000000fe0300fe0300fe0300fe0300fe0300fe0300a203000c6b89d46525ad000205067201009cda69cb5b9b73fc4eb2458b37d37f04ff507fe6c9cd2ab704a05ea9dae3cd61760002000000020000").unwrap();
-        let payload_envelop = OpNetworkPayloadEnvelope::decode_v2(&data).unwrap();
-        assert_eq!(1708427627, payload_envelop.payload.timestamp());
-        assert_payload_envelope_encoding(&payload_envelop);
-        let encoded = payload_envelop.encode_v2().unwrap();
-        assert_eq!(data, encoded);
-    }
-
-    #[test]
-    #[cfg(feature = "std")]
-    fn test_roundtrip_encode_envelope_v3() {
-        use alloy_primitives::hex;
-        let data = hex::decode("0xf104f0434442b9eb38b259f5b23826e6b623e829d2fb878dac70187a1aecf42a3f9bedfd29793d1fcb5822324be0d3e12340a95855553a65d64b83e5579dffb31470df5d010000006a03000412346a1d00fe0100fe0100fe0100fe0100fe0100fe01004201000cc588d465219504100201067601007cfece77b89685f60e3663b6e0faf2de0734674eb91339700c4858c773a8ff921e014401043e0100").unwrap();
-        let payload_envelop = OpNetworkPayloadEnvelope::decode_v3(&data).unwrap();
-        assert_eq!(1708427461, payload_envelop.payload.timestamp());
-        assert_payload_envelope_encoding(&payload_envelop);
-        let encoded = payload_envelop.encode_v3().unwrap();
-        assert_eq!(data, encoded);
-    }
-
-    #[test]
-    #[cfg(feature = "std")]
-    fn test_roundtrip_encode_envelope_v4() {
-        use alloy_primitives::hex;
-        let data = hex::decode("0x9105f043cee25401b6853202950d1d8a082f31a80c4fef5782c049a731f5d104b1b9b9aa7618605b420438ae98b44c8aaaebd482854473c2ae57c079286bb634bece5210000000006a03000412346a1d00fe0100fe0100fe0100fe0100fe0100fe01004201000c5766d26721950430020106f6010001440104b60100049876").unwrap();
-        let payload_envelop = OpNetworkPayloadEnvelope::decode_v4(&data).unwrap();
-        assert_eq!(1741842007, payload_envelop.payload.timestamp());
-        assert_payload_envelope_encoding(&payload_envelop);
-        let encoded = payload_envelop.encode_v4().unwrap();
-        assert_eq!(data, encoded);
     }
 
     #[cfg(test)]

--- a/rust/op-alloy/crates/rpc-types-engine/src/lib.rs
+++ b/rust/op-alloy/crates/rpc-types-engine/src/lib.rs
@@ -15,10 +15,7 @@ mod attributes;
 pub use attributes::OpPayloadAttributes;
 
 mod envelope;
-pub use envelope::{
-    OpExecutionData, OpExecutionPayloadEnvelope, OpNetworkPayloadEnvelope,
-    PayloadEnvelopeEncodeError, PayloadEnvelopeError, PayloadHash,
-};
+pub use envelope::{OpExecutionData, OpExecutionPayloadEnvelope, PayloadHash};
 
 mod execution;
 


### PR DESCRIPTION
## Summary

- Move signed gossip framing, Snappy compression, and V1–V4 SSZ codecs out of Engine RPC types and into private `kona-gossip` wire types.
- Authenticate the exact received envelope bytes before SSZ payload decoding.
- Decode validated gossip messages directly into `OpExecutionPayloadEnvelope`.
- Check claimed block hashes from raw transaction bytes without transaction decoding or execution.
- Preserve existing P2P wire bytes with V1–V4 golden-vector coverage.
- Update P2P documentation and validation metrics terminology.

## Dependency

Depends only on #22304. It does not depend on either of the other sibling follow-ups.

## Testing

- `cargo +nightly-2026-02-20 fmt --all -- --check`
- `cargo test -p op-alloy-rpc-types-engine -p kona-gossip -p kona-node-service`
- `cargo clippy -p op-alloy-rpc-types-engine -p kona-gossip -p kona-node-service --all-targets --all-features -- -D warnings`
