### PR TITLE
contracts-bedrock: Bind the SystemConfig chain ID in the standard validator

### DIFF
--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -20,8 +20,8 @@
     "sourceCodeHash": "0x0ef8461e8bc55314e61e60924465574db17bdf30bbbfe9739b52cac623bba2db"
   },
   "src/L1/OPContractsManagerStandardValidator.sol:OPContractsManagerStandardValidator": {
-    "initCodeHash": "0x111eb6926457a4721d2d43920043370322963e590f3df56b57084073809e8dba",
-    "sourceCodeHash": "0x37f01de7f914c716e6752024f704ee2bf82aa8515ac8fa0aaca8f35bd40dfdd8"
+    "initCodeHash": "0xec4baf21016f8ac2723dc8b4731a7673f843c9e80a7b6d02ac87a306974132d9",
+    "sourceCodeHash": "0xfe708354880639da56c969640f80b61a531e4bec8e4e5649950faab404a16279"
   },
   "src/L1/OptimismPortal2.sol:OptimismPortal2": {
     "initCodeHash": "0x67bbf6c9b344870cdbd7b041ddad6fb69057a4b48ec6dd96876af55d14fc1943",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -21,7 +21,7 @@
   },
   "src/L1/OPContractsManagerStandardValidator.sol:OPContractsManagerStandardValidator": {
     "initCodeHash": "0xec4baf21016f8ac2723dc8b4731a7673f843c9e80a7b6d02ac87a306974132d9",
-    "sourceCodeHash": "0xfe708354880639da56c969640f80b61a531e4bec8e4e5649950faab404a16279"
+    "sourceCodeHash": "0x659df71f1e1e054d149b3f3a7f757ab5a4bf6bb59b6626f81749091008c5a47b"
   },
   "src/L1/OptimismPortal2.sol:OptimismPortal2": {
     "initCodeHash": "0x67bbf6c9b344870cdbd7b041ddad6fb69057a4b48ec6dd96876af55d14fc1943",

--- a/packages/contracts-bedrock/src/L1/OPContractsManagerStandardValidator.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManagerStandardValidator.sol
@@ -46,8 +46,8 @@ import { IBigStepper } from "interfaces/dispute/IBigStepper.sol";
 /// before and after an upgrade.
 contract OPContractsManagerStandardValidator is ISemver {
     /// @notice The semantic version of the OPContractsManagerStandardValidator contract.
-    /// @custom:semver 3.0.0
-    string public constant version = "3.0.0";
+    /// @custom:semver 3.1.0
+    string public constant version = "3.1.0";
 
     /// @notice The SuperchainConfig contract.
     ISuperchainConfig public superchainConfig;
@@ -280,7 +280,8 @@ contract OPContractsManagerStandardValidator is ISemver {
     function assertValidSystemConfig(
         string memory _errors,
         ISystemConfig _sysCfg,
-        IProxyAdmin _admin
+        IProxyAdmin _admin,
+        uint256 _l2ChainID
     )
         internal
         view
@@ -305,6 +306,10 @@ contract OPContractsManagerStandardValidator is ISemver {
         _errors = internalRequire(_sysCfg.operatorFeeScalar() == 0, "SYSCON-110", _errors);
         _errors = internalRequire(_sysCfg.operatorFeeConstant() == 0, "SYSCON-120", _errors);
         _errors = internalRequire(_sysCfg.superchainConfig() == superchainConfig, "SYSCON-130", _errors);
+        // OptimismPortal2 selects the member output root with rootClaimByChainId(sysCfg.l2ChainId()), so this
+        // binds the validated configuration to the chain the caller asked about. Super game args store
+        // l2ChainId=0, so this is the only check tying a super game deployment to its domain.
+        _errors = internalRequire(_sysCfg.l2ChainId() == _l2ChainID, "SYSCON-140", _errors);
         return _errors;
     }
 
@@ -896,7 +901,7 @@ contract OPContractsManagerStandardValidator is ISemver {
 
         _errors = assertValidSuperchainConfig(_errors);
         _errors = assertValidProxyAdmin(_errors, _proxyAdmin, _overrides);
-        _errors = assertValidSystemConfig(_errors, _input.sysCfg, _proxyAdmin);
+        _errors = assertValidSystemConfig(_errors, _input.sysCfg, _proxyAdmin, _input.l2ChainID);
         _errors = assertValidL1CrossDomainMessenger(_errors, _input.sysCfg, _proxyAdmin);
         _errors = assertValidL1StandardBridge(_errors, _input.sysCfg, _proxyAdmin);
         _errors = assertValidOptimismMintableERC20Factory(_errors, _input.sysCfg, _proxyAdmin);

--- a/packages/contracts-bedrock/src/L1/OPContractsManagerStandardValidator.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManagerStandardValidator.sol
@@ -306,9 +306,6 @@ contract OPContractsManagerStandardValidator is ISemver {
         _errors = internalRequire(_sysCfg.operatorFeeScalar() == 0, "SYSCON-110", _errors);
         _errors = internalRequire(_sysCfg.operatorFeeConstant() == 0, "SYSCON-120", _errors);
         _errors = internalRequire(_sysCfg.superchainConfig() == superchainConfig, "SYSCON-130", _errors);
-        // OptimismPortal2 selects the member output root with rootClaimByChainId(sysCfg.l2ChainId()), so this
-        // binds the validated configuration to the chain the caller asked about. Super game args store
-        // l2ChainId=0, so this is the only check tying a super game deployment to its domain.
         _errors = internalRequire(_sysCfg.l2ChainId() == _l2ChainID, "SYSCON-140", _errors);
         return _errors;
     }

--- a/packages/contracts-bedrock/test/L1/OPContractsManagerStandardValidator.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManagerStandardValidator.t.sol
@@ -612,13 +612,6 @@ contract OPContractsManagerStandardValidator_SystemConfig_Test is OPContractsMan
         );
         assertEq("SYSCON-130", _validate(true));
     }
-
-    /// @notice Tests that the validate function successfully returns the right error when the
-    ///         SystemConfig l2ChainId does not match the expected chain ID.
-    function test_validate_systemConfigInvalidL2ChainId_succeeds() public {
-        vm.mockCall(address(systemConfig), abi.encodeCall(ISystemConfig.l2ChainId, ()), abi.encode(l2ChainId + 1));
-        assertEq("SYSCON-140", _validate(true));
-    }
 }
 
 /// @title OPContractsManagerStandardValidator_L1CrossDomainMessenger_Test

--- a/packages/contracts-bedrock/test/L1/OPContractsManagerStandardValidator.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManagerStandardValidator.t.sol
@@ -612,6 +612,13 @@ contract OPContractsManagerStandardValidator_SystemConfig_Test is OPContractsMan
         );
         assertEq("SYSCON-130", _validate(true));
     }
