### PR TITLE
docs: add subblocks notice

### DIFF
--- a/docs/public-docs/docs.json
+++ b/docs/public-docs/docs.json
@@ -3611,7 +3611,8 @@
               {
                 "group": "Operations",
                 "pages": [
-                  "notices/specialized-node-topology"
+                  "notices/specialized-node-topology",
+                  "notices/subblocks"
                 ]
               },
               "notices/archive/index"

--- a/docs/public-docs/notices/index.mdx
+++ b/docs/public-docs/notices/index.mdx
@@ -53,4 +53,7 @@ notices are archived after activation, registry pages are forever.
   <Card title="Specialized Node Topology" href="/notices/specialized-node-topology" icon="circle-info" horizontal>
     Guidance for Supernode and Light CL node topology
   </Card>
+  <Card title="Flashblocks evolve into subblocks" href="/notices/subblocks" icon="circle-info" horizontal>
+    A 200 ms subblock interval and two zeroed stream payload fields on OP Sepolia and OP Mainnet
+  </Card>
 </CardGroup>

--- a/docs/public-docs/notices/index.mdx
+++ b/docs/public-docs/notices/index.mdx
@@ -53,7 +53,7 @@ notices are archived after activation, registry pages are forever.
   <Card title="Specialized Node Topology" href="/notices/specialized-node-topology" icon="circle-info" horizontal>
     Guidance for Supernode and Light CL node topology
   </Card>
-  <Card title="Flashblocks evolve into subblocks" href="/notices/subblocks" icon="circle-info" horizontal>
+  <Card title="Subblocks: 200 ms interval and payload changes" href="/notices/subblocks" icon="circle-info" horizontal>
     A 200 ms subblock interval and four zeroed stream payload fields on OP Sepolia and OP Mainnet
   </Card>
 </CardGroup>

--- a/docs/public-docs/notices/index.mdx
+++ b/docs/public-docs/notices/index.mdx
@@ -54,6 +54,6 @@ notices are archived after activation, registry pages are forever.
     Guidance for Supernode and Light CL node topology
   </Card>
   <Card title="Flashblocks evolve into subblocks" href="/notices/subblocks" icon="circle-info" horizontal>
-    A 200 ms subblock interval and two zeroed stream payload fields on OP Sepolia and OP Mainnet
+    A 200 ms subblock interval and four zeroed stream payload fields on OP Sepolia and OP Mainnet
   </Card>
 </CardGroup>

