### PR TITLE
contracts-bedrock: Check registered dispute game implementation identity

### DIFF
--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -20,8 +20,8 @@
     "sourceCodeHash": "0x0ef8461e8bc55314e61e60924465574db17bdf30bbbfe9739b52cac623bba2db"
   },
   "src/L1/OPContractsManagerStandardValidator.sol:OPContractsManagerStandardValidator": {
-    "initCodeHash": "0xec4baf21016f8ac2723dc8b4731a7673f843c9e80a7b6d02ac87a306974132d9",
-    "sourceCodeHash": "0x659df71f1e1e054d149b3f3a7f757ab5a4bf6bb59b6626f81749091008c5a47b"
+    "initCodeHash": "0xe36d1015907e63a115b0661d1c5c631b824b2ac93bc549c8bd52c195dba777a1",
+    "sourceCodeHash": "0x9c78402d783d6a1c83546a122dd5c9e54f796abc5606ef2676197dd8e2bf93a3"
   },
   "src/L1/OptimismPortal2.sol:OptimismPortal2": {
     "initCodeHash": "0x67bbf6c9b344870cdbd7b041ddad6fb69057a4b48ec6dd96876af55d14fc1943",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -20,8 +20,8 @@
     "sourceCodeHash": "0x0ef8461e8bc55314e61e60924465574db17bdf30bbbfe9739b52cac623bba2db"
   },
   "src/L1/OPContractsManagerStandardValidator.sol:OPContractsManagerStandardValidator": {
-    "initCodeHash": "0xe36d1015907e63a115b0661d1c5c631b824b2ac93bc549c8bd52c195dba777a1",
-    "sourceCodeHash": "0x9c78402d783d6a1c83546a122dd5c9e54f796abc5606ef2676197dd8e2bf93a3"
+    "initCodeHash": "0x0b705f03b754c5575ee220c824c3bef68fc98075b7e1e10fc06968b85c1714de",
+    "sourceCodeHash": "0x197e1c42e06597ba49fe5211765a5e4c002ac0d169134bfd3ce82f79f9efc253"
   },
   "src/L1/OptimismPortal2.sol:OptimismPortal2": {
     "initCodeHash": "0x67bbf6c9b344870cdbd7b041ddad6fb69057a4b48ec6dd96876af55d14fc1943",

--- a/packages/contracts-bedrock/src/L1/OPContractsManagerStandardValidator.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManagerStandardValidator.sol
@@ -46,8 +46,8 @@ import { IBigStepper } from "interfaces/dispute/IBigStepper.sol";
 /// before and after an upgrade.
 contract OPContractsManagerStandardValidator is ISemver {
     /// @notice The semantic version of the OPContractsManagerStandardValidator contract.
-    /// @custom:semver 3.1.0
-    string public constant version = "3.1.0";
+    /// @custom:semver 3.2.0
+    string public constant version = "3.2.0";
 
     /// @notice The SuperchainConfig contract.
     ISuperchainConfig public superchainConfig;

--- a/packages/contracts-bedrock/src/L1/OPContractsManagerStandardValidator.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManagerStandardValidator.sol
@@ -1122,6 +1122,8 @@ contract OPContractsManagerStandardValidator is ISemver {
             string.concat(errorPrefix, "-20"),
             _errors
         );
+        _errors =
+            internalRequire(gameImpl.gameAddress == zkDisputeGameImpl, string.concat(errorPrefix, "-150"), _errors);
         return _assertValidZKGameArgs(_errors, _sysCfg, _admin, _overrides, errorPrefix);
     }
 

--- a/packages/contracts-bedrock/src/L1/opcm/StandardValidatorUtils.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/StandardValidatorUtils.sol
@@ -421,9 +421,6 @@ contract StandardValidatorUtils {
             string.concat(errorPrefix, "-20"),
             errors_
         );
-        // The version is self-reported by the registered implementation, so it is not evidence of
-        // identity on its own. Dispute game implementations are release singletons parameterized
-        // by the factory's game args, so the registered address must be the release address.
         errors_ =
             internalRequire(game.gameAddress == _impls.expectedGameImpl, string.concat(errorPrefix, "-150"), errors_);
 
@@ -499,9 +496,6 @@ contract StandardValidatorUtils {
             string.concat(errorPrefix, "-20"),
             errors_
         );
-        // See the identity check in `assertValidDisputeGame` for why the version alone is not
-        // enough. It matters more here: the remaining checks authenticate only the game args, not
-        // the semantics the implementation enforces.
         errors_ =
             internalRequire(game.gameAddress == _impls.expectedGameImpl, string.concat(errorPrefix, "-150"), errors_);
         errors_ = internalRequire(Hash.unwrap(anchorRoot) != bytes32(0), string.concat(errorPrefix, "-120"), errors_);

--- a/packages/contracts-bedrock/src/L1/opcm/StandardValidatorUtils.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/StandardValidatorUtils.sol
@@ -421,6 +421,11 @@ contract StandardValidatorUtils {
             string.concat(errorPrefix, "-20"),
             errors_
         );
+        // The version is self-reported by the registered implementation, so it is not evidence of
+        // identity on its own. Dispute game implementations are release singletons parameterized
+        // by the factory's game args, so the registered address must be the release address.
+        errors_ =
+            internalRequire(game.gameAddress == _impls.expectedGameImpl, string.concat(errorPrefix, "-150"), errors_);
 
         errors_ = internalRequire(
             GameType.unwrap(game.gameType) == GameType.unwrap(_args.gameType),
@@ -494,6 +499,11 @@ contract StandardValidatorUtils {
             string.concat(errorPrefix, "-20"),
             errors_
         );
+        // See the identity check in `assertValidDisputeGame` for why the version alone is not
+        // enough. It matters more here: the remaining checks authenticate only the game args, not
+        // the semantics the implementation enforces.
+        errors_ =
+            internalRequire(game.gameAddress == _impls.expectedGameImpl, string.concat(errorPrefix, "-150"), errors_);
         errors_ = internalRequire(Hash.unwrap(anchorRoot) != bytes32(0), string.concat(errorPrefix, "-120"), errors_);
         errors_ = assertValidAnchorStateRegistry(
             errors_, _args.sysCfg, dgf, game.asr, _args.admin, _impls.anchorStateRegistryImpl, errorPrefix

--- a/packages/contracts-bedrock/test/L1/OPContractsManagerStandardValidator.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManagerStandardValidator.t.sol
@@ -2048,6 +2048,20 @@ contract OPContractsManagerStandardValidator_SuperPermissionlessDisputeGame_Test
         assertEq("SCKDG-20,SCKDG-150", _validate(true));
     }
 
+    /// @notice Tests SCKDG-150 when the registered SUPER_CANNON_KONA implementation is a different
+    ///         contract with identical code and game args.
+    function test_validate_superPermissionlessDisputeGameLookalikeImplementation_succeeds() public {
+        address sckdgImpl = address(disputeGameFactory.gameImpls(GameTypes.SUPER_CANNON_KONA));
+        address lookalike = makeAddr("lookalikeSuperCannonKonaDisputeGame");
+        vm.etch(lookalike, sckdgImpl.code);
+        vm.mockCall(
+            address(disputeGameFactory),
+            abi.encodeCall(IDisputeGameFactory.gameImpls, (GameTypes.SUPER_CANNON_KONA)),
+            abi.encode(lookalike)
+        );
+        assertEq("SCKDG-150", _validate(true));
+    }
+
     /// @notice Tests SCKDG-40 when SUPER_CANNON_KONA absolute prestate is invalid.
     function test_validate_superPermissionlessDisputeGameInvalidPrestate_succeeds() public {
         bytes32 badPrestate = cannonPrestate.raw(); // Use the wrong prestate

--- a/packages/contracts-bedrock/test/L1/OPContractsManagerStandardValidator.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManagerStandardValidator.t.sol
@@ -1078,7 +1078,6 @@ contract OPContractsManagerStandardValidator_PermissionedDisputeGame_Test is
         bytes32 slot =
             bytes32(ForgeArtifacts.getSlot("OPContractsManagerStandardValidator", "permissionedDisputeGameImpl").slot);
         vm.store(address(standardValidator), slot, bytes32(uint256(uint160(address(bad)))));
-        // -150 also fires because the stored implementation address changed.
         assertEq("PDDG-20,PDDG-150", _validate(true));
     }
 
@@ -1446,7 +1445,6 @@ contract OPContractsManagerStandardValidator_FaultDisputeGame_Test is OPContract
         bytes32 slot =
             bytes32(ForgeArtifacts.getSlot("OPContractsManagerStandardValidator", "faultDisputeGameImpl").slot);
         vm.store(address(standardValidator), slot, bytes32(uint256(uint160(address(bad)))));
-        // -150 also fires because the stored implementation address changed.
         assertEq("CKDG-20,CKDG-150", _validate(true));
     }
 
@@ -1957,7 +1955,6 @@ contract OPContractsManagerStandardValidator_SuperPermissionedDisputeGame_Test i
             ForgeArtifacts.getSlot("OPContractsManagerStandardValidator", "superPermissionedDisputeGameImpl").slot
         );
         vm.store(address(standardValidator), slot, bytes32(uint256(uint160(address(bad)))));
