### PR TITLE
op-devstack: retry tx-in-block reads that race canonical head flips

### DIFF
--- a/op-acceptance-tests/tests/supernode/interop/reorg/invalid_message_reorg_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/reorg/invalid_message_reorg_test.go
@@ -19,6 +19,26 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/txplan"
 )
 
+// Wait budgets for the invalid-message replacement scenario. The light-sequencer follow path
+// recovers slowly — cross-safe advances roughly one block per two follow-source poll cycles
+// (#21119) — so the cross-safe waits carry the largest budgets.
+const (
+	// Retry attempts, spaced dsl.DefaultPollInterval apart.
+	canonicalReadSettleAttempts = 15
+	crossSafeMatchAttempts      = 30
+	crossSafeReachAttempts      = 45
+	elSafeReachAttempts         = 30
+
+	// crossSafeAdvanceBlocks is how far cross-safe must advance past the replacement before
+	// the reads below observe the settled chain.
+	crossSafeAdvanceBlocks = 3
+
+	// ResendUntilSafe budget: fresh-tx broadcasts, each polled once per second for inclusion
+	// at/below the safe head.
+	resendPollsPerSend = 20
+	resendSendAttempts = 8
+)
+
 // TestSupernodeInteropInvalidMessageReplacement runs the invalid-message
 // replacement scenario with the supernode virtual sequencer.
 func TestSupernodeInteropInvalidMessageReplacement(gt *testing.T) {
@@ -143,22 +163,24 @@ func runInteropInvalidMessageReplacementScenario(t devtest.T, sys *presets.TwoL2
 	// at the replacement. Gate on cross-safe advancing past it — a match alone passes trivially
 	// while both sides are pinned — so reads below see the settled chain.
 	dsl.CheckAll(t,
-		sys.L2ACL.AdvancedFn(safety.CrossSafe, 3, 45),
-		sys.L2BCL.AdvancedFn(safety.CrossSafe, 3, 45),
+		sys.L2ACL.AdvancedFn(safety.CrossSafe, crossSafeAdvanceBlocks, crossSafeReachAttempts),
+		sys.L2BCL.AdvancedFn(safety.CrossSafe, crossSafeAdvanceBlocks, crossSafeReachAttempts),
 	)
 	dsl.CheckAll(t,
-		sys.L2ACL.MatchedFn(sys.L2ASupernodeCL, safety.CrossSafe, 30),
-		sys.L2BCL.MatchedFn(sys.L2BSupernodeCL, safety.CrossSafe, 30),
+		sys.L2ACL.MatchedFn(sys.L2ASupernodeCL, safety.CrossSafe, crossSafeMatchAttempts),
+		sys.L2BCL.MatchedFn(sys.L2BSupernodeCL, safety.CrossSafe, crossSafeMatchAttempts),
 	)
 
 	// The invalid exec-message tx must be gone from the replacement block on BOTH the light
 	// sequencer's EL and the supernode VN's EL — distinct nodes joined only by L1 + P2P, so
-	// agreement proves one canonical chain. AssertTxNotInBlock reads by number (the oscillating
-	// unsafe head), so gate each read on that EL's safe head reaching the block first; blocks
-	// at/below safe are irreversible.
-	sys.L2ELB.Reached(eth.Safe, invalidBlockNumber, 30)
-	sys.L2ELB.AssertTxNotInBlock(invalidBlockNumber, execMsg.Receipt.TxHash)
-	sys.L2BSupernodeEL.Reached(eth.Safe, invalidBlockNumber, 30)
+	// agreement proves one canonical chain. The reads are by number, so gate each on that EL's
+	// safe head reaching the block first. On the light EL the safe gate alone is not enough:
+	// its sequencer can seal an in-flight block on a stale parent right after a follow-source
+	// reorg, transiently flipping the canonical block at this height back to its own branch
+	// (#22234), so retry the read there until it settles.
+	sys.L2ELB.Reached(eth.Safe, invalidBlockNumber, elSafeReachAttempts)
+	sys.L2ELB.AwaitTxNotInBlock(invalidBlockNumber, execMsg.Receipt.TxHash, canonicalReadSettleAttempts)
+	sys.L2BSupernodeEL.Reached(eth.Safe, invalidBlockNumber, elSafeReachAttempts)
 	sys.L2BSupernodeEL.AssertTxNotInBlock(invalidBlockNumber, execMsg.Receipt.TxHash)
 
 	t.Logger().Info("test complete: invalid block was replaced and verified",
@@ -174,16 +196,18 @@ func runInteropInvalidMessageReplacementScenario(t devtest.T, sys *presets.TwoL2
 		// Fresh funded account per attempt => clean nonce space, immune to an orphaned prior send.
 		eoa := sys.FunderB.NewFundedEOA(eth.OneEther)
 		return txplan.NewPlannedTx(eoa.PlanTransfer(alice.Address(), eth.OneHundredthEther))
-	}, 8, 20)
+	}, resendSendAttempts, resendPollsPerSend)
 	sys.Supernode.AwaitValidatedTimestamp(sys.L2B.TimestampForBlockNum(settledBlock))
 	// The tx is in a derived-safe block on the supernode; the light sequencer must agree there.
 	// The fresh tx re-diverges the light sequencer from upstream, so the follow-source loop must
 	// reconcile again. It advances the light CL's cross-safe roughly one block per two poll cycles
 	// (every other forceReset resets local-safe to genesis before re-adopting upstream, #21119), so
 	// settle on the CL's cross-safe reaching settledBlock before polling the EL: the EL's safe
