### PR TITLE
ci: front-load mise tool installs in the setup pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,12 +87,14 @@ parameters:
 
 orbs:
   continuation: circleci/continuation@2.0.1
+  utils: ethereum-optimism/circleci-utils@1.0.30
 
 jobs:
   # --------------------------------------------------------------------------
   # This job prepares the dynamic continuation pipeline in 7 steps:
   #
-  #   1. Install yq (YAML processor for merging configs)
+  #   1. Install the mise toolset (front-loads the shared mise cache; provides
+  #      yq for merging configs)
   #   2. Store string pipeline params  → /tmp/pipeline-parameters.json
   #   3. Store boolean pipeline params → /tmp/pipeline-parameters.json
   #   4. Detect file-tree changes     → /tmp/pipeline-parameters.json
@@ -112,16 +114,28 @@ jobs:
       BASE_REVISION: develop
     steps:
       - checkout
-      # yq is used by the "Merge continuation configs" step to deep-merge YAML files.
-      # Keep version in sync with mise.toml.
+      # Front-loads the mise toolset for the whole pipeline: this job always
+      # completes before the continuation pipeline exists, so on a cold cache
+      # (mise.toml change or eviction) it is the only job that cold-installs —
+      # every continuation job restores the cache saved here. During an
+      # upstream outage (GitHub rate limits, missing release attestations) the
+      # blast radius is this one job instead of every job on every PR.
+      # Also provides yq (pinned in mise.toml) for the merge/routing scripts.
+      #
+      # This must remain a full, unfiltered `mise install`: the orb saves
+      # /data/mise-data under a write-once key, so narrowing the install here
+      # (e.g. to just yq) would freeze an incomplete toolset for every
+      # continuation job and silently force them all to cold-install forever.
+      - utils/install-mise:
+          enable_mise_cache: true
+      # mise shims re-resolve the tool on every invocation, which the yq/jq
+      # loops in the routing scripts below pay hundreds of times (~9s of
+      # overhead measured). Putting the resolved tool bin directories ahead
+      # of the shims makes those calls direct.
       - run:
-          name: Install yq
+          name: Put mise tool bin paths on PATH
           command: |
-            YQ_VERSION="4.44.5"
-            wget -qO /usr/local/bin/yq \
-              "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64"
-            chmod +x /usr/local/bin/yq
-            echo "yq version: $(yq --version)"
+            echo "export PATH=\"$(mise bin-paths | paste -sd: -):\$PATH\"" >> "$BASH_ENV"
       # Validates the decision tree logic against known scenarios.
       # Fails fast if a refactor breaks expected workflow activation.
       - run:
@@ -213,7 +227,11 @@ workflows:
     when:
       equal: ["", << pipeline.git.tag >>]
     jobs:
-      - prepare-continuation-config
+      - prepare-continuation-config:
+          # MISE_GITHUB_TOKEN: authenticated GitHub API quota for mise's tool
+          # downloads (5,000 req/h per token vs 60/h/IP anonymous).
+          context:
+            - circleci-repo-readonly-authenticated-github-token
 
   setup-tag:
     when:
@@ -221,6 +239,9 @@ workflows:
         equal: ["", << pipeline.git.tag >>]
     jobs:
       - prepare-continuation-config:
+          # MISE_GITHUB_TOKEN, as in the setup workflow above.
+          context:
+            - circleci-repo-readonly-authenticated-github-token
           filters:
             tags:
               only: /.*/

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -3044,6 +3044,7 @@ workflows:
       - circleci-schedule-trigger-check:
           context:
             - circleci-api-token
+            - circleci-repo-readonly-authenticated-github-token
 
   close-issue-workflow:
     when: << pipeline.parameters.c-run_close_issue >>

--- a/docs/ai/ci-config-review.md
+++ b/docs/ai/ci-config-review.md
@@ -9,7 +9,10 @@ hide. For each changed file, walk the relevant items and look for the bad patter
 - **`config.yml` is a setup pipeline** (`setup: true`). `prepare-continuation-config`
   detects changed paths, runs the routing policy (`compute-workflow-conditions.sh`),
   merges the continuation fragments, and continues the pipeline. Only workflows whose
-  `c-run_*` flag the policy set to `true` execute.
+  `c-run_*` flag the policy set to `true` execute. It also front-loads the mise
+  toolset (`utils/install-mise`): it always finishes before any continuation job
+  starts, so on a cold cache it is the only job that installs over the network —
+  continuation jobs restore the mise cache it saved.
 - **Routing is data + logic split**: `routing.yml` holds the declarative data
   (schedule→workflows, API dispatch flag→workflows, change-detection patterns,
   passthrough params); `compute-workflow-conditions.sh` holds the conditions that
@@ -42,10 +45,14 @@ single fragment:
 # 1. Merge the fragments into /tmp/merged-config.yml (uses mise's yq; resolves anchors).
 mise exec -- bash .circleci/scripts/merge-configs.sh
 