-        // -150 also fires because the stored implementation address changed.
         assertEq("SPDG-20,SPDG-150", _validate(true));
     }
 
@@ -2044,7 +2041,6 @@ contract OPContractsManagerStandardValidator_SuperPermissionlessDisputeGame_Test
         bytes32 slot =
             bytes32(ForgeArtifacts.getSlot("OPContractsManagerStandardValidator", "superFaultDisputeGameImpl").slot);
         vm.store(address(standardValidator), slot, bytes32(uint256(uint160(address(bad)))));
-        // -150 also fires because the stored implementation address changed.
         assertEq("SCKDG-20,SCKDG-150", _validate(true));
     }
 
@@ -2322,7 +2318,6 @@ contract OPContractsManagerStandardValidator_ZKValidation_Test is
         BadVersionReturner bad = new BadVersionReturner(standardValidator, ISemver(zkImpl), "0.0.0");
         bytes32 slot = bytes32(ForgeArtifacts.getSlot("OPContractsManagerStandardValidator", "zkDisputeGameImpl").slot);
         vm.store(address(standardValidator), slot, bytes32(uint256(uint160(address(bad)))));
-        // -150 also fires because the stored implementation address changed.
         assertEq("ZKDG-20,ZKDG-150", _validate(true));
     }
 