-	// forkchoice pointer only moves once the CL emits the FCU for that cross-safe head.
-	sys.L2BCL.Reached(safety.CrossSafe, settledBlock, 45)
+	// forkchoice pointer only moves once the CL emits the FCU for that cross-safe head. Even
+	// then the light EL's canonical block at settledBlock can transiently flip back to its own
+	// branch via a stale-parent seal (#22234), so retry that read until it settles.
+	sys.L2BCL.Reached(safety.CrossSafe, settledBlock, crossSafeReachAttempts)
 	sys.L2BSupernodeEL.AssertTxInBlock(settledBlock, settledTxHash)
-	sys.L2ELB.Reached(eth.Safe, settledBlock, 30)
-	sys.L2ELB.AssertTxInBlock(settledBlock, settledTxHash)
+	sys.L2ELB.Reached(eth.Safe, settledBlock, elSafeReachAttempts)
+	sys.L2ELB.AwaitTxInBlock(settledBlock, settledTxHash, canonicalReadSettleAttempts)
 }

--- a/op-devstack/dsl/l2_el.go
+++ b/op-devstack/dsl/l2_el.go
@@ -657,35 +657,75 @@ func (el *L2ELNode) AssertExecMessageNotInBlock(execMessage *ExecMessage) {
 	el.AssertTxNotInBlock(bigs.Uint64Strict(execMessage.BlockNumber()), execMessage.TxHash())
 }
 
