### PR TITLE
op-acceptance-tests: run invalid unsafe payload coverage against kona

### DIFF
--- a/op-acceptance-tests/tests/sync/elsync/gap_elp2p/sync_test.go
+++ b/op-acceptance-tests/tests/sync/elsync/gap_elp2p/sync_test.go
@@ -402,18 +402,11 @@ func TestSafeDoesNotAdvanceWhenUnsafeIsSyncing_NoELP2P(gt *testing.T) {
 //     A new payload builds on a previously rejected block (an invalid parent),
 //     causing the EL to reject it as referencing an invalid ancestor.
 //
-// In all scenarios, both CL and EL remain at the same head height, confirming that
-// invalid payloads—whether rejected at the CL or EL—do not advance the chain.
+// In all invalid scenarios, both CL and EL remain at the same head height. The test
+// then posts a valid payload and requires both to advance, confirming that rejecting
+// an invalid payload does not wedge subsequent unsafe payload processing.
 func TestInvalidPayloadThroughCLP2P(gt *testing.T) {
 	t := devtest.ParallelT(gt)
-	// Example error with kona-node:
-	//
-	// assertions.go:387:             ERROR[03-31|10:42:03.034]
-	// assertions.go:387:             	Error Trace:	/Users/josh/repos/optimism/op-acceptance-tests/tests/sync/elsync/gap_elp2p/sync_test.go:436
-	// assertions.go:387:             	Error:      	An error is expected but got nil.
-	// assertions.go:387:             	Test:       	TestInvalidPayloadThroughCLP2P
-	// assertions.go:387:
-	sysgo.SkipOnKonaNode(t, "not supported")
 	sys := newGapELP2PSystem(t)
 	logger := t.Logger()
 	require := t.Require()
@@ -442,7 +435,7 @@ func TestInvalidPayloadThroughCLP2P(gt *testing.T) {
 	payload.ExecutionPayload.StateRoot = eth.Bytes32{}
 	logger.Info("Injected fault to payload but not updated hash")
 	// Post invalid payload with the fault that can be checked at the CL side
-	require.Error(sys.L2CLB.Escape().RollupAPI().PostUnsafePayload(ctx, payload))
+	require.ErrorContains(sys.L2CLB.Escape().RollupAPI().PostUnsafePayload(ctx, payload), "bad block hash")
 	// ex) op-node error msg: "payload has bad block hash"
 	// CL will not send the payload but drop immediately due to hash mismatch
 	// EL did not advance
@@ -480,10 +473,10 @@ func TestInvalidPayloadThroughCLP2P(gt *testing.T) {
 	require.False(ok)
 	logger.Info("Updated payload parent to invalid payload", "newHash", newHash)
 	payload2.ExecutionPayload.BlockHash = newHash
-	_, ok = payload.CheckBlockHash()
+	_, ok = payload2.CheckBlockHash()
 	require.True(ok)
 	// Post invalid payload with the fault that can be only checked at the EL side
-	sys.L2CLB.PostUnsafePayload(payload)
+	sys.L2CLB.PostUnsafePayload(payload2)
 	// ex) op-geth error msg: "ignoring bad block: links to previously rejected block"
 	sys.L2CLB.NotAdvanced(safety.LocalUnsafe, attempts)
 	sys.L2ELB.NotAdvanced(eth.Unsafe, attempts)
@@ -491,4 +484,12 @@ func TestInvalidPayloadThroughCLP2P(gt *testing.T) {
 	sys.L2ELB.UnsafeHead().NumEqualTo(startNum + 1)
 	// CL did not advance
 	sys.L2CLB.UnsafeHead().NumEqualTo(startNum + 1)
+
+	// A valid payload must still advance both the CL and EL after the invalid payloads.
+	// This ensures an EL INVALID response does not block the unsafe payload queue.
+	validTargetNum := startNum + 2
+	logger.Info("Posting valid payload after invalid payloads", "target", validTargetNum)
+	sys.L2CLB.PostUnsafePayload(sys.L2EL.PayloadByNumber(validTargetNum))
+	sys.L2CLB.Reached(safety.LocalUnsafe, validTargetNum, attempts)
+	sys.L2ELB.Reached(eth.Unsafe, validTargetNum, attempts)
 }


### PR DESCRIPTION
## Summary

- Run `TestInvalidPayloadThroughCLP2P` against Kona now that #22405 synchronously rejects admin payloads whose claimed block hash does not match their contents.
- Require the CL-side rejection to report a bad block hash.
- Fix the EL-only invalid-ancestor scenario to post the intended second payload.
- Post a valid payload afterward and require both CL and EL advancement, proving invalid payload handling does not wedge subsequent unsafe payload processing.

## Stack

Stacked on #22405, which implements Kona's synchronous `admin_postUnsafePayload` block-hash validation.

## Testing

- `go test ./op-acceptance-tests/tests/sync/elsync/gap_elp2p -run '^$'`
- `cargo test -p kona-rpc --test admin_unsafe_payload` and targeted Clippy passed before the now-removed redundant RPC tests were dropped
- A targeted Kona acceptance run was attempted after the rebase but stopped during fixture startup when kona-node could not connect to op-reth; the test scenario itself was not reached

Closes #22250.