--- a/packages/contracts-bedrock/test/L1/OPContractsManagerStandardValidator.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManagerStandardValidator.t.sol
@@ -1078,7 +1078,22 @@ contract OPContractsManagerStandardValidator_PermissionedDisputeGame_Test is
         bytes32 slot =
             bytes32(ForgeArtifacts.getSlot("OPContractsManagerStandardValidator", "permissionedDisputeGameImpl").slot);
         vm.store(address(standardValidator), slot, bytes32(uint256(uint160(address(bad)))));
-        assertEq("PDDG-20", _validate(true));
+        // -150 also fires: swapping the validator's stored implementation address makes the
+        // registered implementation no longer the expected one.
+        assertEq("PDDG-20,PDDG-150", _validate(true));
+    }
+
+    /// @notice Tests PDDG-150 when the registered PERMISSIONED_CANNON implementation is a different
+    ///         contract with identical code and game args.
+    function test_validate_permissionedDisputeGameLookalikeImplementation_succeeds() public {
+        address lookalike = makeAddr("lookalikePermissionedDisputeGame");
+        vm.etch(lookalike, address(pdgImpl).code);
+        vm.mockCall(
+            address(disputeGameFactory),
+            abi.encodeCall(IDisputeGameFactory.gameImpls, (GameTypes.PERMISSIONED_CANNON)),
+            abi.encode(lookalike)
+        );
+        assertEq("PDDG-150", _validate(true));
     }
 
     /// @notice Tests that the validate function successfully returns the right error when the
@@ -1432,7 +1447,9 @@ contract OPContractsManagerStandardValidator_FaultDisputeGame_Test is OPContract
         bytes32 slot =
             bytes32(ForgeArtifacts.getSlot("OPContractsManagerStandardValidator", "faultDisputeGameImpl").slot);
         vm.store(address(standardValidator), slot, bytes32(uint256(uint160(address(bad)))));
-        assertEq("CKDG-20", _validate(true));
+        // -150 also fires: swapping the validator's stored implementation address makes the
+        // registered implementation no longer the expected one.
+        assertEq("CKDG-20,CKDG-150", _validate(true));
     }
 
     /// @notice Tests that the validate function successfully returns the right error when the
@@ -1942,7 +1959,23 @@ contract OPContractsManagerStandardValidator_SuperPermissionedDisputeGame_Test i
             ForgeArtifacts.getSlot("OPContractsManagerStandardValidator", "superPermissionedDisputeGameImpl").slot
         );
         vm.store(address(standardValidator), slot, bytes32(uint256(uint160(address(bad)))));
