### PR TITLE
ci: remove post-merge image builds

### DIFF
--- a/.github/workflows/build-images.apko.yaml
+++ b/.github/workflows/build-images.apko.yaml
@@ -5,8 +5,6 @@ name: build-images.apko
 
 on:
   push:
-    branches:
-      - develop
     tags:
       - "*/v*"
       - "op-reth/bench*"
@@ -27,12 +25,15 @@ on:
       - ".github/images.apko.json"
       - "apko/**"
       - "melange/**"
+  # Publish the full development image catalog once per night instead of after
+  # every merge to develop. A unique concurrency key below ensures that a
+  # scheduled build cannot be superseded while it is waiting to run.
   schedule:
     - cron: "0 2 * * *"
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'schedule' && github.run_id || github.ref }}
   cancel-in-progress: false
 
 env:


### PR DESCRIPTION
## Summary

Remove the trigger that starts a full-catalog APKO image build after every merge to `develop`.

Keep the existing 02:00 UTC nightly schedule, but give each scheduled run a unique concurrency key so another workflow invocation cannot supersede it while it is pending. Release-tag builds, path-filtered PR builds, and manual dispatches remain unchanged.

## Rationale

A full development image build takes longer than the typical interval between merges. `cancel-in-progress: false` protects the active build, but GitHub Actions retains only one pending run per concurrency group; each subsequent merge replaces the previous pending `develop` run. Most post-merge SHAs therefore never produce images despite repeatedly scheduling the full catalog.

Removing the post-merge trigger avoids that churn. Making the existing nightly runs concurrency-isolated ensures each scheduled development snapshot gets an opportunity to run to completion.

## Validation

- Parsed `.github/workflows/build-images.apko.yaml` with Ruby YAML
- Inspected the resulting triggers and concurrency configuration with `yq`
- Ran `actionlint` 1.7.7, ignoring its pre-existing diagnostics for the repository-specific `ubuntu-slim` runner and `artifact-metadata` permission scope
