### PR TITLE
rust: refresh op-rbuilder and rollup-boost lockfiles

### DIFF
--- a/rust/op-rbuilder/Cargo.lock
+++ b/rust/op-rbuilder/Cargo.lock
@@ -7945,7 +7945,6 @@ dependencies = [
  "op-alloy-consensus",
  "serde",
  "sha2",
- "snap",
  "thiserror 2.0.18",
 ]
 

--- a/rust/rollup-boost/Cargo.lock
+++ b/rust/rollup-boost/Cargo.lock
@@ -6084,7 +6084,6 @@ dependencies = [
  "op-alloy-consensus",
  "serde",
  "sha2",
- "snap",
  "thiserror 2.0.18",
 ]
 


### PR DESCRIPTION
## Summary

- remove the stale `snap` dependency edge from the vendored `op-rbuilder` and `rollup-boost` lockfiles after #22305 removed it from `op-alloy-rpc-types-engine`
- restore the Cargo 1.97 `--locked` builds for both stages of the `op-stack-rust` melange image

## Test plan

- red on `origin/develop`: Cargo 1.97.1 locked dependency resolution fails for both nested workspaces
- `cargo +1.97.1 tree --manifest-path rust/op-rbuilder/Cargo.toml --locked --offline --package op-rbuilder`
- `cargo +1.97.1 tree --manifest-path rust/rollup-boost/Cargo.toml --locked --offline --package rollup-boost`
- `cargo +1.97.1 build --manifest-path rust/op-rbuilder/Cargo.toml --release --locked --package op-rbuilder`
- `cargo +1.97.1 build --manifest-path rust/rollup-boost/Cargo.toml --release --locked --package rollup-boost`
- `cd rust/op-rbuilder && mise exec -- just lint`
- `cd rust/rollup-boost && mise exec -- make lint`
- `git diff --check`