### PR TITLE
op-deployer: select the release SP1 verifier for ZK-enabled apply

### DIFF
--- a/docs/ai/devfeatures.md
+++ b/docs/ai/devfeatures.md
@@ -39,6 +39,7 @@ The bitmap has **two operator-facing input surfaces**, both in op-deployer:
    - Schema field on `Intent`, `op-deployer/pkg/deployer/state/intent.go`
    - Lives in the operator's intent TOML/JSON
    - Read by the L2 genesis pipeline.
+   - All of the following applies only when `apply` deploys new implementations. With a predeployed OPCM (`opcmAddress` set), the implementations already exist and `ValidateInputs` rejects `sp1Verifier` outright, so those operators must not set the override.
    - A live ZK-enabled `apply` selects the same release-approved verifier as bootstrap on Ethereum mainnet and Sepolia; other L1 networks must set `globalDeployOverrides.sp1Verifier`, which always wins where it is set. Enabling ZK stays an explicit operator choice — the default only picks the verifier, never the feature.
    - Both surfaces read the mapping from `standard.SP1VerifierFor`, so bootstrap and apply can never drift.
    - The selected raw verifier is recorded in deployment state (`State.SP1Verifier`) and never written back into intent. A resumed deployment reuses the recorded address rather than re-resolving the default, so upgrading op-deployer mid-deployment cannot swap the verifier under a chain.

--- a/docs/ai/devfeatures.md
+++ b/docs/ai/devfeatures.md
@@ -33,14 +33,16 @@ The bitmap has **two operator-facing input surfaces**, both in op-deployer:
    - `--dev-feature-bitmap` (env: `OP_DEPLOYER_DEV_FEATURE_BITMAP`), defined in `op-deployer/pkg/deployer/bootstrap/flags.go`
    - Raw 32-byte hex; default empty
    - Flows into `ImplementationsConfig.DevFeatureBitmap` and on into `DeployImplementationsInput` for L1 implementation deployment.
-   - When the ZK bit is enabled, Ethereum mainnet and Sepolia default to Succinct's v6.1.0 PLONK verifier. `--sp1-verifier-address` (env: `DEPLOYER_SP1_VERIFIER_ADDRESS`) overrides that release input and is required on other L1 networks.
+   - When the ZK bit is enabled, Ethereum mainnet and Sepolia default to Succinct's v6.1.0 PLONK verifier, resolved by `standard.SP1VerifierFor`. `--sp1-verifier-address` (env: `DEPLOYER_SP1_VERIFIER_ADDRESS`) overrides that release input and is required on other L1 networks.
 
 2. **Intent file (`globalDeployOverrides.devFeatureBitmap`)**
    - Schema field on `Intent`, `op-deployer/pkg/deployer/state/intent.go`
    - Lives in the operator's intent TOML/JSON
    - Read by the L2 genesis pipeline.
-   - A live ZK-enabled deployment must also set `globalDeployOverrides.sp1Verifier`.
-   - The op-devstack builder instead explicitly opts into deploying a test raw verifier during genesis. The generated address is recorded in deployment state, not written back into intent.
+   - A live ZK-enabled `apply` selects the same release-approved verifier as bootstrap on Ethereum mainnet and Sepolia; other L1 networks must set `globalDeployOverrides.sp1Verifier`, which always wins where it is set. Enabling ZK stays an explicit operator choice — the default only picks the verifier, never the feature.
+   - Both surfaces read the mapping from `standard.SP1VerifierFor`, so bootstrap and apply can never drift.
+   - The selected raw verifier is recorded in deployment state (`State.SP1Verifier`) and never written back into intent. A resumed deployment reuses the recorded address rather than re-resolving the default, so upgrading op-deployer mid-deployment cannot swap the verifier under a chain.
+   - Genesis deployments never select the release verifier: it does not exist in a generated genesis. They must set `sp1Verifier` explicitly, or the op-devstack builder can opt into deploying a test raw verifier during genesis.
 
 There is no other production operator-facing surface. `op-node`, `op-program`, `kona`, and rollup config do not take a bitmap at runtime.
 
@@ -132,6 +134,7 @@ Interop and ZK use the bitmap as their per-chain provisioning switch and have no
 | Solidity constants & predicate | `packages/contracts-bedrock/src/libraries/DevFeatures.sol` |
 | CLI input | `op-deployer/pkg/deployer/bootstrap/flags.go` |
 | Intent input + composition | `op-deployer/pkg/deployer/pipeline/l2genesis.go` |