-        assertEq("SPDG-20", _validate(true));
+        // -150 also fires: swapping the validator's stored implementation address makes the
+        // registered implementation no longer the expected one.
+        assertEq("SPDG-20,SPDG-150", _validate(true));
+    }
+
+    /// @notice Tests SPDG-150 when the registered SUPER_PERMISSIONED implementation is a different
+    ///         contract that reports the expected version and canonical game args.
+    function test_validate_superPermissionedDisputeGameLookalikeImplementation_succeeds() public {
+        address spdgImpl = address(disputeGameFactory.gameImpls(GameTypes.SUPER_PERMISSIONED));
+        address lookalike = makeAddr("lookalikeSuperPermissionedDisputeGame");
+        vm.etch(lookalike, spdgImpl.code);
+        vm.mockCall(
+            address(disputeGameFactory),
+            abi.encodeCall(IDisputeGameFactory.gameImpls, (GameTypes.SUPER_PERMISSIONED)),
+            abi.encode(lookalike)
+        );
+        assertEq("SPDG-150", _validate(true));
     }
 
     /// @notice Tests SPDG-GARGS-10 when SUPER_PERMISSIONED game args are invalid.
@@ -2014,7 +2047,9 @@ contract OPContractsManagerStandardValidator_SuperPermissionlessDisputeGame_Test
         bytes32 slot =
             bytes32(ForgeArtifacts.getSlot("OPContractsManagerStandardValidator", "superFaultDisputeGameImpl").slot);
         vm.store(address(standardValidator), slot, bytes32(uint256(uint160(address(bad)))));
-        assertEq("SCKDG-20", _validate(true));
+        // -150 also fires: swapping the validator's stored implementation address makes the
+        // registered implementation no longer the expected one.
+        assertEq("SCKDG-20,SCKDG-150", _validate(true));
     }
 
     /// @notice Tests SCKDG-40 when SUPER_CANNON_KONA absolute prestate is invalid.
@@ -2277,7 +2312,23 @@ contract OPContractsManagerStandardValidator_ZKValidation_Test is
         BadVersionReturner bad = new BadVersionReturner(standardValidator, ISemver(zkImpl), "0.0.0");
         bytes32 slot = bytes32(ForgeArtifacts.getSlot("OPContractsManagerStandardValidator", "zkDisputeGameImpl").slot);
         vm.store(address(standardValidator), slot, bytes32(uint256(uint160(address(bad)))));
-        assertEq("ZKDG-20", _validate(true));
+        // -150 also fires: swapping the validator's stored implementation address makes the
+        // registered implementation no longer the expected one.
+        assertEq("ZKDG-20,ZKDG-150", _validate(true));
+    }
+
+    /// @notice Tests ZKDG-150 when the registered ZK_DISPUTE_GAME implementation is a different
+    ///         contract with identical code and game args.
+    function test_validate_zkDisputeGameLookalikeImplementation_succeeds() public {
+        address zkImpl = address(dgf.gameImpls(GameTypes.ZK_DISPUTE_GAME));
+        address lookalike = makeAddr("lookalikeZKDisputeGame");
+        vm.etch(lookalike, zkImpl.code);
+        vm.mockCall(
+            address(dgf),
+            abi.encodeCall(IDisputeGameFactory.gameImpls, (GameTypes.ZK_DISPUTE_GAME)),
+            abi.encode(lookalike)
+        );
+        assertEq("ZKDG-150", _validate(true));
     }
 
     /// @notice Tests ZKDG-70 when the absolutePrestate encoded in the ZK game args is zero.

--- a/packages/contracts-bedrock/test/L1/OPContractsManagerStandardValidator.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManagerStandardValidator.t.sol
@@ -1078,6 +1078,8 @@ contract OPContractsManagerStandardValidator_PermissionedDisputeGame_Test is
         bytes32 slot =
             bytes32(ForgeArtifacts.getSlot("OPContractsManagerStandardValidator", "permissionedDisputeGameImpl").slot);
         vm.store(address(standardValidator), slot, bytes32(uint256(uint160(address(bad)))));
+        // PDDG-150 fires because overwriting the expected implementation address also makes the
+        // registered implementation address mismatch.
         assertEq("PDDG-20,PDDG-150", _validate(true));
     }
 