-// AssertTxNotInBlock asserts that a transaction with the given hash does not exist in the block at the given number.
-func (el *L2ELNode) AssertTxNotInBlock(blockNumber uint64, txHash common.Hash) {
+// blockContainsTx reports whether the canonical block at blockNumber contains a
+// transaction with the given hash.
+func (el *L2ELNode) blockContainsTx(blockNumber uint64, txHash common.Hash) (bool, error) {
 	ctx, cancel := context.WithTimeout(el.ctx, DefaultTimeout)
 	defer cancel()
 
 	_, txs, err := el.inner.EthClient().InfoAndTxsByNumber(ctx, blockNumber)
-	el.require.NoError(err, "failed to fetch block %d", blockNumber)
-
-	for _, tx := range txs {
-		el.require.NotEqualf(tx.Hash(), txHash, "transaction should not exist in block", "Found tx %v in block %v", tx.Hash(), blockNumber)
+	if err != nil {
+		return false, fmt.Errorf("failed to fetch block %d: %w", blockNumber, err)
 	}
-	el.log.Info("confirmed transaction not in block", "blockNumber", blockNumber, "txHash", txHash)
-}
-
-// AssertTxInBlock asserts that a transaction with the given hash does not exist in the block at the given number.
-func (el *L2ELNode) AssertTxInBlock(blockNumber uint64, txHash common.Hash) {
-	ctx, cancel := context.WithTimeout(el.ctx, DefaultTimeout)
-	defer cancel()
-
-	_, txs, err := el.inner.EthClient().InfoAndTxsByNumber(ctx, blockNumber)
-	el.require.NoError(err, "failed to fetch block %d", blockNumber)
-
 	for _, tx := range txs {
 		if tx.Hash() == txHash {
-			el.log.Info("confirmed transaction in block", "blockNumber", blockNumber, "txHash", txHash)
-			return
+			return true, nil
 		}
 	}
-	el.require.Fail("transaction should exist in block", "blockNumber", blockNumber, "txHash", txHash)
+	return false, nil
+}
+
+// AssertTxNotInBlock asserts that a transaction with the given hash does not exist in the
+// canonical block at the given number. The read is single-shot; on a node whose canonical
+// head can transiently flip between branches, use AwaitTxNotInBlock instead.
+func (el *L2ELNode) AssertTxNotInBlock(blockNumber uint64, txHash common.Hash) {
+	el.awaitTxPresence(blockNumber, txHash, false, 1)
+}
+
+// AssertTxInBlock asserts that a transaction with the given hash exists in the canonical
+// block at the given number. The read is single-shot; on a node whose canonical head can
+// transiently flip between branches, use AwaitTxInBlock instead.
+func (el *L2ELNode) AssertTxInBlock(blockNumber uint64, txHash common.Hash) {
+	el.awaitTxPresence(blockNumber, txHash, true, 1)
+}
+
+// AwaitTxInBlock waits until the canonical block at blockNumber contains a transaction with
+// the given hash. A by-number read resolves against the canonical head chain, and on a node
+// whose canonical head can transiently flip between branches — e.g. a light follow-CL whose
+// sequencer seals an in-flight block on a stale parent right after a follow-source reorg —
+// a single read races the flip even when blockNumber is at/below the safe label. Polls every
+// DefaultPollInterval.
+func (el *L2ELNode) AwaitTxInBlock(blockNumber uint64, txHash common.Hash, attempts int) {
+	el.awaitTxPresence(blockNumber, txHash, true, attempts)
+}
+
+// AwaitTxNotInBlock waits until the canonical block at blockNumber does not contain a
+// transaction with the given hash, re-reading until a successful read shows it absent. See
+// AwaitTxInBlock for why a single by-number read is not always enough. Polls every
+// DefaultPollInterval.
+func (el *L2ELNode) AwaitTxNotInBlock(blockNumber uint64, txHash common.Hash, attempts int) {
+	el.awaitTxPresence(blockNumber, txHash, false, attempts)
+}
+
+// awaitTxPresence re-reads the canonical block at blockNumber until its inclusion of the
+// transaction with the given hash matches wantInBlock, failing the test after attempts reads
+// spaced DefaultPollInterval apart.
+func (el *L2ELNode) awaitTxPresence(blockNumber uint64, txHash common.Hash, wantInBlock bool, attempts int) {
+	el.require.NoError(retry.Do0(el.ctx, attempts, &retry.FixedStrategy{Dur: DefaultPollInterval}, func() error {
+		found, err := el.blockContainsTx(blockNumber, txHash)
+		if err != nil {
+			el.log.Warn("block read failed; will retry", "blockNumber", blockNumber, "err", err)
+			return err
+		}
+		if found != wantInBlock {
+			if wantInBlock {
+				return fmt.Errorf("tx %s absent from canonical block %d, expected present", txHash, blockNumber)
+			}
+			return fmt.Errorf("tx %s present in canonical block %d, expected absent", txHash, blockNumber)
+		}
+		el.log.Info("confirmed transaction presence in block", "blockNumber", blockNumber, "txHash", txHash, "inBlock", found)
+		return nil
+	}))
 }
 
 // ResendUntilSafe broadcasts a transaction from makeTx and waits for it to derive onto this

--- a/op-devstack/dsl/params.go
+++ b/op-devstack/dsl/params.go
@@ -2,4 +2,9 @@ package dsl
 
 import "time"
 
-const DefaultTimeout = 30 * time.Second
+const (
+	// DefaultPollInterval is the pause between attempts of retrying checks.
+	DefaultPollInterval = 2 * time.Second
+	// DefaultTimeout bounds individual RPC reads.
+	DefaultTimeout = 30 * time.Second
+)


### PR DESCRIPTION
Fixes the dominant failure signature of #22234 (2 of 3 recent occurrences): `TestSupernodeLightSequencerInteropInvalidMessageReplacement` failing `AssertTxInBlock` milliseconds after `Reached(eth.Safe, N)` passed on the same EL — [root-cause analysis](https://github.com/ethereum-optimism/optimism/issues/22234#issuecomment-5215613729).

**The race:** `AssertTxInBlock`/`AssertTxNotInBlock` are single-shot by-number reads against the canonical head, while `Reached(eth.Safe, N)` only checks the safe label number. On the light-sequencer follow path these transiently disagree: when an in-flight build job seals on a stale parent right after a follow-source reorg, the canonical head flips back to the divergent branch, and a by-number read in that window returns a block without the tx.

**The fix:** add retrying `AwaitTxInBlock`/`AwaitTxNotInBlock` to `L2ELNode`; all four tx-in-block methods are one-line wrappers around a shared `awaitTxPresence` retry core, with the single-shot `Assert*` variants as the single-attempt case (also fixing their malformed failure-message formatting). The invalid-message replacement test uses the `Await*` variants for its two light-EL reads; the supernode VN's EL does not oscillate, so its reads stay single-shot. The retry converges once the light sequencer builds on the adopted head, since the divergence point then moves above the asserted height. The poll cadence is named `DefaultPollInterval`, and the test's wait budgets are named constants (`canonicalReadSettleAttempts`, `crossSafeReachAttempts`, …) instead of magic numbers.

The third #22234 occurrence (cross-safe wedge) is a different failure, tracked in #22325.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