+| Release-approved SP1 verifier | `op-deployer/pkg/deployer/standard/standard.go` |
 | Genesis writer | `packages/contracts-bedrock/scripts/L2Genesis.s.sol` |
 | L2 storage | `packages/contracts-bedrock/src/L2/L2DevFeatureFlags.sol` |
 | L2 runtime reader | `packages/contracts-bedrock/src/L2/L2ContractsManager.sol` |

--- a/op-deployer/pkg/deployer/bootstrap/implementations.go
+++ b/op-deployer/pkg/deployer/bootstrap/implementations.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/broadcaster"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/forge"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/opcm"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/standard"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/verify"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/env"
 	"github.com/ethereum-optimism/optimism/op-service/bigs"
@@ -60,16 +61,6 @@ type ImplementationsConfig struct {
 
 	privateKeyECDSA *ecdsa.PrivateKey
 }
-
-const (
-	// Source: succinctlabs/sp1-contracts@2ac5ecbbe473421a963d67e55f182e9a36576f7c,
-	// contracts/deployments/1.json, V6_1_0_SP1_VERIFIER_PLONK.
-	mainnetSP1VerifierV610 = "0xc3c6dDDAc8829b233Dc6536Ec024775a57b0AF2A"
-	// Succinct deploys the same verifier bytecode and address deterministically on both networks.
-	// Source: succinctlabs/sp1-contracts@2ac5ecbbe473421a963d67e55f182e9a36576f7c,
-	// contracts/deployments/11155111.json, V6_1_0_SP1_VERIFIER_PLONK.
-	sepoliaSP1VerifierV610 = "0xc3c6dDDAc8829b233Dc6536Ec024775a57b0AF2A"
-)
 
 func (c *ImplementationsConfig) Check() error {
 	if c.L1RPCUrl == "" {
@@ -154,18 +145,15 @@ func (c *ImplementationsConfig) resolveSP1Verifier(chainID *big.Int) error {
 		)
 	}
 	chainIDUint64 := bigs.Uint64Strict(chainID)
-	switch chainIDUint64 {
-	case 1:
-		c.SP1Verifier = common.HexToAddress(mainnetSP1VerifierV610)
-	case 11155111:
-		c.SP1Verifier = common.HexToAddress(sepoliaSP1VerifierV610)
-	default:
+	verifier, err := standard.SP1VerifierFor(chainIDUint64)
+	if err != nil {
 		return fmt.Errorf(
 			"no default SP1 verifier for L1 chain ID %d; specify --%s",
 			chainIDUint64,
 			SP1VerifierAddressFlagName,
 		)
 	}
+	c.SP1Verifier = verifier
 	return nil
 }
 

--- a/op-deployer/pkg/deployer/integration_test/apply_test.go
+++ b/op-deployer/pkg/deployer/integration_test/apply_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/addresses"
+	"github.com/ethereum-optimism/optimism/op-core/devfeatures"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/bootstrap"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/broadcaster"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/inspect"
@@ -210,6 +211,71 @@ func TestEndToEndBootstrapApplyWithUpgrade(t *testing.T) {
 	}
 
 	runEndToEndBootstrapAndApplyUpgradeTest(t, afactsFS, cfg)
+}
+
+// TestApplyDefaultsSP1VerifierOnSepolia pins that a ZK-enabled live apply with no sp1Verifier
+// override deploys an SP1PlonkAdapter wrapping the release-approved raw verifier.
+func TestApplyDefaultsSP1VerifierOnSepolia(t *testing.T) {
+	op_e2e.InitParallel(t)
+
+	lgr := testlog.Logger(t, slog.LevelDebug)
+
+	forkedL1, stopL1, err := devnet.NewForkedSepolia(lgr)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, stopL1())
+	})
+	l1RPC := forkedL1.RPCUrl()
+
+	loc, _ := testutil.LocalArtifacts(t)
+	testCacheDir := testutils.IsolatedTestDirWithAutoCleanup(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	const sepoliaChainID = 11155111
+	_, pk, dk := shared.DefaultPrivkey(t)
+	intent, st := shared.NewIntent(t, big.NewInt(sepoliaChainID), dk, uint256.NewInt(12345), loc, loc, 30_000_000)
+	intent.GlobalDeployOverrides = map[string]any{
+		"devFeatureBitmap": devfeatures.EnableDevFeature(common.Hash{}, devfeatures.ZKDisputeGameFlag),
+	}
+
+	require.NoError(t, deployer.ApplyPipeline(ctx, deployer.ApplyPipelineOpts{
+		DeploymentTarget:   deployer.DeploymentTargetLive,
+		L1RPCUrl:           l1RPC,
+		DeployerPrivateKey: pk,
+		Intent:             intent,
+		State:              st,
+		Logger:             lgr,
+		StateWriter:        pipeline.NoopStateWriter(),
+		CacheDir:           testCacheDir,
+	}))
+
+	expected, err := standard.SP1VerifierFor(sepoliaChainID)
+	require.NoError(t, err)
+	require.NotNil(t, st.SP1Verifier)
+	require.Equal(t, expected, *st.SP1Verifier, "apply should persist the selected raw verifier")
+	require.NotContains(t, intent.GlobalDeployOverrides, "sp1Verifier", "apply must not rewrite the intent")
+
+	client, err := ethclient.Dial(l1RPC)
+	require.NoError(t, err)
+	defer client.Close()
+
+	verifierCode, err := client.CodeAt(ctx, expected, nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, verifierCode, "release verifier must already be deployed on Sepolia")
+
+	adapter := st.ImplementationsDeployment.SP1PlonkAdapterImpl
+	require.NotEqual(t, common.Address{}, adapter, "ZK-enabled apply should deploy an SP1PlonkAdapter")
+
+	sp1VerifierFn := w3.MustNewFunc("sp1Verifier()", "address")
+	calldata, err := sp1VerifierFn.EncodeArgs()
+	require.NoError(t, err)
+	ret, err := client.CallContract(ctx, ethereum.CallMsg{To: &adapter, Data: calldata}, nil)
+	require.NoError(t, err)
+	var wrapped common.Address
+	require.NoError(t, sp1VerifierFn.DecodeReturns(ret, &wrapped))
+	require.Equal(t, expected, wrapped, "adapter should wrap the release verifier")
 }
 
 func TestEndToEndApply(t *testing.T) {

--- a/op-deployer/pkg/deployer/pipeline/implementations.go
+++ b/op-deployer/pkg/deployer/pipeline/implementations.go
@@ -74,7 +74,6 @@ func DeployImplementations(env *Env, intent *state.Intent, st *state.State) erro
 		if err != nil {
 			return fmt.Errorf("sp1Verifier must be specified when ZK dispute games are enabled on L1 chain ID %d: %w", intent.L1ChainID, err)
 		}
-		lgr.Info("selected release-approved SP1 verifier", "address", selectedSP1Verifier)
 	}
 
 	if !shouldDeployImplementations(intent, st) {
@@ -126,6 +125,9 @@ func DeployImplementations(env *Env, intent *state.Intent, st *state.State) erro
 		if err != nil {
 			return err
 		}
+	}
+	if zkEnabled {
+		lgr.Info("using SP1 verifier", "address", input.SP1Verifier)
 	}
 
 	if env.UseForge {

--- a/op-deployer/pkg/deployer/pipeline/implementations.go
+++ b/op-deployer/pkg/deployer/pipeline/implementations.go
@@ -64,8 +64,17 @@ func DeployImplementations(env *Env, intent *state.Intent, st *state.State) erro
 	if !zkEnabled && hasSP1VerifierOverride {
 		return fmt.Errorf("sp1Verifier must not be specified when ZK dispute games are disabled")
 	}
+	selectedSP1Verifier := requestedSP1Verifier
 	if intent.OPCMAddress == nil && zkEnabled && !hasSP1VerifierOverride && !env.DeployMockSP1Verifier {
-		return fmt.Errorf("sp1Verifier must be specified when ZK dispute games are enabled")
+		// A generated genesis contains no release-approved verifier, so it must be selected explicitly.
+		if env.IsGenesis {
+			return fmt.Errorf("sp1Verifier must be specified when ZK dispute games are enabled")
+		}
+		selectedSP1Verifier, err = standard.SP1VerifierFor(intent.L1ChainID)
+		if err != nil {
+			return fmt.Errorf("sp1Verifier must be specified when ZK dispute games are enabled on L1 chain ID %d: %w", intent.L1ChainID, err)
+		}
+		lgr.Info("selected release-approved SP1 verifier", "address", selectedSP1Verifier)
 	}
 
 	if !shouldDeployImplementations(intent, st) {
@@ -110,7 +119,7 @@ func DeployImplementations(env *Env, intent *state.Intent, st *state.State) erro
 		SuperchainProxyAdmin:            st.SuperchainDeployment.SuperchainProxyAdminImpl,
 		L1ProxyAdminOwner:               st.SuperchainRoles.SuperchainProxyAdminOwner,
 		Challenger:                      st.SuperchainRoles.Challenger,
-		SP1Verifier:                     proofParams.SP1Verifier,
+		SP1Verifier:                     selectedSP1Verifier,
 	}
 	if zkEnabled && input.SP1Verifier == (common.Address{}) {
 		input.SP1Verifier, err = deployGenesisMockSP1Verifier(env)

--- a/op-deployer/pkg/deployer/pipeline/implementations_test.go
+++ b/op-deployer/pkg/deployer/pipeline/implementations_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-chain-ops/script"
 	"github.com/ethereum-optimism/optimism/op-core/devfeatures"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/artifacts"
+	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/opcm"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/state"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum/go-ethereum/common"
@@ -41,19 +42,21 @@ func TestParseSP1VerifierOverrideRequiresExactKey(t *testing.T) {
 	require.False(t, found)
 }
 
-func TestDeployImplementationsSP1VerifierValidation(t *testing.T) {
-	newState := func() *state.State {
-		return &state.State{
-			SuperchainDeployment: &addresses.SuperchainContracts{
-				SuperchainConfigProxy:    common.Address{0x01},
-				SuperchainProxyAdminImpl: common.Address{0x02},
-			},
-			SuperchainRoles: &addresses.SuperchainRoles{
-				SuperchainProxyAdminOwner: common.Address{0x03},
-				Challenger:                common.Address{0x04},
-			},
-		}
+func newSP1VerifierTestState() *state.State {
+	return &state.State{
+		SuperchainDeployment: &addresses.SuperchainContracts{
+			SuperchainConfigProxy:    common.Address{0x01},
+			SuperchainProxyAdminImpl: common.Address{0x02},
+		},
+		SuperchainRoles: &addresses.SuperchainRoles{
+			SuperchainProxyAdminOwner: common.Address{0x03},
+			Challenger:                common.Address{0x04},
+		},
 	}
+}
+
+func TestDeployImplementationsSP1VerifierValidation(t *testing.T) {
+	newState := newSP1VerifierTestState
 	env := &Env{Logger: testlog.Logger(t, slog.LevelDebug)}
 
 	t.Run("disabled rejects verifier", func(t *testing.T) {
@@ -178,5 +181,100 @@ func TestDeployImplementationsSP1VerifierValidation(t *testing.T) {
 		}}
 		err = DeployImplementations(&resumeEnv, changedIntent, st)
 		require.ErrorContains(t, err, "does not match")
+	})
+}
+
+// capturingDeployImplementations records the input DeployImplementations would broadcast. The
+// embedded nil ForgeScript satisfies the rest of the interface; only Run is exercised.
+type capturingDeployImplementations struct {
+	script.ForgeScript
+	input opcm.DeployImplementationsInput
+	ran   bool
+}
+
+func (c *capturingDeployImplementations) Run(input opcm.DeployImplementationsInput) (opcm.DeployImplementationsOutput, error) {
+	c.input = input
+	c.ran = true
+	var out opcm.DeployImplementationsOutput
+	return out, nil
+}
+
+// TestDeployImplementationsSelectsStandardSP1Verifier pins which raw SP1 verifier a live
+// ZK-enabled apply hands to DeployImplementations.
+func TestDeployImplementationsSelectsStandardSP1Verifier(t *testing.T) {
+	const standardVerifier = "0xc3c6dDDAc8829b233Dc6536Ec024775a57b0AF2A"
+
+	deploy := func(t *testing.T, env Env, intent *state.Intent, st *state.State) (*capturingDeployImplementations, error) {
+		capture := new(capturingDeployImplementations)
+		env.Logger = testlog.Logger(t, slog.LevelDebug)
+		env.Scripts = &opcm.Scripts{DeployImplementations: capture}
+		return capture, DeployImplementations(&env, intent, st)
+	}
+
+	zkIntent := func(l1ChainID uint64, overrides map[string]any) *state.Intent {
+		merged := map[string]any{"devFeatureBitmap": devfeatures.ZKDisputeGameFlag}
+		for k, v := range overrides {
+			merged[k] = v
+		}
+		return &state.Intent{L1ChainID: l1ChainID, GlobalDeployOverrides: merged}
+	}
+
+	for _, tt := range []struct {
+		name      string
+		l1ChainID uint64
+	}{
+		{"mainnet", 1},
+		{"sepolia", 11155111},
+	} {
+		t.Run(tt.name+" defaults to the release verifier", func(t *testing.T) {
+			st := newSP1VerifierTestState()
+			intent := zkIntent(tt.l1ChainID, nil)
+			capture, err := deploy(t, Env{}, intent, st)
+			require.NoError(t, err)
+			require.Equal(t, common.HexToAddress(standardVerifier), capture.input.SP1Verifier)
+			require.NotNil(t, st.SP1Verifier)
+			require.Equal(t, common.HexToAddress(standardVerifier), *st.SP1Verifier)
+			require.NotContains(t, intent.GlobalDeployOverrides, "sp1Verifier")
+		})
+	}
+
+	t.Run("explicit override wins", func(t *testing.T) {
+		override := common.Address{0x05}
+		capture, err := deploy(t, Env{}, zkIntent(11155111, map[string]any{"sp1Verifier": override}), newSP1VerifierTestState())
+		require.NoError(t, err)
+		require.Equal(t, override, capture.input.SP1Verifier)
+	})
+
+	t.Run("unsupported network requires an override", func(t *testing.T) {
+		capture, err := deploy(t, Env{}, zkIntent(900, nil), newSP1VerifierTestState())
+		require.ErrorContains(t, err, "sp1Verifier must be specified")
+		require.ErrorContains(t, err, "900")
+		require.False(t, capture.ran)
+	})
+
+	t.Run("disabled ZK selects nothing", func(t *testing.T) {
+		st := newSP1VerifierTestState()
+		capture, err := deploy(t, Env{}, &state.Intent{L1ChainID: 11155111}, st)
+		require.NoError(t, err)
+		require.Equal(t, common.Address{}, capture.input.SP1Verifier)
+		require.Nil(t, st.SP1Verifier)
+	})
+
+	t.Run("genesis does not select the release verifier", func(t *testing.T) {
+		capture, err := deploy(t, Env{IsGenesis: true}, zkIntent(11155111, nil), newSP1VerifierTestState())
+		require.ErrorContains(t, err, "sp1Verifier must be specified")
+		require.False(t, capture.ran)
+	})
+
+	t.Run("resumed deployment keeps the verifier recorded in state", func(t *testing.T) {
+		recorded := common.Address{0x06}
+		st := newSP1VerifierTestState()
+		st.ImplementationsDeployment = &addresses.ImplementationsContracts{SP1PlonkAdapterImpl: common.Address{0xad}}
+		st.SP1Verifier = &recorded
+
+		capture, err := deploy(t, Env{}, zkIntent(11155111, nil), st)
+		require.NoError(t, err)
+		require.False(t, capture.ran)
+		require.Equal(t, recorded, *st.SP1Verifier)
 	})
 }

--- a/op-deployer/pkg/deployer/pipeline/implementations_test.go
+++ b/op-deployer/pkg/deployer/pipeline/implementations_test.go
@@ -204,11 +204,15 @@ func (c *capturingDeployImplementations) Run(input opcm.DeployImplementationsInp
 func TestDeployImplementationsSelectsStandardSP1Verifier(t *testing.T) {
 	const standardVerifier = "0xc3c6dDDAc8829b233Dc6536Ec024775a57b0AF2A"
 
-	deploy := func(t *testing.T, env Env, intent *state.Intent, st *state.State) (*capturingDeployImplementations, error) {
+	// Matches any line reporting a raw verifier, so a reintroduced premature log is caught too.
+	verifierLogged := testlog.NewMessageContainsFilter("SP1 verifier")
+
+	deploy := func(t *testing.T, env Env, intent *state.Intent, st *state.State) (*capturingDeployImplementations, *testlog.CapturingHandler, error) {
 		capture := new(capturingDeployImplementations)
-		env.Logger = testlog.Logger(t, slog.LevelDebug)
+		lgr, logs := testlog.CaptureLogger(t, slog.LevelDebug)
+		env.Logger = lgr
 		env.Scripts = &opcm.Scripts{DeployImplementations: capture}
-		return capture, DeployImplementations(&env, intent, st)
+		return capture, logs, DeployImplementations(&env, intent, st)
 	}
 
 	zkIntent := func(l1ChainID uint64, overrides map[string]any) *state.Intent {
@@ -229,24 +233,28 @@ func TestDeployImplementationsSelectsStandardSP1Verifier(t *testing.T) {
 		t.Run(tt.name+" defaults to the release verifier", func(t *testing.T) {
 			st := newSP1VerifierTestState()
 			intent := zkIntent(tt.l1ChainID, nil)
-			capture, err := deploy(t, Env{}, intent, st)
+			capture, logs, err := deploy(t, Env{}, intent, st)
 			require.NoError(t, err)
 			require.Equal(t, common.HexToAddress(standardVerifier), capture.input.SP1Verifier)
 			require.NotNil(t, st.SP1Verifier)
 			require.Equal(t, common.HexToAddress(standardVerifier), *st.SP1Verifier)
 			require.NotContains(t, intent.GlobalDeployOverrides, "sp1Verifier")
+			require.NotNil(t, logs.FindLog(
+				verifierLogged,
+				testlog.NewAttributesFilter("address", common.HexToAddress(standardVerifier).String()),
+			), "should log the verifier it actually deploys against")
 		})
 	}
 
 	t.Run("explicit override wins", func(t *testing.T) {
 		override := common.Address{0x05}
-		capture, err := deploy(t, Env{}, zkIntent(11155111, map[string]any{"sp1Verifier": override}), newSP1VerifierTestState())
+		capture, _, err := deploy(t, Env{}, zkIntent(11155111, map[string]any{"sp1Verifier": override}), newSP1VerifierTestState())
 		require.NoError(t, err)
 		require.Equal(t, override, capture.input.SP1Verifier)
 	})
 
 	t.Run("unsupported network requires an override", func(t *testing.T) {
-		capture, err := deploy(t, Env{}, zkIntent(900, nil), newSP1VerifierTestState())
+		capture, _, err := deploy(t, Env{}, zkIntent(900, nil), newSP1VerifierTestState())
 		require.ErrorContains(t, err, "sp1Verifier must be specified")
 		require.ErrorContains(t, err, "900")
 		require.False(t, capture.ran)
@@ -254,16 +262,32 @@ func TestDeployImplementationsSelectsStandardSP1Verifier(t *testing.T) {
 
 	t.Run("disabled ZK selects nothing", func(t *testing.T) {
 		st := newSP1VerifierTestState()
-		capture, err := deploy(t, Env{}, &state.Intent{L1ChainID: 11155111}, st)
+		capture, logs, err := deploy(t, Env{}, &state.Intent{L1ChainID: 11155111}, st)
 		require.NoError(t, err)
 		require.Equal(t, common.Address{}, capture.input.SP1Verifier)
 		require.Nil(t, st.SP1Verifier)
+		require.Nil(t, logs.FindLog(verifierLogged))
 	})
 
 	t.Run("genesis does not select the release verifier", func(t *testing.T) {
-		capture, err := deploy(t, Env{IsGenesis: true}, zkIntent(11155111, nil), newSP1VerifierTestState())
+		capture, _, err := deploy(t, Env{IsGenesis: true}, zkIntent(11155111, nil), newSP1VerifierTestState())
 		require.ErrorContains(t, err, "sp1Verifier must be specified")
 		require.False(t, capture.ran)
+	})
+
+	t.Run("predeployed OPCM bypasses selection", func(t *testing.T) {
+		opcmAddr := common.Address{0x07}
+		st := newSP1VerifierTestState()
+		st.ImplementationsDeployment = &addresses.ImplementationsContracts{OpcmV2Impl: opcmAddr}
+		// An L1 with no release verifier proves the bypass: selection would otherwise error here.
+		intent := zkIntent(900, nil)
+		intent.OPCMAddress = &opcmAddr
+
+		capture, logs, err := deploy(t, Env{}, intent, st)
+		require.NoError(t, err)
+		require.False(t, capture.ran)
+		require.Nil(t, st.SP1Verifier)
+		require.Nil(t, logs.FindLog(verifierLogged))
 	})
 
 	t.Run("resumed deployment keeps the verifier recorded in state", func(t *testing.T) {
@@ -272,9 +296,10 @@ func TestDeployImplementationsSelectsStandardSP1Verifier(t *testing.T) {
 		st.ImplementationsDeployment = &addresses.ImplementationsContracts{SP1PlonkAdapterImpl: common.Address{0xad}}
 		st.SP1Verifier = &recorded
 
-		capture, err := deploy(t, Env{}, zkIntent(11155111, nil), st)
+		capture, logs, err := deploy(t, Env{}, zkIntent(11155111, nil), st)
 		require.NoError(t, err)
 		require.False(t, capture.ran)
 		require.Equal(t, recorded, *st.SP1Verifier)
+		require.Nil(t, logs.FindLog(verifierLogged), "resume must not report a verifier it is not using")
 	})
 }

--- a/op-deployer/pkg/deployer/standard/standard.go
+++ b/op-deployer/pkg/deployer/standard/standard.go
@@ -102,6 +102,31 @@ func ChallengerAddressFor(chainID uint64) (common.Address, error) {
 	}
 }
 
+const (
+	// Source: succinctlabs/sp1-contracts@2ac5ecbbe473421a963d67e55f182e9a36576f7c,
+	// contracts/deployments/1.json, V6_1_0_SP1_VERIFIER_PLONK.
+	mainnetSP1VerifierV610 = "0xc3c6dDDAc8829b233Dc6536Ec024775a57b0AF2A"
+	// Succinct deploys the same verifier bytecode and address deterministically on both networks.
+	// Source: succinctlabs/sp1-contracts@2ac5ecbbe473421a963d67e55f182e9a36576f7c,
+	// contracts/deployments/11155111.json, V6_1_0_SP1_VERIFIER_PLONK.
+	sepoliaSP1VerifierV610 = "0xc3c6dDDAc8829b233Dc6536Ec024775a57b0AF2A"
+)
+
+// SP1VerifierFor returns the raw SP1 verifier approved for the current OPCM release on the given L1
+// chain ID. Both `bootstrap implementations` and `apply` default to it when ZK dispute games are
+// enabled and the operator did not pin a verifier explicitly.
+// DO NOT MODIFY THIS METHOD WITHOUT CLEARING IT WITH THE EVM SAFETY TEAM.
+func SP1VerifierFor(chainID uint64) (common.Address, error) {
+	switch chainID {
+	case 1:
+		return common.HexToAddress(mainnetSP1VerifierV610), nil
+	case 11155111:
+		return common.HexToAddress(sepoliaSP1VerifierV610), nil
+	default:
+		return common.Address{}, fmt.Errorf("unsupported chain ID: %d", chainID)
+	}
+}
+
 func SuperchainFor(chainID uint64) (superchain.Superchain, error) {
 	switch chainID {
 	case 1:

--- a/op-deployer/pkg/deployer/standard/standard_test.go
+++ b/op-deployer/pkg/deployer/standard/standard_test.go
@@ -95,6 +95,11 @@ func TestStandardAddresses(t *testing.T) {
 			common.HexToAddress("0x5a0Aae59D09fccBdDb6C6CcEB07B7279367C3d2A"),
 			common.HexToAddress("0x1Eb2fFc903729a0F03966B917003800b145F56E2"),
 		},
+		{
+			SP1VerifierFor,
+			common.HexToAddress("0xc3c6dDDAc8829b233Dc6536Ec024775a57b0AF2A"),
+			common.HexToAddress("0xc3c6dDDAc8829b233Dc6536Ec024775a57b0AF2A"),
+		},
 	}
 	for _, test := range tests {
 		fname := runtime.FuncForPC(reflect.ValueOf(test.f).Pointer()).Name()
@@ -109,6 +114,13 @@ func TestStandardAddresses(t *testing.T) {
 			require.Equal(t, test.sepoliaAddr, sepoliaAddr)
 		})
 	}
+}
+
+// TestSP1VerifierForUnsupportedChain pins that networks outside the OPCM release require an
+// explicitly supplied verifier.
+func TestSP1VerifierForUnsupportedChain(t *testing.T) {
+	_, err := SP1VerifierFor(900)
+	require.ErrorContains(t, err, "unsupported chain ID: 900")
 }
 
 func TestL2ProxyAdminOwner(t *testing.T) {

--- a/op-deployer/pkg/deployer/state/intent.go
+++ b/op-deployer/pkg/deployer/state/intent.go
@@ -34,18 +34,17 @@ var (
 )
 
 type SuperchainProofParams struct {
-	WithdrawalDelaySeconds          uint64         `json:"faultGameWithdrawalDelay" toml:"faultGameWithdrawalDelay"`
-	MinProposalSizeBytes            uint64         `json:"preimageOracleMinProposalSize" toml:"preimageOracleMinProposalSize"`
-	ChallengePeriodSeconds          uint64         `json:"preimageOracleChallengePeriod" toml:"preimageOracleChallengePeriod"`
-	ProofMaturityDelaySeconds       uint64         `json:"proofMaturityDelaySeconds" toml:"proofMaturityDelaySeconds"`
-	DisputeGameFinalityDelaySeconds uint64         `json:"disputeGameFinalityDelaySeconds" toml:"disputeGameFinalityDelaySeconds"`
-	DisputeMaxGameDepth             uint64         `json:"faultGameMaxDepth" toml:"faultGameMaxDepth"`
-	DisputeSplitDepth               uint64         `json:"faultGameSplitDepth" toml:"faultGameSplitDepth"`
-	DisputeClockExtension           uint64         `json:"faultGameClockExtension" toml:"faultGameClockExtension"`
-	DisputeMaxClockDuration         uint64         `json:"faultGameMaxClockDuration" toml:"faultGameMaxClockDuration"`
-	MIPSVersion                     uint64         `json:"mipsVersion" toml:"mipsVersion"`
-	DevFeatureBitmap                common.Hash    `json:"devFeatureBitmap" toml:"devFeatureBitmap"`
-	SP1Verifier                     common.Address `json:"sp1Verifier" toml:"sp1Verifier"`
+	WithdrawalDelaySeconds          uint64      `json:"faultGameWithdrawalDelay" toml:"faultGameWithdrawalDelay"`
+	MinProposalSizeBytes            uint64      `json:"preimageOracleMinProposalSize" toml:"preimageOracleMinProposalSize"`
+	ChallengePeriodSeconds          uint64      `json:"preimageOracleChallengePeriod" toml:"preimageOracleChallengePeriod"`
+	ProofMaturityDelaySeconds       uint64      `json:"proofMaturityDelaySeconds" toml:"proofMaturityDelaySeconds"`
+	DisputeGameFinalityDelaySeconds uint64      `json:"disputeGameFinalityDelaySeconds" toml:"disputeGameFinalityDelaySeconds"`
+	DisputeMaxGameDepth             uint64      `json:"faultGameMaxDepth" toml:"faultGameMaxDepth"`
+	DisputeSplitDepth               uint64      `json:"faultGameSplitDepth" toml:"faultGameSplitDepth"`
+	DisputeClockExtension           uint64      `json:"faultGameClockExtension" toml:"faultGameClockExtension"`
+	DisputeMaxClockDuration         uint64      `json:"faultGameMaxClockDuration" toml:"faultGameMaxClockDuration"`
+	MIPSVersion                     uint64      `json:"mipsVersion" toml:"mipsVersion"`
+	DevFeatureBitmap                common.Hash `json:"devFeatureBitmap" toml:"devFeatureBitmap"`
 }
 
 type L1DevGenesisBlockParams struct {


### PR DESCRIPTION
## Purpose

`bootstrap implementations` already selects Succinct's approved v6.1.0 PLONK verifier on mainnet and Sepolia (#22218), but `apply` didn't — so every fresh ZK deployment had to hand-write `globalDeployOverrides.sp1Verifier` for an address op-deployer already knows. That falls hardest on tooling that scaffolds an intent offline and then applies it: `init` can't know the final ZK feature bitmap, so the policy belongs in `apply`, which already owns feature detection, adapter deployment, and verified L1 identity.

## Change

The mapping moves to `standard.SP1VerifierFor`, shared by bootstrap and apply so the two can't drift on a release-specific address. A fresh, live, ZK-enabled `apply` with no override now selects it for L1 chain 1 and 11155111; other networks still error. Apply keys off `intent.L1ChainID`, which `InitLiveStrategy` has already checked against the chain's own `eth_chainId`.

Precedence is unchanged: an explicit override still wins everywhere, ZK is never auto-enabled, ZK-disabled still rejects a verifier, and predeployed-OPCM is untouched. Genesis still requires an explicit or mock verifier, since a generated genesis contains no release verifier. A resumed deployment reuses `State.SP1Verifier` rather than re-resolving, so upgrading op-deployer mid-deployment can't swap the verifier under a chain.

## Testing

Unit tests pin the resolver and the apply-side selection (mainnet, Sepolia, override, unsupported network, ZK-disabled, genesis, resume); four subtests fail on the baseline. Two forked-Sepolia end-to-end runs cover both paths: a new test proves a ZK apply with no override deploys an `SP1PlonkAdapter` wrapping the release verifier, and the existing `TestSetInteropDisputeGames` confirms the explicit override still works. Docs updated in `docs/ai/devfeatures.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
