### PR TITLE
feat(kona-node): add follow source request metrics

### DIFF
--- a/rust/kona/crates/node/service/src/actors/derivation/delegated/actor.rs
+++ b/rust/kona/crates/node/service/src/actors/derivation/delegated/actor.rs
@@ -143,7 +143,10 @@ where
 
     /// Verifies that the L1 info reported by the derivation delegate
     /// are consistent with canonical L1 chain.
-    async fn validate_sync_status(&mut self, v: &SyncStatus) -> bool {
+    async fn validate_sync_status(
+        &mut self,
+        v: &SyncStatus,
+    ) -> Result<(), DerivationDelegationError> {
         let checks = [
             ("L1 Origin of Safe L2", v.safe_l2.l1_origin.number, v.safe_l2.l1_origin.hash),
             (
@@ -161,10 +164,10 @@ where
                     error = %err,
                     "L1 inconsistency detected at sync status from delegate"
                 );
-                return false;
+                return Err(err);
             }
         }
-        true
+        Ok(())
     }
 
     /// Fetches, validates, and applies sync status from the derivation delegate.
@@ -173,14 +176,35 @@ where
             Ok(status) => status,
             Err(_) => {
                 warn!(target: "derivation", "Failed to fetch sync status from delegate");
+                kona_macros::inc!(
+                    counter,
+                    crate::Metrics::FOLLOW_SOURCE_REQUESTS,
+                    "result" => crate::Metrics::FOLLOW_SOURCE_ERROR_FETCH_STATUS
+                );
                 return Ok(());
             }
         };
 
-        if !self.validate_sync_status(&sync_status).await {
+        if let Err(err) = self.validate_sync_status(&sync_status).await {
             // Validation failures here are expected to be transient, so we skip processing
             // this sync status and continue delegating derivation instead of treating it as
             // fatal.
+            match err {
+                DerivationDelegationError::L1Provider(_) => {
+                    kona_macros::inc!(
+                        counter,
+                        crate::Metrics::FOLLOW_SOURCE_REQUESTS,
+                        "result" => crate::Metrics::FOLLOW_SOURCE_ERROR_L1_LOOKUP
+                    );
+                }
+                DerivationDelegationError::L1ValidationFailed { .. } => {
+                    kona_macros::inc!(
+                        counter,
+                        crate::Metrics::FOLLOW_SOURCE_REQUESTS,
+                        "result" => crate::Metrics::FOLLOW_SOURCE_ERROR_L1_MISMATCH
+                    );
+                }
+            }
             return Ok(());
         }
 
@@ -204,6 +228,12 @@ where
             safe_l2 = ?sync_status.safe_l2,
             finalized_l2 = ?sync_status.finalized_l2,
             "Processed sync status from delegate"
+        );
+
+        kona_macros::inc!(
+            counter,
+            crate::Metrics::FOLLOW_SOURCE_REQUESTS,
+            "result" => crate::Metrics::FOLLOW_SOURCE_SUCCESS
         );
 
         Ok(())