--- a/docs/public-docs/notices/subblocks.mdx
+++ b/docs/public-docs/notices/subblocks.mdx
@@ -1,0 +1,77 @@
+---
+title: Flashblocks evolve into subblocks
+description: Subblocks bring a 200 ms interval to OP Sepolia and OP Mainnet, and zero two fields in the stream payload.
+date: 2026-08-14
+diataxis: reference
+lang: en-US
+content_type: notice
+topic: subblocks
+personas:
+  - app-developer
+  - node-operator
+categories:
+  - protocol
+  - infrastructure
+is_imported_content: 'false'
+audit-source:
+  - rust/rollup-boost/crates/rollup-boost/src/flashblocks/primitives.rs
+---
+
+Flashblocks are evolving into *subblocks*, a more native in-house implementation of pre-confirmation streaming.
+The change brings a shorter subblock interval and four zeroed fields in the stream payload.
+Both apply to OP Sepolia and OP Mainnet.
+
+<Warning>
+  The subblock stream sets `state_root`, `block_hash`, `withdrawals_root`, and `withdrawals` to their zero value.
+  The stream remains wire compatible, so reads return a zero value rather than raising an error.
+  Audit stream integrations before **August 14, 2026**.
+</Warning>
+
+## What this means
+
+*   **The interval drops from 250 ms to 200 ms.** This brings OP Sepolia and OP Mainnet to `FLASHBLOCKS_TIME = 200ms`, the default in the [Flashblocks specification](https://specs.optimism.io/protocol/flashblocks.html).
+*   **Four payload fields are set to their zero value.** All four remain present in `ExecutionPayloadFlashblockDeltaV1`. Nothing is removed from the wire format.
+*   **Every other field, including `receipts_root` and `logs_bloom`, continues to carry a real value.**
+
+| Field | Zero value on the stream |
+| --- | --- |
+| `state_root` | `0x0000...0000` |
+| `block_hash` | `0x0000...0000` |
+| `withdrawals_root` | `0x0000...0000` |
+| `withdrawals` | `[]` |
+
+The failure mode is silent.
+An integration that reads any of these fields receives a zero value and continues, rather than failing loudly at the parse boundary.
+Audit for these reads directly instead of waiting for an error to surface.
+
+## The rollout is gradual
+
+This is not a hardfork, and there is no single activation point.
+The change rolls out incrementally across the sequencer fleet, converging on all subblock sequencers.
+During a rollout window, the stream may reflect either the previous or the new behavior, depending on which sequencer produced a given subblock.
+Handle both until the rollout completes.
+
+## Action required
+
+For teams consuming the subblock stream directly:
+
+*   Audit integrations for reads of `state_root`, `block_hash`, `withdrawals_root`, and `withdrawals`.
+*   Confirm that a zero value in any of them cannot propagate into downstream state, balances, or proofs.
+*   RPC providers that forward stream payloads to their own consumers should pass this notice on to those consumers.
+
+## Timeline
+
+| Network | Target rollout |
+| --- | --- |
+| OP Sepolia | August 14, 2026 |
+| OP Mainnet | August 19, 2026 |
+
+Both dates are targets and may move.
+
+## Key links
+
+| Resource | Link |
+| --- | --- |
+| Flashblocks specification | [specs.optimism.io](https://specs.optimism.io/protocol/flashblocks.html) |
+| Flashblocks explainer | [How Flashblocks work](/op-stack/features/flashblocks) |
+| App integration guide | [Integrate Flashblocks in your app](/app-developers/guides/transactions/integrating-flashblocks) |

--- a/docs/public-docs/notices/subblocks.mdx
+++ b/docs/public-docs/notices/subblocks.mdx
@@ -1,6 +1,6 @@
 ---
-title: Flashblocks evolve into subblocks
-description: Subblocks bring a 200 ms interval to OP Sepolia and OP Mainnet, and zero four fields in the stream payload.
+title: "Subblocks: 200 ms interval and stream payload changes"
+description: Subblocks (formerly Flashblocks) move to a 200 ms interval on OP Sepolia and OP Mainnet, and zero four fields in the stream payload.
 date: 2026-08-14
 diataxis: reference
 lang: en-US
@@ -17,9 +17,10 @@ audit-source:
   - rust/rollup-boost/crates/rollup-boost/src/flashblocks/primitives.rs
 ---
 
-Flashblocks are evolving into *subblocks*, a more native in-house implementation of pre-confirmation streaming.
-The change brings a shorter subblock interval and four zeroed fields in the stream payload.
-Both apply to OP Sepolia and OP Mainnet.
+Subblocks (formerly Flashblocks) stream pre-confirmations on OP Stack chains.
+Two changes are rolling out to OP Sepolia and OP Mainnet: the subblock interval drops from 250 ms to 200 ms, and four fields in the stream payload are set to their zero value.
+
+The stream keeps its existing wire format, and the payload type is still named `ExecutionPayloadFlashblockDeltaV1`.
 
 <Warning>
   The subblock stream sets `state_root`, `block_hash`, `withdrawals_root`, and `withdrawals` to their zero value.

--- a/docs/public-docs/notices/subblocks.mdx
+++ b/docs/public-docs/notices/subblocks.mdx
@@ -1,6 +1,6 @@
 ---
 title: Flashblocks evolve into subblocks
-description: Subblocks bring a 200 ms interval to OP Sepolia and OP Mainnet, and zero two fields in the stream payload.
+description: Subblocks bring a 200 ms interval to OP Sepolia and OP Mainnet, and zero four fields in the stream payload.
 date: 2026-08-14
 diataxis: reference
 lang: en-US

--- a/docs/public-docs/notices/subblocks.mdx
+++ b/docs/public-docs/notices/subblocks.mdx
@@ -41,9 +41,8 @@ The stream keeps its existing wire format, and the payload type is still named `
 | `withdrawals_root` | `0x0000...0000` |
 | `withdrawals` | `[]` |
 
-The failure mode is silent.
 An integration that reads any of these fields receives a zero value and continues, rather than failing loudly at the parse boundary.
-Audit for these reads directly instead of waiting for an error to surface.
+We recommend you audit your application or integration for these reads directly ahead of the migration.
 
 ## The rollout is gradual
 

--- a/docs/public-docs/notices/subblocks.mdx
+++ b/docs/public-docs/notices/subblocks.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Subblocks: 200 ms interval and stream payload changes"
 description: Subblocks (formerly Flashblocks) move to a 200 ms interval on OP Sepolia and OP Mainnet, and zero four fields in the stream payload.
-date: 2026-08-14
+date: 2026-08-17
 diataxis: reference
 lang: en-US
 content_type: notice
@@ -25,7 +25,7 @@ The stream keeps its existing wire format, and the payload type is still named `
 <Warning>
   The subblock stream sets `state_root`, `block_hash`, `withdrawals_root`, and `withdrawals` to their zero value.
   The stream remains wire compatible, so reads return a zero value rather than raising an error.
-  Audit stream integrations before **August 14, 2026**.
+  Audit stream integrations before **August 17, 2026**.
 </Warning>
 
 ## What this means
@@ -46,10 +46,7 @@ We recommend you audit your application or integration for these reads directly 
 
 ## The rollout is gradual
 
-This is not a hardfork, and there is no single activation point.
-The change rolls out incrementally across the sequencer fleet, converging on all subblock sequencers.
-During a rollout window, the stream may reflect either the previous or the new behavior, depending on which sequencer produced a given subblock.
-Handle both until the rollout completes.
+This is a rolling change rather than a single switch, so you may see both the previous and the new behavior for a period.
 
 ## Action required
 
@@ -63,8 +60,8 @@ For teams consuming the subblock stream directly:
 
 | Network | Target rollout |
 | --- | --- |
-| OP Sepolia | August 14, 2026 |
-| OP Mainnet | August 19, 2026 |
+| OP Sepolia | August 17, 2026 |
+| OP Mainnet | August 31, 2026 |
 
 Both dates are targets and may move.
 


### PR DESCRIPTION
## Summary

New notice: the subblock interval drops from 250 ms to 200 ms, and four stream payload fields are set to their zero value. Rolling out to OP Sepolia on Aug 17 and OP Mainnet on Aug 31.

Naming follows the Aug 12 comms sync: **Subblocks** is canonical across all surfaces, written one word, introduced once as "Subblocks (formerly Flashblocks)". The page does not narrate the transition. `ExecutionPayloadFlashblockDeltaV1` and `FLASHBLOCKS_TIME` keep their Flashblock names deliberately — engineering is not renaming in the codebase, and those are the identifiers a stream consumer greps for.

Audience is teams consuming the pre-confirmation stream directly.

| File | Change |
|---|---|
| `notices/subblocks.mdx` | New notice |
| `docs.json` | Entry in the Notices → Operations group |
| `notices/index.mdx` | Card under Operations, per that page's maintenance contract |

## What to review

1. **Field list completeness.** The notice names `state_root`, `block_hash`, `withdrawals_root`, and `withdrawals`. Derived from `ExecutionPayloadFlashblockDeltaV1` in `rust/rollup-boost/crates/rollup-boost/src/flashblocks/primitives.rs`. Confirm nothing is missing.

2. **Surface scoping.** The notice scopes the zeroed fields to the WebSocket stream payload only, on the basis that consuming nodes locally substitute `state_root` and `block_hash`. If the zeros also reach JSON-RPC `pending` responses, the affected audience is much broader and the FAQ entry at `op-stack/features/flashblocks.mdx:136` ("`stateRoot` … represents the cumulative state") becomes incorrect.

3. **Zero representations differ.** Three fields are `B256` → `0x0000...0000`; `withdrawals` is a list → `[]`. The notice tables this so consumers write the right check.

## Out of scope

- **250 ms figures in `op-stack/features/flashblocks.mdx`** (lines 7, 41, 81, 92, 93). Accurate until the Aug 19 Mainnet rollout — updating now would make the explainer wrong in the interim. Follow-up PR after rollout confirms.
- **Docs-wide Flashblocks → Subblocks rename** across the five existing pages. Tracked as a follow-up; the spec at specs.optimism.io still says Flashblocks regardless.
- **"No node upgrade required."** Omitted rather than asserted unsourced.

## Test plan

- [ ] `mintlify dev` renders the page and the Notices → Operations sidebar group.
- [ ] Internal links resolve (2/2 at commit time).
- [ ] `docs.json` parses.
- [ ] Eng sign-off on the field list and the stream-only scoping.


