### PR TITLE
kona-sp1-proposer: rename super root RPC configuration

### DIFF
--- a/op-devstack/sysgo/zk_proposer.go
+++ b/op-devstack/sysgo/zk_proposer.go
@@ -124,7 +124,7 @@ func startZKProposer(
 	l1EL L1ELNode,
 	l1CL *L1CLNode,
 	depSet depset.DependencySet,
-	supernodeRPC string,
+	superRootRPC string,
 	l2Nets []*L2Network,
 	l2ELs []L2ELNode,
 	factoryAddr common.Address,
@@ -191,7 +191,7 @@ func startZKProposer(
 
 	env := []string{
 		"L1_RPC=" + l1EL.UserRPC(),
-		"SUPERNODE_RPC=" + supernodeRPC,
+		"SUPERROOT_RPC=" + superRootRPC,
 		"FACTORY_ADDRESS=" + factoryAddr.Hex(),
 		"PRESTATES_URL=file://" + prestatesDir,
 		"PRIVATE_KEY=" + hexutil.Encode(crypto.FromECDSA(proposerSecret)),

--- a/rust/kona/sp1/README.md
+++ b/rust/kona/sp1/README.md
@@ -187,7 +187,7 @@ Required:
 | Variable | Purpose |
 |---|---|
 | `L1_RPC` | L1 execution RPC |
-| `SUPERNODE_RPC` | supernode (or single-chain op-node) RPC serving `superroot_atTimestamp` |
+| `SUPERROOT_RPC` | op-supernode or single-chain op-node RPC serving `superroot_atTimestamp` |
 | `FACTORY_ADDRESS` | `DisputeGameFactory` address |
 | `PRESTATES_URL` | prestate artifact directory (`<vkey>.agg.bin.gz` + `<vkey>.range.bin.gz`) |
 | `PROOF_PROVIDER` | `network` or `mock`; no default |

--- a/rust/kona/sp1/crates/proposer/src/bin/kona-sp1-proposer.rs
+++ b/rust/kona/sp1/crates/proposer/src/bin/kona-sp1-proposer.rs
@@ -36,7 +36,7 @@ async fn main() -> Result<()> {
 
     tracing::info!(
         l1_rpc = %redacted_url(&config.l1_rpc),
-        supernode_rpc = %redacted_url(&config.supernode_rpc),
+        superroot_rpc = %redacted_url(&config.superroot_rpc),
         factory_address = %config.factory_address,
         prestates_url = %redacted_url(&config.prestates_url),
         proposal_interval_seconds = config.proposal_interval_seconds,

--- a/rust/kona/sp1/crates/proposer/src/config.rs
+++ b/rust/kona/sp1/crates/proposer/src/config.rs
@@ -72,9 +72,9 @@ pub struct ProposerConfig {
     /// The L1 RPC URL.
     pub l1_rpc: Url,
 
-    /// The supernode (or single-chain op-node) RPC URL serving
-    /// `superroot_atTimestamp`.
-    pub supernode_rpc: Url,
+    /// The RPC URL serving `superroot_atTimestamp`, provided by an op-supernode
+    /// or a single-chain op-node.
+    pub superroot_rpc: Url,
 
     /// The address of the `DisputeGameFactory` contract.
     pub factory_address: Address,
@@ -218,10 +218,10 @@ impl ProposerConfig {
                 .context("L1_RPC not set")?
                 .parse()
                 .map_err(|err| anyhow!("invalid L1_RPC: {err}"))?,
-            supernode_rpc: env::var("SUPERNODE_RPC")
-                .context("SUPERNODE_RPC not set")?
+            superroot_rpc: env::var("SUPERROOT_RPC")
+                .context("SUPERROOT_RPC not set")?
                 .parse()
-                .map_err(|err| anyhow!("invalid SUPERNODE_RPC: {err}"))?,
+                .map_err(|err| anyhow!("invalid SUPERROOT_RPC: {err}"))?,
             factory_address: env::var("FACTORY_ADDRESS")
                 .context("FACTORY_ADDRESS not set")?
                 .parse()
@@ -703,7 +703,7 @@ mod tests {
         fn from_env_requires_defend_path_vars() {
             unsafe {
                 env::set_var("L1_RPC", "http://127.0.0.1:8545");
-                env::set_var("SUPERNODE_RPC", "http://127.0.0.1:9545");
+                env::set_var("SUPERROOT_RPC", "http://127.0.0.1:9545");
                 env::set_var("FACTORY_ADDRESS", "0x000000000000000000000000000000000000dEaD");
                 env::set_var("PRESTATES_URL", "file:///tmp/prestates");
             }
@@ -741,7 +741,7 @@ mod tests {
         fn zero_defense_cap_is_rejected() {
             unsafe {
                 env::set_var("L1_RPC", "http://127.0.0.1:8545");
-                env::set_var("SUPERNODE_RPC", "http://127.0.0.1:9545");
+                env::set_var("SUPERROOT_RPC", "http://127.0.0.1:9545");
                 env::set_var("FACTORY_ADDRESS", "0x000000000000000000000000000000000000dEaD");
                 env::set_var("PRESTATES_URL", "file:///tmp/prestates");
                 env::set_var("PROOF_PROVIDER", "mock");
@@ -760,7 +760,7 @@ mod tests {
         fn zero_spn_timeouts_are_rejected() {
             unsafe {
                 env::set_var("L1_RPC", "http://127.0.0.1:8545");
-                env::set_var("SUPERNODE_RPC", "http://127.0.0.1:9545");
+                env::set_var("SUPERROOT_RPC", "http://127.0.0.1:9545");
                 env::set_var("FACTORY_ADDRESS", "0x000000000000000000000000000000000000dEaD");
                 env::set_var("PRESTATES_URL", "file:///tmp/prestates");
                 env::set_var("PROOF_PROVIDER", "mock");

--- a/rust/kona/sp1/crates/proposer/src/proposer.rs
+++ b/rust/kona/sp1/crates/proposer/src/proposer.rs
@@ -468,7 +468,7 @@ where
         identity.log_startup_info(&config.prestates_url);
 
         let l1_provider = ProviderBuilder::default().connect_http(config.l1_rpc.clone());
-        let superroot_client = SuperrootClient::new(config.supernode_rpc.as_str())?;
+        let superroot_client = SuperrootClient::new(config.superroot_rpc.as_str())?;
 
         let prestates = Arc::new(PrestateCache::new(config.prestates_url.clone()));
         let host_inputs = Arc::new(HostInputs {
@@ -3548,7 +3548,7 @@ mod tests {
     fn test_config() -> ProposerConfig {
         ProposerConfig {
             l1_rpc: "http://127.0.0.1:1".parse().unwrap(),
-            supernode_rpc: "http://127.0.0.1:1".parse().unwrap(),
+            superroot_rpc: "http://127.0.0.1:1".parse().unwrap(),
             factory_address: Address::ZERO,
             prestates_url: "file:///nonexistent".parse().unwrap(),
             proposal_interval_seconds: 3600,


### PR DESCRIPTION
## Summary

- rename the kona-sp1-proposer environment variable from SUPERNODE_RPC to SUPERROOT_RPC
- rename the corresponding Rust config and startup-log fields
- update the devstack wiring and proposer documentation

This is intentionally a hard rename with no compatibility alias. The endpoint may be provided by either an op-supernode or a single-chain op-node, so SUPERROOT_RPC describes the required interface rather than one implementation.