### PR TITLE
alloy-op-evm,kona: harden deposit gas accounting against upstream changes

### DIFF
--- a/rust/alloy-op-evm/src/lib.rs
+++ b/rust/alloy-op-evm/src/lib.rs
@@ -331,12 +331,35 @@ where
     ) -> Result<ResultAndState<Self::HaltReason>, Self::Error> {
         self.last_tx_post_exec_result = post_exec::PostExecExecutedTx::default();
 
+        let tx = OpTx(tx.into());
+
+        // Deposits are force-included from L1 and are exempt from EIP-7825's per-transaction gas
+        // limit cap: https://specs.optimism.io/protocol/karst/overview.html#execution-layer
+        // Temporarily remove the cap so it cannot limit the deposit's execution, then restore it
+        // so non-deposit transactions remain subject to it. Changing the cap itself, rather than
+        // special-casing deposits at each place that reads it, means every reader sees the
+        // exemption, including any added upstream later.
+        //
+        // The cap feeds `initial_gas_and_reservoir`, which splits the gas limit between the first
+        // frame's budget and the EIP-8037 reservoir: removing it hands the frame the whole limit
+        // and leaves the reservoir empty, which is what the exemption means while no OP fork
+        // enables EIP-8037. The cap is shared across every transaction this EVM runs, and the RPC
+        // call, estimate and simulate paths raise it deliberately, so the previous value is put
+        // back rather than recomputed.
+        let saved_tx_gas_limit_cap = (tx.tx_type() ==
+            op_revm::transaction::deposit::DEPOSIT_TRANSACTION_TYPE)
+            .then(|| self.inner.0.ctx.cfg.tx_gas_limit_cap.replace(u64::MAX));
+
         let track_post_exec = self.post_exec_tracking_active;
         let result = if self.inspect || track_post_exec {
-            self.inner.inspect_tx(OpTx(tx.into()))
+            self.inner.inspect_tx(tx)
         } else {
-            self.inner.transact(OpTx(tx.into()))
+            self.inner.transact(tx)
         };
+
+        if let Some(cap) = saved_tx_gas_limit_cap {
+            self.inner.0.ctx.cfg.tx_gas_limit_cap = cap;
+        }
 
         if track_post_exec {
             if self.inner.0.ctx.tx.tx_type() !=
@@ -459,14 +482,18 @@ mod tests {
         precompiles::{Precompile, PrecompileInput},
     };
     use alloy_primitives::{Signature, TxKind, U256};
-    use op_revm::precompiles::{bls12_381, bn254_pair};
+    use op_revm::{
+        OpTransactionError,
+        precompiles::{bls12_381, bn254_pair},
+    };
     use revm::{
         context::CfgEnv,
-        context_interface::ContextTr,
+        context_interface::{ContextTr, result::InvalidTransaction},
         database::{EmptyDB, InMemoryDB},
         inspector::JournalExt,
         interpreter::{CallInputs, CallOutcome, CreateInputs, CreateOutcome, Interpreter},
         precompile::PrecompileHalt,
+        primitives::eip7825::TX_GAS_LIMIT_CAP,
         state::AccountInfo,
     };
 
@@ -548,16 +575,46 @@ mod tests {
         }
     }
 
-    fn legacy_op_tx(nonce: u64, caller: Address, target: Address) -> OpTx {
-        let tx =
-            TxLegacy { nonce, gas_limit: 100_000, to: TxKind::Call(target), ..Default::default() }
-                .into_signed(Signature::new(
-                    Default::default(),
-                    Default::default(),
-                    Default::default(),
-                ));
+    fn legacy_op_tx(nonce: u64, caller: Address, target: Address, gas_limit: u64) -> OpTx {
+        let tx = TxLegacy { nonce, gas_limit, to: TxKind::Call(target), ..Default::default() }
+            .into_signed(Signature::new(
+                Default::default(),
+                Default::default(),
+                Default::default(),
+            ));
 
         OpTx::from_recovered_tx(&tx, caller)
+    }
+
+    /// EIP-7825 caps a transaction's gas limit, and a transaction above the cap is rejected before
+    /// it executes. The deposit exemption in `transact_raw` is scoped to the deposit that carries
+    /// it and must leave that rule intact for every other transaction.
+    #[test]
+    fn non_deposit_above_tx_gas_limit_cap_is_rejected() {
+        let caller = Address::ZERO;
+        let target = Address::from([0x22; 20]);
+        // Karst is Osaka-based, so EIP-7825 is live. The block gas limit is set above the
+        // transaction's so that the cap is the only limit the transaction can trip over.
+        let mut evm = OpEvmFactory::<OpTx>::default().create_evm(
+            EmptyDB::default(),
+            EvmEnv::new(
+                CfgEnv::new_with_spec(OpSpecId::KARST),
+                BlockEnv { gas_limit: 60_000_000, ..Default::default() },
+            ),
+        );
+
+        let err = evm
+            .transact_raw(legacy_op_tx(0, caller, target, TX_GAS_LIMIT_CAP + 1))
+            .expect_err("a transaction above the cap must be rejected");
+        assert!(
+            matches!(
+                err,
+                EVMError::Transaction(OpTxError(OpTransactionError::Base(
+                    InvalidTransaction::TxGasLimitGreaterThanCap { .. }
+                )))
+            ),
+            "expected TxGasLimitGreaterThanCap, got {err:?}",
+        );
     }
 
     #[test]
@@ -581,7 +638,7 @@ mod tests {
             tx_index: 0,
             kind: post_exec::PostExecTxKind::Normal,
         });
-        evm.transact_raw(legacy_op_tx(0, caller, target)).expect("tx executes");
+        evm.transact_raw(legacy_op_tx(0, caller, target, 100_000)).expect("tx executes");
         assert_eq!(evm.take_last_post_exec_tx_result().refund_total, 7);
         assert_eq!(evm.refund_snapshot(), 1);
         evm.seed_refund_snapshot(9);

--- a/rust/kona/bin/client/src/fpvm_evm/precompiles/provider.rs
+++ b/rust/kona/bin/client/src/fpvm_evm/precompiles/provider.rs
@@ -12,8 +12,8 @@ use op_revm::{
 };
 use revm::{
     context::{Cfg, ContextTr},
-    handler::{EthPrecompiles, PrecompileProvider},
-    interpreter::{CallInputs, Gas, InstructionResult, InterpreterResult},
+    handler::{EthPrecompiles, PrecompileProvider, precompile_output_to_interpreter_result},
+    interpreter::{CallInputs, InterpreterResult},
     precompile::{
         EthPrecompileResult, PrecompileError, PrecompileOutput, Precompiles, bls12_381_const, bn254,
     },
@@ -102,12 +102,6 @@ where
         context: &mut CTX,
         inputs: &CallInputs,
     ) -> Result<Option<Self::Output>, String> {
-        let mut result = InterpreterResult {
-            result: InstructionResult::Return,
-            gas: Gas::new(inputs.gas_limit),
-            output: Bytes::new(),
-        };
-
         use revm::context::LocalContextTr;
         let input = match &inputs.input {
             revm::interpreter::CallInput::Bytes(bytes) => bytes.clone(),
@@ -137,27 +131,10 @@ where
                 return Ok(None);
             };
 
-        if output.is_halt() {
-            result.gas.spend_all();
-            result.result = if output.halt_reason().is_some_and(|r| r.is_oog()) {
-                InstructionResult::PrecompileOOG
-            } else {
-                InstructionResult::PrecompileError
-            };
-        } else if result.gas.record_regular_cost(output.gas_used) {
-            result.result = InstructionResult::Return;
-            result.output = output.bytes;
-        } else {
-            // Mirror revm's `EthPrecompiles::run`: a precompile reporting more gas than the
-            // call limit gracefully out-of-gases instead of panicking. Unreachable for the
-            // registered precompile set (each checks cost <= gas_limit before returning `Ok`),
-            // but matching upstream keeps the FPVM and op-reth aligned by construction and
-            // avoids halting the fault-proof program on a future precompile that omits the check.
-            result.gas.spend_all();
-            result.result = InstructionResult::PrecompileOOG;
-        }
-
-        Ok(Some(result))
+        // Turning the output into an interpreter result is revm's job, not ours: every field it
+        // sets on the result gas has to reach the caller frame the same way it does under
+        // `EthPrecompiles`, which op-reth uses.
+        Ok(Some(precompile_output_to_interpreter_result(output, inputs.gas_limit)))
     }
 
     #[inline]
@@ -331,18 +308,29 @@ mod test {
     use kona_preimage::{HintWriterClient, PreimageOracleClient};
     use op_revm::{L1BlockInfo, OpSpecId, OpTransaction};
     use revm::{
-        Context, MainContext, database::EmptyDB, handler::PrecompileProvider,
-        interpreter::CallInput,
+        Context, MainContext,
+        database::EmptyDB,
+        handler::PrecompileProvider,
+        interpreter::{CallInput, InstructionResult},
     };
 
     type TestContext = OpEvmContext<EmptyDB>;
 
     fn create_call_inputs(address: Address, input: Bytes, gas_limit: u64) -> CallInputs {
+        create_call_inputs_with_reservoir(address, input, gas_limit, 0)
+    }
+
+    fn create_call_inputs_with_reservoir(
+        address: Address,
+        input: Bytes,
+        gas_limit: u64,
+        reservoir: u64,
+    ) -> CallInputs {
         CallInputs {
             input: CallInput::Bytes(input),
             return_memory_offset: 0..0,
             gas_limit,
-            reservoir: 0,
+            reservoir,
             bytecode_address: address,
             known_bytecode: (revm::primitives::KECCAK_EMPTY, revm::bytecode::Bytecode::new()),
             target_address: Address::ZERO,
@@ -513,6 +501,62 @@ mod test {
         let interpreter_result = result.unwrap();
         assert_eq!(interpreter_result.result, InstructionResult::Return);
         assert!(!interpreter_result.output.is_empty());
+    }
+
+    /// At every address it does not accelerate, this provider is a pass-through to the
+    /// [`EthPrecompiles`] it wraps — the one op-reth runs — so it has to hand back exactly what
+    /// that provider would. Compares the whole [`InterpreterResult`], gas tracker included,
+    /// rather than the few fields any one test happens to look at: the conversion from
+    /// [`PrecompileOutput`] carries more state than a returned status and gas cost.
+    #[test]
+    fn test_non_accelerated_result_matches_wrapped_provider() {
+        let (hint_chan, preimage_chan) = (
+            kona_preimage::BidirectionalChannel::new().unwrap(),
+            kona_preimage::BidirectionalChannel::new().unwrap(),
+        );
+        let hint_writer = kona_preimage::HintWriter::new(hint_chan.client);
+        let oracle_reader = kona_preimage::OracleReader::new(preimage_chan.client);
+
+        let mut ctx = create_test_context();
+
+        let mut precompiles =
+            OpFpvmPrecompiles::new_with_spec(OpSpecId::KARST, hint_writer, oracle_reader);
+        let mut wrapped = precompiles.inner.clone();
+
+        // Neither address is accelerated at KARST. SHA-256 (0x02) succeeds, or runs out of gas
+        // when the call forwards none; blake2f (0x09) rejects any input that is not exactly 213
+        // bytes, halting for a reason that is not out-of-gas. Each is driven with and without a
+        // reservoir on the call.
+        let sha256 = revm::precompile::u64_to_address(2);
+        let blake2f = revm::precompile::u64_to_address(9);
+        let cases: [(Address, &[u8], u64, u64); 6] = [
+            (sha256, b"hello world", 100_000, 0),
+            (sha256, b"hello world", 100_000, 4_096),
+            (sha256, b"hello world", 0, 0),
+            (sha256, b"hello world", 0, 4_096),
+            (blake2f, b"too short", 100_000, 0),
+            (blake2f, b"too short", 100_000, 4_096),
+        ];
+
+        for (address, input, gas_limit, reservoir) in cases {
+            let call_inputs = create_call_inputs_with_reservoir(
+                address,
+                input.to_vec().into(),
+                gas_limit,
+                reservoir,
+            );
+
+            let ours = precompiles.run(&mut ctx, &call_inputs).unwrap();
+            let theirs =
+                PrecompileProvider::<TestContext>::run(&mut wrapped, &mut ctx, &call_inputs)
+                    .unwrap();
+
+            assert_eq!(
+                ours, theirs,
+                "diverged from the wrapped provider at {address} with gas limit {gas_limit} \
+                 and reservoir {reservoir}",
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Deposit transactions are force-included from L1 and are not subject to EIP-7825's per-transaction gas limit cap. This change hardens the implementation by lifting the cap in `OpEvm::transact_raw` too so no future upstream changes can interfere with this rule.

A second commit retires a hand-rolled copy in kona's FPVM precompile provider: it built its own `InterpreterResult` from a `PrecompileOutput` instead of calling revm's `precompile_output_to_interpreter_result`. Delegating to revm removes the copy, so there is nothing left to keep in sync.

🤖 _Co-created with Claude Opus 5_