--- a/rust/kona/crates/node/service/src/metrics/mod.rs
+++ b/rust/kona/crates/node/service/src/metrics/mod.rs
@@ -14,6 +14,17 @@ impl Metrics {
     /// Identifier for the counter of critical derivation errors (strictly for alerting.)
     pub const DERIVATION_CRITICAL_ERROR: &str = "kona_node_derivation_critical_errors";
 
+    /// Identifier for the counter that tracks delegated derivation follow source requests.
+    pub const FOLLOW_SOURCE_REQUESTS: &str = "kona_node_follow_source_requests_total";
+    /// Label for a follow source request that was fetched, validated, and applied.
+    pub const FOLLOW_SOURCE_SUCCESS: &str = "success";
+    /// Label for a follow source request whose sync status fetch failed.
+    pub const FOLLOW_SOURCE_ERROR_FETCH_STATUS: &str = "error_fetch_status";
+    /// Label for a follow source request whose L1 lookup against the canonical chain failed.
+    pub const FOLLOW_SOURCE_ERROR_L1_LOOKUP: &str = "error_l1_lookup";
+    /// Label for a follow source request whose L1 block hash disagreed with the canonical chain.
+    pub const FOLLOW_SOURCE_ERROR_L1_MISMATCH: &str = "error_l1_mismatch";
+
     /// Identifier for the counter that tracks sequencer state flags.
     pub const SEQUENCER_STATE: &str = "kona_node_sequencer_state";
 
@@ -63,6 +74,13 @@ impl Metrics {
             "Critical errors in the derivation pipeline"
         );
 
+        // Follow source requests
+        metrics::describe_counter!(
+            Self::FOLLOW_SOURCE_REQUESTS,
+            metrics::Unit::Count,
+            "Count of delegated derivation follow source requests by result"
+        );
+
         // Sequencer state
         metrics::describe_counter!(Self::SEQUENCER_STATE, "Tracks sequencer state flags");
 
@@ -107,6 +125,36 @@ impl Metrics {
 
         // Derivation critical error
         kona_macros::set!(counter, Self::DERIVATION_CRITICAL_ERROR, 0);
+
+        // Follow source requests
+        kona_macros::set!(
+            counter,
+            Self::FOLLOW_SOURCE_REQUESTS,
+            "result",
+            Self::FOLLOW_SOURCE_SUCCESS,
+            0
+        );
+        kona_macros::set!(
+            counter,
+            Self::FOLLOW_SOURCE_REQUESTS,
+            "result",
+            Self::FOLLOW_SOURCE_ERROR_FETCH_STATUS,
+            0
+        );
+        kona_macros::set!(
+            counter,
+            Self::FOLLOW_SOURCE_REQUESTS,
+            "result",
+            Self::FOLLOW_SOURCE_ERROR_L1_LOOKUP,
+            0
+        );
+        kona_macros::set!(
+            counter,
+            Self::FOLLOW_SOURCE_REQUESTS,
+            "result",
+            Self::FOLLOW_SOURCE_ERROR_L1_MISMATCH,
+            0
+        );
 
         // Sequencer: reset total transactions sequenced
         kona_macros::set!(counter, Self::SEQUENCER_TOTAL_TRANSACTIONS_SEQUENCED, 0);


### PR DESCRIPTION
## Description

The delegated derivation actor (`DelegateDerivationActor`) has no metrics instrumentation at all today, so there is no kona equivalent of op-node's `op_node_default_follow_source_requests_total`. That means a kona node running with `--l2.follow-source` cannot be alerted on for follow-source health, while an op-node in the same role can.

This adds `kona_node_follow_source_requests_total`, a counter labelled by `result` and incremented once per delegate poll:

| `result` | Condition |
|---|---|
| `success` | Sync status fetched, L1-validated, and applied to the engine |
| `error_fetch_status` | `fetch_sync_status()` on the delegate provider failed |
| `error_l1_lookup` | The L1 provider errored while validating a reported L1 block |
| `error_l1_mismatch` | The delegate reported an L1 hash that disagrees with the canonical chain |

The label values mirror the subset of op-node's `RecordFollowSourceRequest` results that apply to kona's delegated flow (op-node additionally emits `error_invalid_state`, which has no counterpart in `fetch_and_apply_delegate_safe_head`).

`validate_sync_status` previously returned `bool`, which collapsed "couldn't reach L1" and "L1 says something different" into one outcome. It now returns `Result<(), DerivationDelegationError>` so those two failure modes get distinct labels. Both remain non-fatal and still skip the poll, exactly as before — the only behavior change is that the error is now propagated to the caller for labelling. Both methods are private; no public API changes.

## Tests

- `cargo check -p kona-node-service` and `cargo check -p kona-node-service --features metrics` — both clean, no new warnings in either configuration (the counter macros compile out under the default no-metrics build, so `Metrics` is referenced by full path to avoid an unused-import warning).
- `cargo clippy -p kona-node-service --features metrics` — clean.
- `cargo test -p kona-node-service --features metrics` — 4 passed, 0 failed.
- `cargo +nightly fmt -p kona-node-service`.

Not covered: there is no existing test harness around `DelegateDerivationActor` (no unit tests in the `delegated` module), so the counter increments are verified by inspection rather than by test. Happy to add a stub provider and assert on the recorder if that's wanted.

## Additional context

Consumed by a pair of Grafana alerts on follow-source error rate in the k8s repo ([ethereum-optimism/k8s#12747](https://github.com/ethereum-optimism/k8s/pull/12747)), which currently only cover op-node. The kona variants are blocked on this metric shipping.

## Metadata

- Fixes: N/A