@@ -1445,6 +1447,8 @@ contract OPContractsManagerStandardValidator_FaultDisputeGame_Test is OPContract
         bytes32 slot =
             bytes32(ForgeArtifacts.getSlot("OPContractsManagerStandardValidator", "faultDisputeGameImpl").slot);
         vm.store(address(standardValidator), slot, bytes32(uint256(uint160(address(bad)))));
+        // CKDG-150 fires because overwriting the expected implementation address also makes the
+        // registered implementation address mismatch.
         assertEq("CKDG-20,CKDG-150", _validate(true));
     }
 
@@ -1955,6 +1959,8 @@ contract OPContractsManagerStandardValidator_SuperPermissionedDisputeGame_Test i
             ForgeArtifacts.getSlot("OPContractsManagerStandardValidator", "superPermissionedDisputeGameImpl").slot
         );
         vm.store(address(standardValidator), slot, bytes32(uint256(uint160(address(bad)))));
+        // SPDG-150 fires because overwriting the expected implementation address also makes the
+        // registered implementation address mismatch.
         assertEq("SPDG-20,SPDG-150", _validate(true));
     }
 
@@ -2041,6 +2047,8 @@ contract OPContractsManagerStandardValidator_SuperPermissionlessDisputeGame_Test
         bytes32 slot =
             bytes32(ForgeArtifacts.getSlot("OPContractsManagerStandardValidator", "superFaultDisputeGameImpl").slot);
         vm.store(address(standardValidator), slot, bytes32(uint256(uint160(address(bad)))));
+        // SCKDG-150 fires because overwriting the expected implementation address also makes the
+        // registered implementation address mismatch.
         assertEq("SCKDG-20,SCKDG-150", _validate(true));
     }
 
@@ -2318,6 +2326,8 @@ contract OPContractsManagerStandardValidator_ZKValidation_Test is
         BadVersionReturner bad = new BadVersionReturner(standardValidator, ISemver(zkImpl), "0.0.0");
         bytes32 slot = bytes32(ForgeArtifacts.getSlot("OPContractsManagerStandardValidator", "zkDisputeGameImpl").slot);
         vm.store(address(standardValidator), slot, bytes32(uint256(uint160(address(bad)))));
+        // ZKDG-150 fires because overwriting the expected implementation address also makes the
+        // registered implementation address mismatch.
         assertEq("ZKDG-20,ZKDG-150", _validate(true));
     }
 

--- a/packages/contracts-bedrock/test/L1/OPContractsManagerStandardValidator.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManagerStandardValidator.t.sol
@@ -1078,8 +1078,7 @@ contract OPContractsManagerStandardValidator_PermissionedDisputeGame_Test is
         bytes32 slot =
             bytes32(ForgeArtifacts.getSlot("OPContractsManagerStandardValidator", "permissionedDisputeGameImpl").slot);
         vm.store(address(standardValidator), slot, bytes32(uint256(uint160(address(bad)))));
-        // -150 also fires: swapping the validator's stored implementation address makes the
-        // registered implementation no longer the expected one.
+        // -150 also fires because the stored implementation address changed.
         assertEq("PDDG-20,PDDG-150", _validate(true));
     }
 
@@ -1447,8 +1446,7 @@ contract OPContractsManagerStandardValidator_FaultDisputeGame_Test is OPContract
         bytes32 slot =
             bytes32(ForgeArtifacts.getSlot("OPContractsManagerStandardValidator", "faultDisputeGameImpl").slot);
         vm.store(address(standardValidator), slot, bytes32(uint256(uint160(address(bad)))));
-        // -150 also fires: swapping the validator's stored implementation address makes the
-        // registered implementation no longer the expected one.
+        // -150 also fires because the stored implementation address changed.
         assertEq("CKDG-20,CKDG-150", _validate(true));
     }
 
@@ -1959,8 +1957,7 @@ contract OPContractsManagerStandardValidator_SuperPermissionedDisputeGame_Test i
             ForgeArtifacts.getSlot("OPContractsManagerStandardValidator", "superPermissionedDisputeGameImpl").slot
         );
         vm.store(address(standardValidator), slot, bytes32(uint256(uint160(address(bad)))));
-        // -150 also fires: swapping the validator's stored implementation address makes the
-        // registered implementation no longer the expected one.
+        // -150 also fires because the stored implementation address changed.
         assertEq("SPDG-20,SPDG-150", _validate(true));
     }
 
