### PR TITLE
op-node: don't lose the sequencer deadline on an early timer fire

### DIFF
--- a/op-node/rollup/sequencing/sequencer.go
+++ b/op-node/rollup/sequencing/sequencer.go
@@ -236,15 +236,16 @@ func (d *Sequencer) wake() {
 	}
 }
 
-// drainInbox replays queued external events in arrival order.
+// drainInbox replays queued external events in arrival order, and reports
+// whether they mutated the action schedule.
 // Must only be called from the sequencer goroutine.
-func (d *Sequencer) drainInbox() {
+func (d *Sequencer) drainInbox() (scheduleChanged bool) {
 	d.inboxMu.Lock()
 	events := d.inbox
 	d.inbox = nil
 	d.inboxMu.Unlock()
 	if len(events) == 0 {
-		return
+		return false
 	}
 
 	d.l.Lock()
@@ -257,7 +258,9 @@ func (d *Sequencer) drainInbox() {
 	if d.nextActionOK != preOk || d.nextAction != preTime {
 		d.log.Debug("Sequencer action schedule changed",
 			"time", d.nextAction, "wait", d.nextAction.Sub(d.timeNow()), "ok", d.nextActionOK)
+		return true
 	}
+	return false
 }
 
 // handleIngest dispatches a single inbox event to its handler.
@@ -286,20 +289,24 @@ func (d *Sequencer) handleIngest(ev event.Event) {
 func (d *Sequencer) RunLoop(ctx context.Context) {
 	timer := time.NewTimer(0)
 	defer timer.Stop()
-	// lastRan is the deadline the previous action fired at. An action that
-	// leaves the schedule untouched (e.g. a no-op while state is unknown) must
-	// not re-arm the same deadline, or the loop would spin on it; the next
-	// schedule mutation wakes the loop and re-plans with a fresh deadline.
+	// lastRan is the deadline the previous action fired at, and is only
+	// meaningful while the schedule still holds exactly that state: an action
+	// that leaves the schedule untouched (e.g. a no-op while state is unknown)
+	// must not re-arm the same deadline, or the loop would spin on it. Any
+	// schedule mutation invalidates the guard — arming a byte-identical
+	// instant after a mutation is a fresh deadline, not the fired one.
 	var lastRan time.Time
 	for {
-		d.drainInbox()
+		if d.drainInbox() {
+			lastRan = time.Time{}
+		}
 
 		// Re-plan from post-drain state. A nil channel blocks forever,
 		// disarming the timer case while no action is scheduled.
 		var timerC <-chan time.Time
 		var armed time.Time
 		if nextAction, ok := d.NextAction(); ok && nextAction != lastRan {
-			timer.Reset(time.Until(nextAction))
+			timer.Reset(nextAction.Sub(d.timeNow()))
 			timerC = timer.C
 			armed = nextAction
 		} else {
@@ -317,14 +324,34 @@ func (d *Sequencer) RunLoop(ctx context.Context) {
 		case <-d.wakeCh:
 			// loop around: drain the inbox and re-plan
 		case <-timerC:
-			lastRan = armed
-			d.drainInbox() // events may have arrived while we were sleeping
+			if d.drainInbox() { // events may have arrived while we were sleeping
+				lastRan = time.Time{}
+			}
 			// The drain may have pushed the deadline out (engine backoff, the
 			// post-reset delay). Acting on the fired deadline would defeat it.
-			if next, ok := d.NextAction(); !ok || next.After(d.timeNow()) {
+			// The timer can also deliver while timeNow() still reads before the
+			// unchanged deadline: deadlines are wall-clock values but the timer
+			// sleeps monotonic time, so a backward wall-clock step (VM time
+			// sync, NTP) makes the fire early. Either way, don't touch lastRan:
+			// recording a deadline that never ran would let the planning pass
+			// above disarm it forever, silently freezing the sequencer.
+			next, ok := d.NextAction()
+			if !ok || next.After(d.timeNow()) {
+				if ok && next.Equal(armed) {
+					d.log.Debug("Timer fired before its wall-clock deadline, re-arming",
+						"deadline", next, "early_by", next.Sub(d.timeNow()))
+				}
 				continue
 			}
+			// Record the post-drain deadline the action actually consumes (the
+			// armed one may have been replaced while sleeping).
+			lastRan = next
 			d.RunAction()
+			if after, stillOk := d.NextAction(); stillOk && after != next {
+				// The action re-planned: whatever is scheduled now is a fresh
+				// deadline, even if a later event re-creates the fired instant.
+				lastRan = time.Time{}
+			}
 		}
 	}
 }

--- a/op-node/rollup/sequencing/sequencer_runloop_test.go
+++ b/op-node/rollup/sequencing/sequencer_runloop_test.go
@@ -1,0 +1,202 @@
+package sequencing
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/engine"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/event"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+)
+
+// logSignalHandler signals a channel whenever a log record containing match
+// passes through. Safe to select on from the test goroutine while the loop
+// goroutine logs.
+type logSignalHandler struct {
+	inner slog.Handler
+	match string
+	ch    chan struct{}
+}
+
+func (s *logSignalHandler) Enabled(ctx context.Context, lvl slog.Level) bool {
+	return s.inner.Enabled(ctx, lvl)
+}
+
+func (s *logSignalHandler) Handle(ctx context.Context, r slog.Record) error {
+	if strings.Contains(r.Message, s.match) {
+		select {
+		case s.ch <- struct{}{}:
+		default:
+		}
+	}
+	return s.inner.Handle(ctx, r)
+}
+
+func (s *logSignalHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &logSignalHandler{inner: s.inner.WithAttrs(attrs), match: s.match, ch: s.ch}
+}
+
+func (s *logSignalHandler) WithGroup(name string) slog.Handler {
+	return &logSignalHandler{inner: s.inner.WithGroup(name), match: s.match, ch: s.ch}
+}
+
+// runLoopHarness runs the real RunLoop against an active sequencer with a
+// future deadline armed, exactly the state scheduleNextAction leaves behind
+// after a block insertion. The clock offset simulates the wall clock being
+// stepped relative to the monotonic clock (as VM time-sync daemons do): the
+// sequencer's clock reads time.Now().Add(offset), while the loop's timer
+// sleeps monotonic time.
+type runLoopHarness struct {
+	seq          *Sequencer
+	offsetNs     atomic.Int64
+	buildStarted chan struct{}
+	earlyFire    chan struct{}
+	head         eth.L2BlockRef
+	deadline     time.Time
+}
+
+func newRunLoopHarness(t *testing.T) *runLoopHarness {
+	h := &runLoopHarness{
+		buildStarted: make(chan struct{}, 16),
+		earlyFire:    make(chan struct{}, 1),
+	}
+	logger := testlog.LoggerWithHandlerMod(t, log.LevelDebug, func(inner slog.Handler) slog.Handler {
+		return &logSignalHandler{inner: inner, match: "fired before its wall-clock deadline", ch: h.earlyFire}
+	})
+	seq, deps := createSequencer(logger)
+	// The harness asserts no emitted events; a permissive emitter keeps an
+	// accidental Emit from panicking inside the loop goroutine.
+	seq.AttachEmitter(event.NoopEmitter{})
+	deps.conductor.leader = true
+
+	h.seq = seq
+	seq.timeNow = func() time.Time { return time.Now().Add(time.Duration(h.offsetNs.Load())) }
+
+	h.head = eth.L2BlockRef{Hash: common.Hash{0xaa}, Number: 100, Time: uint64(time.Now().Unix())}
+	deps.l1OriginSelector.l1OriginFn = func(l2Head eth.L2BlockRef) (eth.L1BlockRef, error) {
+		return eth.L1BlockRef{Number: 3000001, Time: h.head.Time}, nil
+	}
+	deps.eng.startBuildFn = func(ctx context.Context, attrs *derive.AttributesWithParent) (*engine.BuildStartResult, error) {
+		h.buildStarted <- struct{}{}
+		// Drop the job; the sequencer parks afterwards, which keeps the
+		// harness simple: these tests only care whether the action fired.
+		return nil, engine.ErrStaleBuild
+	}
+
+	ctx := context.Background()
+	require.NoError(t, seq.Init(ctx, false))
+	deliver(seq, engine.ForkchoiceUpdateEvent{UnsafeL2Head: h.head})
+	seq.latestSealed = h.head
+	require.NoError(t, seq.Start(ctx, h.head.Hash))
+
+	// Overwrite the schedule with a future deadline, as scheduleNextAction
+	// leaves it right after a block insertion.
+	h.deadline = time.Now().Add(500 * time.Millisecond)
+	seq.l.Lock()
+	seq.nextAction = h.deadline
+	seq.nextActionOK = true
+	seq.l.Unlock()
+	return h
+}
+
+// start runs RunLoop until the test ends.
+func (h *runLoopHarness) start(t *testing.T) {
+	loopCtx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		h.seq.RunLoop(loopCtx)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		<-done
+	})
+}
+
+// TestRunLoopActionFiresOnSchedule is the control for the early-fire test
+// below: with a well-behaved clock, the armed deadline fires and a build
+// starts.
+func TestRunLoopActionFiresOnSchedule(t *testing.T) {
+	h := newRunLoopHarness(t)
+	h.start(t)
+	select {
+	case <-h.buildStarted:
+	case <-time.After(10 * time.Second):
+		t.Fatal("armed deadline never fired under a healthy clock")
+	}
+}
+
+// TestRunLoopSurvivesEarlyTimerFire covers the deadline scheduling against
+// wall-clock regressions. The armed deadlines are wall-only time.Unix values,
+// so the timer duration is a wall-clock difference while the timer itself
+// sleeps monotonic time: if the wall clock is stepped backward between arm
+// and fire (VM time sync, NTP), the timer delivers while the sequencer clock
+// still reads before the deadline and RunLoop takes the not-yet-due continue
+// path.
+//
+// RunLoop used to record lastRan = armed before that check. The planning pass
+// refuses to arm a deadline equal to lastRan (the anti-spin guard), and
+// lastRan was only reset when the schedule emptied — which never happens
+// while a valid, overdue action is scheduled. One early delivery therefore
+// lost the deadline forever: the sequencer sat parked in its select with
+// admin_sequencerActive=true and block production permanently frozen, with no
+// log, metric, or error. Observed as intermittent total L2 freezes on Docker
+// Desktop devnets, where the VM wall clock is periodically stepped by up to
+// ~10ms.
+func TestRunLoopSurvivesEarlyTimerFire(t *testing.T) {
+	h := newRunLoopHarness(t)
+	h.start(t)
+
+	// Let the loop consume the pending wake-up from Start() and settle into
+	// its timer wait, so the deadline's duration is computed pre-regression.
+	time.Sleep(50 * time.Millisecond)
+
+	// Step the wall clock 1s backward while the timer (armed ~450ms out) is
+	// sleeping: the monotonic timer will deliver while the sequencer's clock
+	// still reads before the deadline.
+	h.offsetNs.Store(int64(-time.Second))
+
+	// Wait until the loop demonstrably handles the early fire. On the pre-fix
+	// code the log never appears: the deadline is silently lost instead.
+	select {
+	case <-h.buildStarted:
+		// The regression landed after the timer had already fired (heavily
+		// loaded machine); the scenario under test did not occur.
+		t.Skip("timer fired before the clock regression took effect")
+	case <-h.earlyFire:
+	case <-time.After(10 * time.Second):
+		t.Fatal("RunLoop never handled the early timer fire: pre-fix code silently drops the deadline here")
+	}
+
+	// While the clock still reads before the deadline, wake-ups must re-plan
+	// without running the action early — and without losing the deadline.
+	h.seq.OnEvent(context.Background(), engine.ForkchoiceUpdateEvent{UnsafeL2Head: h.head})
+	time.Sleep(50 * time.Millisecond)
+	select {
+	case <-h.buildStarted:
+		t.Fatal("action ran while the sequencer clock still read before its deadline")
+	default:
+	}
+
+	// The regression was transient: once the clock recovers, the re-armed
+	// deadline must fire and the action must run.
+	h.offsetNs.Store(0)
+	select {
+	case <-h.buildStarted:
+	case <-time.After(10 * time.Second):
+		next, ok := h.seq.NextAction()
+		t.Fatalf("deadline lost to the early timer fire (NextAction still claims ok=%v at %s, %s overdue)",
+			ok, next, time.Since(next))
+	}
+}


### PR DESCRIPTION
# op-node: don't lose the sequencer deadline on an early timer fire

## Description

Since #22241 the sequencer runs on its own goroutine: a planning pass arms a timer for the
next action, and a `lastRan` guard prevents re-arming a deadline that already fired but whose
action left the schedule untouched (so the loop can't spin on it).

`RunLoop` recorded `lastRan = armed` **before** checking whether the fired deadline is
actually due:

```go
case <-timerC:
    lastRan = armed                    // recorded before the due-check
    d.drainInbox()
    if next, ok := d.NextAction(); !ok || next.After(d.timeNow()) {
        continue                       // "not due yet" — but deadline now == lastRan
    }
    d.RunAction()
```

If the timer delivers while `d.timeNow()` still reads *before* the armed deadline, the loop
`continue`s without acting — but the planning pass now refuses to arm the deadline
(`nextAction != lastRan` fails), and `lastRan` is only reset when the schedule empties, which
never happens while a valid (now overdue) action remains scheduled. One early delivery loses
the deadline forever: the sequencer parks in its `select`, `admin_sequencerActive` stays
`true`, and block production freezes permanently with **no log, no metric, no error**.

### Why the timer can fire "early"

The armed deadlines are wall-only `time.Unix` values, so `time.Until(D)` is a *wall-clock*
difference — but Go timers sleep *monotonic* time. A backward wall-clock step between arm and
fire (VM time sync, NTP) makes the fire early. Only the wall-derived deadlines — the normal
healthy sequencing cadence — are vulnerable; error-path deadlines built from `timeNow()`
carry a monotonic reading and cannot misfire this way.

### Real-world impact

This was root-caused from intermittent, permanent L2 freezes on a local Kupcake devnet
(Docker Desktop on macOS), where the VM's wall clock is periodically stepped:

- A timer-pattern probe measured early fires of 47µs–11ms roughly every ~3 minutes inside
  the VM, matching the observed time-to-freeze distribution (80s–15min).
- An op-node instrumented with a WARN on the early-fire path froze at block 211 logging
  `early timer fire … early_by=691µs` at the exact freeze moment, then
  `disarmed with overdue deadline equal to lastRan` on every subsequent wake.
- With the core of this fix (don't record `lastRan` on the early-fire path), the same devnet
  survived 8 early-fire events over a 66-minute soak (~1990 blocks, one per 2s) with no
  missed blocks — each event a guaranteed permanent freeze on the unfixed build, which never
  survived past 15 minutes in 5 attempts.
- The op-conductor cannot self-heal a frozen node: its `admin_startSequencer` recovery hits
  `ErrSequencerAlreadyStarted` because the sequencer is parked-but-active. Manual
  `admin_stopSequencer` + `admin_startSequencer` recovers instantly (verified live).

Any sequencer ≥ #22241 on a host whose wall clock can step backward (VMs, laptops,
aggressively disciplined NTP) is exposed.

## The fix

`lastRan` now records a fired deadline only when its action actually runs, and any schedule
mutation invalidates it:

- On the early-fire (or drain-moved-deadline) `continue` path, `lastRan` is left untouched,
  so the planning pass re-arms the pending deadline for the remaining wall-clock difference.
  A `Debug` log makes the previously invisible early fire observable.
- `lastRan` records the **post-drain** deadline the action actually consumes, not the stale
  `armed` value (the drain while sleeping may have replaced it).
- Schedule mutations — by the inbox drain or by the action itself — reset `lastRan`: arming
  a byte-identical instant after a mutation is a fresh deadline, not the fired one. This
  closes the residual equality-collision freezes (wall-only `time.Unix` deadlines can
  legitimately recompute to the same instant, e.g. for a same-timestamp head replacement
  after a backward clock step).
- The timer is armed via `nextAction.Sub(d.timeNow())` (identical to `time.Until` in
  production, where `timeNow` is `time.Now`), so the loop's scheduling is fully exercisable
  with an injected clock.

The anti-spin purpose of `lastRan` is preserved: an action that runs but leaves the schedule
untouched still won't be re-armed.

## Tests

- `TestRunLoopSurvivesEarlyTimerFire` — drives the real `RunLoop` with an injectable wall
  clock through a transient 1s backward step while the timer sleeps: the loop must handle the
  early fire (observed via the new debug log), must not act before the deadline is due, and
  must act once the clock recovers. Fails on the previous code — the deadline is silently
  dropped and the sequencer never acts again — and passes with the fix. Degenerate CI timing
  (the step landing after the timer already fired) is detected and skips rather than
  silently passing.
- `TestRunLoopActionFiresOnSchedule` — control: the harness's armed deadline fires normally
  under a healthy clock.
- Full `op-node` test suite passes, including with `-race`; `just lint-go` clean.

## Follow-ups (not in this PR)

- Consider deriving sequencer deadlines from the monotonic clock so scheduling never trusts
  raw wall-clock comparisons.
- Consider a metric/log for "overdue `NextAction` with no timer armed" — this failure was
  invisible to every existing signal.
- `FindL1Origin`/`SealBuild` use `d.ctx` with no timeout (unlike
  `PreparePayloadAttributes`' 20s) — a latent liveness gap observed while ruling out
  alternatives, worth hardening separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
