### PR TITLE
ci: build op-reth and Kona image binaries once

### DIFF
--- a/melange/op-stack-rust.yaml
+++ b/melange/op-stack-rust.yaml
@@ -2,9 +2,9 @@
 # op-reth live in the same cargo workspace (rust/) with a single Cargo.lock,
 # so one melange run shares the whole common dependency graph (alloy,
 # op-alloy, revm, ...) across all five binaries instead of compiling it once
-# per CI leg. Subpackage builds run sequentially in one sandbox with a shared
-# target dir: the first build does the heavy lifting, the rest are
-# incremental.
+# per CI leg. The main pipeline builds all five binaries once into a shared
+# target dir, then the ordered subpackage pipelines install those outputs into
+# separate APKs.
 #
 # Each binary is its own subpackage/APK so images pull only what they run:
 # each Kona image pulls its matching binary, while op-challenger pulls just
@@ -45,24 +45,27 @@ environment:
     CARGO_HOME: /var/cache/melange/cargo
     CARGO_TARGET_DIR: /var/cache/melange/target
 
+# Melange runs the main pipeline before subpackage pipelines. Build all five
+# main-workspace binaries here so each subpackage below only packages an
+# existing output. Selecting one package at a time changes feature unification
+# and can make Cargo recompile and relink outputs from the combined command.
+pipeline:
+  - uses: cargo/build
+    with:
+      install-output: "false"
+      modroot: rust
+      profile: "${MELANGE_CARGO_PROFILE}"
+      opts: --locked --package op-reth --package kona-node --package kona-host --package kona-client --package kona-sp1-proposer
+
 subpackages:
-  # The first subpackage builds ALL five packages in one cargo invocation:
-  # one scheduler pass over the whole workspace graph keeps every core busy
-  # instead of serializing five builds. The later subpackages install those
-  # outputs directly from the shared target dir. Do not invoke Cargo again:
-  # selecting one package at a time changes feature unification and can make
-  # Cargo recompile and relink workspace crates built by the combined command.
   - name: op-reth
     description: op-reth — OP Stack Reth execution client
     pipeline:
-      - uses: cargo/build
-        with:
-          # /usr/local/bin, where upstream's images install binaries.
-          prefix: usr/local
-          modroot: rust
-          output: op-reth
-          profile: "${MELANGE_CARGO_PROFILE}"
-          opts: --locked --package op-reth --package kona-node --package kona-host --package kona-client --package kona-sp1-proposer
+      - runs: |
+          profile="${MELANGE_CARGO_PROFILE:-release}"
+          install -Dm755 \
+            "${CARGO_TARGET_DIR}/rust/${profile}/op-reth" \
+            "${{targets.contextdir}}/usr/local/bin/op-reth"
       - uses: strip
 
   - name: kona-node

--- a/melange/op-stack-rust.yaml
+++ b/melange/op-stack-rust.yaml
@@ -48,9 +48,10 @@ environment:
 subpackages:
   # The first subpackage builds ALL five packages in one cargo invocation:
   # one scheduler pass over the whole workspace graph keeps every core busy
-  # instead of serializing five builds. The shared target dir persists across
-  # subpackages, so the later four cargo runs are no-op fingerprint checks
-  # followed by an install.
+  # instead of serializing five builds. The later subpackages install those
+  # outputs directly from the shared target dir. Do not invoke Cargo again:
+  # selecting one package at a time changes feature unification and can make
+  # Cargo recompile and relink workspace crates built by the combined command.
   - name: op-reth
     description: op-reth — OP Stack Reth execution client
     pipeline:
@@ -67,53 +68,41 @@ subpackages:
   - name: kona-node
     description: kona-node — OP Stack Kona rollup node
     pipeline:
-      - uses: cargo/build
-        with:
-          # /usr/local/bin, where upstream's images install binaries.
-          prefix: usr/local
-          modroot: rust
-          output: kona-node
-          profile: "${MELANGE_CARGO_PROFILE}"
-          opts: --locked --package kona-node
+      - runs: |
+          profile="${MELANGE_CARGO_PROFILE:-release}"
+          install -Dm755 \
+            "${CARGO_TARGET_DIR}/rust/${profile}/kona-node" \
+            "${{targets.contextdir}}/usr/local/bin/kona-node"
       - uses: strip
 
   - name: kona-host
     description: kona-host — OP Stack Kona fault proof host
     pipeline:
-      - uses: cargo/build
-        with:
-          # /usr/local/bin, where upstream's images install binaries.
-          prefix: usr/local
-          modroot: rust
-          output: kona-host
-          profile: "${MELANGE_CARGO_PROFILE}"
-          opts: --locked --package kona-host
+      - runs: |
+          profile="${MELANGE_CARGO_PROFILE:-release}"
+          install -Dm755 \
+            "${CARGO_TARGET_DIR}/rust/${profile}/kona-host" \
+            "${{targets.contextdir}}/usr/local/bin/kona-host"
       - uses: strip
 
   - name: kona-client
     description: kona-client — OP Stack Kona fault proof client
     pipeline:
