### PR TITLE
op-deployer: support output root genesis bootstrap

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -3136,6 +3136,7 @@ workflows:
                 - CUSTOM_GAS_TOKEN
                 - OPTIMISM_PORTAL_INTEROP
                 - ZK_DISPUTE_GAME
+                - OUTPUT_ROOT_GAMES
           context:
             - circleci-repo-readonly-authenticated-github-token
             - slack

--- a/docs/ai/devfeatures.md
+++ b/docs/ai/devfeatures.md
@@ -19,9 +19,17 @@ Active flags:
 | `DeployV2DisputeGames` | Legacy, no longer used; constant kept for historical reasons |
 | `ZKDisputeGame` | ZK dispute game system |
 | `SuperRootGamesMigration` | Super-root games migration path in OPCM upgrade — **enabled by default** |
+| `OutputRootGames` | Internal capability selected by `--output-root-bootstrap` for fresh output-root deployments |
 
 
-The predicate is a bitwise AND (`(bitmap & flag) == flag && flag != 0`) — except that `IsDevFeatureEnabled` short-circuits to `true` for `SuperRootGamesMigration`, which is enabled by default on both the Go and Solidity sides. The bitmap no longer acts as a circuit breaker for it; removal is tracked in #21662.
+The predicate is a bitwise AND (`(bitmap & flag) == flag && flag != 0`) — except that `IsDevFeatureEnabled` short-circuits to `true` for `SuperRootGamesMigration`, which is enabled by default on both the Go and Solidity sides. `OutputRootGames` disables that default for fresh output-root chains. If both flags are set, the explicit `SuperRootGamesMigration` flag takes precedence. Removal of the migration flag is tracked in #21662.
+
+Operators should use `op-deployer init --output-root-bootstrap` and
+`op-deployer bootstrap implementations --output-root-bootstrap`, not construct the internal
+`OutputRootGames` bit manually. The persisted intent makes `prepare` reject an OPCM from the wrong
+game family and causes L2 genesis to receive the matching bitmap. For each undeployed chain,
+`prepare` derives the V0 output root from the generated L2 genesis block and commits it as the ASR
+starting proposal with L2 block number `0`.
 
 **Adding a new dev feature**: the full checklist lives in the `DevFeatures.sol` natspec — both constant files, the env-var reader in `scripts/libraries/Config.sol`, the test assembler in `test/setup/FeatureFlags.sol`, and the CI `&features_matrix` anchor in `.circleci/continue/main.yml` all need updating; there is no compile-time link between them.
 
@@ -64,8 +72,9 @@ A separate, **test-only** assembler exists for Foundry tests and fork scripts. I
 
 - `DEV_FEATURE__OPTIMISM_PORTAL_INTEROP`
 - `DEV_FEATURE__ZK_DISPUTE_GAME`
+- `DEV_FEATURE__OUTPUT_ROOT_GAMES`
 
-Interop and ZK are read via `vm.envOr(..., false)` in `packages/contracts-bedrock/scripts/libraries/Config.sol`; `devFeatureSuperRootGamesMigration()` returns `true` unconditionally. The only callers are under `test/`:
+Interop, ZK, and output-root games are read via `vm.envOr(..., false)` in `packages/contracts-bedrock/scripts/libraries/Config.sol`; `devFeatureSuperRootGamesMigration()` defaults to true unless output-root games are selected. The only callers are under `test/`:
 
 - `test/setup/FeatureFlags.sol` — `resolveFeaturesFromEnv()` OR-s each enabled flag into `devFeatureBitmap`
 - `test/setup/CommonTest.sol`, `test/setup/ForkL1Live.s.sol`, `test/setup/ForkL2Live.s.sol` — branch on individual `Config.devFeature*` returns
@@ -121,7 +130,7 @@ Interop and ZK use the bitmap as their per-chain provisioning switch and have no
 
 ## G. Lifecycle direction
 
-- SuperRootGamesMigration is **default-on**: `IsDevFeatureEnabled` / `isDevFeatureEnabled` return `true` for it regardless of the bitmap.
+- SuperRootGamesMigration is **default-on**: `IsDevFeatureEnabled` / `isDevFeatureEnabled` return `true` unless `OutputRootGames` is set without an explicit `SuperRootGamesMigration` bit.
 - **#21662** tracks removing the SuperRootGamesMigration flag and its remaining scaffolding.
 
 ## File index

--- a/docs/ai/devfeatures.md
+++ b/docs/ai/devfeatures.md
@@ -29,7 +29,12 @@ Operators should use `op-deployer init --output-root-bootstrap` and
 `OutputRootGames` bit manually. The persisted intent makes `prepare` reject an OPCM from the wrong
 game family and causes L2 genesis to receive the matching bitmap. For each undeployed chain,
 `prepare` derives the V0 output root from the generated L2 genesis block and commits it as the ASR
-starting proposal with L2 block number `0`.
+starting proposal with L2 block number `0`. This gives proof systems the trusted starting state
+needed to prove the first post-genesis state transition.
+
+When the Superchain and implementations are bootstrapped before intent creation, pass their
+`--opcm-address` and `--superchain-config-proxy` outputs to `op-deployer init`. This creates a
+valid pinned custom intent without manual TOML editing.
 
 **Adding a new dev feature**: the full checklist lives in the `DevFeatures.sol` natspec — both constant files, the env-var reader in `scripts/libraries/Config.sol`, the test assembler in `test/setup/FeatureFlags.sol`, and the CI `&features_matrix` anchor in `.circleci/continue/main.yml` all need updating; there is no compile-time link between them.
 

