### PR TITLE
[DO NOT MERGE] CI baseline probe for v7.0.0 cherry-picks

### DIFF
--- a/docs/public-docs/node-operators/reference/op-node-config.mdx
+++ b/docs/public-docs/node-operators/reference/op-node-config.mdx
@@ -1249,3 +1249,4 @@ op-node --log.level=debug
 By adjusting the log level, operators can control the amount and type of information that
 gets logged, helping to manage log data volume and focus on relevant details during
 different operational scenarios.
+

--- a/op-node/rollup/types.go
+++ b/op-node/rollup/types.go
@@ -888,3 +888,5 @@ func fmtTime(v uint64) string {
 }
 
 type Epoch uint64
+
+// CI baseline probe - do not merge

--- a/packages/contracts-bedrock/scripts/getting-started/config.sh
+++ b/packages/contracts-bedrock/scripts/getting-started/config.sh
@@ -151,3 +151,5 @@ EOL
 
 # Write the final config file
 mv tmp_config.json "$CONTRACTS_BASE/deploy-config/getting-started.json"
+
+# CI baseline probe - do not merge

--- a/rust/kona/crates/protocol/hardforks/src/forks.rs
+++ b/rust/kona/crates/protocol/hardforks/src/forks.rs
@@ -100,3 +100,5 @@ mod tests {
         assert_eq!(cross_l2_inbox_txs.collect::<Vec<_>>().len(), 2);
     }
 }
+
+// CI baseline probe - do not merge

--- a/rust/op-reth/crates/node/src/node.rs
+++ b/rust/op-reth/crates/node/src/node.rs
@@ -1509,3 +1509,5 @@ where
 
 /// Network primitive types used by Optimism networks.
 pub type OpNetworkPrimitives = BasicNetworkPrimitives<OpPrimitives, OpPooledTransaction>;
+
+// CI baseline probe - do not merge


### PR DESCRIPTION
Throwaway probe: unmodified `proposal/op-contracts/v7.0.0` plus a no-op comment, to establish which CI failures on #22330 / #22331 are pre-existing on this branch. Will be closed once the run completes.