### PR TITLE
contracts-bedrock: Require a new anchor root when migrating to super root games

### DIFF
--- a/packages/contracts-bedrock/interfaces/L1/opcm/IOPContractsManagerUtils.sol
+++ b/packages/contracts-bedrock/interfaces/L1/opcm/IOPContractsManagerUtils.sol
@@ -8,7 +8,7 @@ import { IDisputeGame } from "interfaces/dispute/IDisputeGame.sol";
 import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.sol";
 import { IDelayedWETH } from "interfaces/dispute/IDelayedWETH.sol";
 import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
-import { Claim, Duration, GameType } from "src/dispute/lib/Types.sol";
+import { Claim, Duration, GameType, Proposal } from "src/dispute/lib/Types.sol";
 
 interface IOPContractsManagerUtils {
     struct ProxyDeployArgs {
@@ -63,6 +63,8 @@ interface IOPContractsManagerUtils {
     error OPContractsManagerUtils_OZv5InitializableUnsupported();
     error OPContractsManagerUtils_ConfigLoadFailed(string _name);
     error OPContractsManagerUtils_ProxyMustLoad(string _name);
+    error OPContractsManagerUtils_MissingStartingAnchorRoot();
+    error OPContractsManagerUtils_InvalidStartingAnchorRoot();
     error OPContractsManagerUtils_UnsupportedGameType();
     error OPContractsManagerUtils_InvalidZKGameArgsLength(uint256 length);
     error ReservedBitsSet();
@@ -121,6 +123,17 @@ interface IOPContractsManagerUtils {
         external
         pure
         returns (ExtraInstruction memory);
+
+    function assertValidSuperRootMigration(
+        IAnchorStateRegistry _anchorStateRegistry,
+        GameType _startingRespectedGameType,
+        Proposal memory _startingAnchorRoot,
+        ExtraInstruction[] memory _instructions
+    )
+        external
+        view;
+
+    function hasOutputRootAnchor(IAnchorStateRegistry _anchorStateRegistry) external view returns (bool);
 
     function loadBytes(
         address _source,

--- a/packages/contracts-bedrock/snapshots/abi/OPContractsManagerUtils.json
+++ b/packages/contracts-bedrock/snapshots/abi/OPContractsManagerUtils.json
@@ -11,6 +11,58 @@
     "type": "constructor"
   },
   {
+    "inputs": [
+      {
+        "internalType": "contract IAnchorStateRegistry",
+        "name": "_anchorStateRegistry",
+        "type": "address"
+      },
+      {
+        "internalType": "GameType",
+        "name": "_startingRespectedGameType",
+        "type": "uint32"
+      },
+      {
+        "components": [
+          {
+            "internalType": "Hash",
+            "name": "root",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint256",
+            "name": "l2SequenceNumber",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct Proposal",
+        "name": "_startingAnchorRoot",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          {
+            "internalType": "string",
+            "name": "key",
+            "type": "string"
+          },
+          {
+            "internalType": "bytes",
+            "name": "data",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct OPContractsManagerUtils.ExtraInstruction[]",
+        "name": "_instructions",
+        "type": "tuple[]"
+      }
+    ],
+    "name": "assertValidSuperRootMigration",
+    "outputs": [],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [],
     "name": "blueprints",
     "outputs": [
@@ -217,6 +269,25 @@
       }
     ],
     "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IAnchorStateRegistry",
+        "name": "_anchorStateRegistry",
+        "type": "address"
+      }
+    ],
+    "name": "hasOutputRootAnchor",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -721,6 +792,11 @@
     "type": "error"
   },
   {
+    "inputs": [],
+    "name": "OPContractsManagerUtils_InvalidStartingAnchorRoot",
+    "type": "error"
+  },
+  {
     "inputs": [
       {
         "internalType": "uint256",
@@ -729,6 +805,11 @@
       }
     ],
     "name": "OPContractsManagerUtils_InvalidZKGameArgsLength",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "OPContractsManagerUtils_MissingStartingAnchorRoot",
     "type": "error"
   },
   {

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -36,8 +36,8 @@
     "sourceCodeHash": "0xceeedf69dcb6c05b88fd1569c53606dec02195b4d393a6491876b6d2f0c2ff1f"
   },
   "src/L1/opcm/OPContractsManagerV2.sol:OPContractsManagerV2": {
-    "initCodeHash": "0x59ea6c5177c5e96f170c443430b505a05ec3dbf77fea7f833e97cfa41b637298",
-    "sourceCodeHash": "0x3a258f2611e4de790554aac8d4685811d7d36db9b2f84c57b32fcd7fa3a01b68"
+    "initCodeHash": "0x362bb02bda133b79707d20658d6e3117e9d4c7fa1502f7e58efa14cb4e017b26",
+    "sourceCodeHash": "0x62a4ee185d868d0c8b9acefb94d74831ce623a959f73d192db348eebaf1ed335"
   },
   "src/L2/BaseFeeVault.sol:BaseFeeVault": {
     "initCodeHash": "0x18650c65fa6f23fefc6f0c5fff605f12be99fce0bfbcbc0644403138e4c8bb12",

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerUtils.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerUtils.sol
@@ -194,12 +194,9 @@ contract OPContractsManagerUtils {
     }
 
     /// @notice Asserts that an upgrade that moves a chain from output root games to super root
-    ///         games supplies a new starting anchor root.
-    /// @dev Without the override, the AnchorStateRegistry is re-initialized with its existing
-    ///      starting anchor root. The root then counts as unchanged, so the registry keeps the
-    ///      legacy anchor game and new super root games start from an output root and an L2 block
-    ///      number that the super trace reads as a super root and a timestamp. Honest challengers
-    ///      cannot build a trace for that prestate, so invalid claims would go uncontested.
+    ///         games supplies a new starting anchor root. Without it the AnchorStateRegistry sees
+    ///         an unchanged root, keeps the legacy anchor game, and super root games inherit an
+    ///         output root that no honest challenger can build a trace for.
     ///
     /// @param _anchorStateRegistry The AnchorStateRegistry of the chain being upgraded.
     /// @param _startingRespectedGameType The respected game type the upgrade will install.
@@ -214,20 +211,16 @@ contract OPContractsManagerUtils {
         external
         view
     {
-        // Only the move onto super root games needs a new anchor root. A chain that already runs
-        // super root games holds an anchor that super root games can interpret.
+        // Only the move onto super root games needs a new anchor root.
         if (!GameTypes.isSuperGame(_startingRespectedGameType)) return;
         if (!hasOutputRootAnchor(_anchorStateRegistry)) return;
 
-        // The anchor root must be supplied explicitly. Falling back to the value already stored in
-        // the registry would retain the legacy anchor game.
         if (bytes(getInstructionByKey(_instructions, "overrides.cfg.startingAnchorRoot").key).length == 0) {
             revert OPContractsManagerUtils_MissingStartingAnchorRoot();
         }
 
-        // The anchor must be a real commitment at a sequence number that leaves room for a uint64
-        // successor. AnchorStateRegistry.initialize separately requires that the sequence number is
-        // ahead of the current anchor, which is what clears the legacy anchor game.
+        // AnchorStateRegistry.initialize separately requires the sequence number to be ahead of the
+        // current anchor, which is what clears the legacy anchor game.
         if (
             _startingAnchorRoot.root.raw() == bytes32(0)
                 || _startingAnchorRoot.root.raw() == Constants.PLACEHOLDER_STARTING_ANCHOR_ROOT
@@ -238,8 +231,9 @@ contract OPContractsManagerUtils {
     }
 
     /// @notice Checks whether an AnchorStateRegistry currently respects an output root game type.
-    /// @dev A registry that cannot report a respected game type was deployed by this upgrade and
-    ///      therefore holds no anchor state to carry over.
+    ///         A registry that cannot report one was deployed by this upgrade, so it holds no
+    ///         anchor state to carry over.
+    ///
     /// @param _anchorStateRegistry The AnchorStateRegistry to check.
     /// @return True if the registry reports an output root game type, false otherwise.
     function hasOutputRootAnchor(IAnchorStateRegistry _anchorStateRegistry) public view returns (bool) {

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerUtils.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerUtils.sol
@@ -6,7 +6,7 @@ import { LibString } from "@solady/utils/LibString.sol";
 import { SemverComp } from "src/libraries/SemverComp.sol";
 import { Blueprint } from "src/libraries/Blueprint.sol";
 import { Constants } from "src/libraries/Constants.sol";
-import { GameType, GameTypes } from "src/dispute/lib/Types.sol";
+import { GameType, GameTypes, Proposal } from "src/dispute/lib/Types.sol";
 
 // Interfaces
 import { IOPContractsManagerContainer } from "interfaces/L1/opcm/IOPContractsManagerContainer.sol";
@@ -71,6 +71,13 @@ contract OPContractsManagerUtils {
     /// @notice Thrown when a proxy must be loaded but couldn't be.
     /// @param _name The name of the proxy that couldn't be loaded.
     error OPContractsManagerUtils_ProxyMustLoad(string _name);
+
+    /// @notice Thrown when an upgrade moves a chain from output root games to super root games
+    ///         without supplying a new starting anchor root.
+    error OPContractsManagerUtils_MissingStartingAnchorRoot();
+
+    /// @notice Thrown when the starting anchor root supplied for a super root migration is invalid.
+    error OPContractsManagerUtils_InvalidStartingAnchorRoot();
 
     /// @notice Container of blueprint and implementation contract addresses.
     IOPContractsManagerContainer public immutable contractsContainer;
@@ -184,6 +191,65 @@ contract OPContractsManagerUtils {
             }
         }
         return ExtraInstruction({ key: "", data: bytes("") });
+    }
+
+    /// @notice Asserts that an upgrade that moves a chain from output root games to super root
+    ///         games supplies a new starting anchor root.
+    /// @dev Without the override, the AnchorStateRegistry is re-initialized with its existing
+    ///      starting anchor root. The root then counts as unchanged, so the registry keeps the
+    ///      legacy anchor game and new super root games start from an output root and an L2 block
+    ///      number that the super trace reads as a super root and a timestamp. Honest challengers
+    ///      cannot build a trace for that prestate, so invalid claims would go uncontested.
+    ///
+    /// @param _anchorStateRegistry The AnchorStateRegistry of the chain being upgraded.
+    /// @param _startingRespectedGameType The respected game type the upgrade will install.
+    /// @param _startingAnchorRoot The starting anchor root the upgrade will install.
+    /// @param _instructions The extra upgrade instructions for the upgrade.
+    function assertValidSuperRootMigration(
+        IAnchorStateRegistry _anchorStateRegistry,
+        GameType _startingRespectedGameType,
+        Proposal memory _startingAnchorRoot,
+        ExtraInstruction[] memory _instructions
+    )
+        external
+        view
+    {
+        // Only the move onto super root games needs a new anchor root. A chain that already runs
+        // super root games holds an anchor that super root games can interpret.
+        if (!GameTypes.isSuperGame(_startingRespectedGameType)) return;
+        if (!hasOutputRootAnchor(_anchorStateRegistry)) return;
+
+        // The anchor root must be supplied explicitly. Falling back to the value already stored in
+        // the registry would retain the legacy anchor game.
+        if (bytes(getInstructionByKey(_instructions, "overrides.cfg.startingAnchorRoot").key).length == 0) {
+            revert OPContractsManagerUtils_MissingStartingAnchorRoot();
+        }
+
+        // The anchor must be a real commitment at a sequence number that leaves room for a uint64
+        // successor. AnchorStateRegistry.initialize separately requires that the sequence number is
+        // ahead of the current anchor, which is what clears the legacy anchor game.
+        if (
+            _startingAnchorRoot.root.raw() == bytes32(0)
+                || _startingAnchorRoot.root.raw() == Constants.PLACEHOLDER_STARTING_ANCHOR_ROOT
+                || _startingAnchorRoot.l2SequenceNumber >= type(uint64).max
+        ) {
+            revert OPContractsManagerUtils_InvalidStartingAnchorRoot();
+        }
+    }
+
+    /// @notice Checks whether an AnchorStateRegistry currently respects an output root game type.
+    /// @dev A registry that cannot report a respected game type was deployed by this upgrade and
+    ///      therefore holds no anchor state to carry over.
+    /// @param _anchorStateRegistry The AnchorStateRegistry to check.
+    /// @return True if the registry reports an output root game type, false otherwise.
+    function hasOutputRootAnchor(IAnchorStateRegistry _anchorStateRegistry) public view returns (bool) {
+        if (address(_anchorStateRegistry).code.length == 0) return false;
+
+        (bool success, bytes memory result) =
+            address(_anchorStateRegistry).staticcall(abi.encodeCall(IAnchorStateRegistry.respectedGameType, ()));
+        if (!success || result.length != 32) return false;
+
+        return !GameTypes.isSuperGame(abi.decode(result, (GameType)));
     }
 
     /// @notice Helper function to load data from a source contract as bytes.

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerUtilsCaller.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerUtilsCaller.sol
@@ -87,8 +87,8 @@ abstract contract OPContractsManagerUtilsCaller {
         );
     }
 
-    /// @notice Asserts that an upgrade onto super root games supplies a new starting anchor root.
-    ///         See OPContractsManagerUtils.assertValidSuperRootMigration.
+    /// @notice See OPContractsManagerUtils.assertValidSuperRootMigration.
+    ///
     /// @param _anchorStateRegistry The AnchorStateRegistry of the chain being upgraded.
     /// @param _startingRespectedGameType The respected game type the upgrade will install.
     /// @param _startingAnchorRoot The starting anchor root the upgrade will install.

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerUtilsCaller.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerUtilsCaller.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 // Libraries
-import { GameType } from "src/dispute/lib/Types.sol";
+import { GameType, Proposal } from "src/dispute/lib/Types.sol";
 
 // Interfaces
 import { IOPContractsManagerUtils } from "interfaces/L1/opcm/IOPContractsManagerUtils.sol";
@@ -84,6 +84,29 @@ abstract contract OPContractsManagerUtilsCaller {
         return abi.decode(
             _staticcall(abi.encodeCall(IOPContractsManagerUtils.isMatchingInstruction, (_instruction, _key, _data))),
             (bool)
+        );
+    }
+
+    /// @notice Asserts that an upgrade onto super root games supplies a new starting anchor root.
+    ///         See OPContractsManagerUtils.assertValidSuperRootMigration.
+    /// @param _anchorStateRegistry The AnchorStateRegistry of the chain being upgraded.
+    /// @param _startingRespectedGameType The respected game type the upgrade will install.
+    /// @param _startingAnchorRoot The starting anchor root the upgrade will install.
+    /// @param _instructions The extra upgrade instructions for the upgrade.
+    function _assertValidSuperRootMigration(
+        IAnchorStateRegistry _anchorStateRegistry,
+        GameType _startingRespectedGameType,
+        Proposal memory _startingAnchorRoot,
+        IOPContractsManagerUtils.ExtraInstruction[] memory _instructions
+    )
+        internal
+        view
+    {
+        _staticcall(
+            abi.encodeCall(
+                IOPContractsManagerUtils.assertValidSuperRootMigration,
+                (_anchorStateRegistry, _startingRespectedGameType, _startingAnchorRoot, _instructions)
+            )
         );
     }
 

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
@@ -158,9 +158,9 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
     ///         - Major bump: New required sequential upgrade
     ///         - Minor bump: Replacement OPCM for same upgrade
     ///         - Patch bump: Development changes (expected for normal dev work)
-    /// @custom:semver 8.0.1
+    /// @custom:semver 8.0.2
     function version() public pure returns (string memory) {
-        return "8.0.1";
+        return "8.0.2";
     }
 
     /// @param _standardValidator The standard validator for this OPCM release.
@@ -263,6 +263,11 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
 
         // Load the full config.
         FullConfig memory cfg = _loadFullConfig(_inp, cts);
+
+        // Assert that a migration onto super root games carries a usable anchor root.
+        _assertValidSuperRootMigration(
+            cts.anchorStateRegistry, cfg.startingRespectedGameType, cfg.startingAnchorRoot, _inp.extraInstructions
+        );
 
         // Execute the upgrade.
         return _apply(cfg, cts, false);

--- a/packages/contracts-bedrock/test/L1/OPContractsManagerStandardValidator.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManagerStandardValidator.t.sol
@@ -10,7 +10,7 @@ import { OPContractsManagerMigrationValidator_TestInit } from "test/L1/opcm/OPCo
 
 // Libraries
 import { GameType, Hash } from "src/dispute/lib/LibUDT.sol";
-import { GameTypes, Duration, Claim } from "src/dispute/lib/Types.sol";
+import { GameTypes, Duration, Claim, Proposal } from "src/dispute/lib/Types.sol";
 import { ForgeArtifacts } from "scripts/libraries/ForgeArtifacts.sol";
 import { Features } from "src/libraries/Features.sol";
 import { DevFeatures } from "src/libraries/DevFeatures.sol";
@@ -2209,11 +2209,19 @@ abstract contract OPContractsManagerStandardValidator_ZKMode_TestInit is CommonT
                 )
             });
 
+            // Moving off the output root games requires a new anchor root, ahead of the current one.
+            (, uint256 currentSeqNum) = anchorStateRegistry.getAnchorRoot();
             IOPContractsManagerUtils.ExtraInstruction[] memory extraInstructions =
-                new IOPContractsManagerUtils.ExtraInstruction[](1);
+                new IOPContractsManagerUtils.ExtraInstruction[](2);
             extraInstructions[0] = IOPContractsManagerUtils.ExtraInstruction({
                 key: "overrides.cfg.startingRespectedGameType",
                 data: abi.encode(GameTypes.SUPER_CANNON_KONA)
+            });
+            extraInstructions[1] = IOPContractsManagerUtils.ExtraInstruction({
+                key: "overrides.cfg.startingAnchorRoot",
+                data: abi.encode(
+                    Proposal({ root: Hash.wrap(keccak256("zkAnchorRoot")), l2SequenceNumber: currentSeqNum + 1 })
+                )
             });
 
             prankDelegateCall(owner);

--- a/packages/contracts-bedrock/test/L1/OPContractsManagerStandardValidator.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManagerStandardValidator.t.sol
@@ -1780,11 +1780,12 @@ abstract contract OPContractsManagerStandardValidator_SuperMode_TestInit is Supe
         });
 
         IOPContractsManagerUtils.ExtraInstruction[] memory extraInstructions =
-            new IOPContractsManagerUtils.ExtraInstruction[](1);
+            new IOPContractsManagerUtils.ExtraInstruction[](2);
         extraInstructions[0] = IOPContractsManagerUtils.ExtraInstruction({
             key: "overrides.cfg.startingRespectedGameType",
             data: abi.encode(GameTypes.SUPER_PERMISSIONED)
         });
+        extraInstructions[1] = _superRootAnchorInstruction();
 
         prankDelegateCall(owner);
         (bool success,) = address(opcmV2).delegatecall(

--- a/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
@@ -1335,6 +1335,31 @@ contract OPContractsManagerV2_Upgrade_Test is OPContractsManagerV2_Upgrade_TestI
         );
     }
 
+    /// @notice Removes the extra instruction with the given key from v2UpgradeInput.
+    /// @param _key The key of the instruction to remove.
+    function _removeExtraInstruction(string memory _key) internal {
+        uint256 length = v2UpgradeInput.extraInstructions.length;
+        for (uint256 i = 0; i < length; i++) {
+            if (keccak256(bytes(v2UpgradeInput.extraInstructions[i].key)) == keccak256(bytes(_key))) {
+                v2UpgradeInput.extraInstructions[i] = v2UpgradeInput.extraInstructions[length - 1];
+                v2UpgradeInput.extraInstructions.pop();
+                return;
+            }
+        }
+    }
+
+    /// @notice Replaces the data of the extra instruction with the given key in v2UpgradeInput.
+    /// @param _key The key of the instruction to replace.
+    /// @param _data The new instruction data.
+    function _setExtraInstructionData(string memory _key, bytes memory _data) internal {
+        for (uint256 i = 0; i < v2UpgradeInput.extraInstructions.length; i++) {
+            if (keccak256(bytes(v2UpgradeInput.extraInstructions[i].key)) == keccak256(bytes(_key))) {
+                v2UpgradeInput.extraInstructions[i].data = _data;
+                return;
+            }
+        }
+    }
+
     /// @notice Tests that the full super root migration upgrade succeeds end-to-end with overrides.
     function test_upgrade_superRootMigration_succeeds() public {
         skipIfNotForkTest("FeatSuperRootMigration: only runs in forked tests");
@@ -1404,6 +1429,83 @@ contract OPContractsManagerV2_Upgrade_Test is OPContractsManagerV2_Upgrade_TestI
         // Verify ASR state: anchor game cleared, new anchor root and game type set.
         assertEq(address(anchorStateRegistry.anchorGame()), address(0), "anchor game not cleared");
         assertEq(anchorStateRegistry.respectedGameType().raw(), targetGameType.raw(), "respected game type not updated");
+    }
+
+    /// @notice Tests that migrating onto super root games without a new starting anchor root
+    ///         reverts. Falling back to the stored root would retain the legacy anchor game.
+    function test_upgrade_superRootMigrationWithoutAnchorRoot_reverts() public {
+        skipIfNotForkTest("FeatSuperRootMigration: only runs in forked tests");
+        skipIfDevFeatureDisabled(DevFeatures.SUPER_ROOT_GAMES_MIGRATION);
+
+        GameType originalGameType = optimismPortal2.respectedGameType();
+        if (GameTypes.isSuperGame(originalGameType)) {
+            vm.skip(true, "Skipping: fork chain already migrated to SUPER_ game type");
+        }
+
+        uint32 originalRaw = originalGameType.raw();
+        bool isPermissionless = originalRaw == GameTypes.CANNON.raw() || originalRaw == GameTypes.CANNON_KONA.raw();
+        _setupSuperRootConfigs(isPermissionless, DisputeGames.permissionedGameProposer(disputeGameFactory));
+        _removeExtraInstruction("overrides.cfg.startingAnchorRoot");
+
+        // nosemgrep: sol-style-use-abi-encodecall
+        runCurrentUpgradeV2(
+            chainPAO,
+            abi.encodeWithSelector(IOPContractsManagerUtils.OPContractsManagerUtils_MissingStartingAnchorRoot.selector)
+        );
+    }
+
+    /// @notice Tests that migrating onto super root games with an empty starting anchor root reverts.
+    function test_upgrade_superRootMigrationWithEmptyAnchorRoot_reverts() public {
+        skipIfNotForkTest("FeatSuperRootMigration: only runs in forked tests");
+        skipIfDevFeatureDisabled(DevFeatures.SUPER_ROOT_GAMES_MIGRATION);
+
+        GameType originalGameType = optimismPortal2.respectedGameType();
+        if (GameTypes.isSuperGame(originalGameType)) {
+            vm.skip(true, "Skipping: fork chain already migrated to SUPER_ game type");
+        }
+
+        uint32 originalRaw = originalGameType.raw();
+        bool isPermissionless = originalRaw == GameTypes.CANNON.raw() || originalRaw == GameTypes.CANNON_KONA.raw();
+        _setupSuperRootConfigs(isPermissionless, DisputeGames.permissionedGameProposer(disputeGameFactory));
+
+        (, uint256 currentSeqNum) = anchorStateRegistry.getAnchorRoot();
+        _setExtraInstructionData(
+            "overrides.cfg.startingAnchorRoot",
+            abi.encode(Proposal({ root: Hash.wrap(bytes32(0)), l2SequenceNumber: currentSeqNum + 1 }))
+        );
+
+        // nosemgrep: sol-style-use-abi-encodecall
+        runCurrentUpgradeV2(
+            chainPAO,
+            abi.encodeWithSelector(IOPContractsManagerUtils.OPContractsManagerUtils_InvalidStartingAnchorRoot.selector)
+        );
+    }
+
+    /// @notice Tests that a chain already running super root games can upgrade without supplying a
+    ///         new starting anchor root. The requirement covers the migration only.
+    function test_upgrade_superRootUpgradeWithoutAnchorRoot_succeeds() public {
+        skipIfNotForkTest("FeatSuperRootMigration: only runs in forked tests");
+        skipIfDevFeatureDisabled(DevFeatures.SUPER_ROOT_GAMES_MIGRATION);
+
+        GameType originalGameType = optimismPortal2.respectedGameType();
+        if (GameTypes.isSuperGame(originalGameType)) {
+            vm.skip(true, "Skipping: fork chain already migrated to SUPER_ game type");
+        }
+
+        uint32 originalRaw = originalGameType.raw();
+        bool isPermissionless = originalRaw == GameTypes.CANNON.raw() || originalRaw == GameTypes.CANNON_KONA.raw();
+        GameType targetGameType =
+            _setupSuperRootConfigs(isPermissionless, DisputeGames.permissionedGameProposer(disputeGameFactory));
+
+        // Migrate onto super root games with the anchor root override.
+        runCurrentUpgradeV2(chainPAO);
+
+        // Upgrade again without the override. The chain is already on super root games, so the
+        // stored anchor root is a valid super root anchor.
+        _removeExtraInstruction("overrides.cfg.startingAnchorRoot");
+        runCurrentUpgradeV2(chainPAO);
+
+        assertEq(anchorStateRegistry.respectedGameType().raw(), targetGameType.raw(), "respected game type changed");
     }
 
     /// @notice Tests that upgrade() can be called twice with the super root flag without reverting.

--- a/packages/contracts-bedrock/test/setup/SuperGameTestInit.sol
+++ b/packages/contracts-bedrock/test/setup/SuperGameTestInit.sol
@@ -25,9 +25,9 @@ abstract contract SuperGameTestInit is CommonTest {
     /// @notice The challenger role.
     address challenger;
 
-    /// @notice Builds the starting anchor root override that a migration onto super root games
-    ///         must supply. The sequence number must be ahead of the current anchor so the
-    ///         AnchorStateRegistry clears the output root anchor game.
+    /// @notice Builds the starting anchor root override a migration onto super root games must
+    ///         supply. The sequence number must be ahead of the current anchor.
+    ///
     /// @return The starting anchor root instruction.
     function _superRootAnchorInstruction() internal view returns (IOPContractsManagerUtils.ExtraInstruction memory) {
         (, uint256 currentSeqNum) = anchorStateRegistry.getAnchorRoot();

--- a/packages/contracts-bedrock/test/setup/SuperGameTestInit.sol
+++ b/packages/contracts-bedrock/test/setup/SuperGameTestInit.sol
@@ -5,7 +5,7 @@ pragma solidity 0.8.15;
 import { CommonTest } from "test/setup/CommonTest.sol";
 
 // Libraries
-import { GameTypes, Claim } from "src/dispute/lib/Types.sol";
+import { GameTypes, Claim, Hash, Proposal } from "src/dispute/lib/Types.sol";
 
 // Interfaces
 import { IOPContractsManagerV2 } from "interfaces/L1/opcm/IOPContractsManagerV2.sol";
@@ -24,6 +24,20 @@ abstract contract SuperGameTestInit is CommonTest {
 
     /// @notice The challenger role.
     address challenger;
+
+    /// @notice Builds the starting anchor root override that a migration onto super root games
+    ///         must supply. The sequence number must be ahead of the current anchor so the
+    ///         AnchorStateRegistry clears the output root anchor game.
+    /// @return The starting anchor root instruction.
+    function _superRootAnchorInstruction() internal view returns (IOPContractsManagerUtils.ExtraInstruction memory) {
+        (, uint256 currentSeqNum) = anchorStateRegistry.getAnchorRoot();
+        return IOPContractsManagerUtils.ExtraInstruction({
+            key: "overrides.cfg.startingAnchorRoot",
+            data: abi.encode(
+                Proposal({ root: Hash.wrap(keccak256("superRootAnchorRoot")), l2SequenceNumber: currentSeqNum + 1 })
+            )
+        });
+    }
 
     /// @notice Runs an upgrade that enables SUPER_CANNON_KONA alongside SUPER_PERMISSIONED.
     function _enableSuperCannonKona() internal virtual {
@@ -73,11 +87,12 @@ abstract contract SuperGameTestInit is CommonTest {
         });
 
         IOPContractsManagerUtils.ExtraInstruction[] memory extraInstructions =
-            new IOPContractsManagerUtils.ExtraInstruction[](1);
+            new IOPContractsManagerUtils.ExtraInstruction[](2);
         extraInstructions[0] = IOPContractsManagerUtils.ExtraInstruction({
             key: "overrides.cfg.startingRespectedGameType",
             data: abi.encode(GameTypes.SUPER_PERMISSIONED)
         });
+        extraInstructions[1] = _superRootAnchorInstruction();
 
         prankDelegateCall(owner);
         (bool success,) = address(opcmV2).delegatecall(


### PR DESCRIPTION
`OPContractsManagerV2.upgrade` now requires the `overrides.cfg.startingAnchorRoot` instruction when an upgrade installs a super root respected game type while the AnchorStateRegistry still respects an output root game type. The root must also be non-zero and in range.

Without the instruction, OPCM read the anchor root back from the registry. The root looked unchanged, so the registry kept the legacy `anchorGame` and new super root games inherited an output root and an L2 block number that the super trace reads as a super root and a timestamp. Honest challengers cannot build a trace for that prestate, so invalid claims would go uncontested.

The requirement covers only that first transition. Chains already on super root games, and initial deployments, are unaffected. `AnchorStateRegistry.initialize` already rejects an anchor that is not ahead of the current one and clears the legacy anchor game.

The check lives in `OPContractsManagerUtils` because `OPContractsManagerV2` had 512 bytes of EIP-170 headroom and inlining it overflowed by 218.

`SuperGameTestInit` and the StandardValidator super-mode and ZK setups performed this omission, so they now supply the override.