-# 2. Validate it. --org-slug is REQUIRED: the private org orb
-#    ethereum-optimism/circleci-utils won't resolve without it (even with a token).
-export CIRCLECI_CLI_TOKEN="$CIRCLE_TOKEN"
-circleci config validate --org-slug gh/ethereum-optimism /tmp/merged-config.yml
+# 2. Validate it. --org is REQUIRED: the private org orb
+#    ethereum-optimism/circleci-utils won't resolve without it (and the CLI
+#    needs CIRCLE_TOKEN set to resolve --org).
+export CIRCLE_TOKEN="<your token>"
+circleci config validate --org gh/ethereum-optimism /tmp/merged-config.yml
+
+# 3. The setup config imports the private orb too, so it needs the same flag.
+circleci config validate --org gh/ethereum-optimism .circleci/config.yml
 ```
 
 Install the CLI without sudo:


### PR DESCRIPTION
## Summary

Implements the in-repo fixes from #22223 — `mise install` is the largest verified CI infra-failure class of 2026, and its dominant failure modes (multi-hour attestation propagation gaps, hourly GitHub rate-limit windows) outlast any sane retry schedule.

### What was already done

- **Wrapper exit-code fix** (issue item 2): landed upstream — circleci-utils tag `orb/1.0.30` is the merge of ethereum-optimism/circleci-utils#34, and all fragments already pin `@1.0.30`.
- **Authenticated mise traffic** (issue item 1): the `circleci-repo-readonly-authenticated-github-token` context already carries `MISE_GITHUB_TOKEN` and was already attached to every mise-running job entry in the merged config **except one** (closed here).

### What this PR changes

1. **Front-load the mise toolset in the setup pipeline** (issue item 3). `prepare-continuation-config` now runs `utils/install-mise`. The setup job always completes before the continuation pipeline exists, so on a cold cache (mise.toml change or eviction) it is the *only* job that installs over the network — every continuation job restores the cache it saves. This needs zero `requires:` wiring (vs. ~46 root-job edits for a `prep-mise` continuation job), covers all current and future workflows automatically, and the ordering guarantee is absolute. It works as a single warmer because every executor in this repo runs as user `circleci`, so there is exactly one `mise-v8-*` cache key per `mise.toml` checksum.
2. **Drop the setup job's yq wget** — an unauthenticated GitHub-releases fetch of the exact yq version `mise.toml` already pins (4.44.5), i.e. the same failure class.
3. **Bypass mise shim overhead for the routing scripts** — the yq/jq loops pay shim resolution on every spawn (~9 s measured); exporting the resolved bin dirs ahead of the shims restored baseline script timings.
4. **Attach the token context to both setup workflows** so cold installs use authenticated quota (5,000 req/h per token vs 60/h per shared egress IP), and to `circleci-schedule-trigger-check` — the last unauthenticated mise job.
5. **Docs**: the front-load in the CI wiring overview, and a `--org-slug` → `--org` CLI flag fix in the validation guide. (A bump-hygiene note for issue item 4 was included initially and dropped per review — a not-yet-propagated release fails CI visibly, and the case is rare enough not to spend AI-doc context on.)

## Cost (measured on this PR)

| path | before | after | dominant step |
|---|---|---|---|
| setup job, warm cache (every pipeline) | 14.7 s (build 5442018) | **38.6 s** (build 5442670) | mise cache restore ~20 s |
| setup job, cold cache (mise.toml change / eviction) | n/a — every cache-missing job cold-installed in parallel | **2 m 46 s** (build 5442565) | `mise install` 102.6 s + cache save 45.4 s |

The +24 s warm delta is ~2–3 % of a typical 15-minute critical path, in exchange for one cold network install per pipeline instead of ~50 during upstream events. The cold path was measured by temporarily touching `mise.toml` (commit dropped); at 2 m 46 s on the default `medium` executor there is no need to bump the resource class for a path that only runs on mise.toml changes.

## Trade-off to be aware of

A mise outage previously showed as many red jobs; it now shows as a red `prepare-continuation-config` with **no continuation workflows at all** (required checks stay "Expected"). Rarer, but different to triage: "no checks appeared on a mise.toml bump" means "look at the setup job".

## Validation

- `merge-configs.sh` + `test-decision-tree.sh` (20/20)
- `circleci config validate --org gh/ethereum-optimism` on both the setup config and the merged config
- `circleci config process` on the setup config, and on the merged config with `c-run_main`, `c-run_rust_ci`, `c-run_rust_e2e_ci`, `c-run_circleci_schedule_trigger_check` enabled
- Warm, cold, and post-shim-fix setup runs all green on this PR (builds above), with continuation pipelines created normally each time
- Reviewed by the `ci-config-reviewer` agent (no blocking findings; its suggestions are folded in). It verified this project never builds forked PRs, so the restricted context on the setup workflow cannot block external contributions, and that scheduled / merge-queue actors already resolve this context today.

## Follow-ups (deliberately not in this PR)

- **Marker cache to reclaim most of the +24 s warm cost.** The warm delta is almost entirely the multi-GB `mise-v8` restore, but the setup job only needs to know the cache *exists* (plus yq/jq for its own scripts). A tiny companion cache (`mise-setup-marker-{user}-{mise.toml checksum}`, holding a marker file plus yq/jq binaries, ~0.3 s to restore) can answer that: marker hit → skip restore/install entirely (~1 s overhead); marker miss → cold-install and save both caches, exactly as this PR does today. The setup job must then never have a big-cache `restore_cache` step at all (cache steps can't be conditioned on runtime state; on a miss it doesn't need one, on a hit it skips everything — `save_cache` stays unconditional since it no-ops on existing keys). Two rare, self-healing edges: marker outliving the big cache degrades to today's parallel cold-install behavior; the reverse wastes one setup-job cold install. Best implemented as an orb command in circleci-utils (e.g. a marker option on `install-mise`) so this repo keeps a single stock command; done inline it is ~50 lines of hand-rolled install logic in the most consequential job in CI.
- The `ubuntu-2204` machine jobs now always consume a mise cache written by cimg/base (24.04); glibc risk is low (static Go/Rust binaries, rustup/python target old glibc) but worth one confirming look here.
- Durable orb fix for the cache-key formula (fold OS/arch/libc into `.executor-user`) — pairs naturally with the marker work above.

Closes #22223

🤖 Generated with [Claude Code](https://claude.com/claude-code)
