### PR TITLE
mise: fix missing rust 1.95.0 warning

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -7,7 +7,7 @@ golangci-lint = "2.8.0"
 gotestsum = "1.12.3"
 mockery = "2.53.6"
 rust = [
-  { version = "1.95.0", components = "clippy,rustfmt,llvm-tools-preview", targets = "riscv32imac-unknown-none-elf,wasm32-unknown-unknown,wasm32-wasip1" },
+  { version = "1.95.0", components = "clippy,rustfmt,llvm-tools", targets = "riscv32imac-unknown-none-elf,wasm32-unknown-unknown,wasm32-wasip1" },
   { version = "nightly-2026-02-20", components = "rustfmt,clippy" },
 ]
 python = "3.12.13"


### PR DESCRIPTION
The `rust = "1.95.0"` pin in `mise.toml` requested the `llvm-tools-preview` component. rustup still accepts that name as a legacy install-time alias, but reports the component under its graduated name:

```
$ rustup component list --installed --toolchain 1.95.0
llvm-tools-aarch64-unknown-linux-gnu
```

Current mise verifies requested components against that listing literally, so the component never matches and the toolchain is permanently considered missing:

```
DEBUG [src/plugins/core/rust.rs:253] rust@1.95.0 missing rustup component(s): llvm-tools-preview
WARN  missing: rust@1.95.0
```

Consequences, reproduced with mise 2026.8.3 / rustup 1.29.0:

- Every `mise hook-env` warns `missing: rust@1.95.0` — i.e. on every directory change in an activated shell.
- Every `mise install` re-runs `rustup toolchain install 1.95.0` and re-syncs the channel instead of hitting the already-installed fast path, so each CI job that runs `utils/install-mise` pays for it.

Requesting `llvm-tools` fixes both. What gets installed is unchanged — rustup resolves the two names to the same component — and `cargo-llvm-cov`, the consumer of those binaries, is unaffected. `llvm-tools-preview` appeared nowhere else in the repo.

Verified: with the old spelling `mise hook-env` warns and `mise install` re-installs; with the new spelling `mise hook-env` is silent, `mise ls --missing` is empty, and `mise install` reports `all tools are installed`.