### PR TITLE
op-node: drop the sequencer run-loop's fired-deadline guard

### DIFF
--- a/op-node/rollup/sequencing/sequencer.go
+++ b/op-node/rollup/sequencing/sequencer.go
@@ -286,29 +286,19 @@ func (d *Sequencer) handleIngest(ev event.Event) {
 func (d *Sequencer) RunLoop(ctx context.Context) {
 	timer := time.NewTimer(0)
 	defer timer.Stop()
-	// lastRan is the deadline the previous action fired at. An action that
-	// leaves the schedule untouched (e.g. a no-op while state is unknown) must
-	// not re-arm the same deadline, or the loop would spin on it; the next
-	// schedule mutation wakes the loop and re-plans with a fresh deadline.
-	var lastRan time.Time
 	for {
 		d.drainInbox()
 
 		// Re-plan from post-drain state. A nil channel blocks forever,
 		// disarming the timer case while no action is scheduled.
 		var timerC <-chan time.Time
-		var armed time.Time
-		if nextAction, ok := d.NextAction(); ok && nextAction != lastRan {
-			timer.Reset(time.Until(nextAction))
+		if nextAction, ok := d.NextAction(); ok {
+			// Same clock the due-check below uses, so an early fire re-arms on
+			// the true remaining wait instead of busy-looping.
+			timer.Reset(nextAction.Sub(d.timeNow()))
 			timerC = timer.C
-			armed = nextAction
 		} else {
 			timer.Stop()
-			if !ok {
-				// Forget the fired deadline on disarm, so re-arming at the very
-				// same instant later still schedules the action.
-				lastRan = time.Time{}
-			}
 		}
 
 		select {
@@ -317,11 +307,14 @@ func (d *Sequencer) RunLoop(ctx context.Context) {
 		case <-d.wakeCh:
 			// loop around: drain the inbox and re-plan
 		case <-timerC:
-			lastRan = armed
 			d.drainInbox() // events may have arrived while we were sleeping
-			// The drain may have pushed the deadline out (engine backoff, the
-			// post-reset delay). Acting on the fired deadline would defeat it.
+			// Only act on a deadline that is actually due. The drain may have
+			// pushed it out (engine backoff, post-reset delay), and the timer
+			// itself can fire early: deadlines are wall-clock values while the
+			// sleep is monotonic, so a backward clock step arrives here as an
+			// early fire. Either way, loop around and re-plan on the remainder.
 			if next, ok := d.NextAction(); !ok || next.After(d.timeNow()) {
+				d.log.Debug("Sequencer deadline not due yet, re-planning", "next", next)
 				continue
 			}
 			d.RunAction()
@@ -390,6 +383,10 @@ func (d *Sequencer) RunAction() {
 	d.log.Debug("Sequencer action")
 	if !d.active.Load() {
 		d.log.Debug("Ignoring stale sequencer action while inactive")
+		// Every exit must leave the schedule changed or disarmed, so the loop
+		// never re-fires an unchanged deadline. Start/Stop normally keep these
+		// two in step; this makes it structural rather than incidental.
+		d.nextActionOK = false
 		return
 	}
 	// The inbox drain above may have parked the schedule (reset, derivation

--- a/op-node/rollup/sequencing/sequencer_inbox_test.go
+++ b/op-node/rollup/sequencing/sequencer_inbox_test.go
@@ -519,3 +519,52 @@ func TestSequencerRunLoop_NoSpinOnUnchangedSchedule(t *testing.T) {
 	require.Less(t, clockReads.Load(), int64(10),
 		"loop re-fired the same deadline instead of parking")
 }
+
+// TestSequencerRunLoop_EarlyTimerFireKeepsDeadline covers a backward wall-clock
+// step (VM time sync, NTP) landing between arming the timer and its fire.
+// Sequencing deadlines are wall-clock values while the timer sleeps monotonic
+// time, so the step delivers the fire before the deadline is due. The loop must
+// re-plan on the remaining wait and still act: dropping the deadline here froze
+// block production permanently, with no log, metric or error (#22357).
+func TestSequencerRunLoop_EarlyTimerFireKeepsDeadline(t *testing.T) {
+	f := newRunLoopFixture(t)
+	deliver(f.seq, engine.ForkchoiceUpdateEvent{UnsafeL2Head: f.head})
+
+	const step = 500 * time.Millisecond
+	start := time.Now()
+	deadline := start.Add(150 * time.Millisecond)
+	// The step lands after the loop has armed its timer, so the fire is early.
+	stepAt := start.Add(50 * time.Millisecond)
+	f.seq.timeNow = func() time.Time {
+		now := time.Now()
+		if now.Before(stepAt) {
+			return now
+		}
+		return now.Add(-step)
+	}
+
+	var actions atomic.Int64
+	f.deps.eng.startBuildFn = func(context.Context, *derive.AttributesWithParent) (*engine.BuildStartResult, error) {
+		actions.Add(1)
+		return nil, context.Canceled // the outcome is irrelevant; only that we ran
+	}
+
+	f.seq.l.Lock()
+	f.seq.active.Store(true)
+	f.seq.nextActionOK = true
+	f.seq.nextAction = deadline
+	f.seq.l.Unlock()
+
+	stop := f.startLoop(t)
+	defer stop()
+	f.seq.wake() // re-plan onto the deadline set above
+
+	// The timer fires at +150ms, but the stepped clock still reads before the
+	// deadline, so the action is not due yet.
+	time.Sleep(300 * time.Millisecond)
+	require.Zero(t, actions.Load(), "must not act before the deadline is due")
+
+	// Once the stepped clock reaches the deadline, the action must still run.
+	require.Eventually(t, func() bool { return actions.Load() > 0 }, 3*time.Second, 20*time.Millisecond,
+		"early timer fire dropped the deadline: the sequencer never acted again")
+}


### PR DESCRIPTION
Alternative to #22357, which diagnosed this. Same root cause, opposite direction: this deletes the mechanism instead of repairing it.

Since #22241 the sequencer's `RunLoop` recorded `lastRan = armed` **before** checking whether the fired deadline was due, so the "not due yet" `continue` marked the deadline as fired without acting on it. The planning pass then refused to re-arm it (`nextAction != lastRan`), and `lastRan` only resets when the schedule empties — which never happens while a valid action is pending. One early timer fire froze block production permanently: no log, no metric, `admin_sequencerActive` still `true`, and op-conductor unable to recover because `admin_startSequencer` returns `ErrSequencerAlreadyStarted`.

Timers can fire early because sequencing deadlines are wall-clock values while the sleep is monotonic, so a backward clock step (VM time sync, NTP) between arm and fire delivers early. See #22357 for the field diagnosis: a Kupcake devnet on Docker Desktop/macOS, early fires of 47µs–11ms roughly every ~3 minutes, freezing within 80s–15min.

## The fix

`lastRan` existed to stop the loop re-arming a deadline whose action left the schedule untouched, which would spin. That guard is removed and its purpose made structural instead:

- **Delete `lastRan`** and its machinery: the `!= lastRan` planning condition, the `armed` temporary, the unconditional record on fire, and the reset-on-disarm block. With no memory of fired deadlines there is nothing to lose, and the equality-collision case (wall-clock deadlines legitimately recomputing to the same instant) disappears by construction.
- **Clear `nextActionOK` on `RunAction`'s inactive exit.** Every other exit already changes the schedule or disarms it; this was the one that did neither, and `Start`/`Stop` only kept it consistent incidentally. Making it structural is what lets the guard go.
- **Arm from the loop's own clock** — `nextAction.Sub(d.timeNow())` rather than `time.Until`. Identical in production, where `timeNow` is `time.Now`. Without it an early fire re-arms against a clock that disagrees with the due-check and busy-loops until wall time catches up.

Net: two variables and two branches removed, one assignment added.

The due-check itself stays — it was added for a real reason (the drain can push the deadline out via an engine backoff or the post-reset delay) and is now also what absorbs early fires. A debug log makes the previously invisible early fire observable.

## Why remove rather than repair

When this guard was reviewed in #22241 an audit of all 25 `RunAction` exits found it defended an empty class: no exit could leave the schedule armed and unchanged. It was kept anyway, as a backstop against a future edit introducing one, on the grounds that the CPU spin it prevented was severe.

That weighed the spin against nothing, and never weighed the guard's own failure mode. A spin is loud and immediately diagnosable; this freeze was invisible to every existing signal and unrecoverable by the conductor. A backstop whose failure mode is worse than the fault it prevents is not worth its state.

## Tests

`TestSequencerRunLoop_EarlyTimerFireKeepsDeadline` drives the real `RunLoop` through a backward clock step that lands after the timer is armed, and asserts the loop does not act early and still acts once the stepped clock reaches the deadline. Verified red on `develop` (`the sequencer never acted again`) and green here.

`TestSequencerRunLoop_NoSpinOnUnchangedSchedule` still passes, now via the structural invariant rather than the guard — verified by mutation: deleting the new `nextActionOK = false` line turns it red, so the anti-spin property is genuinely carried, not passing vacuously.

`-race` green across `op-node/rollup/sequencing` and `op-node/rollup/driver`; `just lint-go` 0 issues.

## Follow-ups not in this PR

- Deriving sequencer deadlines from a monotonic reading so scheduling never compares raw wall clocks (from #22357).
- `FindL1Origin`/`SealBuild` run on `d.ctx` with no timeout, unlike `PreparePayloadAttributes`' 20s (from #22357).
- #22318 — `Sequencer.Stop` can block indefinitely, a separate liveness gap in the same file.

🤖 *Co-created with Claude (Opus 5)*