@@ -2047,8 +2044,7 @@ contract OPContractsManagerStandardValidator_SuperPermissionlessDisputeGame_Test
         bytes32 slot =
             bytes32(ForgeArtifacts.getSlot("OPContractsManagerStandardValidator", "superFaultDisputeGameImpl").slot);
         vm.store(address(standardValidator), slot, bytes32(uint256(uint160(address(bad)))));
-        // -150 also fires: swapping the validator's stored implementation address makes the
-        // registered implementation no longer the expected one.
+        // -150 also fires because the stored implementation address changed.
         assertEq("SCKDG-20,SCKDG-150", _validate(true));
     }
 
@@ -2312,8 +2308,7 @@ contract OPContractsManagerStandardValidator_ZKValidation_Test is
         BadVersionReturner bad = new BadVersionReturner(standardValidator, ISemver(zkImpl), "0.0.0");
         bytes32 slot = bytes32(ForgeArtifacts.getSlot("OPContractsManagerStandardValidator", "zkDisputeGameImpl").slot);
         vm.store(address(standardValidator), slot, bytes32(uint256(uint160(address(bad)))));
-        // -150 also fires: swapping the validator's stored implementation address makes the
-        // registered implementation no longer the expected one.
+        // -150 also fires because the stored implementation address changed.
         assertEq("ZKDG-20,ZKDG-150", _validate(true));
     }
 

--- a/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerMigrationValidator.t.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerMigrationValidator.t.sol
@@ -410,7 +410,24 @@ contract OPContractsManagerMigrationValidator_SPDG_Test is OPContractsManagerMig
             abi.encode(address(bad))
         );
 
-        assertEq("MIG-SPDG-20", _validateMigration(true));
+        // MIG-SPDG-150 also fires: mocking the expected implementation address makes the registered
+        // implementation no longer the expected one.
+        assertEq("MIG-SPDG-20,MIG-SPDG-150", _validateMigration(true));
+    }
+
+    /// @notice MIG-SPDG-150: Registered SPDG implementation is a different contract with identical
+    ///         code and game args.
+    function test_validate_spdg150LookalikeImplementation_succeeds() public {
+        address spdgImpl = address(sharedDGF.gameImpls(GameTypes.SUPER_PERMISSIONED));
+        address lookalike = makeAddr("lookalikeSuperPermissionedDisputeGame");
+        vm.etch(lookalike, spdgImpl.code);
+        vm.mockCall(
+            address(sharedDGF),
+            abi.encodeCall(IDisputeGameFactory.gameImpls, (GameTypes.SUPER_PERMISSIONED)),
+            abi.encode(lookalike)
+        );
+
+        assertEq("MIG-SPDG-150", _validateMigration(true));
     }
 
     /// @notice MIG-SPDG-GARGS-10: Invalid game args length for SPDG.

--- a/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerMigrationValidator.t.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerMigrationValidator.t.sol
@@ -410,7 +410,7 @@ contract OPContractsManagerMigrationValidator_SPDG_Test is OPContractsManagerMig
             abi.encode(address(bad))
         );
 
-        // MIG-SPDG-150 also fires because the expected implementation address changed.
+        // MIG-SPDG-150 also fires because the stored implementation address changed.
         assertEq("MIG-SPDG-20,MIG-SPDG-150", _validateMigration(true));
     }
 
@@ -467,6 +467,21 @@ contract OPContractsManagerMigrationValidator_SCKDG_Test is OPContractsManagerMi
             abi.encode(hex"deadbeef")
         );
         assertEq("MIG-SCKDG-GARGS-10", _validateMigration(true));
+    }
+
+    /// @notice MIG-SCKDG-150: Registered SCKDG implementation is a different contract with identical
+    ///         code and game args.
+    function test_validate_sckdg150LookalikeImplementation_succeeds() public {
+        address sckdgImpl = address(sharedDGF.gameImpls(GameTypes.SUPER_CANNON_KONA));
+        address lookalike = makeAddr("lookalikeSuperCannonKonaDisputeGame");
+        vm.etch(lookalike, sckdgImpl.code);
+        vm.mockCall(
+            address(sharedDGF),
+            abi.encodeCall(IDisputeGameFactory.gameImpls, (GameTypes.SUPER_CANNON_KONA)),
+            abi.encode(lookalike)
+        );
+
+        assertEq("MIG-SCKDG-150", _validateMigration(true));
     }
 
     /// @notice MIG-SCKDG-60: l2ChainId != 0 in SCKDG game args.

