### PR TITLE
op-supernode: Resume chains whose invalidation triggered no rewind

### DIFF
--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -826,6 +826,8 @@ func (i *Interop) applyPendingTransition(pending PendingTransition) (bool, error
 			}
 		}
 		var failedAny bool
+		// Chains RewindEngine resumed for us; every other chain is resumed below.
+		rewound := make(map[eth.ChainID]bool, len(invalidations))
 		for _, p := range invalidations {
 			parentPayload, ok := pending.InvalidationParentPayloads[p.ChainID]
 			if !ok || parentPayload == nil {
@@ -837,18 +839,24 @@ func (i *Interop) applyPendingTransition(pending PendingTransition) (bool, error
 				failedAny = true
 				continue
 			}
-			if err := i.invalidateBlock(p.ChainID, p.BlockID, p.Timestamp, p.StateRoot, p.MessagePasserStorageRoot, parentPayload); err != nil {
+			didRewind, err := i.invalidateBlock(p.ChainID, p.BlockID, p.Timestamp, p.StateRoot, p.MessagePasserStorageRoot, parentPayload)
+			if err != nil {
 				i.log.Error("invalidation failed, transition preserved for retry on restart",
 					"chain", p.ChainID, "block", p.BlockID, "err", err)
 				failedAny = true
-			} else {
-				i.metrics.InteropInvalidations.WithLabelValues(p.ChainID.String()).Inc()
+				continue
 			}
+			if didRewind {
+				rewound[p.ChainID] = true
+			}
+			i.metrics.InteropInvalidations.WithLabelValues(p.ChainID.String()).Inc()
 		}
-		// Resume non-invalidated chains. Invalidated chains are resumed by
-		// RewindEngine internally (which also waits for readiness).
+		needsResume := func(chainID eth.ChainID) bool { return !rewound[chainID] }
+		// RewindEngine is the only other path that resumes a chain, so anything it did
+		// not run for stays stopped unless resumed here — including invalidations that
+		// needed no rewind, and failed ones, which are retried rather than left wedged.
 		for chainID, chain := range i.chains {
-			if _, isInvalid := pending.Result.InvalidHeads[chainID]; !isInvalid {
+			if needsResume(chainID) {
 				if err := chain.Resume(i.ctx); err != nil {
 					i.log.Error("failed to resume chain after rewind", "chainID", chainID, "err", err)
 				}
@@ -866,7 +874,7 @@ func (i *Interop) applyPendingTransition(pending PendingTransition) (bool, error
 		// verifier backoff loop, so we log and continue rather than return.
 		waitCtx, cancel := context.WithTimeout(i.ctx, cc.DefaultWaitReadyTimeout)
 		for chainID, chain := range i.chains {
-			if _, isInvalid := pending.Result.InvalidHeads[chainID]; !isInvalid {
+			if needsResume(chainID) {
 				if err := chain.WaitReady(waitCtx); err != nil {
 					i.log.Error("chain not ready after resume", "chainID", chainID, "err", err)
 				}
@@ -1362,11 +1370,11 @@ func (i *Interop) Reset(chainID eth.ChainID, timestamp uint64, invalidatedBlock 
 // invalidateBlock notifies the chain container to add the block to the denylist
 // and potentially rewind if the chain is currently using that block. parentPayload
 // is the canonical payload at the rewind destination (height-1), captured from the WAL.
-func (i *Interop) invalidateBlock(chainID eth.ChainID, blockID eth.BlockID, decisionTimestamp uint64, stateRoot, messagePasserStorageRoot eth.Bytes32, parentPayload *eth.ExecutionPayloadEnvelope) error {
+// Reports whether a rewind was triggered.
+func (i *Interop) invalidateBlock(chainID eth.ChainID, blockID eth.BlockID, decisionTimestamp uint64, stateRoot, messagePasserStorageRoot eth.Bytes32, parentPayload *eth.ExecutionPayloadEnvelope) (bool, error) {
 	chain, ok := i.chains[chainID]
 	if !ok {
-		return fmt.Errorf("chain %s not found", chainID)
+		return false, fmt.Errorf("chain %s not found", chainID)
 	}
-	_, err := chain.InvalidateBlock(i.ctx, blockID.Number, blockID.Hash, decisionTimestamp, stateRoot, messagePasserStorageRoot, parentPayload)
-	return err
+	return chain.InvalidateBlock(i.ctx, blockID.Number, blockID.Hash, decisionTimestamp, stateRoot, messagePasserStorageRoot, parentPayload)
 }

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -3217,6 +3217,20 @@ func TestFreezeAllBeforeRewind(t *testing.T) {
 
 		require.Equal(t, 1, h.Mock(10).resumeCalls, "a failed invalidation must not leave the chain frozen")
 		require.Equal(t, 1, h.Mock(8453).resumeCalls, "unaffected chain should be resumed")
+		require.Len(t, h.Mock(10).invalidateBlockCalls, 1)
+
+		// The engine recovers, so the preserved transition must replay to completion.
+		h.Mock(10).invalidateBlockErr = nil
+		_, err = h.interop.progressAndRecord()
+		require.NoError(t, err)
+
+		require.Len(t, h.Mock(10).invalidateBlockCalls, 2, "invalidation should be retried from the WAL")
+		require.Equal(t, 2, h.Mock(10).resumeCalls, "chain 10 should be resumed again after the retry")
+		require.Equal(t, 2, h.Mock(8453).resumeCalls, "chain 8453 should be resumed again after the retry")
+
+		cleared, err := h.interop.verifiedDB.GetPendingTransition()
+		require.NoError(t, err)
+		require.Nil(t, cleared, "a successful retry clears the transition")
 	})
 
 	t.Run("single chain invalidated freezes and does not resume", func(t *testing.T) {

--- a/op-supernode/supernode/activity/interop/interop_test.go
+++ b/op-supernode/supernode/activity/interop/interop_test.go
@@ -1194,7 +1194,7 @@ func TestInvalidateBlock(t *testing.T) {
 			run: func(t *testing.T, h *interopTestHarness) {
 				mock := h.Mock(10)
 				blockID := eth.BlockID{Number: 500, Hash: common.HexToHash("0xBAD")}
-				err := h.interop.invalidateBlock(mock.id, blockID, 0, eth.Bytes32{}, eth.Bytes32{}, dummyParentPayload(blockID))
+				_, err := h.interop.invalidateBlock(mock.id, blockID, 0, eth.Bytes32{}, eth.Bytes32{}, dummyParentPayload(blockID))
 				require.NoError(t, err)
 
 				require.Len(t, mock.invalidateBlockCalls, 1)
@@ -1211,7 +1211,7 @@ func TestInvalidateBlock(t *testing.T) {
 				mock := h.Mock(10)
 				unknownChain := eth.ChainIDFromUInt64(999)
 				blockID := eth.BlockID{Number: 500, Hash: common.HexToHash("0xBAD")}
-				err := h.interop.invalidateBlock(unknownChain, blockID, 0, eth.Bytes32{}, eth.Bytes32{}, dummyParentPayload(blockID))
+				_, err := h.interop.invalidateBlock(unknownChain, blockID, 0, eth.Bytes32{}, eth.Bytes32{}, dummyParentPayload(blockID))
 
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "not found")
@@ -1228,7 +1228,7 @@ func TestInvalidateBlock(t *testing.T) {
 			run: func(t *testing.T, h *interopTestHarness) {
 				mock := h.Mock(10)
 				blockID := eth.BlockID{Number: 500, Hash: common.HexToHash("0xBAD")}
-				err := h.interop.invalidateBlock(mock.id, blockID, 0, eth.Bytes32{}, eth.Bytes32{}, dummyParentPayload(blockID))
+				_, err := h.interop.invalidateBlock(mock.id, blockID, 0, eth.Bytes32{}, eth.Bytes32{}, dummyParentPayload(blockID))
 
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "engine failure")
@@ -3026,10 +3026,12 @@ func TestFreezeAllBeforeRewind(t *testing.T) {
 			WithChain(10, func(m *mockChainContainer) {
 				m.blockAtTimestamp = eth.L2BlockRef{Number: 100, Hash: common.HexToHash("0x1")}
 				m.callLog = cl
+				m.invalidateBlockRet = true
 			}).
 			WithChain(8453, func(m *mockChainContainer) {
 				m.blockAtTimestamp = eth.L2BlockRef{Number: 200, Hash: common.HexToHash("0x2")}
 				m.callLog = cl
+				m.invalidateBlockRet = true
 			}).
 			WithChain(42, func(m *mockChainContainer) {
 				m.blockAtTimestamp = eth.L2BlockRef{Number: 300, Hash: common.HexToHash("0x3")}
@@ -3130,12 +3132,100 @@ func TestFreezeAllBeforeRewind(t *testing.T) {
 		}
 	})
 
+	t.Run("invalidated chain is resumed when no rewind was needed", func(t *testing.T) {
+		h := newInteropTestHarness(t).
+			WithChain(10, func(m *mockChainContainer) {
+				m.blockAtTimestamp = eth.L2BlockRef{Number: 100, Hash: common.HexToHash("0x1")}
+				// The chain moved off the invalidated block between the decision and
+				// the freeze, so InvalidateBlock reports no rewind and RewindEngine —
+				// the only other path that resumes — never runs.
+				m.invalidateBlockRet = false
+			}).
+			WithChain(8453, func(m *mockChainContainer) {
+				m.blockAtTimestamp = eth.L2BlockRef{Number: 200, Hash: common.HexToHash("0x2")}
+			}).
+			Build()
+
+		chain10 := h.Mock(10).id
+		chain8453 := h.Mock(8453).id
+
+		invalidResult := Result{
+			Timestamp:   1000,
+			L1Inclusion: eth.BlockID{Number: 100, Hash: common.HexToHash("0xL1")},
+			L2Heads: map[eth.ChainID]eth.BlockID{
+				chain10:   {Number: 500, Hash: common.HexToHash("0xL2-10")},
+				chain8453: {Number: 600, Hash: common.HexToHash("0xL2-8453")},
+			},
+			InvalidHeads: map[eth.ChainID]InvalidHead{
+				chain10: {BlockID: eth.BlockID{Number: 500, Hash: common.HexToHash("0xBAD")}},
+			},
+		}
+
+		pending, err := h.interop.buildPendingTransition(
+			StepOutput{Decision: DecisionInvalidate, Result: invalidResult},
+			RoundObservation{},
+		)
+		require.NoError(t, err)
+		require.NoError(t, h.interop.verifiedDB.SetPendingTransition(pending))
+		_, err = h.interop.applyPendingTransition(pending)
+		require.NoError(t, err)
+
+		require.Equal(t, 1, h.Mock(10).pauseAndStopVNCalls, "chain 10 should be frozen")
+		require.Equal(t, 1, h.Mock(10).resumeCalls,
+			"a frozen chain whose invalidation triggered no rewind must be resumed, or its VN stays stopped for the life of the process")
+		require.Equal(t, 1, h.Mock(8453).resumeCalls, "non-invalidated chain should be resumed")
+
+		cleared, err := h.interop.verifiedDB.GetPendingTransition()
+		require.NoError(t, err)
+		require.Nil(t, cleared, "the transition is cleared, so nothing retries the resume")
+	})
+
+	t.Run("failed invalidation resumes rather than wedging the chain", func(t *testing.T) {
+		h := newInteropTestHarness(t).
+			WithChain(10, func(m *mockChainContainer) {
+				m.blockAtTimestamp = eth.L2BlockRef{Number: 100, Hash: common.HexToHash("0x1")}
+				m.invalidateBlockErr = errors.New("engine failure")
+			}).
+			WithChain(8453, func(m *mockChainContainer) {
+				m.blockAtTimestamp = eth.L2BlockRef{Number: 200, Hash: common.HexToHash("0x2")}
+			}).
+			Build()
+
+		chain10 := h.Mock(10).id
+		chain8453 := h.Mock(8453).id
+
+		invalidResult := Result{
+			Timestamp:   1000,
+			L1Inclusion: eth.BlockID{Number: 100, Hash: common.HexToHash("0xL1")},
+			L2Heads: map[eth.ChainID]eth.BlockID{
+				chain10:   {Number: 500, Hash: common.HexToHash("0xL2-10")},
+				chain8453: {Number: 600, Hash: common.HexToHash("0xL2-8453")},
+			},
+			InvalidHeads: map[eth.ChainID]InvalidHead{
+				chain10: {BlockID: eth.BlockID{Number: 500, Hash: common.HexToHash("0xBAD")}},
+			},
+		}
+
+		pending, err := h.interop.buildPendingTransition(
+			StepOutput{Decision: DecisionInvalidate, Result: invalidResult},
+			RoundObservation{},
+		)
+		require.NoError(t, err)
+		require.NoError(t, h.interop.verifiedDB.SetPendingTransition(pending))
+		_, err = h.interop.applyPendingTransition(pending)
+		require.Error(t, err, "the transition must be preserved for retry")
+
+		require.Equal(t, 1, h.Mock(10).resumeCalls, "a failed invalidation must not leave the chain frozen")
+		require.Equal(t, 1, h.Mock(8453).resumeCalls, "unaffected chain should be resumed")
+	})
+
 	t.Run("single chain invalidated freezes and does not resume", func(t *testing.T) {
 		cl := &callLog{}
 		h := newInteropTestHarness(t).
 			WithChain(10, func(m *mockChainContainer) {
 				m.blockAtTimestamp = eth.L2BlockRef{Number: 100, Hash: common.HexToHash("0x1")}
 				m.callLog = cl
+				m.invalidateBlockRet = true
 			}).
 			Build()
 


### PR DESCRIPTION
## Problem

`RewindEngine` is the only path that resumes an invalidated chain — it does so via its internal `defer c.Resume(...)` plus `WaitReady`. The resume loop in `applyPendingTransition` relied on that and skipped every chain in `InvalidHeads`.

But `InvalidateBlock` returns `(false, nil)` — without ever calling `RewindEngine` — when the engine reports a different block at the invalidated height. That chain had already been frozen by the freeze-all `PauseAndStopVN`, so it keeps a stopped virtual node for the life of the process.

Nothing recovers it: the invalidation reported success, so `failedAny` stays false and the pending transition is cleared. The only trace is `"current block differs from invalidated block, no rewind needed"` at Info.

Reachable when the chain reorgs off the invalidated block between the verifier's decision and the freeze (verification I/O + parent-payload capture + WAL fsync — and the chain is reorging by construction at that moment), or when a multi-chain transition is retried after one chain succeeded and a sibling keeps failing.

## Fix

Track the chains `RewindEngine` actually resumed and resume the rest. This also covers failed invalidations, which are retried on the next round rather than left wedged — previously a permanent error (corrupt WAL parent payload, `height == 0`) froze the chain forever while the transition retried forever.