+
+    /// @notice Tests that the validate function successfully returns the right error when the
+    ///         SystemConfig l2ChainId does not match the expected chain ID.
+    function test_validate_systemConfigInvalidL2ChainId_succeeds() public {
+        vm.mockCall(address(systemConfig), abi.encodeCall(ISystemConfig.l2ChainId, ()), abi.encode(l2ChainId + 1));
+        assertEq("SYSCON-140", _validate(true));
+    }
 }
 
 /// @title OPContractsManagerStandardValidator_L1CrossDomainMessenger_Test
@@ -1840,6 +1847,14 @@ contract OPContractsManagerStandardValidator_SuperModeCoreValidation_Test is
     function test_validate_succeeds() public view {
         string memory errors = _validate(false);
         assertEq(errors, "");
+    }
+
+    /// @notice Tests that validation fails when the SystemConfig is configured for a different chain
+    ///         than the one being validated. Super game args store l2ChainId=0, so SYSCON-140 is the
+    ///         only check binding the deployment to the chain the Portal settles withdrawals for.
+    function test_validate_systemConfigInvalidL2ChainId_succeeds() public {
+        vm.mockCall(address(systemConfig), abi.encodeCall(ISystemConfig.l2ChainId, ()), abi.encode(l2ChainId + 1));
+        assertEq("SYSCON-140", _validate(true));
     }
 }
 

