### PR TITLE
ci: run dependency review for merge groups

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,6 +1,8 @@
 name: Dependency Review
 
-on: pull_request
+on:
+  pull_request:
+  merge_group:
 
 jobs:
   dependency-review:


### PR DESCRIPTION
## Summary

Run the required dependency-review check for merge-group commits as well as pull-request commits.

The `Require dependency-review` ruleset applies `dependency-review / dependency-review` to `develop`, but the workflow currently only listens for `pull_request`. Merge-queue commits therefore never emit the required check and are removed after the 45-minute check timeout. `actions/dependency-review-action@v5` supports `merge_group` and derives the comparison from the event's `base_sha` and `head_sha`.

## Validation

- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/dependency-review.yml`
- `mise exec -- yq eval '.' .github/workflows/dependency-review.yml`
- `git diff --check`