-      - uses: cargo/build
-        with:
-          # /usr/local/bin, where upstream's images install binaries.
-          prefix: usr/local
-          modroot: rust
-          output: kona-client
-          profile: "${MELANGE_CARGO_PROFILE}"
-          opts: --locked --package kona-client
+      - runs: |
+          profile="${MELANGE_CARGO_PROFILE:-release}"
+          install -Dm755 \
+            "${CARGO_TARGET_DIR}/rust/${profile}/kona-client" \
+            "${{targets.contextdir}}/usr/local/bin/kona-client"
       - uses: strip
 
   - name: kona-sp1-proposer
     description: kona-sp1-proposer — OP Stack SP1 fault proof proposer
     pipeline:
-      - uses: cargo/build
-        with:
-          # /usr/local/bin, where upstream's images install binaries.
-          prefix: usr/local
-          modroot: rust
-          output: kona-sp1-proposer
-          profile: "${MELANGE_CARGO_PROFILE}"
-          opts: --locked --package kona-sp1-proposer
+      - runs: |
+          profile="${MELANGE_CARGO_PROFILE:-release}"
+          install -Dm755 \
+            "${CARGO_TARGET_DIR}/rust/${profile}/kona-sp1-proposer" \
+            "${{targets.contextdir}}/usr/local/bin/kona-sp1-proposer"
       - uses: strip
 
   # The monorepo vendors op-rbuilder and rollup-boost as NESTED workspaces

--- a/melange/pipelines/cargo/build.yaml
+++ b/melange/pipelines/cargo/build.yaml
@@ -55,6 +55,12 @@ inputs:
       Directory where binaries will be installed
     default: bin
 
+  install-output:
+    description: |
+      Whether to install Cargo's output into the package context after building.
+      Set to false for a build-only pipeline whose subpackages install the outputs.
+    default: "true"
+
   output-dir:
     description: |
       Directory where the binaris will be placed after building. Defaults to target/release
@@ -143,8 +149,17 @@ pipeline:
       RUSTFLAGS="${{inputs.rustflags}}" $run_wrap cargo auditable build \
         $profile_flag $build_opts $jobs_flag
 
-      if [ -n "${{inputs.output}}" ]; then
-        install -Dm755 "${OUTPUT_PATH}/${{inputs.output}}" "${INSTALL_PATH}/${{inputs.output}}"
-      else
-        install -Dm755 "${OUTPUT_PATH}"/* -t "${INSTALL_PATH}"
-      fi
+      case "${{inputs.install-output}}" in
+        true)
+          if [ -n "${{inputs.output}}" ]; then
+            install -Dm755 "${OUTPUT_PATH}/${{inputs.output}}" "${INSTALL_PATH}/${{inputs.output}}"
+          else
+            install -Dm755 "${OUTPUT_PATH}"/* -t "${INSTALL_PATH}"
+          fi
+          ;;
+        false) ;;
+        *)
+          echo "install-output must be true or false" >&2
+          exit 1
+          ;;
+      esac

--- a/rust/op-rbuilder/Cargo.lock
+++ b/rust/op-rbuilder/Cargo.lock
@@ -7945,7 +7945,6 @@ dependencies = [
  "op-alloy-consensus",
  "serde",
  "sha2",
- "snap",
  "thiserror 2.0.18",
 ]
 

--- a/rust/rollup-boost/Cargo.lock
+++ b/rust/rollup-boost/Cargo.lock
@@ -6084,7 +6084,6 @@ dependencies = [
  "op-alloy-consensus",
  "serde",
  "sha2",
- "snap",
  "thiserror 2.0.18",
 ]
 


### PR DESCRIPTION
## Summary

Build `op-reth` and all four Kona binaries once in the top-level `op-stack-rust` Melange pipeline, then have all five ordered subpackages install their existing outputs into separate APKs.

The shared `cargo/build` pipeline gains an `install-output` switch so the top-level pipeline can compile without placing a binary in the empty meta-package. `op-rbuilder` and `rollup-boost` remain separate because they are nested Cargo workspaces. Their locks are also refreshed to remove the stale `snap` dependency entry that prevented both image builds from running with `--locked`.

## Rationale

The previous per-Kona Cargo invocations were intended to be fingerprint-only checks, but they select packages individually and do substantial recompilation and relinking. In [development image run 31511495701](https://github.com/ethereum-optimism/optimism/actions/runs/31511495701), those four repeated builds added:

| Repeated builds | x86_64 | aarch64 |
|---|---:|---:|
| `kona-node` | 6m 49s | 7m 37s |
| `kona-host` | 4m 09s | 4m 37s |
| `kona-client` | 1m 50s | 2m 00s |
| `kona-sp1-proposer` | 18m 53s | 22m 19s |
| **Total** | **31m 41s** | **36m 33s** |

Reusing the combined build's outputs preserves separate, stripped APKs while approximately halving the Rust build's critical path:

| `maxperf` Rust leg | Before | This PR | Reduction |
|---|---:|---:|---:|
| x86_64 | 66m 34s | 35m 55s | 30m 39s (46%) |
| aarch64 | 73m 31s | 35m 16s | 38m 15s (52%) |

## Validation

- Compiled `melange/op-stack-rust.yaml` with Melange v0.50.8
- Verified the compiled pipeline runs one build-only main-workspace Cargo step followed by five direct binary installs
- Verified the default `cargo/build` path still installs outputs for the two nested workspaces
- Checked the rendered pipeline scripts with `sh -n`
- Verified both nested workspaces resolve successfully with `cargo metadata --locked`
- [Built the full image catalog on both architectures, published every image, and passed every smoke test](https://github.com/ethereum-optimism/optimism/actions/runs/31545172248)
- Parsed the YAML and ran `git diff --check`