--- a/packages/contracts-bedrock/test/L1/OPContractsManagerStandardValidator.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManagerStandardValidator.t.sol
@@ -1726,11 +1726,12 @@ abstract contract OPContractsManagerStandardValidator_SuperMode_TestInit is Supe
         dgf = IDisputeGameFactory(artifacts.mustGetAddress("DisputeGameFactoryProxy"));
         standardValidator = opcmV2.opcmStandardValidator();
 
-        l2ChainId = deploy.cfg().l2ChainID();
         cannonPrestate = Claim.wrap(bytes32(deploy.cfg().faultGameAbsolutePrestate()));
         if (isL1ForkTest()) {
+            l2ChainId = uint256(uint160(address(artifacts.mustGetAddress("L2ChainId"))));
             proposer = DisputeGames.permissionedGameProposer(dgf);
         } else {
+            l2ChainId = deploy.cfg().l2ChainID();
             proposer = deploy.cfg().l2OutputOracleProposer();
         }
 
@@ -2130,7 +2131,8 @@ abstract contract OPContractsManagerStandardValidator_ZKMode_TestInit is CommonT
                 LibGameArgs.decode(dgf.gameArgs(permissionlessGameType));
             cannonKonaPrestate = Claim.wrap(permissionlessGameArgs.absolutePrestate);
             cannonPrestate = cannonKonaPrestate;
-            l2ChainId = permissionlessGameArgs.l2ChainId;
+            // Super game args store l2ChainId=0, so take the chain ID from the fork fixture.
+            l2ChainId = uint256(uint160(address(artifacts.mustGetAddress("L2ChainId"))));
             proposer = DisputeGames.permissionedGameProposer(dgf);
 
             // ZK game is not deployed on mainnet. Mock it using the same ASR and WETH as the active

--- a/packages/contracts-bedrock/test/L1/OPContractsManagerStandardValidator.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManagerStandardValidator.t.sol
@@ -1850,9 +1850,8 @@ contract OPContractsManagerStandardValidator_SuperModeCoreValidation_Test is
         assertEq(errors, "");
     }
 
-    /// @notice Tests that validation fails when the SystemConfig is configured for a different chain
-    ///         than the one being validated. Super game args store l2ChainId=0, so SYSCON-140 is the
-    ///         only check binding the deployment to the chain the Portal settles withdrawals for.
+    /// @notice Tests that the validate function returns SYSCON-140 when the SystemConfig l2ChainId
+    ///         does not match the expected chain ID.
     function test_validate_systemConfigInvalidL2ChainId_succeeds() public {
         vm.mockCall(address(systemConfig), abi.encodeCall(ISystemConfig.l2ChainId, ()), abi.encode(l2ChainId + 1));
         assertEq("SYSCON-140", _validate(true));
@@ -2131,7 +2130,6 @@ abstract contract OPContractsManagerStandardValidator_ZKMode_TestInit is CommonT
                 LibGameArgs.decode(dgf.gameArgs(permissionlessGameType));
             cannonKonaPrestate = Claim.wrap(permissionlessGameArgs.absolutePrestate);
             cannonPrestate = cannonKonaPrestate;
-            // Super game args store l2ChainId=0, so take the chain ID from the fork fixture.
             l2ChainId = uint256(uint160(address(artifacts.mustGetAddress("L2ChainId"))));
             proposer = DisputeGames.permissionedGameProposer(dgf);
 


### PR DESCRIPTION
The standard validator took the expected L2 chain ID as caller-supplied input but never compared it with `SystemConfig.l2ChainId()`. Check it as `SYSCON-140`.

Without it, validation of chain X returns success for a SystemConfig configured for chain Y. The Portal then settles X's withdrawals against Y.

The second commit fixes the fork test fixtures, which took the expected chain ID from the local deploy config rather than the forked chain. They now read the `L2ChainId` artifact from the superchain registry, as the non-super fixture already does.

## Test plan

- New test mocks `SystemConfig.l2ChainId()` to a different value. It fails on the unmodified validator with an empty success string.
- `just test-dev` and `just pr` pass.
- Upgrade fork tests over `test/{L1,dispute,cannon}/**` pass for op-mainnet, ink-mainnet, unichain-mainnet, and the ZK_DISPUTE_GAME and OPTIMISM_PORTAL_INTEROP variants.