--- a/op-core/devfeatures/devfeatures.go
+++ b/op-core/devfeatures/devfeatures.go
@@ -30,15 +30,20 @@ var (
 
 	// SuperRootGamesMigrationFlag enables the super root games migration path in OPCM upgrade.
 	SuperRootGamesMigrationFlag = common.HexToHash("0x0000000000000000000000000000000000000000000000000000000010000000")
+
+	// OutputRootGamesFlag selects output root dispute games instead of the default super root games.
+	OutputRootGamesFlag = common.HexToHash("0x0000000000000000000000000000000000000000000000000000001000000000")
 )
 
 // IsDevFeatureEnabled checks if a specific development feature is enabled in a feature bitmap.
 // It performs a bitwise AND between the bitmap and flag to determine if the feature
 // is set. This follows the same pattern as the Solidity DevFeatures library.
 func IsDevFeatureEnabled(bitmap, flag common.Hash) bool {
-	// SuperRootGamesMigration is enabled by default.
+	// SuperRootGamesMigration is enabled by default, but fresh chains may explicitly select
+	// output root games. If both flags are set, the explicit super root flag takes precedence.
 	// TODO(#21662): remove with the broader SuperRootGamesMigrationFlag cleanup.
-	if hasFlag(flag, SuperRootGamesMigrationFlag) {
+	if hasFlag(flag, SuperRootGamesMigrationFlag) &&
+		(!hasFlag(bitmap, OutputRootGamesFlag) || hasFlag(bitmap, SuperRootGamesMigrationFlag)) {
 		return true
 	}
 	return flag != (common.Hash{}) && hasFlag(bitmap, flag)

--- a/op-core/devfeatures/devfeatures_test.go
+++ b/op-core/devfeatures/devfeatures_test.go
@@ -79,7 +79,7 @@ func TestIsDevFeatureEnabled(t *testing.T) {
 		require.False(t, IsDevFeatureEnabled(ALL_FEATURES, EMPTY_FEATURES))
 	})
 
-	// SuperRootGamesMigration is hardcoded on. TODO(#21662): remove with the broader DevFeatures cleanup.
+	// SuperRootGamesMigration is default-on. TODO(#21662): remove with the broader DevFeatures cleanup.
 	hardcoded := []struct {
 		name string
 		flag common.Hash
@@ -96,7 +96,7 @@ func TestIsDevFeatureEnabled(t *testing.T) {
 	})
 
 	for _, c := range hardcoded {
-		t.Run(c.name+" always enabled regardless of bitmap", func(t *testing.T) {
+		t.Run(c.name+" enabled by default", func(t *testing.T) {
 			require.True(t, IsDevFeatureEnabled(EMPTY_FEATURES, c.flag))
 			require.True(t, IsDevFeatureEnabled(FEATURE_A, c.flag))
 			require.True(t, IsDevFeatureEnabled(c.flag, c.flag))
@@ -107,6 +107,15 @@ func TestIsDevFeatureEnabled(t *testing.T) {
 			require.True(t, IsDevFeatureEnabled(EMPTY_FEATURES, or(FEATURE_B, c.flag)))
 		})
 	}
+
+	t.Run("OutputRootGames disables the default super root games migration", func(t *testing.T) {
+		require.False(t, IsDevFeatureEnabled(OutputRootGamesFlag, SuperRootGamesMigrationFlag))
+	})
+
+	t.Run("explicit SuperRootGamesMigration takes precedence over OutputRootGames", func(t *testing.T) {
+		bitmap := or(OutputRootGamesFlag, SuperRootGamesMigrationFlag)
+		require.True(t, IsDevFeatureEnabled(bitmap, SuperRootGamesMigrationFlag))
+	})
 }
 
 func TestEnableDevFeature(t *testing.T) {

--- a/op-deployer/pkg/deployer/apply.go
+++ b/op-deployer/pkg/deployer/apply.go
@@ -155,6 +155,9 @@ func Apply(ctx context.Context, cfg ApplyConfig) error {
 	if err != nil {
 		return fmt.Errorf("failed to read intent: %w", err)
 	}
+	if intent.OutputRootBootstrap {
+		return fmt.Errorf("output root bootstrap requires the bootstrap implementations, prepare, prestate, and continue workflow")
+	}
 
 	st, err := pipeline.ReadState(cfg.Workdir)
 	if err != nil {

--- a/op-deployer/pkg/deployer/bootstrap/flags.go
+++ b/op-deployer/pkg/deployer/bootstrap/flags.go
@@ -161,6 +161,7 @@ var ImplementationsFlags = []cli.Flag{
 	deployer.ArtifactsLocatorFlag,
 	MIPSVersionFlag,
 	DevFeatureBitmapFlag,
+	deployer.OutputRootBootstrapFlag,
 	SP1VerifierAddressFlag,
 	WithdrawalDelaySecondsFlag,
 	MinProposalSizeBytesFlag,

--- a/op-deployer/pkg/deployer/bootstrap/implementations.go
+++ b/op-deployer/pkg/deployer/bootstrap/implementations.go
@@ -44,6 +44,7 @@ type ImplementationsConfig struct {
 	ProofMaturityDelaySeconds       uint64             `cli:"proof-maturity-delay-seconds"`
 	DisputeGameFinalityDelaySeconds uint64             `cli:"dispute-game-finality-delay-seconds"`
 	DevFeatureBitmap                common.Hash        `cli:"dev-feature-bitmap"`
+	OutputRootBootstrap             bool               `cli:"output-root-bootstrap"`
 	SP1Verifier                     common.Address     `cli:"sp1-verifier-address"`
 	FaultGameMaxGameDepth           uint64             `cli:"dispute-max-game-depth"`
 	FaultGameSplitDepth             uint64             `cli:"dispute-split-depth"`
@@ -108,6 +109,12 @@ func (c *ImplementationsConfig) Check() error {
 	}
 	if c.DisputeGameFinalityDelaySeconds == 0 {
 		return errors.New("dispute game finality delay in seconds must be specified")
+	}
+	if c.OutputRootBootstrap {
+		if devfeatures.EnableDevFeature(c.DevFeatureBitmap, devfeatures.SuperRootGamesMigrationFlag) == c.DevFeatureBitmap {
+			return errors.New("output root bootstrap conflicts with an explicit super root games migration feature")
+		}
+		c.DevFeatureBitmap = devfeatures.EnableDevFeature(c.DevFeatureBitmap, devfeatures.OutputRootGamesFlag)
 	}
 	if c.FaultGameMaxGameDepth == 0 {
 		return errors.New("fault game max game depth must be specified")

--- a/op-deployer/pkg/deployer/bootstrap/implementations_test.go
+++ b/op-deployer/pkg/deployer/bootstrap/implementations_test.go
@@ -68,6 +68,38 @@ func TestImplementationsConfigSP1Verifier(t *testing.T) {
 	})
 }
 
+func TestImplementationsConfigOutputRootBootstrap(t *testing.T) {
+	valid := ImplementationsConfig{
+		L1RPCUrl:                        "http://localhost:8545",
+		PrivateKey:                      testutil.AnvilDefaultPrivateKey,
+		ArtifactsLocator:                artifacts.EmbeddedLocator,
+		MIPSVersion:                     int(standard.MIPSVersion),
+		WithdrawalDelaySeconds:          1,
+		MinProposalSizeBytes:            1,
+		ChallengePeriodSeconds:          1,
+		ProofMaturityDelaySeconds:       1,
+		DisputeGameFinalityDelaySeconds: 1,
+		FaultGameMaxGameDepth:           1,
+		FaultGameSplitDepth:             1,
+		FaultGameClockExtension:         1,
+		FaultGameMaxClockDuration:       1,
+		SuperchainConfigProxy:           common.Address{0x01},
+		L1ProxyAdminOwner:               common.Address{0x02},
+		SuperchainProxyAdmin:            common.Address{0x03},
+		Challenger:                      common.Address{0x04},
+		Logger:                          testlog.Logger(t, slog.LevelDebug),
+		OutputRootBootstrap:             true,
+	}
+
+	require.NoError(t, valid.Check())
+	require.True(t, devfeatures.IsDevFeatureEnabled(valid.DevFeatureBitmap, devfeatures.OutputRootGamesFlag))
+	require.False(t, devfeatures.IsDevFeatureEnabled(valid.DevFeatureBitmap, devfeatures.SuperRootGamesMigrationFlag))
+
+	conflict := valid
+	conflict.DevFeatureBitmap = devfeatures.SuperRootGamesMigrationFlag
+	require.ErrorContains(t, conflict.Check(), "conflicts with an explicit super root games migration feature")
+}
+
 func TestImplementationsConfigResolveSP1Verifier(t *testing.T) {
 	t.Run("mainnet default", func(t *testing.T) {
 		cfg := ImplementationsConfig{DevFeatureBitmap: devfeatures.ZKDisputeGameFlag}

--- a/op-deployer/pkg/deployer/continue_verify_test.go
+++ b/op-deployer/pkg/deployer/continue_verify_test.go
@@ -128,10 +128,6 @@ func newContinuationVerificationFixture(
 	t *testing.T,
 	gameType embedded.GameType,
 ) *continuationVerificationFixture {
-	// devfeatures.IsDevFeatureEnabled hardcodes SuperRootGamesMigrationFlag to true, so
-	// resolveGameMode always observes a super-root OPCM regardless of the bitmap the
-	// fixture serves. See TODO(#21662) for the eventual cleanup. Flip the super canon cases
-	// back to cannon to improve coverage.
 	return newContinuationVerificationFixtureWithMode(t, gameType, true)
 }
 
@@ -429,7 +425,7 @@ func (f *continuationVerificationFixture) devFeatureBitmap() common.Hash {
 	if f.superRoot {
 		return devfeatures.SuperRootGamesMigrationFlag
 	}
-	return common.Hash{}
+	return devfeatures.OutputRootGamesFlag
 }
 
 func (f *continuationVerificationFixture) seedGameImplementation(
@@ -564,9 +560,6 @@ func TestVerifyContinuationDeploymentRejectsHeadChange(t *testing.T) {
 }
 
 func TestVerifyContinuationDeploymentRejectsOPCMGameModeMismatch(t *testing.T) {
-	// Only the CANNON_KONA direction is reachable: devfeatures.IsDevFeatureEnabled hardcodes
-	// SuperRootGamesMigrationFlag to true, so an OPCM without super-root cannot be observed and
-	// the SUPER_CANNON_KONA mismatch cannot be constructed. Restore that case with TODO(#21662).
 	t.Run("CANNON_KONA with super-root OPCM", func(t *testing.T) {
 		fixture := newContinuationVerificationFixture(t, embedded.GameTypeCannonKona)
 		fixture.backend.set(
@@ -581,6 +574,11 @@ func TestVerifyContinuationDeploymentRejectsOPCMGameModeMismatch(t *testing.T) {
 			fixture.verify(t),
 			"initial dispute game type CANNON_KONA (8) is not deployable by the OPCM",
 		)
+	})
+
+	t.Run("SUPER_CANNON_KONA with output-root OPCM", func(t *testing.T) {
+		fixture := newContinuationVerificationFixtureWithMode(t, embedded.GameTypeSuperCannonKona, false)
+		require.ErrorContains(t, fixture.verify(t), "has SUPER_ROOT_GAMES_MIGRATION disabled")
 	})
 }
 

--- a/op-deployer/pkg/deployer/flags.go
+++ b/op-deployer/pkg/deployer/flags.go
@@ -35,6 +35,8 @@ const (
 	GenesisTimeOffsetFlagName = flags.GenesisTimeOffsetFlagName
 )
 
+const OutputRootBootstrapFlagName = flags.OutputRootBootstrapFlagName
+
 var (
 	L1RPCURLFlag = &cli.StringFlag{
 		Name: L1RPCURLFlagName,
@@ -152,6 +154,12 @@ var (
 		EnvVars: PrefixEnvVar("GENESIS_TIME_OFFSET"),
 		Value:   standard.DefaultGenesisTimeOffsetSeconds,
 	}
+	OutputRootBootstrapFlag = &cli.BoolFlag{
+		Name: OutputRootBootstrapFlagName,
+		Usage: "Deploy output-root dispute games and initialize each ASR with its L2 genesis output root at block 0. " +
+			"Only supported for custom deployment intents.",
+		EnvVars: PrefixEnvVar("OUTPUT_ROOT_BOOTSTRAP"),
+	}
 )
 
 var GlobalFlags = append([]cli.Flag{CacheDirFlag}, oplog.CLIFlags(EnvVarPrefix)...)
@@ -161,6 +169,7 @@ var InitFlags = []cli.Flag{
 	L2ChainIDsFlag,
 	WorkdirFlag,
 	IntentTypeFlag,
+	OutputRootBootstrapFlag,
 }
 
 var PrepareFlags = []cli.Flag{

--- a/op-deployer/pkg/deployer/flags.go
+++ b/op-deployer/pkg/deployer/flags.go
@@ -37,6 +37,11 @@ const (
 
 const OutputRootBootstrapFlagName = flags.OutputRootBootstrapFlagName
 
+const (
+	OPCMAddressFlagName           = flags.OPCMAddressFlagName
+	SuperchainConfigProxyFlagName = flags.SuperchainConfigProxyFlagName
+)
+
 var (
 	L1RPCURLFlag = &cli.StringFlag{
 		Name: L1RPCURLFlagName,
@@ -160,6 +165,16 @@ var (
 			"Only supported for custom deployment intents.",
 		EnvVars: PrefixEnvVar("OUTPUT_ROOT_BOOTSTRAP"),
 	}
+	OPCMAddressFlag = &cli.StringFlag{
+		Name:    OPCMAddressFlagName,
+		Usage:   "Existing OPCM address to pin in a custom intent.",
+		EnvVars: PrefixEnvVar("OPCM_ADDRESS"),
+	}
+	SuperchainConfigProxyFlag = &cli.StringFlag{
+		Name:    SuperchainConfigProxyFlagName,
+		Usage:   "Existing SuperchainConfig proxy address to pin in a custom intent.",
+		EnvVars: PrefixEnvVar("SUPERCHAIN_CONFIG_PROXY"),
+	}
 )
 
 var GlobalFlags = append([]cli.Flag{CacheDirFlag}, oplog.CLIFlags(EnvVarPrefix)...)
@@ -170,6 +185,8 @@ var InitFlags = []cli.Flag{
 	WorkdirFlag,
 	IntentTypeFlag,
 	OutputRootBootstrapFlag,
+	OPCMAddressFlag,
+	SuperchainConfigProxyFlag,
 }
 
 var PrepareFlags = []cli.Flag{

--- a/op-deployer/pkg/deployer/flags/names.go
+++ b/op-deployer/pkg/deployer/flags/names.go
@@ -28,6 +28,8 @@ const (
 	GenesisTimeOffsetFlagName = "genesis-time-offset"
 )
 
+const OutputRootBootstrapFlagName = "output-root-bootstrap"
+
 func DefaultCacheDir() string {
 	var cacheDir string
 

--- a/op-deployer/pkg/deployer/flags/names.go
+++ b/op-deployer/pkg/deployer/flags/names.go
@@ -30,6 +30,11 @@ const (
 
 const OutputRootBootstrapFlagName = "output-root-bootstrap"
 
+const (
+	OPCMAddressFlagName           = "opcm-address"
+	SuperchainConfigProxyFlagName = "superchain-config-proxy"
+)
+
 func DefaultCacheDir() string {
 	var cacheDir string
 

--- a/op-deployer/pkg/deployer/init.go
+++ b/op-deployer/pkg/deployer/init.go
@@ -17,10 +17,11 @@ import (
 )
 
 type InitConfig struct {
-	IntentType state.IntentType
-	L1ChainID  uint64
-	Outdir     string
-	L2ChainIDs []common.Hash
+	IntentType          state.IntentType
+	L1ChainID           uint64
+	Outdir              string
+	L2ChainIDs          []common.Hash
+	OutputRootBootstrap bool
 }
 
 func (c *InitConfig) Check() error {
@@ -35,6 +36,9 @@ func (c *InitConfig) Check() error {
 	if len(c.L2ChainIDs) == 0 {
 		return fmt.Errorf("must specify at least one L2 chain ID")
 	}
+	if c.OutputRootBootstrap && c.IntentType != state.IntentTypeCustom {
+		return fmt.Errorf("output root bootstrap requires intent-type=%s", state.IntentTypeCustom)
+	}
 
 	return nil
 }
@@ -45,6 +49,7 @@ func InitCLI() func(ctx *cli.Context) error {
 		outdir := ctx.String(OutdirFlagName)
 		l2ChainIDsRaw := ctx.String(L2ChainIDsFlagName)
 		intentType := ctx.String(IntentTypeFlagName)
+		outputRootBootstrap := ctx.Bool(OutputRootBootstrapFlagName)
 
 		if len(l2ChainIDsRaw) == 0 {
 			return fmt.Errorf("must specify at least one L2 chain ID")
@@ -61,10 +66,11 @@ func InitCLI() func(ctx *cli.Context) error {
 		}
 
 		err := Init(InitConfig{
-			IntentType: state.IntentType(intentType),
-			L1ChainID:  l1ChainID,
-			Outdir:     outdir,
-			L2ChainIDs: l2ChainIDs,
+			IntentType:          state.IntentType(intentType),
+			L1ChainID:           l1ChainID,
+			Outdir:              outdir,
+			L2ChainIDs:          l2ChainIDs,
+			OutputRootBootstrap: outputRootBootstrap,
 		})
 		if err != nil {
 			return err
@@ -84,6 +90,7 @@ func Init(cfg InitConfig) error {
 	if err != nil {
 		return err
 	}
+	intent.OutputRootBootstrap = cfg.OutputRootBootstrap
 
 	st := &state.State{
 		Version:           1,

--- a/op-deployer/pkg/deployer/init.go
+++ b/op-deployer/pkg/deployer/init.go
@@ -17,11 +17,13 @@ import (
 )
 
 type InitConfig struct {
-	IntentType          state.IntentType
-	L1ChainID           uint64
-	Outdir              string
-	L2ChainIDs          []common.Hash
-	OutputRootBootstrap bool
+	IntentType            state.IntentType
+	L1ChainID             uint64
+	Outdir                string
+	L2ChainIDs            []common.Hash
+	OutputRootBootstrap   bool
+	OPCMAddress           *common.Address
+	SuperchainConfigProxy *common.Address
 }
 
 func (c *InitConfig) Check() error {
@@ -39,6 +41,15 @@ func (c *InitConfig) Check() error {
 	if c.OutputRootBootstrap && c.IntentType != state.IntentTypeCustom {
 		return fmt.Errorf("output root bootstrap requires intent-type=%s", state.IntentTypeCustom)
 	}
+	if (c.OPCMAddress == nil) != (c.SuperchainConfigProxy == nil) {
+		return fmt.Errorf("opcm address and superchain config proxy must be specified together")
+	}
+	if c.OPCMAddress != nil && c.IntentType != state.IntentTypeCustom {
+		return fmt.Errorf("pinned OPCM requires intent-type=%s", state.IntentTypeCustom)
+	}
+	if c.OPCMAddress != nil && (*c.OPCMAddress == (common.Address{}) || *c.SuperchainConfigProxy == (common.Address{})) {
+		return fmt.Errorf("opcm address and superchain config proxy must not be zero")
+	}
 
 	return nil
 }
@@ -50,6 +61,14 @@ func InitCLI() func(ctx *cli.Context) error {
 		l2ChainIDsRaw := ctx.String(L2ChainIDsFlagName)
 		intentType := ctx.String(IntentTypeFlagName)
 		outputRootBootstrap := ctx.Bool(OutputRootBootstrapFlagName)
+		opcmAddress, err := optionalAddressFlag(ctx, OPCMAddressFlagName)
+		if err != nil {
+			return err
+		}
+		superchainConfig, err := optionalAddressFlag(ctx, SuperchainConfigProxyFlagName)
+		if err != nil {
+			return err
+		}
 
 		if len(l2ChainIDsRaw) == 0 {
 			return fmt.Errorf("must specify at least one L2 chain ID")
@@ -65,12 +84,14 @@ func InitCLI() func(ctx *cli.Context) error {
 			l2ChainIDs[i] = id
 		}
 
-		err := Init(InitConfig{
-			IntentType:          state.IntentType(intentType),
-			L1ChainID:           l1ChainID,
-			Outdir:              outdir,
-			L2ChainIDs:          l2ChainIDs,
-			OutputRootBootstrap: outputRootBootstrap,
+		err = Init(InitConfig{
+			IntentType:            state.IntentType(intentType),
+			L1ChainID:             l1ChainID,
+			Outdir:                outdir,
+			L2ChainIDs:            l2ChainIDs,
+			OutputRootBootstrap:   outputRootBootstrap,
+			OPCMAddress:           opcmAddress,
+			SuperchainConfigProxy: superchainConfig,
 		})
 		if err != nil {
 			return err
@@ -91,6 +112,11 @@ func Init(cfg InitConfig) error {
 		return err
 	}
 	intent.OutputRootBootstrap = cfg.OutputRootBootstrap
+	if cfg.OPCMAddress != nil {
+		intent.OPCMAddress = cfg.OPCMAddress
+		intent.SuperchainConfigProxy = cfg.SuperchainConfigProxy
+		intent.SuperchainRoles = nil
+	}
 
 	st := &state.State{
 		Version:           1,
@@ -115,4 +141,19 @@ func Init(cfg InitConfig) error {
 		return fmt.Errorf("failed to write state to file: %w", err)
 	}
 	return nil
+}
+
+func optionalAddressFlag(ctx *cli.Context, name string) (*common.Address, error) {
+	if !ctx.IsSet(name) {
+		return nil, nil
+	}
+	raw := ctx.String(name)
+	if !common.IsHexAddress(raw) {
+		return nil, fmt.Errorf("--%s must be a valid address", name)
+	}
+	addr := common.HexToAddress(raw)
+	if addr == (common.Address{}) {
+		return nil, fmt.Errorf("--%s must not be zero", name)
+	}
+	return &addr, nil
 }

--- a/op-deployer/pkg/deployer/integration_test/cli/init_test.go
+++ b/op-deployer/pkg/deployer/integration_test/cli/init_test.go
@@ -138,6 +138,41 @@ func TestCLIInitOutputRootBootstrap(t *testing.T) {
 	require.True(t, intent.OutputRootBootstrap)
 }
 
+func TestCLIInitPinnedOPCM(t *testing.T) {
+	runner := NewCLITestRunner(t)
+	workDir := runner.GetWorkDir()
+	opcm := common.HexToAddress("0x1111111111111111111111111111111111111111")
+	superchainConfig := common.HexToAddress("0x2222222222222222222222222222222222222222")
+
+	runner.ExpectSuccess(t, []string{
+		"init",
+		"--l1-chain-id", "11155111",
+		"--l2-chain-ids", "1",
+		"--intent-type", "custom",
+		"--opcm-address", opcm.Hex(),
+		"--superchain-config-proxy", superchainConfig.Hex(),
+		"--workdir", workDir,
+	}, nil)
+
+	intent, err := pipeline.ReadIntent(workDir)
+	require.NoError(t, err)
+	require.Equal(t, opcm, *intent.OPCMAddress)
+	require.Equal(t, superchainConfig, *intent.SuperchainConfigProxy)
+	require.Nil(t, intent.SuperchainRoles)
+}
+
+func TestCLIInitPinnedOPCMRequiresBothAddresses(t *testing.T) {
+	runner := NewCLITestRunner(t)
+	runner.ExpectErrorContains(t, []string{
+		"init",
+		"--l1-chain-id", "11155111",
+		"--l2-chain-ids", "1",
+		"--intent-type", "custom",
+		"--opcm-address", "0x1111111111111111111111111111111111111111",
+		"--workdir", runner.GetWorkDir(),
+	}, nil, "must be specified together")
+}
+
 func TestCLIInitOutputRootBootstrapRejectsStandardIntent(t *testing.T) {
 	runner := NewCLITestRunner(t)
 	runner.ExpectErrorContains(t, []string{

--- a/op-deployer/pkg/deployer/integration_test/cli/init_test.go
+++ b/op-deployer/pkg/deployer/integration_test/cli/init_test.go
@@ -119,3 +119,32 @@ func TestCLIInitCustomIntentType(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, st.Chains, 0)
 }
+
+func TestCLIInitOutputRootBootstrap(t *testing.T) {
+	runner := NewCLITestRunner(t)
+	workDir := runner.GetWorkDir()
+
+	runner.ExpectSuccess(t, []string{
+		"init",
+		"--l1-chain-id", "11155111",
+		"--l2-chain-ids", "1",
+		"--intent-type", "custom",
+		"--output-root-bootstrap",
+		"--workdir", workDir,
+	}, nil)
+
+	intent, err := pipeline.ReadIntent(workDir)
+	require.NoError(t, err)
+	require.True(t, intent.OutputRootBootstrap)
+}
+
+func TestCLIInitOutputRootBootstrapRejectsStandardIntent(t *testing.T) {
+	runner := NewCLITestRunner(t)
+	runner.ExpectErrorContains(t, []string{
+		"init",
+		"--l1-chain-id", "11155111",
+		"--l2-chain-ids", "1",
+		"--output-root-bootstrap",
+		"--workdir", runner.GetWorkDir(),
+	}, nil, "output root bootstrap requires intent-type=custom")
+}

--- a/op-deployer/pkg/deployer/integration_test/continue_test.go
+++ b/op-deployer/pkg/deployer/integration_test/continue_test.go
@@ -59,6 +59,9 @@ func TestEndToEndContinuePreparedChain(t *testing.T) {
 	t.Run("permissionless", func(t *testing.T) {
 		testContinuePermissionless(t)
 	})
+	t.Run("permissionless output-root bootstrap", func(t *testing.T) {
+		testContinuePermissionlessOutputRoot(t)
+	})
 	t.Run("permissionless with custom roles", func(t *testing.T) {
 		testContinuePermissionlessWithCustomRoles(t)
 	})
@@ -164,6 +167,32 @@ func testContinuePermissionless(t *testing.T) {
 	require.Equal(t, originalContracts, env.preparedSnapshotChain.OpChainContracts)
 	require.NotNil(t, reconciledChain.Continuation)
 	require.Nil(t, reconciled.AppliedIntent)
+}
+
+func testContinuePermissionlessOutputRoot(t *testing.T) {
+	t.Helper()
+	env := newContinuationEnvWithIntentMutator(
+		t,
+		[]embedded.GameType{embedded.GameTypeCannonKona},
+		devfeatures.OutputRootGamesFlag,
+		func(intent *state.Intent) {
+			intent.Chains[0].DeployOverrides = map[string]any{
+				state.FaultGameAbsolutePrestateOverrideKey: standard.DisputeAbsolutePrestate,
+			}
+		},
+	)
+	require.NotNil(t, env.preparedChain.StartingAnchorRoot)
+	require.NotZero(t, env.preparedChain.StartingAnchorRoot.Root)
+	require.NotEqual(t, opcm.DefaultStartingAnchorRoot.Root, env.preparedChain.StartingAnchorRoot.Root)
+	require.Zero(t, env.preparedChain.StartingAnchorRoot.L2SequenceNumber)
+
+	require.NoError(t, deployer.Prestate(env.ctx, deployer.PrestateConfig{
+		Workdir: env.workdir,
+		Logger:  env.lgr,
+	}))
+	nonceBefore := pendingNonce(t, env)
+	require.NoError(t, deployer.Continue(env.ctx, env.config()))
+	assertContinuationCompleted(t, env, nonceBefore)
 }
 
 func testContinuePermissionlessWithCustomRoles(t *testing.T) {
@@ -540,6 +569,8 @@ func newContinuationEnvWithIntentMutator(
 	loc, _ := testutil.LocalArtifacts(t)
 	cacheDir := testutils.IsolatedTestDirWithAutoCleanup(t)
 	intent, st := shared.NewIntent(t, l1ChainID, dk, uint256.NewInt(1), loc, loc, testCustomGasLimit)
+	outputRootBootstrap := devfeatures.IsDevFeatureEnabled(devFeatureBitmap, devfeatures.OutputRootGamesFlag)
+	intent.OutputRootBootstrap = outputRootBootstrap
 	for i := 1; i < len(gameTypes); i++ {
 		intent.Chains = append(
 			intent.Chains,
@@ -570,6 +601,7 @@ func newContinuationEnvWithIntentMutator(
 		ProofMaturityDelaySeconds:       standard.ProofMaturityDelaySeconds,
 		DisputeGameFinalityDelaySeconds: standard.DisputeGameFinalityDelaySeconds,
 		DevFeatureBitmap:                devFeatureBitmap,
+		OutputRootBootstrap:             outputRootBootstrap,
 		SuperchainConfigProxy:           bstrap.SuperchainConfigProxy,
 		L1ProxyAdminOwner:               intent.Chains[0].Roles.L1ProxyAdminOwner,
 		SuperchainProxyAdmin:            bstrap.SuperchainProxyAdmin,
@@ -590,7 +622,10 @@ func newContinuationEnvWithIntentMutator(
 	intent.OPCMAddress = &impls.OpcmV2
 	intent.SuperchainConfigProxy = &bstrap.SuperchainConfigProxy
 	for i, gameType := range gameTypes {
-		intent.Chains[i].DeployOverrides = map[string]any{"respectedGameType": gameType}
+		if intent.Chains[i].DeployOverrides == nil {
+			intent.Chains[i].DeployOverrides = make(map[string]any)
+		}
+		intent.Chains[i].DeployOverrides["respectedGameType"] = gameType
 	}
 	workdir := t.TempDir()
 	require.NoError(t, intent.WriteToFile(filepath.Join(workdir, "intent.toml")))

--- a/op-deployer/pkg/deployer/pipeline/l2genesis.go
+++ b/op-deployer/pkg/deployer/pipeline/l2genesis.go
@@ -227,6 +227,12 @@ func buildDevFeatureBitmap(intent *state.Intent) (common.Hash, error) {
 	case string:
 		devFeatureBitmap = common.HexToHash(v)
 	}
+	if intent.OutputRootBootstrap {
+		if devfeatures.EnableDevFeature(devFeatureBitmap, devfeatures.SuperRootGamesMigrationFlag) == devFeatureBitmap {
+			return common.Hash{}, fmt.Errorf("output root bootstrap conflicts with an explicit super root games migration feature")
+		}
+		devFeatureBitmap = devfeatures.EnableDevFeature(devFeatureBitmap, devfeatures.OutputRootGamesFlag)
+	}
 
 	interopBitEnabled := devfeatures.IsDevFeatureEnabled(devFeatureBitmap, devfeatures.OptimismPortalInteropFlag)
 

--- a/op-deployer/pkg/deployer/pipeline/l2genesis_test.go
+++ b/op-deployer/pkg/deployer/pipeline/l2genesis_test.go
@@ -82,6 +82,25 @@ func TestBuildDevFeatureBitmap(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("output root bootstrap enables its internal feature", func(t *testing.T) {
+		intent := &state.Intent{OutputRootBootstrap: true, GlobalDeployOverrides: map[string]any{}}
+		result, err := buildDevFeatureBitmap(intent)
+		require.NoError(t, err)
+		require.True(t, devfeatures.IsDevFeatureEnabled(result, devfeatures.OutputRootGamesFlag))
+		require.False(t, devfeatures.IsDevFeatureEnabled(result, devfeatures.SuperRootGamesMigrationFlag))
+	})
+
+	t.Run("output root bootstrap rejects an explicit super root feature", func(t *testing.T) {
+		intent := &state.Intent{
+			OutputRootBootstrap: true,
+			GlobalDeployOverrides: map[string]any{
+				"devFeatureBitmap": devfeatures.SuperRootGamesMigrationFlag,
+			},
+		}
+		_, err := buildDevFeatureBitmap(intent)
+		require.ErrorContains(t, err, "conflicts with an explicit super root games migration feature")
+	})
 }
 
 func TestCalculateL2GenesisOverrides(t *testing.T) {

--- a/op-deployer/pkg/deployer/pipeline/prepared.go
+++ b/op-deployer/pkg/deployer/pipeline/prepared.go
@@ -244,6 +244,7 @@ func canonicalPreparedIntent(
 		FundDevAccounts:       intent.FundDevAccounts,
 		GlobalDeployOverrides: intent.GlobalDeployOverrides,
 		UseInterop:            intent.UseInterop,
+		OutputRootBootstrap:   intent.OutputRootBootstrap,
 	}
 
 	for _, chain := range intent.Chains {

--- a/op-deployer/pkg/deployer/prepare.go
+++ b/op-deployer/pkg/deployer/prepare.go
@@ -179,6 +179,13 @@ func Prepare(ctx context.Context, cfg PrepareConfig) error {
 	if err != nil {
 		return fmt.Errorf("failed to read the OPCM game mode at %s: %w", opcmAddr, err)
 	}
+	if superRoot == intent.OutputRootBootstrap {
+		mode := "super-root"
+		if intent.OutputRootBootstrap {
+			mode = "output-root"
+		}
+		return fmt.Errorf("intent requests %s bootstrap, but OPCM at %s has the opposite game mode", mode, opcmAddr)
+	}
 	if err := validateInitialGameTypes(intent, st, superRoot, opcmAddr); err != nil {
 		return err
 	}

--- a/op-deployer/pkg/deployer/state/intent.go
+++ b/op-deployer/pkg/deployer/state/intent.go
@@ -97,7 +97,9 @@ type Intent struct {
 	Chains                []*ChainIntent             `json:"chains" toml:"chains"`
 	GlobalDeployOverrides map[string]any             `json:"globalDeployOverrides" toml:"globalDeployOverrides"`
 	UseInterop            bool                       `json:"useInterop" toml:"useInterop"`
-	OutputRootBootstrap   bool                       `json:"outputRootBootstrap" toml:"outputRootBootstrap"`
+	// OutputRootBootstrap initializes each ASR with the L2 genesis output root at block 0,
+	// allowing proof systems to prove the first post-genesis state transition.
+	OutputRootBootstrap bool `json:"outputRootBootstrap" toml:"outputRootBootstrap"`
 
 	// L1DevGenesisParams is optional. This may be used to customize the L1 genesis when
 	// the deployer output is directed to produce a L1 genesis state for development.

--- a/op-deployer/pkg/deployer/state/intent.go
+++ b/op-deployer/pkg/deployer/state/intent.go
@@ -97,6 +97,7 @@ type Intent struct {
 	Chains                []*ChainIntent             `json:"chains" toml:"chains"`
 	GlobalDeployOverrides map[string]any             `json:"globalDeployOverrides" toml:"globalDeployOverrides"`
 	UseInterop            bool                       `json:"useInterop" toml:"useInterop"`
+	OutputRootBootstrap   bool                       `json:"outputRootBootstrap" toml:"outputRootBootstrap"`
 
 	// L1DevGenesisParams is optional. This may be used to customize the L1 genesis when
 	// the deployer output is directed to produce a L1 genesis state for development.
@@ -238,6 +239,9 @@ func GetStandardSuperchainRoles(l1ChainId uint64) (*addresses.SuperchainRoles, e
 func (c *Intent) Check() error {
 	if c.L1ChainID == 0 {
 		return fmt.Errorf("l1ChainID cannot be 0")
+	}
+	if c.OutputRootBootstrap && c.ConfigType != IntentTypeCustom {
+		return fmt.Errorf("%w: output root bootstrap requires intent-type=%s", ErrIncompatibleValue, IntentTypeCustom)
 	}
 
 	if c.L1ContractsLocator == nil {

--- a/op-deployer/pkg/deployer/state/intent_test.go
+++ b/op-deployer/pkg/deployer/state/intent_test.go
@@ -135,6 +135,13 @@ func TestValidateStandardValues(t *testing.T) {
 			},
 			ErrNonStandardValue,
 		},
+		{
+			"OutputRootBootstrap",
+			func(intent *Intent) {
+				intent.OutputRootBootstrap = true
+			},
+			ErrIncompatibleValue,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/packages/contracts-bedrock/scripts/libraries/Config.sol
+++ b/packages/contracts-bedrock/scripts/libraries/Config.sol
@@ -336,10 +336,15 @@ library Config {
         return vm.envOr("DEV_FEATURE__ZK_DISPUTE_GAME", false);
     }
 
+    /// @notice Returns true if output root dispute games are selected instead of super root games.
+    function devFeatureOutputRootGames() internal view returns (bool) {
+        return vm.envOr("DEV_FEATURE__OUTPUT_ROOT_GAMES", false);
+    }
+
     /// @notice Returns true if the development feature super root games migration is enabled.
     /// @dev Defaults to true: SUPER_ROOT_GAMES_MIGRATION is the default OPCM migration codepath. See TODO(#21662).
-    function devFeatureSuperRootGamesMigration() internal pure returns (bool) {
-        return true;
+    function devFeatureSuperRootGamesMigration() internal view returns (bool) {
+        return !devFeatureOutputRootGames();
     }
 
     /// @notice Returns true if the system feature custom_gas_token is enabled.

--- a/packages/contracts-bedrock/src/libraries/DevFeatures.sol
+++ b/packages/contracts-bedrock/src/libraries/DevFeatures.sol
@@ -46,6 +46,10 @@ library DevFeatures {
     bytes32 public constant SUPER_ROOT_GAMES_MIGRATION =
         bytes32(0x0000000000000000000000000000000000000000000000000000000010000000);
 
+    /// @notice The feature that selects output root dispute games instead of the default super root games.
+    bytes32 public constant OUTPUT_ROOT_GAMES =
+        bytes32(0x0000000000000000000000000000000000000000000000000000001000000000);
+
     /// @notice Checks if a feature is enabled in a bitmap. Note that this function does not check
     ///         that the input feature represents a single feature and the bitwise AND operation
     ///         allows for multiple features to be enabled at once. Users should generally check
@@ -54,9 +58,13 @@ library DevFeatures {
     /// @param _feature The feature to check.
     /// @return True if the feature is enabled, false otherwise.
     function isDevFeatureEnabled(bytes32 _bitmap, bytes32 _feature) internal pure returns (bool) {
-        // SuperRootGamesMigration is enabled by default.
+        // SuperRootGamesMigration is enabled by default, but fresh chains may explicitly select
+        // output root games. If both flags are set, the explicit super root flag takes precedence.
         // TODO(#21662): remove with the broader SuperRootGamesMigration cleanup.
-        if (hasFlag(_feature, SUPER_ROOT_GAMES_MIGRATION)) return true;
+        if (
+            hasFlag(_feature, SUPER_ROOT_GAMES_MIGRATION)
+                && (!hasFlag(_bitmap, OUTPUT_ROOT_GAMES) || hasFlag(_bitmap, SUPER_ROOT_GAMES_MIGRATION))
+        ) return true;
         return _feature != 0 && hasFlag(_bitmap, _feature);
     }
 

--- a/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerContainer.t.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerContainer.t.sol
@@ -147,7 +147,7 @@ contract OPContractsManagerContainer_IsDevFeatureEnabled_Test is OPContractsMana
     /// @param _bitIndex The bit index to test.
     function testFuzz_isDevFeatureEnabled_bitNotSet_succeeds(uint8 _bitIndex) public {
         bytes32 feature = bytes32(uint256(1) << _bitIndex);
-        // SuperRootGamesMigration is hardcoded enabled. TODO(#21662): remove with the broader migration cleanup.
+        // SuperRootGamesMigration is default-on. TODO(#21662): remove with the broader migration cleanup.
         vm.assume(feature != DevFeatures.SUPER_ROOT_GAMES_MIGRATION);
 
         // Create a bitmap with all bits set except the one we're testing.
@@ -161,11 +161,18 @@ contract OPContractsManagerContainer_IsDevFeatureEnabled_Test is OPContractsMana
     /// @notice Tests that isDevFeatureEnabled returns false when the bitmap is zero.
     /// @param _feature The feature to check.
     function testFuzz_isDevFeatureEnabled_zeroBitmap_succeeds(bytes32 _feature) public {
-        // SuperRootGamesMigration is hardcoded enabled. TODO(#21662): remove with the broader migration cleanup.
+        // SuperRootGamesMigration is default-on. TODO(#21662): remove with the broader migration cleanup.
         vm.assume((_feature & DevFeatures.SUPER_ROOT_GAMES_MIGRATION) != DevFeatures.SUPER_ROOT_GAMES_MIGRATION);
         OPContractsManagerContainer container = _deploy(bytes32(0));
 
         assertFalse(container.isDevFeatureEnabled(_feature));
+    }
+
+    /// @notice Tests that OUTPUT_ROOT_GAMES disables the default super-root mode.
+    function test_isDevFeatureEnabled_outputRootGames_succeeds() public {
+        OPContractsManagerContainer container = _deploy(DevFeatures.OUTPUT_ROOT_GAMES);
+
+        assertFalse(container.isDevFeatureEnabled(DevFeatures.SUPER_ROOT_GAMES_MIGRATION));
     }
 
     /// @notice Tests that isDevFeatureEnabled returns true for multiple features set at once.

--- a/packages/contracts-bedrock/test/L2/L2DevFeatureFlags.t.sol
+++ b/packages/contracts-bedrock/test/L2/L2DevFeatureFlags.t.sol
@@ -62,18 +62,28 @@ contract L2DevFeatureFlags_IsDevFeatureEnabled_Test is L2DevFeatureFlags_TestIni
     /// @notice Tests that `isDevFeatureEnabled` returns false when the bitmap is zero.
     function testFuzz_isDevFeatureEnabled_zeroBitmap_succeeds(bytes32 _feature) public {
         vm.assume(_feature != bytes32(0));
-        // SuperRootGamesMigration is hardcoded enabled. TODO(#21662): remove with the broader migration cleanup.
+        // SuperRootGamesMigration is default-on. TODO(#21662): remove with the broader migration cleanup.
         vm.assume((_feature & DevFeatures.SUPER_ROOT_GAMES_MIGRATION) != DevFeatures.SUPER_ROOT_GAMES_MIGRATION);
         // Ensure `devFeatureBitmap` contains bytes32(0)
         vm.store(address(l2DevFeatureFlags), bytes32(uint256(keccak256("l2devfeatureflags.bitmap")) - 1), bytes32(0));
         assertFalse(l2DevFeatureFlags.isDevFeatureEnabled(_feature));
     }
 
-    /// @notice Tests that `isDevFeatureEnabled(SUPER_ROOT_GAMES_MIGRATION)` always returns true regardless of stored
-    /// bitmap.
+    /// @notice Tests that `isDevFeatureEnabled(SUPER_ROOT_GAMES_MIGRATION)` defaults to true.
     /// @dev TODO(#21662): remove with the broader SuperRootGamesMigration cleanup.
-    function test_isDevFeatureEnabled_superRootGamesMigrationAlwaysEnabled_succeeds() public view {
+    function test_isDevFeatureEnabled_superRootGamesMigrationDefault_succeeds() public {
+        vm.prank(Constants.DEPOSITOR_ACCOUNT);
+        l2DevFeatureFlags.setDevFeatureBitmap(bytes32(0));
+
         assertTrue(l2DevFeatureFlags.isDevFeatureEnabled(DevFeatures.SUPER_ROOT_GAMES_MIGRATION));
+    }
+
+    /// @notice Tests that OUTPUT_ROOT_GAMES disables the default super-root mode.
+    function test_isDevFeatureEnabled_outputRootGames_succeeds() public {
+        vm.prank(Constants.DEPOSITOR_ACCOUNT);
+        l2DevFeatureFlags.setDevFeatureBitmap(DevFeatures.OUTPUT_ROOT_GAMES);
+
+        assertFalse(l2DevFeatureFlags.isDevFeatureEnabled(DevFeatures.SUPER_ROOT_GAMES_MIGRATION));
     }
 
     /// @notice Tests that `isDevFeatureEnabled` returns false for zero feature.

--- a/packages/contracts-bedrock/test/libraries/DevFeatures.t.sol
+++ b/packages/contracts-bedrock/test/libraries/DevFeatures.t.sol
@@ -93,7 +93,7 @@ contract DevFeatures_isDevFeatureEnabled_Test is Test {
 
     /// @notice Tests that ALL_FEATURES against empty bitmap returns false.
     function test_isDevFeatureEnabled_allFeaturesAgainstEmpty_succeeds() public pure {
-        // Strip the default-on feature because it is hardcoded enabled regardless of bitmap.
+        // Strip the default-on feature from this generic bitmap check.
         assertFalse(
             DevFeatures.isDevFeatureEnabled(EMPTY_FEATURES, ALL_FEATURES & ~DevFeatures.SUPER_ROOT_GAMES_MIGRATION)
         );
@@ -120,21 +120,30 @@ contract DevFeatures_isDevFeatureEnabled_Test is Test {
     /// @notice Fuzz test: feature not found when bitmap has none of the feature's bits.
     function testFuzz_isDevFeatureEnabled_featureNotInDisjointBitmap_succeeds(bytes32 _feature) public pure {
         vm.assume(_feature != bytes32(0));
-        // SuperRootGamesMigration is hardcoded enabled. TODO(#21662): remove with the broader DevFeatures cleanup.
+        // SuperRootGamesMigration is default-on. TODO(#21662): remove with the broader DevFeatures cleanup.
         vm.assume((_feature & DevFeatures.SUPER_ROOT_GAMES_MIGRATION) != DevFeatures.SUPER_ROOT_GAMES_MIGRATION);
         bytes32 disjointBitmap = ~_feature;
         assertFalse(DevFeatures.isDevFeatureEnabled(disjointBitmap, _feature));
     }
 
-    /// @notice Tests that the default-on feature is hardcoded enabled regardless of the bitmap.
+    /// @notice Tests that the default-on feature is enabled unless output-root games are explicitly selected.
     /// @dev TODO(#21662): remove with the broader SuperRootGamesMigration cleanup.
-    function test_isDevFeatureEnabled_defaultOnFeatureAlwaysEnabled_succeeds() public pure {
+    function test_isDevFeatureEnabled_defaultOnFeature_succeeds() public pure {
         assertDefaultOnFeatureEnabled(DevFeatures.SUPER_ROOT_GAMES_MIGRATION);
+        assertFalse(
+            DevFeatures.isDevFeatureEnabled(DevFeatures.OUTPUT_ROOT_GAMES, DevFeatures.SUPER_ROOT_GAMES_MIGRATION)
+        );
+        assertTrue(
+            DevFeatures.isDevFeatureEnabled(
+                DevFeatures.OUTPUT_ROOT_GAMES | DevFeatures.SUPER_ROOT_GAMES_MIGRATION,
+                DevFeatures.SUPER_ROOT_GAMES_MIGRATION
+            )
+        );
     }
 
     function assertDefaultOnFeatureEnabled(bytes32 _feature) internal pure {
         assertTrue(DevFeatures.isDevFeatureEnabled(EMPTY_FEATURES, _feature));
-        assertTrue(DevFeatures.isDevFeatureEnabled(~_feature, _feature));
+        assertTrue(DevFeatures.isDevFeatureEnabled(~(_feature | DevFeatures.OUTPUT_ROOT_GAMES), _feature));
         assertTrue(DevFeatures.isDevFeatureEnabled(_feature, _feature));
         assertTrue(DevFeatures.isDevFeatureEnabled(EMPTY_FEATURES, FEATURE_A | _feature));
         assertTrue(DevFeatures.isDevFeatureEnabled(EMPTY_FEATURES, FEATURE_B | _feature));

--- a/packages/contracts-bedrock/test/setup/FeatureFlags.sol
+++ b/packages/contracts-bedrock/test/setup/FeatureFlags.sol
@@ -45,6 +45,10 @@ abstract contract FeatureFlags {
             console.log("Setup: DEV_FEATURE__ZK_DISPUTE_GAME is enabled");
             devFeatureBitmap |= DevFeatures.ZK_DISPUTE_GAME;
         }
+        if (Config.devFeatureOutputRootGames()) {
+            console.log("Setup: DEV_FEATURE__OUTPUT_ROOT_GAMES is enabled");
+            devFeatureBitmap |= DevFeatures.OUTPUT_ROOT_GAMES;
+        }
         if (Config.devFeatureSuperRootGamesMigration()) {
             console.log("Setup: DEV_FEATURE__SUPER_ROOT_GAMES_MIGRATION is enabled");
             devFeatureBitmap |= DevFeatures.SUPER_ROOT_GAMES_MIGRATION;
@@ -59,6 +63,8 @@ abstract contract FeatureFlags {
             return "DEV_FEATURE__OPTIMISM_PORTAL_INTEROP";
         } else if (_feature == DevFeatures.ZK_DISPUTE_GAME) {
             return "DEV_FEATURE__ZK_DISPUTE_GAME";
+        } else if (_feature == DevFeatures.OUTPUT_ROOT_GAMES) {
+            return "DEV_FEATURE__OUTPUT_ROOT_GAMES";
         } else if (_feature == DevFeatures.SUPER_ROOT_GAMES_MIGRATION) {
             return "DEV_FEATURE__SUPER_ROOT_GAMES_MIGRATION";
         } else if (_feature == Features.CUSTOM_GAS_TOKEN) {


### PR DESCRIPTION
## Summary

- add an explicit `--output-root-bootstrap` mode to custom op-deployer intents and implementation bootstrap
- when enabled, derive the V0 L2 genesis output root during `prepare` and initialize ASR with that root at L2 block 0
- add `init --opcm-address` and `--superchain-config-proxy` so bootstrapped contracts can be pinned without manual intent editing
- deploy output-root game implementations while keeping super-root games as the default
- reject mismatched intent/OPCM modes and the unsupported `apply` path

## Why

Fresh output-root chains need a trusted genesis anchor so proof systems can prove the first post-genesis state transition. This opt-in keeps the default unchanged and never accepts an operator-supplied root: op-deployer computes the anchor from the generated L2 genesis.

The flag has one explicit semantic: initialize each ASR starting anchor to `(L2 genesis output root, block 0)`.

## Validation

- focused Go unit tests for intent, feature bitmap, bootstrap configuration, CLI init, and continuation mode validation
- Foundry tests for `DevFeatures`, `L2DevFeatureFlags`, and `OPContractsManagerContainer`
- end-to-end `TestEndToEndContinuePreparedChain/permissionless_output-root_bootstrap`, including deployed ASR root verification
