### PR TITLE
op-deployer: PCD record implementations and game mode

### DIFF
--- a/op-deployer/pkg/deployer/continue.go
+++ b/op-deployer/pkg/deployer/continue.go
@@ -188,7 +188,11 @@ func (r *continuationRunner) run() error {
 	if err != nil {
 		return err
 	}
-	if err := validateContinuationGameTypes(pending); err != nil {
+	superRoot, err := opcm.ReadSuperRootEnabled(r.ctx, l1Client, pinnedOPCM)
+	if err != nil {
+		return fmt.Errorf("failed to read the OPCM game mode at %s: %w", pinnedOPCM, err)
+	}
+	if err := validateContinuationGameTypes(pending, superRoot, pinnedOPCM); err != nil {
 		return err
 	}
 	for i := range pending {
@@ -208,13 +212,19 @@ func (r *continuationRunner) run() error {
 	return nil
 }
 
-func validateContinuationGameTypes(pending []continuationChain) error {
+func validateContinuationGameTypes(pending []continuationChain, superRoot bool, opcmAddr common.Address) error {
 	gameTypes := make([]uint32, 0, len(pending))
 	for _, chain := range pending {
 		gameTypes = append(gameTypes, chain.dci.DisputeGameType)
 	}
 	if err := pipeline.ValidateInitialGameTypeSet(gameTypes); err != nil {
 		return fmt.Errorf("invalid pending continuation game types: %w", err)
+	}
+	// Catch a frozen selector the pinned OPCM rejects before the fork simulation runs it.
+	for _, chain := range pending {
+		if err := pipeline.ValidateInitialGameTypeForOPCM(chain.dci.DisputeGameType, superRoot, opcmAddr); err != nil {
+			return fmt.Errorf("chain %s: %w", chain.id.Hex(), err)
+		}
 	}
 	return nil
 }

--- a/op-deployer/pkg/deployer/continue_test.go
+++ b/op-deployer/pkg/deployer/continue_test.go
@@ -342,15 +342,30 @@ func TestValidateContinuationGameTypes(t *testing.T) {
 		return continuationChain{dci: dci}
 	}
 
-	require.NoError(t, validateContinuationGameTypes(nil))
+	opcmAddr := common.HexToAddress("0xaaaa000000000000000000000000000000000001")
+
+	require.NoError(t, validateContinuationGameTypes(nil, false, opcmAddr))
 	require.NoError(t, validateContinuationGameTypes([]continuationChain{
 		chain(embedded.GameTypePermissionedCannon),
 		chain(embedded.GameTypeCannonKona),
-	}))
+	}, false, opcmAddr))
+	require.NoError(t, validateContinuationGameTypes([]continuationChain{
+		chain(embedded.GameTypeSuperPermissioned),
+		chain(embedded.GameTypeSuperCannonKona),
+	}, true, opcmAddr))
+
+	// The mix check runs first, so it wins over the per-chain family check.
 	require.ErrorContains(t, validateContinuationGameTypes([]continuationChain{
 		chain(embedded.GameTypeCannonKona),
 		chain(embedded.GameTypeSuperCannonKona),
-	}), "cannot mix CANNON_KONA and SUPER_CANNON_KONA")
+	}, true, opcmAddr), "cannot mix CANNON_KONA and SUPER_CANNON_KONA")
+
+	// A frozen selector the pinned OPCM cannot deploy fails before the fork simulation.
+	err := validateContinuationGameTypes([]continuationChain{
+		chain(embedded.GameTypeCannonKona),
+	}, true, opcmAddr)
+	require.ErrorContains(t, err, "CANNON_KONA (8) is not deployable by the OPCM")
+	require.ErrorContains(t, err, opcmAddr.Hex())
 }
 
 func TestClassifyContinuationAddresses(t *testing.T) {

--- a/op-deployer/pkg/deployer/continue_verify.go
+++ b/op-deployer/pkg/deployer/continue_verify.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/addresses"
 	"github.com/ethereum-optimism/optimism/op-chain-ops/script"
-	"github.com/ethereum-optimism/optimism/op-core/devfeatures"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/opcm"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/pipeline"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/state"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/upgrade/embedded"
 	opeth "github.com/ethereum-optimism/optimism/op-service/eth"
@@ -243,47 +243,25 @@ func verifyContinuationDeployment(
 func (v *continuationVerifier) resolveGameMode() (continuationGameMode, error) {
 	gameType := v.dci.DisputeGameType
 
-	bitmap, err := readContinuation[common.Hash](
-		v.ctx,
-		v.backend,
-		v.dci.Opcm,
-		continuationDevFeatureBitmapMethod,
-	)
+	superRoot, err := opcm.ReadSuperRootEnabled(v.ctx, v.backend, v.dci.Opcm)
 	if err != nil {
 		return continuationGameMode{}, fmt.Errorf("failed to read pinned OPCM dev feature bitmap: %w", err)
 	}
-	superRoot := devfeatures.IsDevFeatureEnabled(bitmap, devfeatures.SuperRootGamesMigrationFlag)
+	// The frozen selector must still match the family the pinned OPCM installs.
+	if err := pipeline.ValidateInitialGameTypeForOPCM(gameType, superRoot, v.dci.Opcm); err != nil {
+		return continuationGameMode{}, err
+	}
 
 	mode := continuationGameMode{
 		respectedGameType: gameType,
 	}
 	switch embedded.GameType(gameType) {
-	// DeployOPChain.s.sol requires GameTypes.isSuperGame(gameType) == isSuperRoot, so each
-	// selector is valid for exactly one OPCM family.
 	case embedded.GameTypePermissionedCannon:
-		if superRoot {
-			return continuationGameMode{}, fmt.Errorf(
-				"initial game type mismatch: frozen selector %d requires an OPCM without SUPER_ROOT_GAMES_MIGRATION",
-				gameType,
-			)
-		}
 		mode.respectedImplementation = v.expected.PermissionedDisputeGameImpl
 		mode.hasChallenger = true
 	case embedded.GameTypeSuperPermissioned:
-		if !superRoot {
-			return continuationGameMode{}, fmt.Errorf(
-				"initial game type mismatch: frozen selector %d requires an OPCM with SUPER_ROOT_GAMES_MIGRATION",
-				gameType,
-			)
-		}
 		mode.respectedImplementation = v.expected.PermissionedDisputeGameImpl
 	case embedded.GameTypeCannonKona:
-		if superRoot {
-			return continuationGameMode{}, fmt.Errorf(
-				"initial game type mismatch: frozen selector %d requires an OPCM without SUPER_ROOT_GAMES_MIGRATION",
-				gameType,
-			)
-		}
 		fallback := uint32(embedded.GameTypePermissionedCannon)
 		mode.respectedImplementation = v.expected.FaultDisputeGameImpl
 		mode.fallbackGameType = &fallback
@@ -291,12 +269,6 @@ func (v *continuationVerifier) resolveGameMode() (continuationGameMode, error) {
 		mode.permissionless = true
 		mode.hasChallenger = true
 	case embedded.GameTypeSuperCannonKona:
-		if !superRoot {
-			return continuationGameMode{}, fmt.Errorf(
-				"initial game type mismatch: frozen selector %d requires an OPCM with SUPER_ROOT_GAMES_MIGRATION",
-				gameType,
-			)
-		}
 		fallback := uint32(embedded.GameTypeSuperPermissioned)
 		mode.respectedImplementation = v.expected.FaultDisputeGameImpl
 		mode.fallbackGameType = &fallback
@@ -944,7 +916,6 @@ var (
 	continuationConfigMethod              = w3.MustNewFunc("config()", "address")
 	continuationGuardianMethod            = w3.MustNewFunc("guardian()", "address")
 	continuationStandardValidatorMethod   = w3.MustNewFunc("opcmStandardValidator()", "address")
-	continuationDevFeatureBitmapMethod    = w3.MustNewFunc("devFeatureBitmap()", "bytes32")
 	continuationStartingAnchorRootMethod  = w3.MustNewFunc("getStartingAnchorRoot()", "(bytes32 root,uint256 l2SequenceNumber)")
 )
 

--- a/op-deployer/pkg/deployer/continue_verify.go
+++ b/op-deployer/pkg/deployer/continue_verify.go
@@ -918,7 +918,6 @@ var (
 	continuationRespectedGameTypeMethod   = w3.MustNewFunc("respectedGameType()", "uint32")
 	continuationGameImplMethod            = w3.MustNewFunc("gameImpls(uint32)", "address")
 	continuationGameArgsMethod            = w3.MustNewFunc("gameArgs(uint32)", "bytes")
-	continuationImplementationsMethod     = w3.MustNewFunc("implementations()", `(address superchainConfigImpl,address l1ERC721BridgeImpl,address optimismPortalImpl,address ethLockboxImpl,address systemConfigImpl,address optimismMintableERC20FactoryImpl,address l1CrossDomainMessengerImpl,address l1StandardBridgeImpl,address disputeGameFactoryImpl,address anchorStateRegistryImpl,address delayedWETHImpl,address mipsImpl,address faultDisputeGameImpl,address permissionedDisputeGameImpl,address superFaultDisputeGameImpl,address superPermissionedDisputeGameImpl,address zkDisputeGameImpl,address storageSetterImpl,address sp1PlonkAdapterImpl)`)
 	continuationOwnerMethod               = w3.MustNewFunc("owner()", "address")
 	continuationAddressManagerMethod      = w3.MustNewFunc("addressManager()", "address")
 	continuationProxyImplementationMethod = w3.MustNewFunc("getProxyImplementation(address)", "address")
@@ -980,7 +979,7 @@ func readContinuationOPCMImplementations(
 		ctx,
 		backend,
 		opcmAddress,
-		continuationImplementationsMethod,
+		opcm.ImplementationsMethod,
 	)
 }
 

--- a/op-deployer/pkg/deployer/continue_verify_test.go
+++ b/op-deployer/pkg/deployer/continue_verify_test.go
@@ -260,7 +260,7 @@ func (f *continuationVerificationFixture) seed(t *testing.T, gameType embedded.G
 	f.backend.set(
 		t,
 		f.dci.Opcm,
-		continuationDevFeatureBitmapMethod,
+		opcm.DevFeatureBitmapMethod,
 		nil,
 		f.devFeatureBitmap(),
 	)
@@ -572,11 +572,15 @@ func TestVerifyContinuationDeploymentRejectsOPCMGameModeMismatch(t *testing.T) {
 		fixture.backend.set(
 			t,
 			fixture.dci.Opcm,
-			continuationDevFeatureBitmapMethod,
+			opcm.DevFeatureBitmapMethod,
 			nil,
 			devfeatures.SuperRootGamesMigrationFlag,
 		)
-		require.ErrorContains(t, fixture.verify(t), "requires an OPCM without SUPER_ROOT_GAMES_MIGRATION")
+		require.ErrorContains(
+			t,
+			fixture.verify(t),
+			"initial dispute game type CANNON_KONA (8) is not deployable by the OPCM",
+		)
 	})
 }
 

--- a/op-deployer/pkg/deployer/continue_verify_test.go
+++ b/op-deployer/pkg/deployer/continue_verify_test.go
@@ -267,7 +267,7 @@ func (f *continuationVerificationFixture) seed(t *testing.T, gameType embedded.G
 	f.backend.set(
 		t,
 		f.dci.Opcm,
-		continuationImplementationsMethod,
+		opcm.ImplementationsMethod,
 		nil,
 		f.impls,
 	)

--- a/op-deployer/pkg/deployer/integration_test/cli/e2e_prepare_test.go
+++ b/op-deployer/pkg/deployer/integration_test/cli/e2e_prepare_test.go
@@ -76,8 +76,9 @@ func TestCLIPrepareCommitsSuperchainDeployment(t *testing.T) {
 		require.NotNil(t, prepared.SuperchainDeployment)
 		require.Equal(t, *applied.SuperchainDeployment, *prepared.SuperchainDeployment)
 
-		// prepare deploys no implementations, so it must not claim any.
-		require.Nil(t, prepared.ImplementationsDeployment)
+		// prepare must record implementations the pinned OPCM installs.
+		require.NotNil(t, prepared.ImplementationsDeployment)
+		require.Equal(t, *applied.ImplementationsDeployment, *prepared.ImplementationsDeployment)
 
 		// The committed proxy must match the frozen intent the continuation deploys from.
 		require.NotNil(t, prepared.PreparedDeployment)

--- a/op-deployer/pkg/deployer/integration_test/continue_test.go
+++ b/op-deployer/pkg/deployer/integration_test/continue_test.go
@@ -123,12 +123,15 @@ func testContinuePermissionless(t *testing.T) {
 	require.Equal(t, nonceBefore, pendingNonce(t, env))
 	setAnvilCode(t, env.l1Client, env.standardValidator, validatorCode)
 
+	// The game mode read is the first call made against the pinned OPCM, so an unusable
+	// OPCM stops the run before the fork simulation.
 	opcmCode, err := env.l1Client.CodeAt(env.ctx, env.opcm, nil)
 	require.NoError(t, err)
 	setAnvilCode(t, env.l1Client, env.opcm, []byte{byte(vm.PUSH0), byte(vm.PUSH0), byte(vm.REVERT)})
 	require.NoError(t, pipeline.WriteState(env.workdir, env.prepared))
 	err = deployer.Continue(env.ctx, env.config())
-	require.ErrorContains(t, err, "continuation preflight failed")
+	require.ErrorContains(t, err, "failed to read the OPCM game mode")
+	require.ErrorContains(t, err, env.opcm.Hex())
 	require.Equal(t, nonceBefore, pendingNonce(t, env))
 	setAnvilCode(t, env.l1Client, env.opcm, opcmCode)
 

--- a/op-deployer/pkg/deployer/opcm/reader.go
+++ b/op-deployer/pkg/deployer/opcm/reader.go
@@ -70,7 +70,7 @@ func CallGetter[T any](
 	return value, nil
 }
 
-// TODO(#2162): Remove this function once the super root dispute games are fully deployed and the flag is no longer needed.
+// TODO(#21662): Remove this function once the super root dispute games are fully deployed and the flag is no longer needed.
 // ReadSuperRootEnabled reports whether a deployed OPCM installs super root dispute games.
 // DeployOPChain.s.sol reads the same flag to decide which game family an initial deploy accepts.
 func ReadSuperRootEnabled(

--- a/op-deployer/pkg/deployer/opcm/reader.go
+++ b/op-deployer/pkg/deployer/opcm/reader.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/addresses"
+	"github.com/ethereum-optimism/optimism/op-core/devfeatures"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/lmittmann/w3"
@@ -12,6 +13,9 @@ import (
 
 // ImplementationsMethod is the canonical implementations() signature for OPContractsManagerV2.
 var ImplementationsMethod = w3.MustNewFunc("implementations()", `(address superchainConfigImpl,address l1ERC721BridgeImpl,address optimismPortalImpl,address ethLockboxImpl,address systemConfigImpl,address optimismMintableERC20FactoryImpl,address l1CrossDomainMessengerImpl,address l1StandardBridgeImpl,address disputeGameFactoryImpl,address anchorStateRegistryImpl,address delayedWETHImpl,address mipsImpl,address faultDisputeGameImpl,address permissionedDisputeGameImpl,address superFaultDisputeGameImpl,address superPermissionedDisputeGameImpl,address zkDisputeGameImpl,address storageSetterImpl,address sp1PlonkAdapterImpl)`)
+
+// DevFeatureBitmapMethod is the canonical devFeatureBitmap() signature for OPContractsManagerV2.
+var DevFeatureBitmapMethod = w3.MustNewFunc("devFeatureBitmap()", "bytes32")
 
 var (
 	contractsContainerMethod    = w3.MustNewFunc("contractsContainer()", "address")
@@ -64,6 +68,20 @@ func CallGetter[T any](
 		return value, fmt.Errorf("failed to decode %s result from %s: %w", method.Signature, contract, err)
 	}
 	return value, nil
+}
+
+// ReadSuperRootEnabled reports whether a deployed OPCM installs super root dispute games.
+// DeployOPChain.s.sol reads the same flag to decide which game family an initial deploy accepts.
+func ReadSuperRootEnabled(
+	ctx context.Context,
+	backend CallContractBackend,
+	opcmAddr common.Address,
+) (bool, error) {
+	bitmap, err := CallGetter[common.Hash](ctx, backend, opcmAddr, DevFeatureBitmapMethod)
+	if err != nil {
+		return false, err
+	}
+	return devfeatures.IsDevFeatureEnabled(bitmap, devfeatures.SuperRootGamesMigrationFlag), nil
 }
 
 // ReadImplementations resolves the full implementation address set from a deployed OPCM.

--- a/op-deployer/pkg/deployer/opcm/reader.go
+++ b/op-deployer/pkg/deployer/opcm/reader.go
@@ -70,6 +70,7 @@ func CallGetter[T any](
 	return value, nil
 }
 
+// TODO(#2162): Remove this function once the super root dispute games are fully deployed and the flag is no longer needed.
 // ReadSuperRootEnabled reports whether a deployed OPCM installs super root dispute games.
 // DeployOPChain.s.sol reads the same flag to decide which game family an initial deploy accepts.
 func ReadSuperRootEnabled(

--- a/op-deployer/pkg/deployer/opcm/reader.go
+++ b/op-deployer/pkg/deployer/opcm/reader.go
@@ -1,0 +1,132 @@
+package opcm
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/addresses"
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/lmittmann/w3"
+)
+
+// ImplementationsMethod is the canonical implementations() signature for OPContractsManagerV2.
+var ImplementationsMethod = w3.MustNewFunc("implementations()", `(address superchainConfigImpl,address l1ERC721BridgeImpl,address optimismPortalImpl,address ethLockboxImpl,address systemConfigImpl,address optimismMintableERC20FactoryImpl,address l1CrossDomainMessengerImpl,address l1StandardBridgeImpl,address disputeGameFactoryImpl,address anchorStateRegistryImpl,address delayedWETHImpl,address mipsImpl,address faultDisputeGameImpl,address permissionedDisputeGameImpl,address superFaultDisputeGameImpl,address superPermissionedDisputeGameImpl,address zkDisputeGameImpl,address storageSetterImpl,address sp1PlonkAdapterImpl)`)
+
+var (
+	contractsContainerMethod    = w3.MustNewFunc("contractsContainer()", "address")
+	opcmUtilsMethod             = w3.MustNewFunc("opcmUtils()", "address")
+	opcmMigratorMethod          = w3.MustNewFunc("opcmMigrator()", "address")
+	opcmStandardValidatorMethod = w3.MustNewFunc("opcmStandardValidator()", "address")
+	mipsOracleMethod            = w3.MustNewFunc("oracle()", "address")
+)
+
+// opcmImplementations mirrors IOPContractsManagerContainer.Implementations.
+type opcmImplementations struct {
+	SuperchainConfigImpl             common.Address
+	L1ERC721BridgeImpl               common.Address
+	OptimismPortalImpl               common.Address
+	ETHLockboxImpl                   common.Address `abi:"ethLockboxImpl"`
+	SystemConfigImpl                 common.Address
+	OptimismMintableERC20FactoryImpl common.Address
+	L1CrossDomainMessengerImpl       common.Address
+	L1StandardBridgeImpl             common.Address
+	DisputeGameFactoryImpl           common.Address
+	AnchorStateRegistryImpl          common.Address
+	DelayedWETHImpl                  common.Address
+	MipsImpl                         common.Address
+	FaultDisputeGameImpl             common.Address
+	PermissionedDisputeGameImpl      common.Address
+	SuperFaultDisputeGameImpl        common.Address
+	SuperPermissionedDisputeGameImpl common.Address
+	ZkDisputeGameImpl                common.Address
+	StorageSetterImpl                common.Address
+	SP1PlonkAdapterImpl              common.Address `abi:"sp1PlonkAdapterImpl"`
+}
+
+// CallGetter encodes, calls and decodes a zero-argument view getter.
+func CallGetter[T any](
+	ctx context.Context,
+	backend CallContractBackend,
+	contract common.Address,
+	method *w3.Func,
+) (T, error) {
+	var value T
+	calldata, err := method.EncodeArgs()
+	if err != nil {
+		return value, fmt.Errorf("failed to encode %s call: %w", method.Signature, err)
+	}
+	result, err := backend.CallContract(ctx, ethereum.CallMsg{To: &contract, Data: calldata}, nil)
+	if err != nil {
+		return value, fmt.Errorf("%s call to %s failed: %w", method.Signature, contract, err)
+	}
+	if err := method.DecodeReturns(result, &value); err != nil {
+		return value, fmt.Errorf("failed to decode %s result from %s: %w", method.Signature, contract, err)
+	}
+	return value, nil
+}
+
+// ReadImplementations resolves the full implementation address set from a deployed OPCM.
+// It is the eth_call equivalent of ReadImplementationAddresses.s.sol.
+func ReadImplementations(
+	ctx context.Context,
+	backend CallContractBackend,
+	opcmAddr common.Address,
+) (*addresses.ImplementationsContracts, error) {
+	impls, err := CallGetter[opcmImplementations](ctx, backend, opcmAddr, ImplementationsMethod)
+	if err != nil {
+		return nil, err
+	}
+	container, err := CallGetter[common.Address](ctx, backend, opcmAddr, contractsContainerMethod)
+	if err != nil {
+		return nil, err
+	}
+	utils, err := CallGetter[common.Address](ctx, backend, opcmAddr, opcmUtilsMethod)
+	if err != nil {
+		return nil, err
+	}
+	migrator, err := CallGetter[common.Address](ctx, backend, opcmAddr, opcmMigratorMethod)
+	if err != nil {
+		return nil, err
+	}
+	validator, err := CallGetter[common.Address](ctx, backend, opcmAddr, opcmStandardValidatorMethod)
+	if err != nil {
+		return nil, err
+	}
+
+	// PreimageOracle is not part of the container struct, MIPS holds it.
+	if impls.MipsImpl == (common.Address{}) {
+		return nil, fmt.Errorf("OPCM at %s reports a zero MIPS implementation", opcmAddr)
+	}
+	oracle, err := CallGetter[common.Address](ctx, backend, impls.MipsImpl, mipsOracleMethod)
+	if err != nil {
+		return nil, err
+	}
+
+	return &addresses.ImplementationsContracts{
+		OpcmStandardValidatorImpl:        validator,
+		OpcmUtilsImpl:                    utils,
+		OpcmMigratorImpl:                 migrator,
+		OpcmV2Impl:                       opcmAddr,
+		OpcmContainerImpl:                container,
+		DelayedWethImpl:                  impls.DelayedWETHImpl,
+		OptimismPortalImpl:               impls.OptimismPortalImpl,
+		EthLockboxImpl:                   impls.ETHLockboxImpl,
+		PreimageOracleImpl:               oracle,
+		MipsImpl:                         impls.MipsImpl,
+		SystemConfigImpl:                 impls.SystemConfigImpl,
+		L1CrossDomainMessengerImpl:       impls.L1CrossDomainMessengerImpl,
+		L1Erc721BridgeImpl:               impls.L1ERC721BridgeImpl,
+		L1StandardBridgeImpl:             impls.L1StandardBridgeImpl,
+		OptimismMintableErc20FactoryImpl: impls.OptimismMintableERC20FactoryImpl,
+		DisputeGameFactoryImpl:           impls.DisputeGameFactoryImpl,
+		AnchorStateRegistryImpl:          impls.AnchorStateRegistryImpl,
+		FaultDisputeGameImpl:             impls.FaultDisputeGameImpl,
+		PermissionedDisputeGameImpl:      impls.PermissionedDisputeGameImpl,
+		ZkDisputeGameImpl:                impls.ZkDisputeGameImpl,
+		StorageSetterImpl:                impls.StorageSetterImpl,
+		SP1PlonkAdapterImpl:              impls.SP1PlonkAdapterImpl,
+		SuperFaultDisputeGameImpl:        impls.SuperFaultDisputeGameImpl,
+		SuperPermissionedDisputeGameImpl: impls.SuperPermissionedDisputeGameImpl,
+	}, nil
+}

--- a/op-deployer/pkg/deployer/opcm/reader_test.go
+++ b/op-deployer/pkg/deployer/opcm/reader_test.go
@@ -1,0 +1,186 @@
+package opcm
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"fmt"
+	"math/big"
+	"reflect"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/addresses"
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/lmittmann/w3"
+	"github.com/stretchr/testify/require"
+)
+
+type readerBackend struct {
+	t         *testing.T
+	responses map[string][]byte
+}
+
+func newReaderBackend(t *testing.T) *readerBackend {
+	return &readerBackend{t: t, responses: make(map[string][]byte)}
+}
+
+func readerCallKey(contract common.Address, data []byte) string {
+	return contract.Hex() + ":" + hex.EncodeToString(data)
+}
+
+func (b *readerBackend) set(contract common.Address, method *w3.Func, values ...any) {
+	b.t.Helper()
+	calldata, err := method.EncodeArgs()
+	require.NoError(b.t, err)
+	output, err := method.Returns.Pack(values...)
+	require.NoError(b.t, err)
+	b.responses[readerCallKey(contract, calldata)] = output
+}
+
+func (b *readerBackend) unset(contract common.Address, method *w3.Func) {
+	b.t.Helper()
+	calldata, err := method.EncodeArgs()
+	require.NoError(b.t, err)
+	delete(b.responses, readerCallKey(contract, calldata))
+}
+
+func (b *readerBackend) CallContract(
+	_ context.Context,
+	call ethereum.CallMsg,
+	_ *big.Int,
+) ([]byte, error) {
+	if call.To == nil {
+		return nil, fmt.Errorf("missing call recipient")
+	}
+	result, ok := b.responses[readerCallKey(*call.To, call.Data)]
+	if !ok {
+		return nil, fmt.Errorf("unexpected call to %s with calldata %s", *call.To, hex.EncodeToString(call.Data))
+	}
+	return bytes.Clone(result), nil
+}
+
+func TestReadImplementations(t *testing.T) {
+	var (
+		opcmAddr  = common.Address{0xcc}
+		container = common.Address{0xc1}
+		utils     = common.Address{0xc2}
+		migrator  = common.Address{0xc3}
+		validator = common.Address{0xc4}
+		oracle    = common.Address{0xc5}
+	)
+
+	// Every stub address is distinct and non-zero, so a mis-mapped field fails the comparison
+	// and an unmapped one stays zero.
+	stub := opcmImplementations{
+		SuperchainConfigImpl:             common.Address{0x01},
+		L1ERC721BridgeImpl:               common.Address{0x02},
+		OptimismPortalImpl:               common.Address{0x03},
+		ETHLockboxImpl:                   common.Address{0x04},
+		SystemConfigImpl:                 common.Address{0x05},
+		OptimismMintableERC20FactoryImpl: common.Address{0x06},
+		L1CrossDomainMessengerImpl:       common.Address{0x07},
+		L1StandardBridgeImpl:             common.Address{0x08},
+		DisputeGameFactoryImpl:           common.Address{0x09},
+		AnchorStateRegistryImpl:          common.Address{0x0a},
+		DelayedWETHImpl:                  common.Address{0x0b},
+		MipsImpl:                         common.Address{0x0c},
+		FaultDisputeGameImpl:             common.Address{0x0d},
+		PermissionedDisputeGameImpl:      common.Address{0x0e},
+		SuperFaultDisputeGameImpl:        common.Address{0x0f},
+		SuperPermissionedDisputeGameImpl: common.Address{0x10},
+		ZkDisputeGameImpl:                common.Address{0x11},
+		StorageSetterImpl:                common.Address{0x12},
+		SP1PlonkAdapterImpl:              common.Address{0x13},
+	}
+
+	newBackend := func(t *testing.T) *readerBackend {
+		b := newReaderBackend(t)
+		b.set(opcmAddr, ImplementationsMethod, stub)
+		b.set(opcmAddr, contractsContainerMethod, container)
+		b.set(opcmAddr, opcmUtilsMethod, utils)
+		b.set(opcmAddr, opcmMigratorMethod, migrator)
+		b.set(opcmAddr, opcmStandardValidatorMethod, validator)
+		b.set(stub.MipsImpl, mipsOracleMethod, oracle)
+		return b
+	}
+
+	t.Run("maps every implementation address", func(t *testing.T) {
+		got, err := ReadImplementations(context.Background(), newBackend(t), opcmAddr)
+		require.NoError(t, err)
+
+		require.Equal(t, &addresses.ImplementationsContracts{
+			OpcmStandardValidatorImpl:        validator,
+			OpcmUtilsImpl:                    utils,
+			OpcmMigratorImpl:                 migrator,
+			OpcmV2Impl:                       opcmAddr,
+			OpcmContainerImpl:                container,
+			DelayedWethImpl:                  stub.DelayedWETHImpl,
+			OptimismPortalImpl:               stub.OptimismPortalImpl,
+			EthLockboxImpl:                   stub.ETHLockboxImpl,
+			PreimageOracleImpl:               oracle,
+			MipsImpl:                         stub.MipsImpl,
+			SystemConfigImpl:                 stub.SystemConfigImpl,
+			L1CrossDomainMessengerImpl:       stub.L1CrossDomainMessengerImpl,
+			L1Erc721BridgeImpl:               stub.L1ERC721BridgeImpl,
+			L1StandardBridgeImpl:             stub.L1StandardBridgeImpl,
+			OptimismMintableErc20FactoryImpl: stub.OptimismMintableERC20FactoryImpl,
+			DisputeGameFactoryImpl:           stub.DisputeGameFactoryImpl,
+			AnchorStateRegistryImpl:          stub.AnchorStateRegistryImpl,
+			FaultDisputeGameImpl:             stub.FaultDisputeGameImpl,
+			PermissionedDisputeGameImpl:      stub.PermissionedDisputeGameImpl,
+			ZkDisputeGameImpl:                stub.ZkDisputeGameImpl,
+			StorageSetterImpl:                stub.StorageSetterImpl,
+			SP1PlonkAdapterImpl:              stub.SP1PlonkAdapterImpl,
+			SuperFaultDisputeGameImpl:        stub.SuperFaultDisputeGameImpl,
+			SuperPermissionedDisputeGameImpl: stub.SuperPermissionedDisputeGameImpl,
+		}, got)
+	})
+
+	t.Run("leaves no field unmapped", func(t *testing.T) {
+		got, err := ReadImplementations(context.Background(), newBackend(t), opcmAddr)
+		require.NoError(t, err)
+
+		// A field added to ImplementationsContracts without a source here stays zero.
+		fields := reflect.ValueOf(*got)
+		for i := range fields.NumField() {
+			name := fields.Type().Field(i).Name
+			addr := fields.Field(i).Interface().(common.Address)
+			require.NotEqual(t, common.Address{}, addr, "%s has no source in ReadImplementations", name)
+			// SuperchainConfigImpl belongs to SuperchainContracts and must not leak in.
+			require.NotEqual(t, stub.SuperchainConfigImpl, addr, "%s was mapped from superchainConfigImpl", name)
+		}
+	})
+
+	t.Run("rejects a zero MIPS implementation", func(t *testing.T) {
+		zeroMips := stub
+		zeroMips.MipsImpl = common.Address{}
+		b := newReaderBackend(t)
+		b.set(opcmAddr, ImplementationsMethod, zeroMips)
+		b.set(opcmAddr, contractsContainerMethod, container)
+		b.set(opcmAddr, opcmUtilsMethod, utils)
+		b.set(opcmAddr, opcmMigratorMethod, migrator)
+		b.set(opcmAddr, opcmStandardValidatorMethod, validator)
+
+		_, err := ReadImplementations(context.Background(), b, opcmAddr)
+		require.ErrorContains(t, err, "zero MIPS implementation")
+	})
+
+	t.Run("names the failing getter", func(t *testing.T) {
+		b := newBackend(t)
+		b.unset(opcmAddr, opcmMigratorMethod)
+
+		_, err := ReadImplementations(context.Background(), b, opcmAddr)
+		require.ErrorContains(t, err, "opcmMigrator()")
+		require.ErrorContains(t, err, opcmAddr.Hex())
+	})
+
+	t.Run("names the failing MIPS getter", func(t *testing.T) {
+		b := newBackend(t)
+		b.unset(stub.MipsImpl, mipsOracleMethod)
+
+		_, err := ReadImplementations(context.Background(), b, opcmAddr)
+		require.ErrorContains(t, err, "oracle()")
+		require.ErrorContains(t, err, stub.MipsImpl.Hex())
+	})
+}

--- a/op-deployer/pkg/deployer/opcm/reader_test.go
+++ b/op-deployer/pkg/deployer/opcm/reader_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/addresses"
+	"github.com/ethereum-optimism/optimism/op-core/devfeatures"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/lmittmann/w3"
@@ -58,6 +59,28 @@ func (b *readerBackend) CallContract(
 		return nil, fmt.Errorf("unexpected call to %s with calldata %s", *call.To, hex.EncodeToString(call.Data))
 	}
 	return bytes.Clone(result), nil
+}
+
+func TestReadSuperRootEnabled(t *testing.T) {
+	opcmAddr := common.Address{0xcc}
+
+	// TODO(#21662): devfeatures.IsDevFeatureEnabled hardcodes SuperRootGamesMigrationFlag to
+	// true, so a cleared bitmap still reports super-root. Solidity does the same, so this
+	// deliberately mirrors what DeployOPChain.s.sol observes.
+	for _, bitmap := range []common.Hash{{}, devfeatures.SuperRootGamesMigrationFlag} {
+		b := newReaderBackend(t)
+		b.set(opcmAddr, DevFeatureBitmapMethod, bitmap)
+
+		superRoot, err := ReadSuperRootEnabled(context.Background(), b, opcmAddr)
+		require.NoError(t, err)
+		require.True(t, superRoot)
+	}
+
+	t.Run("surfaces a failing read", func(t *testing.T) {
+		_, err := ReadSuperRootEnabled(context.Background(), newReaderBackend(t), opcmAddr)
+		require.ErrorContains(t, err, "devFeatureBitmap()")
+		require.ErrorContains(t, err, opcmAddr.Hex())
+	})
 }
 
 func TestReadImplementations(t *testing.T) {

--- a/op-deployer/pkg/deployer/pipeline/opchain.go
+++ b/op-deployer/pkg/deployer/pipeline/opchain.go
@@ -315,6 +315,38 @@ func ValidateInitialGameTypeSet(gameTypes []uint32) error {
 	return nil
 }
 
+func ValidateInitialGameTypeForOPCM(gameType uint32, requireSuperGame bool, opcmAddr common.Address) error {
+	var isSuperGame bool
+	switch embedded.GameType(gameType) {
+	case embedded.GameTypePermissionedCannon, embedded.GameTypeCannonKona:
+	case embedded.GameTypeSuperPermissioned, embedded.GameTypeSuperCannonKona:
+		isSuperGame = true
+	default:
+		return fmt.Errorf("unsupported initial dispute game type %d", gameType)
+	}
+	if isSuperGame == requireSuperGame {
+		return nil
+	}
+
+	permissionless, permissioned := embedded.GameTypeCannonKona, embedded.GameTypePermissionedCannon
+	enabled := "disabled"
+	if requireSuperGame {
+		permissionless, permissioned = embedded.GameTypeSuperCannonKona, embedded.GameTypeSuperPermissioned
+		enabled = "enabled"
+	}
+	return fmt.Errorf(
+		"initial dispute game type %s (%d) is not deployable by the OPCM at %s: it has SUPER_ROOT_GAMES_MIGRATION %s, which accepts only %s (%d) or %s (%d)",
+		initialGameTypeName(gameType),
+		gameType,
+		opcmAddr,
+		enabled,
+		initialGameTypeName(uint32(permissionless)),
+		permissionless,
+		initialGameTypeName(uint32(permissioned)),
+		permissioned,
+	)
+}
+
 // ResolveInitialDeployRequirements returns requirements for a supported initial game type.
 func ResolveInitialDeployRequirements(gameType uint32) (InitialDeployRequirements, error) {
 	switch embedded.GameType(gameType) {

--- a/op-deployer/pkg/deployer/pipeline/opchain_test.go
+++ b/op-deployer/pkg/deployer/pipeline/opchain_test.go
@@ -890,6 +890,45 @@ func TestResolveInitialDeployRequirements(t *testing.T) {
 	}
 }
 
+func TestValidateInitialGameTypeForOPCM(t *testing.T) {
+	opcmAddr := common.HexToAddress("0xaaaa000000000000000000000000000000000001")
+
+	// Mirrors DeployOPChain.s.sol: GameTypes.isSuperGame(gameType) == isSuperRoot.
+	tests := []struct {
+		gameType embedded.GameType
+		superOK  bool
+	}{
+		{embedded.GameTypePermissionedCannon, false},
+		{embedded.GameTypeCannonKona, false},
+		{embedded.GameTypeSuperPermissioned, true},
+		{embedded.GameTypeSuperCannonKona, true},
+	}
+	for _, tt := range tests {
+		t.Run(initialGameTypeName(uint32(tt.gameType)), func(t *testing.T) {
+			require.NoError(t, ValidateInitialGameTypeForOPCM(uint32(tt.gameType), tt.superOK, opcmAddr))
+
+			err := ValidateInitialGameTypeForOPCM(uint32(tt.gameType), !tt.superOK, opcmAddr)
+			require.ErrorContains(t, err, initialGameTypeName(uint32(tt.gameType)))
+			require.ErrorContains(t, err, "is not deployable by the OPCM")
+			require.ErrorContains(t, err, opcmAddr.Hex())
+			if tt.superOK {
+				require.ErrorContains(t, err, "SUPER_ROOT_GAMES_MIGRATION disabled")
+				require.ErrorContains(t, err, "CANNON_KONA (8) or PERMISSIONED_CANNON (1)")
+			} else {
+				require.ErrorContains(t, err, "SUPER_ROOT_GAMES_MIGRATION enabled")
+				require.ErrorContains(t, err, "SUPER_CANNON_KONA (9) or SUPER_PERMISSIONED (5)")
+			}
+		})
+	}
+
+	t.Run("unsupported selector", func(t *testing.T) {
+		for _, superRoot := range []bool{false, true} {
+			err := ValidateInitialGameTypeForOPCM(uint32(embedded.GameTypeCannon), superRoot, opcmAddr)
+			require.ErrorContains(t, err, "unsupported initial dispute game type 0")
+		}
+	})
+}
+
 func TestValidateInitialGameTypeSet(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/op-deployer/pkg/deployer/prepare.go
+++ b/op-deployer/pkg/deployer/prepare.go
@@ -169,6 +169,18 @@ func Prepare(ctx context.Context, cfg PrepareConfig) error {
 		return err
 	}
 
+	l1Client := ethclient.NewClient(l1RPC)
+	if err := checkOPCMHasCode(ctx, l1Client, opcmAddr); err != nil {
+		return err
+	}
+
+	// Record the implementations the pinned OPCM installs.
+	impls, err := opcm.ReadImplementations(ctx, l1Client, opcmAddr)
+	if err != nil {
+		return fmt.Errorf("failed to read implementations from OPCM at %s: %w", opcmAddr, err)
+	}
+	st.ImplementationsDeployment = impls
+
 	l1Host, err := env.DefaultForkedScriptHost(
 		ctx,
 		broadcaster.NoopBroadcaster(),
@@ -281,6 +293,18 @@ func validateL1ChainID(ctx context.Context, l1RPC *rpc.Client, intent *state.Int
 	}
 	if l1ChainID.Cmp(intent.L1ChainIDBig()) != 0 {
 		return fmt.Errorf("l1 chain ID mismatch: got %d, expected %d", l1ChainID, intent.L1ChainID)
+	}
+	return nil
+}
+
+// checkOPCMHasCode rejects an unusable OPCM address.
+func checkOPCMHasCode(ctx context.Context, l1Client *ethclient.Client, opcmAddr common.Address) error {
+	code, err := l1Client.CodeAt(ctx, opcmAddr, nil)
+	if err != nil {
+		return fmt.Errorf("failed to read code at OPCM address %s: %w", opcmAddr, err)
+	}
+	if len(code) == 0 {
+		return fmt.Errorf("no contract code at intent.opcmAddress %s", opcmAddr)
 	}
 	return nil
 }

--- a/op-deployer/pkg/deployer/prepare.go
+++ b/op-deployer/pkg/deployer/prepare.go
@@ -174,6 +174,15 @@ func Prepare(ctx context.Context, cfg PrepareConfig) error {
 		return err
 	}
 
+	// Reject early a game type the pinned OPCM cannot deploy.
+	superRoot, err := opcm.ReadSuperRootEnabled(ctx, l1Client, opcmAddr)
+	if err != nil {
+		return fmt.Errorf("failed to read the OPCM game mode at %s: %w", opcmAddr, err)
+	}
+	if err := validateInitialGameTypes(intent, st, superRoot, opcmAddr); err != nil {
+		return err
+	}
+
 	// Record the implementations the pinned OPCM installs.
 	impls, err := opcm.ReadImplementations(ctx, l1Client, opcmAddr)
 	if err != nil {
@@ -305,6 +314,24 @@ func checkOPCMHasCode(ctx context.Context, l1Client *ethclient.Client, opcmAddr 
 	}
 	if len(code) == 0 {
 		return fmt.Errorf("no contract code at intent.opcmAddress %s", opcmAddr)
+	}
+	return nil
+}
+
+// validateInitialGameTypes rejects any chain whose resolved game type belongs to the family the
+// pinned OPCM does not install. Deployed chains are skipped, their games being fixed on L1.
+func validateInitialGameTypes(intent *state.Intent, st *state.State, superRoot bool, opcmAddr common.Address) error {
+	for _, chain := range intent.Chains {
+		if st.IsChainDeployed(chain.ID) {
+			continue
+		}
+		proofParams, err := pipeline.ResolveChainProofParams(intent, chain)
+		if err != nil {
+			return fmt.Errorf("failed to resolve initial dispute game type for chain %s: %w", chain.ID.Hex(), err)
+		}
+		if err := pipeline.ValidateInitialGameTypeForOPCM(proofParams.DisputeGameType, superRoot, opcmAddr); err != nil {
+			return fmt.Errorf("chain %s: %w", chain.ID.Hex(), err)
+		}
 	}
 	return nil
 }

--- a/op-deployer/pkg/deployer/prepare_test.go
+++ b/op-deployer/pkg/deployer/prepare_test.go
@@ -292,6 +292,40 @@ func TestValidateL1ChainID(t *testing.T) {
 	require.ErrorContains(t, err, "l1 chain ID mismatch: got 900, expected 901")
 }
 
+func TestCheckOPCMHasCode(t *testing.T) {
+	opcmAddr := common.HexToAddress("0xaaaa000000000000000000000000000000000001")
+
+	newClient := func(t *testing.T, code string) *ethclient.Client {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			var req struct {
+				ID     any    `json:"id"`
+				Method string `json:"method"`
+			}
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+			require.Equal(t, "eth_getCode", req.Method)
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+				"jsonrpc": "2.0",
+				"id":      req.ID,
+				"result":  code,
+			}))
+		}))
+		t.Cleanup(srv.Close)
+
+		l1RPC, err := rpc.Dial(srv.URL)
+		require.NoError(t, err)
+		t.Cleanup(l1RPC.Close)
+		return ethclient.NewClient(l1RPC)
+	}
+
+	ctx := context.Background()
+	require.NoError(t, checkOPCMHasCode(ctx, newClient(t, "0x60806040"), opcmAddr))
+
+	err := checkOPCMHasCode(ctx, newClient(t, "0x"), opcmAddr)
+	require.ErrorContains(t, err, "no contract code at intent.opcmAddress")
+	require.ErrorContains(t, err, opcmAddr.Hex())
+}
+
 func TestResolveSuperchainConfigProxy(t *testing.T) {
 	opcmAddr := common.HexToAddress("0xaaaa000000000000000000000000000000000001")
 

--- a/op-deployer/pkg/deployer/prepare_test.go
+++ b/op-deployer/pkg/deployer/prepare_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/ptr"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum-optimism/optimism/op-service/testutils/devnet"
 	"github.com/ethereum/go-ethereum/common"
@@ -324,6 +325,56 @@ func TestCheckOPCMHasCode(t *testing.T) {
 	err := checkOPCMHasCode(ctx, newClient(t, "0x"), opcmAddr)
 	require.ErrorContains(t, err, "no contract code at intent.opcmAddress")
 	require.ErrorContains(t, err, opcmAddr.Hex())
+}
+
+func TestValidateInitialGameTypes(t *testing.T) {
+	opcmAddr := common.HexToAddress("0xaaaa000000000000000000000000000000000001")
+
+	newIntent := func(gameTypes ...uint32) (*state.Intent, *state.State) {
+		intent := &state.Intent{}
+		st := &state.State{}
+		for i, gameType := range gameTypes {
+			id := common.BigToHash(big.NewInt(int64(i + 1)))
+			intent.Chains = append(intent.Chains, &state.ChainIntent{
+				ID:              id,
+				DeployOverrides: map[string]any{"respectedGameType": gameType},
+			})
+			st.Chains = append(st.Chains, &state.ChainState{ID: id, Deployed: ptr.New(false)})
+		}
+		return intent, st
+	}
+
+	t.Run("accepts the family the OPCM installs", func(t *testing.T) {
+		intent, st := newIntent(uint32(embedded.GameTypeSuperCannonKona), uint32(embedded.GameTypeSuperPermissioned))
+		require.NoError(t, validateInitialGameTypes(intent, st, true, opcmAddr))
+
+		intent, st = newIntent(uint32(embedded.GameTypeCannonKona), uint32(embedded.GameTypePermissionedCannon))
+		require.NoError(t, validateInitialGameTypes(intent, st, false, opcmAddr))
+	})
+
+	t.Run("rejects the other family, naming the chain and the alternatives", func(t *testing.T) {
+		intent, st := newIntent(uint32(embedded.GameTypeCannonKona))
+		err := validateInitialGameTypes(intent, st, true, opcmAddr)
+		require.ErrorContains(t, err, intent.Chains[0].ID.Hex())
+		require.ErrorContains(t, err, "CANNON_KONA (8) is not deployable by the OPCM")
+		require.ErrorContains(t, err, opcmAddr.Hex())
+		require.ErrorContains(t, err, "SUPER_CANNON_KONA (9) or SUPER_PERMISSIONED (5)")
+	})
+
+	t.Run("skips chains already deployed", func(t *testing.T) {
+		intent, st := newIntent(uint32(embedded.GameTypeCannonKona))
+		st.Chains[0].Deployed = ptr.New(true)
+		require.NoError(t, validateInitialGameTypes(intent, st, true, opcmAddr))
+	})
+
+	t.Run("validates a chain with no state entry yet", func(t *testing.T) {
+		intent, _ := newIntent(uint32(embedded.GameTypeCannonKona))
+		require.ErrorContains(
+			t,
+			validateInitialGameTypes(intent, &state.State{}, true, opcmAddr),
+			"is not deployable by the OPCM",
+		)
+	})
 }
 
 func TestResolveSuperchainConfigProxy(t *testing.T) {


### PR DESCRIPTION
## Context

PCD's prepare stage pins an OPCM address and freezes everything the later continue stage deploys from. There were two gaps that consumers down the line would encounter:

1. prepare left `state.ImplementationsDeployment` nil, so the prepared state file carried no implementation addresses and consumers reading the state between prepare and continue had nothing to read, the field only appeared after the on-chain deploy.
2. The initial dispute game type has to belong to the family the pinned OPCM supports: Deployment script enforces the selected game type belongs to the family OPCM installs off `SUPER_ROOT_GAMES_MIGRATION` dev flag and nothing checked that at prepare time. A mismatched intent got through the whole off-chain phase and only failed later, as a Solidity revert.

## Changes

**opcm/reader.go (new)**: eth_call readers for a deployed OPCM:
- ReadImplementations: the eth_call equivalent of ReadImplementationAddresses.s.sol; resolves the full addresses.ImplementationsContracts set from implementations(), contractsContainer(), opcmUtils(), opcmMigrator(), opcmStandardValidator(), plus PreimageOracle.
- ReadSuperRootEnabled: reads devFeatureBitmap() and uses `devfeatures.IsDevFeatureEnabled` to check if the `SuperRootGamesMigrationFlag` is enabled (**always** enabled by default (#21662)).
- CallGetter[T]: shared helper; ImplementationsMethod and DevFeatureBitmapMethod are now exported here as the single canonical ABI definitions.

**pipeline.ValidateInitialGameTypeForOPCM**: one shared family check. Rejects unsupported selectors and family mismatches with a a clear message.

**prepare**: added `checkOPCMHasCode` (rejects an OPCM address with no code up front), then reads the OPCM's game mode and validates every chain's resolved game type against it before doing any work, already-deployed chains are skipped. Records `ReadImplementations` output into `st.ImplementationsDeployment` so consumers of the prepare output has something to read.

**continue**: reads the pinned OPCM's game mode once and runs the same validation over all pending chains before the fork simulation, so a bad frozen selector fails fast instead of as a script revert. `resolveGameMode` now delegates to `ValidateInitialGameTypeForOPCM`.

## Tests

- **TestReadImplementations**: full field mapping against a stubbed backend; a reflection pass asserts every ImplementationsContracts field has a source (a newly added field left unmapped stays zero and fails), and that superchainConfigImpl doesn't leak in. Pluszero-MIPS rejection and error messages naming the failing getter and its contract.
- **TestReadSuperRootEnabled**: flag decoding and read-failure surfacing.
- **TestValidateInitialGameTypeForOPCM**: all four supported selectors in both OPCM modes, plus an unsupported selector.
- **TestValidateInitialGameTypes (prepare)**: accepts the matching family, rejects the other one naming the chain and alternatives, skips already-deployed chains, and handles a chain with no state entry yet.
- **TestValidateContinuationGameTypes**: both families accepted; confirms the mix check still runs first; a frozen selector the pinnedOPCM can't deploy fails with the new message.
- **TestCheckOPCMHasCode**: code present vs. empty, over a stubbed eth_getCode.
- **TestVerifyContinuationDeploymentRejectsOPCMGameModeMismatch** updated to the unified error text; `TestCLIPrepareCommitsSuperchainDeployment` now asserts prepare writes an ImplementationsDeployment identical to apply's.

Closes #22334 
Closes #22333 