### PR TITLE
op-supernode: Skip recovery for already-applied invalidations

### DIFF
--- a/op-supernode/supernode/activity/interop/algo_test.go
+++ b/op-supernode/supernode/activity/interop/algo_test.go
@@ -1147,6 +1147,9 @@ func (m *algoMockChain) BlockTime() uint64 {
 func (m *algoMockChain) InvalidateBlock(ctx context.Context, height uint64, payloadHash common.Hash, decisionTimestamp uint64, stateRoot, messagePasserStorageRoot eth.Bytes32, parentPayload *eth.ExecutionPayloadEnvelope) (bool, error) {
 	return false, nil
 }
+func (m *algoMockChain) InvalidationRewindRequired(ctx context.Context, height uint64, payloadHash common.Hash, parent eth.BlockID) (bool, error) {
+	return true, nil
+}
 func (m *algoMockChain) OutputV0AtBlockNumber(ctx context.Context, l2BlockNum uint64) (*eth.OutputV0, error) {
 	out := &eth.OutputV0{}
 	if m.blockHashes != nil {

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -812,6 +812,18 @@ func (i *Interop) applyPendingTransition(pending PendingTransition) (bool, error
 		sort.Slice(invalidations, func(i, j int) bool {
 			return invalidations[i].ChainID.Cmp(invalidations[j].ChainID) < 0
 		})
+		// Re-running an already-applied decision is not free: the freeze below restarts
+		// every VN, resetting derivation and walking local-safe back a sequencing window
+		// on chains that were never invalidated.
+		outstanding := i.outstandingInvalidations(invalidations, pending.InvalidationParentPayloads)
+		if len(outstanding) == 0 {
+			i.log.Info("invalidation already applied on every chain, skipping recovery",
+				"timestamp", pending.Result.Timestamp, "chains", len(invalidations))
+			if err := i.verifiedDB.ClearPendingTransition(); err != nil {
+				return false, fmt.Errorf("clear already-applied invalidation transition: %w", err)
+			}
+			return false, nil
+		}
 		// Freeze ALL chains' VNs before rewinding any. Without this, a non-invalidated
 		// chain's still-running VN can observe the interop state change from onReset and
 		// issue a ForkchoiceUpdate that advances its safe head. If that chain is later
@@ -826,6 +838,8 @@ func (i *Interop) applyPendingTransition(pending PendingTransition) (bool, error
 			}
 		}
 		var failedAny bool
+		// Chains RewindEngine resumed for us; every other chain is resumed below.
+		rewound := make(map[eth.ChainID]bool, len(invalidations))
 		for _, p := range invalidations {
 			parentPayload, ok := pending.InvalidationParentPayloads[p.ChainID]
 			if !ok || parentPayload == nil {
@@ -837,18 +851,28 @@ func (i *Interop) applyPendingTransition(pending PendingTransition) (bool, error
 				failedAny = true
 				continue
 			}
-			if err := i.invalidateBlock(p.ChainID, p.BlockID, p.Timestamp, p.StateRoot, p.MessagePasserStorageRoot, parentPayload); err != nil {
+			didRewind, err := i.invalidateBlock(p.ChainID, p.BlockID, p.Timestamp, p.StateRoot, p.MessagePasserStorageRoot, parentPayload)
+			if err != nil {
 				i.log.Error("invalidation failed, transition preserved for retry on restart",
 					"chain", p.ChainID, "block", p.BlockID, "err", err)
 				failedAny = true
-			} else {
+				continue
+			}
+			if didRewind {
+				rewound[p.ChainID] = true
+			}
+			// Count only the chains the preflight found outstanding, so a transition
+			// retried because a sibling chain keeps failing does not inflate the counter.
+			if outstanding[p.ChainID] {
 				i.metrics.InteropInvalidations.WithLabelValues(p.ChainID.String()).Inc()
 			}
 		}
-		// Resume non-invalidated chains. Invalidated chains are resumed by
-		// RewindEngine internally (which also waits for readiness).
+		needsResume := func(chainID eth.ChainID) bool { return !rewound[chainID] }
+		// RewindEngine is the only other path that resumes a chain, so anything it did
+		// not run for stays stopped unless resumed here — including failed invalidations,
+		// which are retried next round rather than left wedged.
 		for chainID, chain := range i.chains {
-			if _, isInvalid := pending.Result.InvalidHeads[chainID]; !isInvalid {
+			if needsResume(chainID) {
 				if err := chain.Resume(i.ctx); err != nil {
 					i.log.Error("failed to resume chain after rewind", "chainID", chainID, "err", err)
 				}
@@ -866,7 +890,7 @@ func (i *Interop) applyPendingTransition(pending PendingTransition) (bool, error
 		// verifier backoff loop, so we log and continue rather than return.
 		waitCtx, cancel := context.WithTimeout(i.ctx, cc.DefaultWaitReadyTimeout)
 		for chainID, chain := range i.chains {
-			if _, isInvalid := pending.Result.InvalidHeads[chainID]; !isInvalid {
+			if needsResume(chainID) {
 				if err := chain.WaitReady(waitCtx); err != nil {
 					i.log.Error("chain not ready after resume", "chainID", chainID, "err", err)
 				}
@@ -1362,11 +1386,41 @@ func (i *Interop) Reset(chainID eth.ChainID, timestamp uint64, invalidatedBlock 
 // invalidateBlock notifies the chain container to add the block to the denylist
 // and potentially rewind if the chain is currently using that block. parentPayload
 // is the canonical payload at the rewind destination (height-1), captured from the WAL.
-func (i *Interop) invalidateBlock(chainID eth.ChainID, blockID eth.BlockID, decisionTimestamp uint64, stateRoot, messagePasserStorageRoot eth.Bytes32, parentPayload *eth.ExecutionPayloadEnvelope) error {
+// Reports whether a rewind was triggered.
+func (i *Interop) invalidateBlock(chainID eth.ChainID, blockID eth.BlockID, decisionTimestamp uint64, stateRoot, messagePasserStorageRoot eth.Bytes32, parentPayload *eth.ExecutionPayloadEnvelope) (bool, error) {
 	chain, ok := i.chains[chainID]
 	if !ok {
-		return fmt.Errorf("chain %s not found", chainID)
+		return false, fmt.Errorf("chain %s not found", chainID)
 	}
-	_, err := chain.InvalidateBlock(i.ctx, blockID.Number, blockID.Hash, decisionTimestamp, stateRoot, messagePasserStorageRoot, parentPayload)
-	return err
+	return chain.InvalidateBlock(i.ctx, blockID.Number, blockID.Hash, decisionTimestamp, stateRoot, messagePasserStorageRoot, parentPayload)
+}
+
+// outstandingInvalidations returns the chains whose pending invalidation would
+// still change chain state. An unreadable chain counts as outstanding: re-running
+// a completed invalidation is idempotent, whereas skipping a real one leaves an
+// invalid block canonical.
+func (i *Interop) outstandingInvalidations(invalidations []PendingInvalidation, parents map[eth.ChainID]*eth.ExecutionPayloadEnvelope) map[eth.ChainID]bool {
+	outstanding := make(map[eth.ChainID]bool, len(invalidations))
+	for _, p := range invalidations {
+		chain, ok := i.chains[p.ChainID]
+		if !ok {
+			// Reported properly by the apply loop, which preserves the transition.
+			outstanding[p.ChainID] = true
+			continue
+		}
+		var parent eth.BlockID
+		if envelope := parents[p.ChainID]; envelope != nil && envelope.ExecutionPayload != nil {
+			parent = envelope.ExecutionPayload.ID()
+		}
+		required, err := chain.InvalidationRewindRequired(i.ctx, p.BlockID.Number, p.BlockID.Hash, parent)
+		if err != nil {
+			i.log.Warn("invalidation preflight failed, proceeding with recovery",
+				"chain", p.ChainID, "block", p.BlockID, "err", err)
+			required = true
+		}
+		if required {
+			outstanding[p.ChainID] = true
+		}
+	}
+	return outstanding
 }

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -1194,7 +1194,7 @@ func TestInvalidateBlock(t *testing.T) {
 			run: func(t *testing.T, h *interopTestHarness) {
 				mock := h.Mock(10)
 				blockID := eth.BlockID{Number: 500, Hash: common.HexToHash("0xBAD")}
-				err := h.interop.invalidateBlock(mock.id, blockID, 0, eth.Bytes32{}, eth.Bytes32{}, dummyParentPayload(blockID))
+				_, err := h.interop.invalidateBlock(mock.id, blockID, 0, eth.Bytes32{}, eth.Bytes32{}, dummyParentPayload(blockID))
 				require.NoError(t, err)
 
 				require.Len(t, mock.invalidateBlockCalls, 1)
@@ -1211,7 +1211,7 @@ func TestInvalidateBlock(t *testing.T) {
 				mock := h.Mock(10)
 				unknownChain := eth.ChainIDFromUInt64(999)
 				blockID := eth.BlockID{Number: 500, Hash: common.HexToHash("0xBAD")}
-				err := h.interop.invalidateBlock(unknownChain, blockID, 0, eth.Bytes32{}, eth.Bytes32{}, dummyParentPayload(blockID))
+				_, err := h.interop.invalidateBlock(unknownChain, blockID, 0, eth.Bytes32{}, eth.Bytes32{}, dummyParentPayload(blockID))
 
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "not found")
@@ -1228,7 +1228,7 @@ func TestInvalidateBlock(t *testing.T) {
 			run: func(t *testing.T, h *interopTestHarness) {
 				mock := h.Mock(10)
 				blockID := eth.BlockID{Number: 500, Hash: common.HexToHash("0xBAD")}
-				err := h.interop.invalidateBlock(mock.id, blockID, 0, eth.Bytes32{}, eth.Bytes32{}, dummyParentPayload(blockID))
+				_, err := h.interop.invalidateBlock(mock.id, blockID, 0, eth.Bytes32{}, eth.Bytes32{}, dummyParentPayload(blockID))
 
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "engine failure")
@@ -1740,6 +1740,8 @@ type mockChainContainer struct {
 	invalidateBlockCalls   []invalidateBlockCall
 	invalidateBlockRet     bool
 	invalidateBlockErr     error
+	rewindNotRequired      bool
+	rewindRequiredErr      error
 	pruneDeniedResult      map[uint64][]common.Hash
 	rewindEngineCalls      []uint64
 	rewindEngineErr        error
@@ -2065,6 +2067,21 @@ func (m *mockChainContainer) InvalidateBlock(ctx context.Context, height uint64,
 		m.callLog.record(m.id, "InvalidateBlock")
 	}
 	return m.invalidateBlockRet, m.invalidateBlockErr
+}
+
+// InvalidationRewindRequired defaults to true — the fresh-invalidation case —
+// so tests that don't care about the duplicate-invalidation preflight keep
+// exercising the full freeze/rewind path.
+func (m *mockChainContainer) InvalidationRewindRequired(ctx context.Context, height uint64, payloadHash common.Hash, parent eth.BlockID) (bool, error) {
+	if m.callLog != nil {
+		m.callLog.record(m.id, "InvalidationRewindRequired")
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.rewindRequiredErr != nil {
+		return false, m.rewindRequiredErr
+	}
+	return !m.rewindNotRequired, nil
 }
 func (m *mockChainContainer) OutputV0AtBlockNumber(ctx context.Context, l2BlockNum uint64) (*eth.OutputV0, error) {
 	if m.outputV0Override != nil {
@@ -3026,10 +3043,12 @@ func TestFreezeAllBeforeRewind(t *testing.T) {
 			WithChain(10, func(m *mockChainContainer) {
 				m.blockAtTimestamp = eth.L2BlockRef{Number: 100, Hash: common.HexToHash("0x1")}
 				m.callLog = cl
+				m.invalidateBlockRet = true
 			}).
 			WithChain(8453, func(m *mockChainContainer) {
 				m.blockAtTimestamp = eth.L2BlockRef{Number: 200, Hash: common.HexToHash("0x2")}
 				m.callLog = cl
+				m.invalidateBlockRet = true
 			}).
 			WithChain(42, func(m *mockChainContainer) {
 				m.blockAtTimestamp = eth.L2BlockRef{Number: 300, Hash: common.HexToHash("0x3")}
@@ -3130,12 +3149,297 @@ func TestFreezeAllBeforeRewind(t *testing.T) {
 		}
 	})
 
+	t.Run("invalidated chain is resumed when no rewind was needed", func(t *testing.T) {
+		cl := &callLog{}
+		h := newInteropTestHarness(t).
+			WithChain(10, func(m *mockChainContainer) {
+				m.blockAtTimestamp = eth.L2BlockRef{Number: 100, Hash: common.HexToHash("0x1")}
+				m.callLog = cl
+				// The deny-list write lands but the engine is already off the
+				// invalidated block, so InvalidateBlock reports no rewind and
+				// RewindEngine — the only other path that resumes — never runs.
+				m.invalidateBlockRet = false
+			}).
+			WithChain(8453, func(m *mockChainContainer) {
+				m.blockAtTimestamp = eth.L2BlockRef{Number: 200, Hash: common.HexToHash("0x2")}
+				m.callLog = cl
+			}).
+			Build()
+
+		chain10 := h.Mock(10).id
+		chain8453 := h.Mock(8453).id
+
+		invalidResult := Result{
+			Timestamp:   1000,
+			L1Inclusion: eth.BlockID{Number: 100, Hash: common.HexToHash("0xL1")},
+			L2Heads: map[eth.ChainID]eth.BlockID{
+				chain10:   {Number: 500, Hash: common.HexToHash("0xL2-10")},
+				chain8453: {Number: 600, Hash: common.HexToHash("0xL2-8453")},
+			},
+			InvalidHeads: map[eth.ChainID]InvalidHead{
+				chain10: {BlockID: eth.BlockID{Number: 500, Hash: common.HexToHash("0xBAD")}},
+			},
+		}
+
+		pending, err := h.interop.buildPendingTransition(
+			StepOutput{Decision: DecisionInvalidate, Result: invalidResult},
+			RoundObservation{},
+		)
+		require.NoError(t, err)
+		require.NoError(t, h.interop.verifiedDB.SetPendingTransition(pending))
+		_, err = h.interop.applyPendingTransition(pending)
+		require.NoError(t, err)
+
+		require.Equal(t, 1, h.Mock(10).pauseAndStopVNCalls, "chain 10 should be frozen")
+		require.Equal(t, 1, h.Mock(10).resumeCalls,
+			"a frozen chain whose invalidation triggered no rewind must be resumed, or its VN stays stopped forever")
+		require.Equal(t, 1, h.Mock(8453).resumeCalls, "non-invalidated chain should be resumed")
+	})
+
+	t.Run("failed invalidation resumes rather than wedging the chain", func(t *testing.T) {
+		h := newInteropTestHarness(t).
+			WithChain(10, func(m *mockChainContainer) {
+				m.blockAtTimestamp = eth.L2BlockRef{Number: 100, Hash: common.HexToHash("0x1")}
+				m.invalidateBlockErr = errors.New("engine failure")
+			}).
+			WithChain(8453, func(m *mockChainContainer) {
+				m.blockAtTimestamp = eth.L2BlockRef{Number: 200, Hash: common.HexToHash("0x2")}
+			}).
+			Build()
+
+		chain10 := h.Mock(10).id
+		chain8453 := h.Mock(8453).id
+
+		invalidResult := Result{
+			Timestamp:   1000,
+			L1Inclusion: eth.BlockID{Number: 100, Hash: common.HexToHash("0xL1")},
+			L2Heads: map[eth.ChainID]eth.BlockID{
+				chain10:   {Number: 500, Hash: common.HexToHash("0xL2-10")},
+				chain8453: {Number: 600, Hash: common.HexToHash("0xL2-8453")},
+			},
+			InvalidHeads: map[eth.ChainID]InvalidHead{
+				chain10: {BlockID: eth.BlockID{Number: 500, Hash: common.HexToHash("0xBAD")}},
+			},
+		}
+
+		pending, err := h.interop.buildPendingTransition(
+			StepOutput{Decision: DecisionInvalidate, Result: invalidResult},
+			RoundObservation{},
+		)
+		require.NoError(t, err)
+		require.NoError(t, h.interop.verifiedDB.SetPendingTransition(pending))
+		_, err = h.interop.applyPendingTransition(pending)
+		require.Error(t, err, "the transition must be preserved for retry")
+
+		// The rewind never ran, so nothing else will ever resume this chain.
+		require.Equal(t, 1, h.Mock(10).resumeCalls, "a failed invalidation must not leave the chain frozen")
+		require.Equal(t, 1, h.Mock(8453).resumeCalls, "unaffected chain should be resumed")
+	})
+
+	t.Run("already-applied invalidation skips the global freeze", func(t *testing.T) {
+		cl := &callLog{}
+		h := newInteropTestHarness(t).
+			WithChain(10, func(m *mockChainContainer) {
+				m.blockAtTimestamp = eth.L2BlockRef{Number: 100, Hash: common.HexToHash("0x1")}
+				m.callLog = cl
+				// Already denied and no longer canonical: a previous recovery
+				// cycle completed this exact invalidation.
+				m.rewindNotRequired = true
+			}).
+			WithChain(8453, func(m *mockChainContainer) {
+				m.blockAtTimestamp = eth.L2BlockRef{Number: 200, Hash: common.HexToHash("0x2")}
+				m.callLog = cl
+			}).
+			Build()
+
+		chain10 := h.Mock(10).id
+		chain8453 := h.Mock(8453).id
+
+		invalidResult := Result{
+			Timestamp:   1000,
+			L1Inclusion: eth.BlockID{Number: 100, Hash: common.HexToHash("0xL1")},
+			L2Heads: map[eth.ChainID]eth.BlockID{
+				chain10:   {Number: 500, Hash: common.HexToHash("0xL2-10")},
+				chain8453: {Number: 600, Hash: common.HexToHash("0xL2-8453")},
+			},
+			InvalidHeads: map[eth.ChainID]InvalidHead{
+				chain10: {BlockID: eth.BlockID{Number: 500, Hash: common.HexToHash("0xBAD")}},
+			},
+		}
+
+		pending, err := h.interop.buildPendingTransition(
+			StepOutput{Decision: DecisionInvalidate, Result: invalidResult},
+			RoundObservation{},
+		)
+		require.NoError(t, err)
+		require.NoError(t, h.interop.verifiedDB.SetPendingTransition(pending))
+		_, err = h.interop.applyPendingTransition(pending)
+		require.NoError(t, err)
+
+		// The unaffected chain must not be dragged through a VN restart: that is
+		// the reset/local-safe-replay storm this preflight exists to stop.
+		require.Zero(t, h.Mock(8453).pauseAndStopVNCalls, "unaffected chain must not be frozen")
+		require.Zero(t, h.Mock(10).pauseAndStopVNCalls, "already-recovered chain must not be frozen")
+		require.Empty(t, h.Mock(10).invalidateBlockCalls, "no invalidation work should be redone")
+
+		cleared, err := h.interop.verifiedDB.GetPendingTransition()
+		require.NoError(t, err)
+		require.Nil(t, cleared, "the duplicate transition must be cleared, not retried forever")
+	})
+
+	t.Run("partially-applied invalidation still freezes every chain", func(t *testing.T) {
+		h := newInteropTestHarness(t).
+			WithChain(10, func(m *mockChainContainer) {
+				m.blockAtTimestamp = eth.L2BlockRef{Number: 100, Hash: common.HexToHash("0x1")}
+				m.rewindNotRequired = true
+			}).
+			WithChain(8453, func(m *mockChainContainer) {
+				m.blockAtTimestamp = eth.L2BlockRef{Number: 200, Hash: common.HexToHash("0x2")}
+				m.invalidateBlockRet = true
+			}).
+			Build()
+
+		chain10 := h.Mock(10).id
+		chain8453 := h.Mock(8453).id
+
+		// Chain 8453 still needs its rewind, so transitive-invalidation safety
+		// requires the full freeze even though chain 10 is already recovered.
+		invalidResult := Result{
+			Timestamp:   1000,
+			L1Inclusion: eth.BlockID{Number: 100, Hash: common.HexToHash("0xL1")},
+			L2Heads: map[eth.ChainID]eth.BlockID{
+				chain10:   {Number: 500, Hash: common.HexToHash("0xL2-10")},
+				chain8453: {Number: 600, Hash: common.HexToHash("0xL2-8453")},
+			},
+			InvalidHeads: map[eth.ChainID]InvalidHead{
+				chain10:   {BlockID: eth.BlockID{Number: 500, Hash: common.HexToHash("0xBAD10")}},
+				chain8453: {BlockID: eth.BlockID{Number: 600, Hash: common.HexToHash("0xBAD8453")}},
+			},
+		}
+
+		pending, err := h.interop.buildPendingTransition(
+			StepOutput{Decision: DecisionInvalidate, Result: invalidResult},
+			RoundObservation{},
+		)
+		require.NoError(t, err)
+		require.NoError(t, h.interop.verifiedDB.SetPendingTransition(pending))
+		_, err = h.interop.applyPendingTransition(pending)
+		require.NoError(t, err)
+
+		require.Equal(t, 1, h.Mock(10).pauseAndStopVNCalls, "chain 10 should be frozen")
+		require.Equal(t, 1, h.Mock(8453).pauseAndStopVNCalls, "chain 8453 should be frozen")
+		require.Equal(t, 1, h.Mock(10).resumeCalls, "chain 10 rewound nothing, so it must be resumed")
+		require.Zero(t, h.Mock(8453).resumeCalls, "chain 8453 is resumed by RewindEngine")
+	})
+
+	t.Run("already-recovered chain is not recounted when a sibling keeps failing", func(t *testing.T) {
+		h := newInteropTestHarness(t).
+			WithChain(10, func(m *mockChainContainer) {
+				m.blockAtTimestamp = eth.L2BlockRef{Number: 100, Hash: common.HexToHash("0x1")}
+				m.rewindNotRequired = true
+			}).
+			WithChain(8453, func(m *mockChainContainer) {
+				m.blockAtTimestamp = eth.L2BlockRef{Number: 200, Hash: common.HexToHash("0x2")}
+				m.invalidateBlockErr = errors.New("engine failure")
+			}).
+			Build()
+
+		chain10 := h.Mock(10).id
+		chain8453 := h.Mock(8453).id
+
+		invalidResult := Result{
+			Timestamp:   1000,
+			L1Inclusion: eth.BlockID{Number: 100, Hash: common.HexToHash("0xL1")},
+			L2Heads: map[eth.ChainID]eth.BlockID{
+				chain10:   {Number: 500, Hash: common.HexToHash("0xL2-10")},
+				chain8453: {Number: 600, Hash: common.HexToHash("0xL2-8453")},
+			},
+			InvalidHeads: map[eth.ChainID]InvalidHead{
+				chain10:   {BlockID: eth.BlockID{Number: 500, Hash: common.HexToHash("0xBAD10")}},
+				chain8453: {BlockID: eth.BlockID{Number: 600, Hash: common.HexToHash("0xBAD8453")}},
+			},
+		}
+
+		pending, err := h.interop.buildPendingTransition(
+			StepOutput{Decision: DecisionInvalidate, Result: invalidResult},
+			RoundObservation{},
+		)
+		require.NoError(t, err)
+		require.NoError(t, h.interop.verifiedDB.SetPendingTransition(pending))
+
+		// Chain 8453 keeps failing, so the transition is retried every round. Chain 10
+		// is dragged along each time but must not be counted as a new invalidation.
+		for range 3 {
+			_, err = h.interop.applyPendingTransition(pending)
+			require.Error(t, err)
+		}
+		v, found := gatheredCounter(t, h.interop.metrics, "supernode_interop_invalidations_total", "chain_id", chain10.String())
+		require.True(t, found)
+		require.Zero(t, v, "an already-recovered chain must not be counted on every retry")
+	})
+
+	t.Run("unconfigured chain is treated as outstanding", func(t *testing.T) {
+		h := newInteropTestHarness(t).
+			WithChain(10, func(m *mockChainContainer) {
+				m.blockAtTimestamp = eth.L2BlockRef{Number: 100, Hash: common.HexToHash("0x1")}
+				m.rewindNotRequired = true
+			}).
+			Build()
+
+		unknown := eth.ChainIDFromUInt64(999)
+		outstanding := h.interop.outstandingInvalidations(
+			[]PendingInvalidation{
+				{ChainID: h.Mock(10).id, BlockID: eth.BlockID{Number: 500, Hash: common.HexToHash("0xBAD")}},
+				{ChainID: unknown, BlockID: eth.BlockID{Number: 500, Hash: common.HexToHash("0xBAD")}},
+			},
+			nil,
+		)
+		require.True(t, outstanding[unknown], "an unreadable chain must never be skipped")
+		require.False(t, outstanding[h.Mock(10).id])
+	})
+
+	t.Run("preflight error falls back to the full freeze", func(t *testing.T) {
+		h := newInteropTestHarness(t).
+			WithChain(10, func(m *mockChainContainer) {
+				m.blockAtTimestamp = eth.L2BlockRef{Number: 100, Hash: common.HexToHash("0x1")}
+				m.rewindRequiredErr = errors.New("denylist read failed")
+				m.invalidateBlockRet = true
+			}).
+			Build()
+
+		chain10 := h.Mock(10).id
+
+		invalidResult := Result{
+			Timestamp:   1000,
+			L1Inclusion: eth.BlockID{Number: 100, Hash: common.HexToHash("0xL1")},
+			L2Heads: map[eth.ChainID]eth.BlockID{
+				chain10: {Number: 500, Hash: common.HexToHash("0xL2-10")},
+			},
+			InvalidHeads: map[eth.ChainID]InvalidHead{
+				chain10: {BlockID: eth.BlockID{Number: 500, Hash: common.HexToHash("0xBAD")}},
+			},
+		}
+
+		pending, err := h.interop.buildPendingTransition(
+			StepOutput{Decision: DecisionInvalidate, Result: invalidResult},
+			RoundObservation{},
+		)
+		require.NoError(t, err)
+		require.NoError(t, h.interop.verifiedDB.SetPendingTransition(pending))
+		_, err = h.interop.applyPendingTransition(pending)
+		require.NoError(t, err)
+
+		require.Equal(t, 1, h.Mock(10).pauseAndStopVNCalls, "an unreadable preflight must not skip the invalidation")
+		require.Len(t, h.Mock(10).invalidateBlockCalls, 1)
+	})
+
 	t.Run("single chain invalidated freezes and does not resume", func(t *testing.T) {
 		cl := &callLog{}
 		h := newInteropTestHarness(t).
 			WithChain(10, func(m *mockChainContainer) {
 				m.blockAtTimestamp = eth.L2BlockRef{Number: 100, Hash: common.HexToHash("0x1")}
 				m.callLog = cl
+				m.invalidateBlockRet = true
 			}).
 			Build()
 

--- a/op-supernode/supernode/chain_container/chain_container.go
+++ b/op-supernode/supernode/chain_container/chain_container.go
@@ -141,6 +141,12 @@ type InteropChain interface {
 	// callers must capture it at build time, before the rewind starts. Returns true if
 	// a rewind was triggered, false otherwise.
 	InvalidateBlock(ctx context.Context, height uint64, payloadHash common.Hash, decisionTimestamp uint64, stateRoot, messagePasserStorageRoot eth.Bytes32, parentPayload *eth.ExecutionPayloadEnvelope) (bool, error)
+	// InvalidationRewindRequired reports whether InvalidateBlock for this target would
+	// still change chain state — false only when a previous recovery cycle completed it.
+	// parent is the WAL-captured rewind destination at height-1, needed to tell a
+	// completed rewind from one that crashed part-way; an empty parent forces true.
+	// Read-only: it never mutates the deny list or the engine.
+	InvalidationRewindRequired(ctx context.Context, height uint64, payloadHash common.Hash, parent eth.BlockID) (bool, error)
 	// WaitReady blocks until IsRPCReady() returns true or ctx is cancelled / times out.
 	// Used by callers that must not return until the chain is actually ready to serve
 	// traffic after a Pause/Resume cycle. Returns ctx.Err() on cancellation or timeout;

--- a/op-supernode/supernode/chain_container/invalidation.go
+++ b/op-supernode/supernode/chain_container/invalidation.go
@@ -428,30 +428,18 @@ func (c *simpleChainContainer) InvalidateBlock(ctx context.Context, height uint6
 
 	// Errors here propagate so the caller preserves the pending transition for
 	// retry on restart; the deny list entry above is already durable.
-	if c.engine == nil {
-		return false, fmt.Errorf("cannot check current block at height %d: %w", height, engine_controller.ErrNoEngineClient)
+	invalidatedBlock, state, err := c.resolveInvalidationTarget(ctx, height, payloadHash)
+	if err != nil {
+		return false, err
 	}
-
-	// Only skip the rewind when the engine reports a block at this height that is not the
-	// invalidated one. A NotFound result is not safe to skip: a prior crashed attempt may
-	// have left the synthetic block at this height with no canonical entry visible by
-	// number, and we need to drive the rewind to completion.
-	var invalidatedBlock eth.BlockRef
-	currentBlock, err := c.engine.L2BlockRefByNumber(ctx, height)
-	switch {
-	case err == nil:
-		if currentBlock.Hash != payloadHash {
-			c.log.Info("current block differs from invalidated block, no rewind needed",
-				"height", height, "currentHash", currentBlock.Hash, "invalidatedHash", payloadHash)
-			return false, nil
-		}
-		invalidatedBlock = currentBlock.BlockRef()
-	case errors.Is(err, ethereum.NotFound):
+	if state == invalidationSuperseded {
+		return false, nil
+	}
+	if state == invalidationAbsent {
+		// Could be a completed rewind or a crashed one; drive it to completion either
+		// way, since Rewind no-ops when the chain already sits on the target.
 		c.log.Warn("no canonical block at invalidated height; assuming partial rewind state and retrying",
 			"height", height, "payloadHash", payloadHash)
-		invalidatedBlock = eth.BlockRef{Number: height, Hash: payloadHash}
-	default:
-		return false, fmt.Errorf("failed to get current block at height %d: %w", height, err)
 	}
 
 	rewindFrom, rewindFromErr := c.engine.L2BlockRefByLabel(ctx, eth.Unsafe)
@@ -485,6 +473,80 @@ func (c *simpleChainContainer) InvalidateBlock(ctx context.Context, height uint6
 	}
 
 	return true, nil
+}
+
+// invalidationState describes where the engine sits relative to an invalidated block.
+type invalidationState int
+
+const (
+	// The invalidated block still occupies its height.
+	invalidationCanonical invalidationState = iota
+	// A different block occupies the height, so the invalidation already took effect.
+	invalidationSuperseded
+	// Nothing is canonical at the height: either a completed rewind still awaiting its
+	// replacement, or an attempt that crashed leaving the synthetic block there.
+	invalidationAbsent
+)
+
+// resolveInvalidationTarget reports where the engine sits relative to the invalidated
+// block, along with the block ref to hand to the rewind.
+func (c *simpleChainContainer) resolveInvalidationTarget(ctx context.Context, height uint64, payloadHash common.Hash) (eth.BlockRef, invalidationState, error) {
+	if c.engine == nil {
+		return eth.BlockRef{}, invalidationCanonical, fmt.Errorf("cannot check current block at height %d: %w", height, engine_controller.ErrNoEngineClient)
+	}
+	currentBlock, err := c.engine.L2BlockRefByNumber(ctx, height)
+	switch {
+	case err == nil:
+		if currentBlock.Hash != payloadHash {
+			c.log.Info("current block differs from invalidated block, no rewind needed",
+				"height", height, "currentHash", currentBlock.Hash, "invalidatedHash", payloadHash)
+			return eth.BlockRef{}, invalidationSuperseded, nil
+		}
+		return currentBlock.BlockRef(), invalidationCanonical, nil
+	case errors.Is(err, ethereum.NotFound):
+		return eth.BlockRef{Number: height, Hash: payloadHash}, invalidationAbsent, nil
+	default:
+		return eth.BlockRef{}, invalidationCanonical, fmt.Errorf("failed to get current block at height %d: %w", height, err)
+	}
+}
+
+func (c *simpleChainContainer) InvalidationRewindRequired(ctx context.Context, height uint64, payloadHash common.Hash, parent eth.BlockID) (bool, error) {
+	if c.denyList == nil {
+		return false, fmt.Errorf("deny list not initialized")
+	}
+	if height == 0 {
+		return false, fmt.Errorf("cannot invalidate genesis block (height=0)")
+	}
+	denied, err := c.denyList.Contains(height, payloadHash)
+	if err != nil {
+		return false, fmt.Errorf("failed to check deny list at height %d: %w", height, err)
+	}
+	// An undenied target always needs the full path: the deny-list write is the
+	// durable part of the invalidation and has not happened yet.
+	if !denied {
+		return true, nil
+	}
+	_, state, err := c.resolveInvalidationTarget(ctx, height, payloadHash)
+	if err != nil {
+		return false, err
+	}
+	switch state {
+	case invalidationSuperseded:
+		return false, nil
+	case invalidationCanonical:
+		return true, nil
+	}
+	// Nothing canonical at the height, which is also what a completed rewind looks like
+	// until derivation produces the replacement. A completed rewind put the unsafe head
+	// exactly on the parent; a crashed one left the synthetic block there.
+	if parent == (eth.BlockID{}) || parent.Number != height-1 {
+		return true, nil
+	}
+	unsafe, err := c.engine.L2BlockRefByLabel(ctx, eth.Unsafe)
+	if err != nil {
+		return false, fmt.Errorf("failed to read unsafe head for invalidation preflight at height %d: %w", height, err)
+	}
+	return unsafe.ID() != parent, nil
 }
 
 func (c *simpleChainContainer) PruneDeniedAtOrAfterTimestamp(timestamp uint64) (map[uint64][]common.Hash, error) {

--- a/op-supernode/supernode/chain_container/invalidation_test.go
+++ b/op-supernode/supernode/chain_container/invalidation_test.go
@@ -298,6 +298,8 @@ func TestDenyList_GetDeniedHashes(t *testing.T) {
 type mockEngineForInvalidation struct {
 	blockRef        eth.L2BlockRef
 	blockRefErr     error
+	labelRef        eth.L2BlockRef
+	labelRefErr     error
 	rewindCalled    bool
 	rewindTimestamp uint64
 }
@@ -339,7 +341,7 @@ func (m *mockEngineForInvalidation) L2BlockRefByNumber(ctx context.Context, num 
 }
 
 func (m *mockEngineForInvalidation) L2BlockRefByLabel(ctx context.Context, label eth.BlockLabel) (eth.L2BlockRef, error) {
-	return eth.L2BlockRef{}, nil
+	return m.labelRef, m.labelRefErr
 }
 
 // mockVNForInvalidation implements virtual_node.VirtualNode for invalidation tests
@@ -653,6 +655,108 @@ func TestInvalidateBlock(t *testing.T) {
 			require.Equal(t, testOut, storedOutput, "OutputV0 should be stored in denylist after InvalidateBlock")
 		})
 	}
+}
+
+func TestInvalidationRewindRequired(t *testing.T) {
+	t.Parallel()
+
+	const height = uint64(5)
+	hash := common.HexToHash("0xdead")
+	parent := eth.BlockID{Number: height - 1, Hash: common.HexToHash("0xpa4e17")}
+	parentRef := eth.L2BlockRef{Number: parent.Number, Hash: parent.Hash}
+
+	newContainer := func(t *testing.T, eng *mockEngineForInvalidation, denied bool) *simpleChainContainer {
+		t.Helper()
+		dl, err := OpenDenyList(filepath.Join(t.TempDir(), "denylist"))
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = dl.Close() })
+		if denied {
+			require.NoError(t, dl.Add(height, hash, 0, eth.Bytes32{}, eth.Bytes32{}))
+		}
+		return &simpleChainContainer{denyList: dl, log: testLogger(), engine: eng, vn: &mockVNForInvalidation{}}
+	}
+
+	t.Run("denied and superseded needs no rewind", func(t *testing.T) {
+		t.Parallel()
+		eng := &mockEngineForInvalidation{blockRef: eth.L2BlockRef{Hash: common.HexToHash("0xbeef")}}
+		required, err := newContainer(t, eng, true).InvalidationRewindRequired(context.Background(), height, hash, parent)
+		require.NoError(t, err)
+		require.False(t, required)
+	})
+
+	t.Run("denied but still canonical needs a rewind", func(t *testing.T) {
+		t.Parallel()
+		eng := &mockEngineForInvalidation{blockRef: eth.L2BlockRef{Hash: hash}}
+		required, err := newContainer(t, eng, true).InvalidationRewindRequired(context.Background(), height, hash, parent)
+		require.NoError(t, err)
+		require.True(t, required)
+	})
+
+	t.Run("not yet denied needs the full path", func(t *testing.T) {
+		t.Parallel()
+		// The engine already moved on, but the durable deny-list write has not happened.
+		eng := &mockEngineForInvalidation{blockRef: eth.L2BlockRef{Hash: common.HexToHash("0xbeef")}}
+		required, err := newContainer(t, eng, false).InvalidationRewindRequired(context.Background(), height, hash, parent)
+		require.NoError(t, err)
+		require.True(t, required)
+	})
+
+	t.Run("completed rewind awaiting its replacement needs no rewind", func(t *testing.T) {
+		t.Parallel()
+		// Nothing canonical at the height and the unsafe head is the rewind target.
+		eng := &mockEngineForInvalidation{blockRefErr: ethereum.NotFound, labelRef: parentRef}
+		required, err := newContainer(t, eng, true).InvalidationRewindRequired(context.Background(), height, hash, parent)
+		require.NoError(t, err)
+		require.False(t, required)
+	})
+
+	t.Run("crashed rewind needs a rewind", func(t *testing.T) {
+		t.Parallel()
+		// The synthetic block from the failed attempt is still the unsafe head.
+		eng := &mockEngineForInvalidation{
+			blockRefErr: ethereum.NotFound,
+			labelRef:    eth.L2BlockRef{Number: parent.Number, Hash: common.HexToHash("0x5417e1")},
+		}
+		required, err := newContainer(t, eng, true).InvalidationRewindRequired(context.Background(), height, hash, parent)
+		require.NoError(t, err)
+		require.True(t, required, "a partial rewind must not be mistaken for a completed one")
+	})
+
+	t.Run("missing parent cannot prove completion", func(t *testing.T) {
+		t.Parallel()
+		eng := &mockEngineForInvalidation{blockRefErr: ethereum.NotFound, labelRef: parentRef}
+		required, err := newContainer(t, eng, true).InvalidationRewindRequired(context.Background(), height, hash, eth.BlockID{})
+		require.NoError(t, err)
+		require.True(t, required)
+	})
+
+	t.Run("engine failure surfaces as an error", func(t *testing.T) {
+		t.Parallel()
+		fetchErr := errors.New("transient RPC failure")
+		eng := &mockEngineForInvalidation{blockRefErr: fetchErr}
+		_, err := newContainer(t, eng, true).InvalidationRewindRequired(context.Background(), height, hash, parent)
+		require.ErrorIs(t, err, fetchErr)
+	})
+
+	t.Run("unsafe head failure surfaces as an error", func(t *testing.T) {
+		t.Parallel()
+		labelErr := errors.New("unsafe head unavailable")
+		eng := &mockEngineForInvalidation{blockRefErr: ethereum.NotFound, labelRefErr: labelErr}
+		_, err := newContainer(t, eng, true).InvalidationRewindRequired(context.Background(), height, hash, parent)
+		require.ErrorIs(t, err, labelErr)
+	})
+
+	t.Run("the check never mutates the deny list", func(t *testing.T) {
+		t.Parallel()
+		eng := &mockEngineForInvalidation{blockRef: eth.L2BlockRef{Hash: common.HexToHash("0xbeef")}}
+		c := newContainer(t, eng, false)
+		_, err := c.InvalidationRewindRequired(context.Background(), height, hash, parent)
+		require.NoError(t, err)
+		found, err := c.denyList.Contains(height, hash)
+		require.NoError(t, err)
+		require.False(t, found)
+		require.False(t, eng.rewindCalled)
+	})
 }
 
 func TestGetDeniedOutput(t *testing.T) {


### PR DESCRIPTION
Part of ethereum-optimism/optimism#21948. Implements the duplicate-invalidation preflight from that issue's "potential fixes to evaluate", plus a wedge bug found on the same path.

The other mechanisms #21948 asks for are already in the tree: unsafe-ingestion deny gating (`EngineController.unsafeDenyGatingActive`, from #21991) and the consolidation-path deny check (#21970). Neither PR references #21948, so I can't confirm they were filed against it — but #21991 describes the same `interop-reorg-2` incident this issue was opened hours after, and the code covers those acceptance criteria either way. The duplicate-invalidation preflight was not implemented by either.

## What changed

An invalidation decision the previous recovery cycle already applied restarted the whole recovery: every chain's virtual node was stopped and restarted, which resets derivation and walks local-safe back a sequencing window on chains that were never invalidated.

`applyPendingTransition` now runs a read-only preflight (`InteropChain.InvalidationRewindRequired`) before the freeze. If every pending invalidation is already applied, it clears the transition and does nothing. If any chain still needs its rewind, the full all-chain freeze runs as before, preserving transitive-invalidation safety.

The preflight is strictly more conservative than `InvalidateBlock`'s own skip: it reports "already applied" only when the hash is denied *and* the chain sits off it, whereas `InvalidateBlock` skips the rewind on the second condition alone. Skipping therefore never drops work `InvalidateBlock` would have done. A second denied hash at the same height is a distinct deny-list key, so transitive invalidation across rounds is unaffected.

A completed rewind leaves nothing canonical at the invalidated height until derivation produces the replacement — indistinguishable from a crashed attempt by height alone. The preflight settles this against the WAL-captured rewind destination: a completed rewind put the unsafe head exactly on the parent, a crashed one left the synthetic block there. Anything unreadable counts as outstanding.

## Wedge fix on the same path

`RewindEngine` is the only path that resumes an invalidated chain. A chain whose `InvalidateBlock` reported no rewind — or that failed before reaching the rewind — was left with a stopped virtual node permanently, since the resume loop skipped every invalidated chain. It now resumes every chain `RewindEngine` did not resume.

## Test plan

Red/green on all three behaviours (confirmed failing on the baseline before the fix):

- `TestFreezeAllBeforeRewind` — invalidated-no-rewind chain is resumed; failed invalidation resumes rather than wedging; already-applied decision skips the global freeze and clears the transition; partially-applied decision still freezes every chain; preflight error falls back to the full freeze; an already-recovered chain is not recounted while a sibling keeps failing.
- `TestInvalidationRewindRequired` — full truth table including completed-vs-crashed rewind, missing parent, both engine error paths, and a no-mutation assertion.

`go test ./op-supernode/...` and `./op-node/rollup/engine/...` pass; `go build ./...`, `go vet ./op-supernode/...` and `gofmt` clean. `golangci-lint` could not run locally: the pinned binary is built with go1.25 and the repo targets go1.26.5.

## Note

The acceptance-test repro for the end-to-end scenario is #21993 (draft, separate stack).