### PR TITLE
ci: update machine and docker builder base images

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -2498,7 +2498,7 @@ jobs:
 
   stale-check:
     machine:
-      image: ubuntu-2204:2024.08.1
+      image: ubuntu-2404:2026.05.1
     steps:
       - utils/github-stale:
           stale-issue-message: "This issue has been automatically marked as stale and will
@@ -2514,7 +2514,7 @@ jobs:
 
   close-issue:
     machine:
-      image: ubuntu-2204:2024.08.1
+      image: ubuntu-2404:2026.05.1
     parameters:
       label_name:
         type: string

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -2498,7 +2498,7 @@ jobs:
 
   stale-check:
     machine:
-      image: ubuntu-2404:2026.05.1
+      image: ubuntu-2604:2026.07.1
     steps:
       - utils/github-stale:
           stale-issue-message: "This issue has been automatically marked as stale and will
@@ -2514,7 +2514,7 @@ jobs:
 
   close-issue:
     machine:
-      image: ubuntu-2404:2026.05.1
+      image: ubuntu-2604:2026.07.1
     parameters:
       label_name:
         type: string

--- a/rust/kona/docker/apps/kona_app_generic.dockerfile
+++ b/rust/kona/docker/apps/kona_app_generic.dockerfile
@@ -5,7 +5,7 @@ ARG BUILDER_VARIANT=default
 #   Dependency Installation    #
 #            Stage             #
 ################################
-FROM ubuntu:22.04 AS dep-setup-stage
+FROM ubuntu:24.04 AS dep-setup-stage
 SHELL ["/bin/bash", "-c"]
 
 # Install deps

--- a/rust/kona/docker/asterisc/asterisc.dockerfile
+++ b/rust/kona/docker/asterisc/asterisc.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 ENV SHELL=/bin/bash
 ENV DEBIAN_FRONTEND noninteractive

--- a/rust/kona/docker/cannon/cannon.dockerfile
+++ b/rust/kona/docker/cannon/cannon.dockerfile
@@ -1,4 +1,5 @@
-FROM ubuntu:24.04
+# Debian base: Ubuntu dropped the big-endian MIPS64 cross toolchain after 24.04.
+FROM debian:trixie-slim
 
 ENV SHELL=/bin/bash
 ENV DEBIAN_FRONTEND=noninteractive

--- a/rust/kona/docker/cannon/cannon.dockerfile
+++ b/rust/kona/docker/cannon/cannon.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 ENV SHELL=/bin/bash
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
## Description

Refreshes the aging base images across CI and the docker builder images:

- **CircleCI machine image** (`stale-check`, `close-issue` jobs): `ubuntu-2204:2024.08.1` → `ubuntu-2604:2026.07.1` (latest pinned stable tag)
- **cannon-builder** (`cannon.dockerfile`): `ubuntu:22.04` → `debian:trixie-slim` — Ubuntu 26.04 dropped the big-endian MIPS64 cross toolchain (`g++-mips64-linux-gnuabi64`, `libc6-dev-mips64-cross`), so 24.04 was the end of the line on Ubuntu; Debian trixie ships the full toolchain (GCC 14 lineage)
- **asterisc builder** (`asterisc.dockerfile`): `ubuntu:22.04` → `ubuntu:24.04`
- **kona app build stage** (`kona_app_generic.dockerfile`): `ubuntu:22.04` → `ubuntu:24.04` (runtime stage stays on wolfi-base)

Left alone: GHA runners and `images.apko.json` (already on 24.04), the `kona-node-dev` recipes (`ubuntu:latest`), and `rust/op-reth/DockerfileOp.cross` (unreferenced in-repo; handled separately).

## Prestate reproducibility note

The reproducible prestate build is **unaffected for now**: `cannon-repro.dockerfile` pins the published `cannon-builder:v2.0.0` image, not the Dockerfile, and cannon-builder is only republished on an explicit `cannon-builder/vX` tag plus manual dispatch. This change takes effect at the next cannon-builder release, which moves the MIPS64 cross-toolchain from Ubuntu jammy's GCC 11 to Debian trixie's GCC 14 — new prestate hashes are expected then, as with any builder republish (apt packages are not pinned).

## Tests

Merged CircleCI config validates clean (`merge-configs.sh` + `circleci config validate --org gh/ethereum-optimism`). Verified against the archive indexes that Debian trixie ships `g++-mips64-linux-gnuabi64` / `libc6-dev-mips64-cross` and that Ubuntu noble ships `g++-riscv64-linux-gnu`. Wiz scanners are green on the head commit; its IaC style findings (apt version pinning, root in build stages) are ignored with reasons on the threads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)