--- a/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerMigrationValidator.t.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerMigrationValidator.t.sol
@@ -410,6 +410,8 @@ contract OPContractsManagerMigrationValidator_SPDG_Test is OPContractsManagerMig
             abi.encode(address(bad))
         );
 
+        // MIG-SPDG-150 fires because mocking the expected implementation getter also makes the
+        // registered implementation address mismatch.
         assertEq("MIG-SPDG-20,MIG-SPDG-150", _validateMigration(true));
     }
 

--- a/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerMigrationValidator.t.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerMigrationValidator.t.sol
@@ -410,8 +410,7 @@ contract OPContractsManagerMigrationValidator_SPDG_Test is OPContractsManagerMig
             abi.encode(address(bad))
         );
 
-        // MIG-SPDG-150 also fires: mocking the expected implementation address makes the registered
-        // implementation no longer the expected one.
+        // MIG-SPDG-150 also fires because the expected implementation address changed.
         assertEq("MIG-SPDG-20,MIG-SPDG-150", _validateMigration(true));
     }
 

--- a/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerMigrationValidator.t.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerMigrationValidator.t.sol
@@ -410,7 +410,6 @@ contract OPContractsManagerMigrationValidator_SPDG_Test is OPContractsManagerMig
             abi.encode(address(bad))
         );
 
-        // MIG-SPDG-150 also fires because the stored implementation address changed.
         assertEq("MIG-SPDG-20,MIG-SPDG-150", _validateMigration(true));
     }
 


### PR DESCRIPTION
StandardValidator identified the dispute game implementation registered in the DisputeGameFactory by the version string the implementation reports about itself. A different contract can report the release version and pass validation. For `SUPER_PERMISSIONED` this was the only check on the implementation — the remaining checks authenticate the packed ASR and proposer args, not the game semantics the implementation enforces (proposer authorization, root claim bound to a decoded super root, sequence newer than the anchor).

Add a `-150` check that the registered implementation address is the release implementation address. Applied to the shared dispute game path, the super permissioned path and the ZK path, so the standard and migration validators are all covered. Dispute game implementations are release singletons parameterized by the factory game args, so the address must match. This mirrors the pattern already used for proxied contracts, where the version check pairs with a `getProxyImplementation` identity check (`SYSCON-40`, `L1xDM-20`).

Behavior change: a chain whose registered game implementation is not the release implementation now fails validation, even when it reports the expected version. There is no override or allowlist for a mismatch. `-20` is now redundant with `-150` — address equality implies version equality — but is kept for diagnostics, and it is what makes validation revert rather than report when the expected implementation address is zero.

The error-code table in `docs/public-docs/chain-operators/tutorials/merge-shared-dispute-game.mdx` covers the game drill-down with a `MIG-SPDG-*` / `MIG-SCKDG-*` wildcard row, so it needs no update.

Reported by a security review of the U20 StandardValidator.

## Test plan

- New negative tests register a lookalike implementation with identical code at a different address: `SPDG-150`, `SCKDG-150`, `ZKDG-150`, `PDDG-150`, `MIG-SPDG-150` and `MIG-SCKDG-150`. The `SPDG-150` test fails on the baseline (validation returns success) and passes with the fix.
- The existing `-20` version tests swap the stored implementation address, so they now also report `-150`. Expectations updated.
- `just test-dev` passes in the default, `DEV_FEATURE__OPTIMISM_PORTAL_INTEROP` and `DEV_FEATURE__ZK_DISPUTE_GAME` configurations. `just check-fast` passes.
- Not executed in any current configuration: the `PDDG-150` test and the `PDDG-20` / `CKDG-20` expectation changes. The non-super `OPContractsManagerStandardValidator` suite skips while `SUPER_ROOT_GAMES_MIGRATION` is on, which is unconditional today. The shared path they cover is proven instead by the `SCKDG-150` and `MIG-SCKDG-150` tests, which do run.

## Notes for review

- `StandardValidatorUtils` implements no `ISemver` version and has no semver-lock entry, so this validation-behavior change carries no version signal of its own. Pre-existing consequence of the EIP-170 split; worth a follow-up.
- `op-deployer manage set-interop-dispute-games` never re-registers `SUPER_PERMISSIONED` on the shared DGF, so that implementation stays at whatever the original super-roots migration installed. Implementations deploy via CREATE2 with a fixed salt, so a same-bytecode implementation lands at the same address, but the failure mode is now hard.