### PR TITLE
ci: trigger checks for dependency-review merge-group fix

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,6 +1,8 @@
 name: Dependency Review
 
-on: pull_request
+on:
+  pull_request:
+  merge_group:
 
 jobs:
   dependency-review:


### PR DESCRIPTION
Temporary same-SHA PR to trigger CircleCI for #22363.

The original PR was opened from a fork, for which this project did not start CircleCI. This branch points to the exact same commit and will be closed after the required statuses attach to that commit.