### PR TITLE
feat: Keccak256 alt-DA without a challenge contract + op-supernode HTTP remote interop nodes

### DIFF
--- a/op-alt-da/damgr.go
+++ b/op-alt-da/damgr.go
@@ -54,7 +54,7 @@ type HeadSignalFn func(eth.L1BlockRef)
 
 // Config is the relevant subset of rollup config for AltDA.
 type Config struct {
-	// Required for filtering contract events
+	// DAChallengeContractAddress filters challenge contract events. Zero means no challenge contract.
 	DAChallengeContractAddress common.Address
 	// Allowed CommitmentType
 	CommitmentType CommitmentType
@@ -410,7 +410,7 @@ func (d *DA) loadChallengeEvents(ctx context.Context, l1 L1Fetcher, block eth.Bl
 func (d *DA) fetchChallengeLogs(ctx context.Context, l1 L1Fetcher, block eth.BlockID) ([]*types.Log, error) {
 	var logs []*types.Log
 	// Don't look at the challenge contract if there is no challenge contract.
-	if d.cfg.CommitmentType == GenericCommitmentType {
+	if d.cfg.DAChallengeContractAddress == (common.Address{}) {
 		return logs, nil
 	}
 	//cached with deposits events call so not expensive

--- a/op-alt-da/damgr_test.go
+++ b/op-alt-da/damgr_test.go
@@ -445,3 +445,37 @@ func TestAdvanceChallengeOrigin(t *testing.T) {
 	_, has = state.GetChallenge(comm, 14)
 	require.False(t, has)
 }
+
+// TestFetchChallengeLogsNoChallengeContract verifies that when DAChallengeContractAddress is zero
+// (no on-chain challenge contract), fetchChallengeLogs skips receipt scanning entirely.
+// This supports Keccak256 commitments without a challenge contract (e.g., permissioned Validium with ZK proofs).
+func TestFetchChallengeLogsNoChallengeContract(t *testing.T) {
+	logger := testlog.Logger(t, log.LevelWarn)
+	ctx := context.Background()
+
+	l1F := &mockL1Fetcher{}
+	defer l1F.AssertExpectations(t)
+
+	storage := NewMockDAClient(logger)
+
+	// Keccak256 commitment type with no challenge contract
+	pcfg := Config{
+		ChallengeWindow: 90,
+		ResolveWindow:   90,
+		CommitmentType:  Keccak256CommitmentType,
+	}
+
+	state := NewState(logger, &NoopMetrics{}, pcfg)
+	da := NewAltDAWithState(logger, pcfg, storage, &NoopMetrics{}, state)
+
+	bhash := common.HexToHash("0xd438144ffab918b1349e7cd06889c26800c26d8edc34d64f750e3e097166a09c")
+	bn := uint64(19)
+	id := eth.BlockID{Number: bn, Hash: bhash}
+
+	// No FetchReceipts expectation set — if fetchChallengeLogs tries to call it, the mock will fail.
+	err := da.AdvanceChallengeOrigin(ctx, l1F, id)
+	require.NoError(t, err)
+
+	// Verify the challenge origin was still advanced
+	require.Equal(t, bn, da.challengeOrigin.Number)
+}

--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -989,9 +989,7 @@ func (d *L1DependenciesConfig) CheckAddresses(dependencyContext DependencyContex
 		return fmt.Errorf("%w: OptimismPortalProxy cannot be address(0)", ErrInvalidDeployConfig)
 	}
 
-	if dependencyContext.UseAltDA && dependencyContext.DACommitmentType == altda.KeccakCommitmentString && d.DAChallengeProxy == (common.Address{}) {
-		return fmt.Errorf("%w: DAChallengeContract cannot be address(0) when using alt-da mode", ErrInvalidDeployConfig)
-	} else if dependencyContext.UseAltDA && dependencyContext.DACommitmentType == altda.GenericCommitmentString && d.DAChallengeProxy != (common.Address{}) {
+	if dependencyContext.UseAltDA && dependencyContext.DACommitmentType == altda.GenericCommitmentString && d.DAChallengeProxy != (common.Address{}) {
 		return fmt.Errorf("%w: DAChallengeContract must be address(0) when using generic commitments in alt-da mode", ErrInvalidDeployConfig)
 	}
 	return nil

--- a/op-node/rollup/derive/altda_data_source_test.go
+++ b/op-node/rollup/derive/altda_data_source_test.go
@@ -24,6 +24,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// testDAChallengeContract is a non-zero DA challenge contract address. The challenge
+// contract is optional for keccak commitments (a zero address means "no challenge
+// contract", and the manager then skips challenge-log lookups entirely), so the tests
+// below that exercise the challenge flow must configure a real address.
+var testDAChallengeContract = common.HexToAddress("0x00000000000000000000000000000000000dead0")
+
 type MockFinalitySignal struct {
 	mock.Mock
 }
@@ -53,7 +59,9 @@ func TestAltDADataSource(t *testing.T) {
 	storage := altda.NewMockDAClient(logger)
 
 	pcfg := altda.Config{
-		ChallengeWindow: 90, ResolveWindow: 90,
+		DAChallengeContractAddress: testDAChallengeContract,
+		ChallengeWindow:            90,
+		ResolveWindow:              90,
 	}
 	metrics := &altda.NoopMetrics{}
 
@@ -296,7 +304,9 @@ func TestAltDADataSourceStall(t *testing.T) {
 	storage := altda.NewMockDAClient(logger)
 
 	pcfg := altda.Config{
-		ChallengeWindow: 90, ResolveWindow: 90,
+		DAChallengeContractAddress: testDAChallengeContract,
+		ChallengeWindow:            90,
+		ResolveWindow:              90,
 	}
 
 	metrics := &altda.NoopMetrics{}
@@ -426,7 +436,9 @@ func TestAltDADataSourceInvalidData(t *testing.T) {
 	storage := altda.NewMockDAClient(logger)
 
 	pcfg := altda.Config{
-		ChallengeWindow: 90, ResolveWindow: 90,
+		DAChallengeContractAddress: testDAChallengeContract,
+		ChallengeWindow:            90,
+		ResolveWindow:              90,
 	}
 
 	da := altda.NewAltDAWithStorage(logger, pcfg, storage, &altda.NoopMetrics{})

--- a/op-node/rollup/types.go
+++ b/op-node/rollup/types.go
@@ -61,7 +61,8 @@ type Genesis struct {
 }
 
 type AltDAConfig struct {
-	// L1 DataAvailabilityChallenge contract proxy address
+	// L1 DataAvailabilityChallenge contract proxy address.
+	// Optional for Keccak256 commitments; must be zero for GenericCommitment.
 	DAChallengeAddress common.Address `json:"da_challenge_contract_address,omitempty"`
 	// CommitmentType specifies which commitment type can be used. Defaults to Keccak (type 0) if not present
 	CommitmentType string `json:"da_commitment_type"`
@@ -429,16 +430,14 @@ func (cfg *Config) ProbablyMissingPectraBlobSchedule() bool {
 	return pragueTime >= cfg.Genesis.L2Time
 }
 
-// validateAltDAConfig checks the two approaches to configuring alt-da mode.
-// If the legacy values are set, they are copied to the new location. If both are set, they are check for consistency.
+// validateAltDAConfig checks that the AltDA configuration is internally consistent.
+// GenericCommitment must not have a DAChallengeAddress set; Keccak256 may optionally have one.
 func validateAltDAConfig(cfg *Config) error {
 	if cfg.AltDAConfig != nil {
 		if !(cfg.AltDAConfig.CommitmentType == altda.KeccakCommitmentString || cfg.AltDAConfig.CommitmentType == altda.GenericCommitmentString) {
 			return fmt.Errorf("invalid commitment type: %v", cfg.AltDAConfig.CommitmentType)
 		}
-		if cfg.AltDAConfig.CommitmentType == altda.KeccakCommitmentString && cfg.AltDAConfig.DAChallengeAddress == (common.Address{}) {
-			return errors.New("Must set da_challenge_contract_address for keccak commitments")
-		} else if cfg.AltDAConfig.CommitmentType == altda.GenericCommitmentString && cfg.AltDAConfig.DAChallengeAddress != (common.Address{}) {
+		if cfg.AltDAConfig.CommitmentType == altda.GenericCommitmentString && cfg.AltDAConfig.DAChallengeAddress != (common.Address{}) {
 			return errors.New("Must set empty da_challenge_contract_address for generic commitments")
 		}
 	}

--- a/op-node/rollup/types_test.go
+++ b/op-node/rollup/types_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 
+	altda "github.com/ethereum-optimism/optimism/op-alt-da"
 	"github.com/ethereum-optimism/optimism/op-core/forks"
 	opparams "github.com/ethereum-optimism/optimism/op-core/params"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -1177,4 +1178,63 @@ func TestConfig_ActivateAtGenesis(t *testing.T) {
 		}
 		require.Zero(t, cfg)
 	})
+}
+
+func TestValidateAltDAConfig(t *testing.T) {
+	tests := []struct {
+		name      string
+		altDA     *AltDAConfig
+		expectErr string
+	}{
+		{
+			name:  "nil config is valid",
+			altDA: nil,
+		},
+		{
+			name: "keccak with challenge address",
+			altDA: &AltDAConfig{
+				CommitmentType:     altda.KeccakCommitmentString,
+				DAChallengeAddress: common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678"),
+			},
+		},
+		{
+			name: "keccak without challenge address",
+			altDA: &AltDAConfig{
+				CommitmentType: altda.KeccakCommitmentString,
+			},
+		},
+		{
+			name: "generic without challenge address",
+			altDA: &AltDAConfig{
+				CommitmentType: altda.GenericCommitmentString,
+			},
+		},
+		{
+			name: "generic with challenge address is invalid",
+			altDA: &AltDAConfig{
+				CommitmentType:     altda.GenericCommitmentString,
+				DAChallengeAddress: common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678"),
+			},
+			expectErr: "Must set empty da_challenge_contract_address for generic commitments",
+		},
+		{
+			name: "invalid commitment type",
+			altDA: &AltDAConfig{
+				CommitmentType: "InvalidType",
+			},
+			expectErr: "invalid commitment type: InvalidType",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{AltDAConfig: tt.altDA}
+			err := validateAltDAConfig(cfg)
+			if tt.expectErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tt.expectErr)
+			}
+		})
+	}
 }

--- a/op-supernode/config/config.go
+++ b/op-supernode/config/config.go
@@ -32,6 +32,10 @@ type CLIConfig struct {
 	// DependencySetPath is the path to a JSON dependency-set file shared by every chain
 	// managed by the supernode. Empty means fall back to per-chain registry lookup.
 	DependencySetPath string
+	// RemoteNodes lists remote interop nodes as "<chainID>=<url>" specs. Each names a
+	// chain the supernode does not drive, whose finalized initiating messages are polled
+	// from the URL via the remote-node HTTP protocol. Parsed in supernode.New.
+	RemoteNodes []string
 }
 
 func (c *CLIConfig) Check() error {
@@ -77,6 +81,7 @@ func NewConfig(ctx *cli.Context) *CLIConfig {
 		RawCtx:                  ctx,
 		InteropLogBackfillDepth: ctx.Duration("interop.log-backfill-depth"),
 		DependencySetPath:       ctx.Path(flags.DependencySet.Name),
+		RemoteNodes:             ctx.StringSlice(flags.RemoteNodes.Name),
 	}
 	if ctx.IsSet("interop.activation-timestamp") {
 		ts := ctx.Uint64("interop.activation-timestamp")

--- a/op-supernode/flags/flags.go
+++ b/op-supernode/flags/flags.go
@@ -74,6 +74,11 @@ var (
 		EnvVars:   prefixEnvVars("DEPENDENCY_SET"),
 		TakesFile: true,
 	}
+	RemoteNodes = &cli.StringSliceFlag{
+		Name:    "interop.remote-nodes",
+		Usage:   "Remote interop nodes as <chainID>=<url> pairs (repeatable or comma-separated). Each is a chain the supernode does not drive: it polls the URL for that chain's finalized initiating messages via the remote-node HTTP protocol, so driven chains can reference them as executing messages.",
+		EnvVars: prefixEnvVars("INTEROP_REMOTE_NODES"),
+	}
 )
 
 var requiredFlags = []cli.Flag{
@@ -85,6 +90,7 @@ var optionalFlags = []cli.Flag{
 	L1HTTPPollInterval,
 	DisableP2P,
 	DependencySet,
+	RemoteNodes,
 }
 
 // activityFlags holds flags registered by activity packages via RegisterActivityFlags.

--- a/op-supernode/supernode/activity/interop/algo.go
+++ b/op-supernode/supernode/activity/interop/algo.go
@@ -173,11 +173,13 @@ func (i *Interop) verifyExecutingMessage(executingChain eth.ChainID, executingTi
 			executingChain, executingTimestamp, i.activationTimestamp, ErrExecutedTooEarly)
 	}
 
-	initChain, ok := i.chains[execMsg.ChainID]
+	// The initiating chain may be a driven chain or a remote (adapter-backed) source;
+	// both can originate initiating messages, so consult both for its block time.
+	initChainBlockTime, ok := i.initiatingBlockTime(execMsg.ChainID)
 	if !ok {
 		return fmt.Errorf("initiating chain %s not registered: %w", execMsg.ChainID, ErrUnknownChain)
 	}
-	if execMsg.Timestamp < i.activationTimestamp+initChain.BlockTime() {
+	if execMsg.Timestamp < i.activationTimestamp+initChainBlockTime {
 		return fmt.Errorf("initiating chain %s timestamp %d < activation %d + blockTime: %w",
 			execMsg.ChainID, execMsg.Timestamp, i.activationTimestamp, ErrInitiatedTooEarly)
 	}

--- a/op-supernode/supernode/activity/interop/interop.go
+++ b/op-supernode/supernode/activity/interop/interop.go
@@ -177,6 +177,11 @@ type Interop struct {
 	verifiedDB *VerifiedDB
 	logsDBs    map[eth.ChainID]LogsDB
 
+	// remoteNodes holds the finalized-only, adapter-backed ingesters for chains the
+	// supernode does not drive. Their initiating messages land in logsDBs (keyed by
+	// chain ID) so driven chains can reference them as executing messages.
+	remoteNodes map[eth.ChainID]*remoteNode
+
 	mu      sync.RWMutex
 	ctx     context.Context
 	cancel  context.CancelFunc
@@ -300,6 +305,7 @@ func New(
 		chains:              chains,
 		verifiedDB:          verifiedDB,
 		logsDBs:             logsDBs,
+		remoteNodes:         make(map[eth.ChainID]*remoteNode),
 		dataDir:             dataDir,
 		activationTimestamp: activationTimestamp,
 		messageExpiryWindow: messageExpiryWindow,
@@ -326,6 +332,8 @@ func (i *Interop) Start(ctx context.Context) error {
 	i.ctx, i.cancel = context.WithCancel(ctx)
 	i.started = true
 	i.mu.Unlock()
+
+	i.startRemoteNodes()
 
 	i.tryInitFromVerifiedDB()
 	return i.runLoop()

--- a/op-supernode/supernode/activity/interop/remote_engine_test.go
+++ b/op-supernode/supernode/activity/interop/remote_engine_test.go
@@ -1,0 +1,151 @@
+package interop
+
+import (
+	"context"
+	"encoding/binary"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/stretchr/testify/require"
+
+	messages "github.com/ethereum-optimism/optimism/op-core/interop/messages"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	cc "github.com/ethereum-optimism/optimism/op-supernode/supernode/chain_container"
+	"github.com/ethereum-optimism/optimism/op-supernode/supernode/remote"
+	"github.com/ethereum-optimism/optimism/op-supernode/supernode/remote/remotetest"
+)
+
+// encodeExecutingMessageLog builds a CrossL2Inbox ExecutingMessage log identifying the
+// given initiating message — the inverse of messages.DecodeExecutingMessageLog. The 160-byte
+// data layout is: [12 zero][20 origin] [24 zero][8 blockNumber] [28 zero][4 logIndex]
+// [24 zero][8 timestamp] [32 chainID].
+func encodeExecutingMessageLog(id messages.Identifier, payloadHash common.Hash) *types.Log {
+	data := make([]byte, 32*5)
+	copy(data[12:32], id.Origin.Bytes())
+	binary.BigEndian.PutUint64(data[56:64], id.BlockNumber)
+	binary.BigEndian.PutUint32(data[92:96], id.LogIndex)
+	binary.BigEndian.PutUint64(data[120:128], id.Timestamp)
+	cid := id.ChainID.Bytes32()
+	copy(data[128:160], cid[:])
+	return &types.Log{
+		Address: params.InteropCrossL2InboxAddress,
+		Topics:  []common.Hash{messages.ExecutingMessageEventTopic, payloadHash},
+		Data:    data,
+	}
+}
+
+// TestEngineVerifiesExecutingMessageFromRemoteNode is an engine-level end-to-end test: a
+// driven chain emits a real CrossL2Inbox executing-message log that references an
+// initiating message served by the mock remote node over HTTP. The log is sealed through
+// the production processBlockLogs path (real DecodeExecutingMessageLog) and validated by
+// the real verifyInteropMessages engine — proving an actual executing message, sourced by
+// a remote node, is accepted, and that a tampered reference is rejected.
+func TestEngineVerifiesExecutingMessageFromRemoteNode(t *testing.T) {
+	t.Parallel()
+
+	const (
+		activation = uint64(1000)
+		blockTime  = uint64(1)
+	)
+	remoteID := eth.ChainIDFromUInt64(8453)
+	drivenID := eth.ChainIDFromUInt64(10)
+
+	// Remote node: serve a deterministic chain over HTTP and ingest its block 1 into a real
+	// logsDB via the real HTTPAdapter. Block 1's timestamp = activation + blockTime = 1001.
+	chain := remotetest.New(remotetest.Config{
+		ChainID: remoteID, BlockTime: blockTime, MsgsPerBlock: 1, StartTimestamp: activation,
+	})
+	srv := httptest.NewServer(chain.Handler())
+	defer srv.Close()
+
+	remoteDB, err := openLogsDB(testLogger(), remoteID, t.TempDir())
+	require.NoError(t, err)
+	defer func() { _ = remoteDB.Close() }()
+	node := &remoteNode{
+		log:     testLogger(),
+		adapter: remote.NewHTTPAdapter(remoteID, srv.URL, srv.Client()),
+		db:      remoteDB,
+		poll:    defaultRemotePollInterval,
+	}
+	ingested, err := node.ingestOnce(context.Background())
+	require.NoError(t, err)
+	require.True(t, ingested)
+
+	const initBlock, initLogIdx = uint64(1), uint32(0)
+	initTimestamp := activation + blockTime // 1001
+
+	// The executing message identifies remote block 1, log 0.
+	initID := messages.Identifier{
+		Origin:      chain.Origin(initBlock, initLogIdx),
+		BlockNumber: initBlock,
+		LogIndex:    initLogIdx,
+		Timestamp:   initTimestamp,
+		ChainID:     remoteID,
+	}
+
+	// runRound seals a driven block carrying the given executing-message log through the
+	// production decode+seal path, runs the real verifyInteropMessages engine, and reports
+	// whether the driven chain was flagged invalid.
+	runRound := func(t *testing.T, logEntry *types.Log) (Result, bool) {
+		t.Helper()
+		drivenDB, err := openLogsDB(testLogger(), drivenID, t.TempDir())
+		require.NoError(t, err)
+		defer func() { _ = drivenDB.Close() }()
+
+		const drivenBlockNum = uint64(5)
+		drivenHash := common.HexToHash("0xd0e5")
+		l1Block := eth.BlockID{Number: 40, Hash: common.HexToHash("0x1")}
+		drivenChain := newMockChainWithL1(drivenID, l1Block, eth.BlockID{Number: drivenBlockNum, Hash: drivenHash})
+
+		i := &Interop{
+			log:                 testLogger(),
+			ctx:                 context.Background(),
+			activationTimestamp: activation,
+			messageExpiryWindow: defaultMessageExpiryWindow,
+			logsDBs:             map[eth.ChainID]LogsDB{drivenID: drivenDB, remoteID: remoteDB},
+			chains:              map[eth.ChainID]cc.InteropChain{drivenID: drivenChain},
+			remoteNodes:         map[eth.ChainID]*remoteNode{remoteID: node},
+		}
+
+		// Seal the driven block through the production decode+seal path.
+		blockInfo := &mockBlockInfo{
+			hash:       drivenHash,
+			parentHash: common.HexToHash("0xd0e4"),
+			number:     drivenBlockNum,
+			timestamp:  initTimestamp, // the executing block's timestamp
+		}
+		require.NoError(t, i.processBlockLogs(drivenDB, blockInfo, types.Receipts{
+			&types.Receipt{Logs: []*types.Log{logEntry}},
+		}))
+
+		// The log must actually decode to one executing message, so "accepted" below
+		// reflects a validated message rather than an empty (vacuously valid) block.
+		_, _, execMsgs, err := drivenDB.OpenBlock(drivenBlockNum)
+		require.NoError(t, err)
+		require.Len(t, execMsgs, 1, "driven block must carry exactly one decoded executing message")
+
+		blocks := map[eth.ChainID]eth.BlockID{drivenID: {Number: drivenBlockNum, Hash: drivenHash}}
+		result, err := i.verifyInteropMessages(initTimestamp, blocks, l1HeadsFromMocks(i.chains, blocks), nil)
+		require.NoError(t, err)
+		_, invalid := result.InvalidHeads[drivenID]
+		return result, invalid
+	}
+
+	t.Run("valid executing message is accepted", func(t *testing.T) {
+		logEntry := encodeExecutingMessageLog(initID, chain.PayloadHash(initBlock, initLogIdx))
+		result, invalid := runRound(t, logEntry)
+		require.False(t, invalid, "executing message referencing the remote node must be accepted")
+		require.Contains(t, result.L2Heads, drivenID)
+	})
+
+	t.Run("tampered reference is rejected", func(t *testing.T) {
+		// Wrong payload hash → the derived checksum no longer matches what the remote node
+		// sealed → conflict → invalid head.
+		logEntry := encodeExecutingMessageLog(initID, common.HexToHash("0xbadbad"))
+		_, invalid := runRound(t, logEntry)
+		require.True(t, invalid, "executing message with a tampered reference must be rejected")
+	})
+}

--- a/op-supernode/supernode/activity/interop/remote_node.go
+++ b/op-supernode/supernode/activity/interop/remote_node.go
@@ -1,0 +1,199 @@
+package interop
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/ethereum/go-ethereum/log"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-supernode/supernode/remote"
+)
+
+// defaultRemotePollInterval bounds how often a remote node is polled for its next
+// finalized block when the adapter does not report a block time.
+const defaultRemotePollInterval = 2 * time.Second
+
+// defaultMaxBlocksPerCycle caps how many blocks a single ingest cycle drains before
+// yielding to the ticker. One block per tick would only ever match the remote chain's
+// production rate, so a node that falls behind (downtime, a slow adapter, a chain that
+// finalizes in bursts) could never catch up. Draining lets it catch up; the cap keeps a
+// cycle bounded so shutdown stays responsive and a slow adapter is not hammered
+// indefinitely within one iteration.
+const defaultMaxBlocksPerCycle = 256
+
+// remoteNode is the finalized-only analogue of a driving virtual node. Instead of
+// running a consensus client, it polls a remote.Adapter (in production, an HTTP client
+// pointed at a remote endpoint) for finalized blocks and seals their initiating messages
+// into the chain's LogsDB, so driven chains can reference them as executing messages.
+type remoteNode struct {
+	log     log.Logger
+	adapter remote.Adapter
+	db      LogsDB
+	poll    time.Duration
+	// maxPerCycle caps the number of blocks ingested by a single run-loop iteration.
+	maxPerCycle int
+}
+
+// AddRemoteNode registers a remote chain represented by the given adapter. It opens a
+// LogsDB for the adapter's chain (keyed by chain ID, the same map executing-message
+// validation reads from) and prepares an ingester that Start launches. It must be called
+// after New and before Start. The chain must not already be a driven chain.
+func (i *Interop) AddRemoteNode(adapter remote.Adapter) error {
+	chainID := adapter.ChainID()
+	if _, ok := i.chains[chainID]; ok {
+		return fmt.Errorf("chain %s is already a driven chain", chainID)
+	}
+	if _, ok := i.remoteNodes[chainID]; ok {
+		return fmt.Errorf("remote node for chain %s already registered", chainID)
+	}
+	db, err := openLogsDB(i.log, chainID, i.dataDir)
+	if err != nil {
+		return fmt.Errorf("open logsDB for remote chain %s: %w", chainID, err)
+	}
+	poll := defaultRemotePollInterval
+	if bt := adapter.BlockTime(); bt > 0 {
+		poll = time.Duration(bt) * time.Second
+	}
+	i.logsDBs[chainID] = db
+	i.remoteNodes[chainID] = &remoteNode{
+		log:         i.log.New("remote_chain", chainID.String()),
+		adapter:     adapter,
+		db:          db,
+		poll:        poll,
+		maxPerCycle: defaultMaxBlocksPerCycle,
+	}
+	i.log.Info("registered remote node", "chain", chainID, "blockTime", adapter.BlockTime())
+	return nil
+}
+
+// startRemoteNodes launches one background ingester per registered remote node. Each
+// runs until i.ctx is cancelled (Stop), then exits; the LogsDBs they write to are closed
+// by Stop's logsDBs cleanup.
+func (i *Interop) startRemoteNodes() {
+	for chainID, node := range i.remoteNodes {
+		i.log.Info("starting remote node ingester", "chain", chainID)
+		go node.run(i.ctx)
+	}
+}
+
+// run drains the adapter on a ticker until the context is cancelled.
+func (n *remoteNode) run(ctx context.Context) {
+	ticker := time.NewTicker(n.poll)
+	defer ticker.Stop()
+	for {
+		if err := n.ingestCycle(ctx); err != nil && ctx.Err() == nil {
+			n.log.Warn("remote node ingest failed, will retry", "err", err)
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
+// ingestCycle drains finalized blocks from the adapter until it reports none left, the
+// per-cycle cap is reached, the context is cancelled, or an error occurs. Draining is
+// what lets a lagging node catch up: at one block per tick the ingester could only ever
+// match the remote chain's production rate and would stay behind forever after any gap.
+func (n *remoteNode) ingestCycle(ctx context.Context) error {
+	maxPerCycle := n.maxPerCycle
+	if maxPerCycle <= 0 {
+		maxPerCycle = defaultMaxBlocksPerCycle
+	}
+	for i := 0; i < maxPerCycle; i++ {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		ingested, err := n.ingestOnce(ctx)
+		if err != nil {
+			return err
+		}
+		if !ingested {
+			return nil
+		}
+	}
+	n.log.Info("remote node hit per-cycle ingest cap, still catching up",
+		"cap", maxPerCycle)
+	return nil
+}
+
+// ingestOnce pulls the next finalized block from the adapter and seals it into the
+// LogsDB. It returns (true, nil) if a block was ingested, (false, nil) if no new block
+// is finalized yet, or (false, err) on failure. The resume cursor is the LogsDB's latest
+// sealed block, so ingestion is idempotent across restarts.
+//
+// Anchoring: when the LogsDB is empty there is no history to be contiguous with, so the
+// ingester accepts whatever height the adapter serves for after=0 and makes it the
+// anchor of this chain's local history. This mirrors how a driven chain's logsDB starts
+// at an arbitrary height (see processBlockLogs, and the --interop.log-backfill-depth
+// window that decides where that history begins): the LogsDB records its first block
+// number and answers ErrSkipped for anything below it, so a non-genesis-rooted history
+// is a first-class state, not a special case. Without this, a remote chain whose head is
+// at block N could only be ingested by replaying all N blocks from genesis. Once an
+// anchor exists, strict contiguity is enforced exactly as before.
+func (n *remoteNode) ingestOnce(ctx context.Context) (bool, error) {
+	var after uint64
+	latest, anchored := n.db.LatestSealedBlock()
+	if anchored {
+		after = latest.Number
+	}
+	blk, ok, err := n.adapter.NextFinalized(ctx, after)
+	if err != nil {
+		return false, fmt.Errorf("fetch next finalized after %d: %w", after, err)
+	}
+	if !ok {
+		return false, nil
+	}
+	if anchored && blk.Number != after+1 {
+		return false, fmt.Errorf("adapter returned non-contiguous block %d, expected %d", blk.Number, after+1)
+	}
+	if err := sealRemoteBlock(n.db, blk); err != nil {
+		return false, fmt.Errorf("seal remote block %d: %w", blk.Number, err)
+	}
+	if !anchored {
+		n.log.Info("anchored remote chain history at first served block",
+			"number", blk.Number, "hash", blk.Hash, "timestamp", blk.Timestamp,
+			"messages", len(blk.Messages))
+		return true, nil
+	}
+	n.log.Debug("ingested finalized remote block",
+		"number", blk.Number, "messages", len(blk.Messages), "timestamp", blk.Timestamp)
+	return true, nil
+}
+
+// sealRemoteBlock writes a remote chain's finalized block into its LogsDB. It mirrors
+// processBlockLogs but takes pre-extracted, normalized initiating messages instead of
+// receipts, and records no executing messages (a remote chain contributes initiating
+// messages only). Any block number >= 1 is accepted as the first seal (see ingestOnce's
+// anchoring note); block 0 is the implicit genesis and can never carry logs.
+func sealRemoteBlock(db LogsDB, blk *remote.FinalizedBlock) error {
+	if blk.Number == 0 {
+		return fmt.Errorf("remote block number must be >= 1 (block 0 is genesis)")
+	}
+	parentBlock := eth.BlockID{Hash: blk.ParentHash, Number: blk.Number - 1}
+	for _, m := range blk.Messages {
+		if err := db.AddLog(m.LogHash, parentBlock, m.LogIndex, nil); err != nil {
+			return fmt.Errorf("add log %d: %w", m.LogIndex, err)
+		}
+	}
+	if err := db.SealBlock(blk.ParentHash, eth.BlockID{Hash: blk.Hash, Number: blk.Number}, blk.Timestamp); err != nil {
+		return fmt.Errorf("seal block: %w", err)
+	}
+	return nil
+}
+
+// initiatingBlockTime returns the block time of a chain that can originate initiating
+// messages — either a driven chain or a registered remote node — and whether such a
+// chain is known.
+func (i *Interop) initiatingBlockTime(chainID eth.ChainID) (uint64, bool) {
+	if c, ok := i.chains[chainID]; ok {
+		return c.BlockTime(), true
+	}
+	if node, ok := i.remoteNodes[chainID]; ok {
+		return node.adapter.BlockTime(), true
+	}
+	return 0, false
+}

--- a/op-supernode/supernode/activity/interop/remote_node_live_test.go
+++ b/op-supernode/supernode/activity/interop/remote_node_live_test.go
@@ -1,0 +1,213 @@
+package interop
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/big"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/stretchr/testify/require"
+
+	coreinterop "github.com/ethereum-optimism/optimism/op-core/interop"
+	"github.com/ethereum-optimism/optimism/op-core/interop/messages"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-supernode/supernode/remote"
+)
+
+// TestLiveRemoteNodeAgainstOPSepolia is the whole chain of custody in one test: a real
+// shim process talking to real OP Sepolia, a real HTTPAdapter, the real ingester, and a
+// real LogsDB — ending with the check that actually matters, that a genuine on-chain log
+// is referenceable by the checksum an executing message would carry.
+//
+// Every link is a place the leg can break silently: an anchor at the wrong height, a
+// logHash derived differently on the two sides, a log index shifted by a filtered log.
+// None of those show up in a unit test with fabricated data, and all of them would
+// surface only as an opaque verification failure once the supernode is running.
+//
+// It is opt-in because it needs the network and a built shim:
+//
+//	ALTDA_SHIM_BIN=/path/to/opsepolia-shim \
+//	  go test ./op-supernode/supernode/activity/interop/ -run TestLiveRemoteNodeAgainstOPSepolia -v
+func TestLiveRemoteNodeAgainstOPSepolia(t *testing.T) {
+	shimBin := os.Getenv("ALTDA_SHIM_BIN")
+	if shimBin == "" {
+		t.Skip("set ALTDA_SHIM_BIN to the opsepolia-shim binary to run the live interop test")
+	}
+	rpcURL := os.Getenv("ALTDA_SHIM_RPC")
+	if rpcURL == "" {
+		rpcURL = "https://sepolia.optimism.io"
+	}
+	const opSepolia = 11155420
+	chainID := eth.ChainIDFromUInt64(opSepolia)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	baseURL := startShim(t, ctx, shimBin, rpcURL, opSepolia)
+
+	// The real production adapter, pointed at the real shim.
+	db, err := openLogsDB(testLogger(), chainID, t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	node := &remoteNode{
+		log:         testLogger(),
+		adapter:     remote.NewHTTPAdapter(chainID, baseURL, nil),
+		db:          db,
+		poll:        2 * time.Second,
+		maxPerCycle: 8,
+	}
+
+	// Ingest at least three live finalized blocks. The first is the anchor, at
+	// whatever height OP Sepolia's finalized head happens to be — the case the
+	// start-height patch exists for.
+	const wantBlocks = 3
+	ingested := 0
+	for ingested < wantBlocks {
+		require.NoError(t, ctx.Err(), "timed out ingesting live blocks")
+		ok, err := node.ingestOnce(ctx)
+		require.NoError(t, err)
+		if !ok {
+			// Nothing finalized yet; the shim's anchor lookback should make this
+			// rare, but wait for the chain rather than failing on timing.
+			select {
+			case <-ctx.Done():
+				t.Fatal("timed out waiting for the next finalized block")
+			case <-time.After(2 * time.Second):
+			}
+			continue
+		}
+		ingested++
+	}
+
+	first, err := db.FirstSealedBlock()
+	require.NoError(t, err)
+	latest, ok := db.LatestSealedBlock()
+	require.True(t, ok)
+	t.Logf("ingested OP Sepolia blocks %d..%d (anchored %d blocks past genesis)",
+		first.Number, latest.Number, first.Number)
+
+	require.Greater(t, first.Number, uint64(1_000_000),
+		"the anchor must be at OP Sepolia's real height, not replayed from genesis")
+	require.Equal(t, first.Number+wantBlocks-1, latest.Number, "blocks must be contiguous")
+
+	// Now the payoff: take a real log from an ingested block, derive the checksum an
+	// executing message would carry, and ask the LogsDB for it.
+	client, err := ethclient.DialContext(ctx, rpcURL)
+	require.NoError(t, err)
+	defer client.Close()
+
+	var (
+		found     bool
+		foundLog  types.Log
+		foundSeal messages.BlockSeal
+	)
+	for num := first.Number; num <= latest.Number && !found; num++ {
+		seal, err := db.FindSealedBlock(num)
+		require.NoError(t, err)
+		logs, err := client.FilterLogs(ctx, ethereum.FilterQuery{
+			FromBlock: new(big.Int).SetUint64(num),
+			ToBlock:   new(big.Int).SetUint64(num),
+		})
+		require.NoError(t, err)
+		if len(logs) == 0 {
+			continue
+		}
+		found, foundLog, foundSeal = true, logs[0], seal
+	}
+	require.True(t, found, "none of the ingested blocks carried logs; rerun to sample another window")
+
+	query := messages.ContainsQuery{
+		BlockNum:  foundSeal.Number,
+		LogIdx:    uint32(foundLog.Index),
+		Timestamp: foundSeal.Timestamp,
+		Checksum: messages.ChecksumArgs{
+			BlockNumber: foundSeal.Number,
+			LogIndex:    uint32(foundLog.Index),
+			Timestamp:   foundSeal.Timestamp,
+			ChainID:     chainID,
+			LogHash:     messages.LogToLogHash(&foundLog),
+		}.Checksum(),
+	}
+	sealed, err := db.Contains(query)
+	require.NoError(t, err,
+		"a real OP Sepolia log ingested through the shim must be referenceable")
+	require.Equal(t, foundSeal.Number, sealed.Number)
+	t.Logf("verified real log: block %d, logIndex %d, address %s",
+		foundSeal.Number, foundLog.Index, foundLog.Address)
+
+	// And the negative, so the positive means something: a tampered checksum at the
+	// same real position must be rejected.
+	bad := query
+	bad.Checksum = messages.MessageChecksum(common.HexToHash("0xdeadbeef"))
+	_, err = db.Contains(bad)
+	require.ErrorIs(t, err, coreinterop.ErrConflict)
+}
+
+// startShim launches the shim on a free port and waits for it to report healthy,
+// returning its base URL. It waits on the service's own readiness signal rather than a
+// fixed sleep, so a slow public RPC lengthens the wait instead of failing the test.
+func startShim(t *testing.T, ctx context.Context, bin, rpcURL string, chainID uint64) string {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := ln.Addr().String()
+	require.NoError(t, ln.Close())
+
+	var out bytes.Buffer
+	cmd := exec.Command(bin,
+		"--listen", addr,
+		"--rpc", rpcURL,
+		"--datadir", t.TempDir(),
+		"--chain-id", fmt.Sprint(chainID),
+		// A lookback, so finalized history is available immediately: an L2's
+		// finalized head jumps forward every few minutes rather than every block.
+		"--anchor-offset", "300",
+		"--log.level", "info",
+	)
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	require.NoError(t, cmd.Start())
+
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+		if t.Failed() {
+			t.Logf("shim output:\n%s", out.String())
+		}
+	})
+
+	baseURL := "http://" + addr
+	healthy := false
+	for !healthy {
+		require.NoError(t, ctx.Err(), "shim never became healthy; output:\n%s", out.String())
+		if cmd.ProcessState != nil && cmd.ProcessState.Exited() {
+			t.Fatalf("shim exited early:\n%s", out.String())
+		}
+		resp, err := http.Get(baseURL + "/healthz")
+		if err == nil {
+			healthy = resp.StatusCode == http.StatusOK
+			resp.Body.Close()
+		}
+		if !healthy {
+			select {
+			case <-ctx.Done():
+				t.Fatalf("shim never became healthy; output:\n%s", out.String())
+			case <-time.After(200 * time.Millisecond):
+			}
+		}
+	}
+	t.Logf("shim ready at %s", baseURL)
+	return baseURL
+}

--- a/op-supernode/supernode/activity/interop/remote_node_test.go
+++ b/op-supernode/supernode/activity/interop/remote_node_test.go
@@ -1,0 +1,527 @@
+package interop
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+
+	coreinterop "github.com/ethereum-optimism/optimism/op-core/interop"
+	"github.com/ethereum-optimism/optimism/op-core/interop/messages"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-supernode/supernode/remote"
+	"github.com/ethereum-optimism/optimism/op-supernode/supernode/remote/remotetest"
+)
+
+// newRemoteNode wires a deterministic test server to a real HTTPAdapter and the ingester,
+// returning the ingester, the fake chain (for ExpectedChecksum), and a LogsDB to seal into.
+func newRemoteNode(t *testing.T, cfg remotetest.Config) (*remoteNode, *remotetest.Chain, LogsDB) {
+	node, chain, db, _ := newRemoteNodeInDir(t, cfg, t.TempDir())
+	return node, chain, db
+}
+
+// newRemoteNodeInDir is newRemoteNode with an explicit LogsDB directory (so a test can
+// reopen the same directory to simulate a restart) and a record of the `after` cursor
+// every request carried, which is what the resume behaviour is actually about.
+func newRemoteNodeInDir(t *testing.T, cfg remotetest.Config, dir string) (*remoteNode, *remotetest.Chain, LogsDB, *[]uint64) {
+	chain := remotetest.New(cfg)
+	var mu sync.Mutex
+	asked := make([]uint64, 0, 8)
+	inner := chain.Handler()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if after, err := strconv.ParseUint(r.URL.Query().Get("after"), 10, 64); err == nil {
+			mu.Lock()
+			asked = append(asked, after)
+			mu.Unlock()
+		}
+		inner.ServeHTTP(w, r)
+	}))
+	t.Cleanup(srv.Close)
+
+	db, err := openLogsDB(testLogger(), cfg.ChainID, dir)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	adapter := remote.NewHTTPAdapter(cfg.ChainID, srv.URL, srv.Client())
+	node := &remoteNode{
+		log: testLogger(), adapter: adapter, db: db,
+		poll: defaultRemotePollInterval, maxPerCycle: defaultMaxBlocksPerCycle,
+	}
+	return node, chain, db, &asked
+}
+
+// scriptedAdapter is a remote.Adapter that returns exactly the blocks a test hands it,
+// including responses no honest server would send, so the ingester's own guards can be
+// exercised directly.
+type scriptedAdapter struct {
+	chainID eth.ChainID
+	next    func(after uint64) (*remote.FinalizedBlock, bool, error)
+}
+
+func (a *scriptedAdapter) ChainID() eth.ChainID { return a.chainID }
+func (a *scriptedAdapter) BlockTime() uint64    { return 2 }
+func (a *scriptedAdapter) NextFinalized(_ context.Context, after uint64) (*remote.FinalizedBlock, bool, error) {
+	return a.next(after)
+}
+func (a *scriptedAdapter) Close() error { return nil }
+
+// TestRemoteNodeIngestAndContains exercises the full path against a real LogsDB: the
+// ingester polls the remote node over HTTP, seals the fabricated initiating messages, and
+// they become referenceable via the checksum the chain advertises (positive), while a
+// wrong checksum is rejected (negative).
+func TestRemoteNodeIngestAndContains(t *testing.T) {
+	t.Parallel()
+	const (
+		activation   = uint64(1000)
+		blockTime    = uint64(2)
+		msgsPerBlock = 2
+	)
+	chainID := eth.ChainIDFromUInt64(8453)
+	node, chain, db := newRemoteNode(t, remotetest.Config{
+		ChainID: chainID, BlockTime: blockTime, MsgsPerBlock: msgsPerBlock, StartTimestamp: activation,
+	})
+
+	// Ingest two finalized blocks; the LogsDB resume cursor advances each time.
+	for n := uint64(1); n <= 2; n++ {
+		ingested, err := node.ingestOnce(context.Background())
+		require.NoError(t, err)
+		require.True(t, ingested)
+		latest, ok := db.LatestSealedBlock()
+		require.True(t, ok)
+		require.Equal(t, n, latest.Number)
+	}
+
+	// Every fabricated message is referenceable via its advertised checksum.
+	for n := uint64(1); n <= 2; n++ {
+		ts := activation + n*blockTime
+		for logIdx := uint32(0); logIdx < msgsPerBlock; logIdx++ {
+			seal, err := db.Contains(messages.ContainsQuery{
+				BlockNum:  n,
+				LogIdx:    logIdx,
+				Timestamp: ts,
+				Checksum:  chain.ExpectedChecksum(n, logIdx),
+			})
+			require.NoError(t, err, "block %d log %d should be referenceable", n, logIdx)
+			require.Equal(t, n, seal.Number)
+			require.Equal(t, ts, seal.Timestamp)
+		}
+	}
+
+	// A wrong checksum at a real (block, log) position is a conflict.
+	_, err := db.Contains(messages.ContainsQuery{
+		BlockNum:  1,
+		LogIdx:    0,
+		Timestamp: activation + blockTime,
+		Checksum:  messages.MessageChecksum(common.HexToHash("0xbad")),
+	})
+	require.ErrorIs(t, err, coreinterop.ErrConflict)
+}
+
+// opSepoliaLikeHeight is a stand-in for a long-running chain's finalized head — the
+// situation that makes replay-from-genesis impossible and anchoring mandatory.
+const opSepoliaLikeHeight = uint64(47_300_000)
+
+// TestRemoteNodeAnchorsAtHeight is the start-height anchoring case: a chain whose
+// finalized head is tens of millions of blocks past genesis. The empty LogsDB accepts
+// the first block served at whatever height it has, and the anchored (non-genesis-rooted)
+// history is fully functional — Contains recomputes the checksum from the sealed record,
+// and everything below the anchor reads as skipped rather than missing.
+func TestRemoteNodeAnchorsAtHeight(t *testing.T) {
+	t.Parallel()
+	const (
+		activation   = uint64(1000)
+		blockTime    = uint64(2)
+		msgsPerBlock = 2
+	)
+	chainID := eth.ChainIDFromUInt64(11155420)
+	node, chain, db, asked := newRemoteNodeInDir(t, remotetest.Config{
+		ChainID: chainID, BlockTime: blockTime, MsgsPerBlock: msgsPerBlock,
+		StartTimestamp: activation, FirstBlock: opSepoliaLikeHeight,
+	}, t.TempDir())
+
+	_, hasBlocks := db.LatestSealedBlock()
+	require.False(t, hasBlocks, "precondition: the LogsDB starts empty")
+
+	ingested, err := node.ingestOnce(context.Background())
+	require.NoError(t, err)
+	require.True(t, ingested)
+	require.Equal(t, []uint64{0}, *asked, "an empty LogsDB asks for the anchor with after=0")
+
+	latest, ok := db.LatestSealedBlock()
+	require.True(t, ok)
+	require.Equal(t, opSepoliaLikeHeight, latest.Number, "the anchor is sealed at its real height")
+
+	first, err := db.FirstSealedBlock()
+	require.NoError(t, err)
+	require.Equal(t, opSepoliaLikeHeight, first.Number, "anchored history starts at the anchor")
+
+	// The anchor block's messages are referenceable: Contains recomputes the checksum
+	// from (logHash, block number, log index, timestamp, chain ID), none of which
+	// depend on the history below the anchor.
+	anchorTS := activation + blockTime
+	for logIdx := uint32(0); logIdx < msgsPerBlock; logIdx++ {
+		seal, err := db.Contains(messages.ContainsQuery{
+			BlockNum:  opSepoliaLikeHeight,
+			LogIdx:    logIdx,
+			Timestamp: anchorTS,
+			Checksum:  chain.ExpectedChecksum(opSepoliaLikeHeight, logIdx),
+		})
+		require.NoError(t, err, "anchor block log %d must be referenceable", logIdx)
+		require.Equal(t, opSepoliaLikeHeight, seal.Number)
+		require.Equal(t, anchorTS, seal.Timestamp)
+	}
+
+	// A wrong checksum at a real position is still a conflict, so anchoring did not
+	// weaken verification.
+	_, err = db.Contains(messages.ContainsQuery{
+		BlockNum: opSepoliaLikeHeight, LogIdx: 0, Timestamp: anchorTS,
+		Checksum: messages.MessageChecksum(common.HexToHash("0xbad")),
+	})
+	require.ErrorIs(t, err, coreinterop.ErrConflict)
+
+	// History below the anchor was never ingested and is reported as such.
+	_, err = db.Contains(messages.ContainsQuery{
+		BlockNum: opSepoliaLikeHeight - 1, LogIdx: 0, Timestamp: anchorTS - blockTime,
+		Checksum: chain.ExpectedChecksum(opSepoliaLikeHeight-1, 0),
+	})
+	require.ErrorIs(t, err, coreinterop.ErrSkipped)
+
+	// Ingestion continues contiguously from the anchor.
+	ingested, err = node.ingestOnce(context.Background())
+	require.NoError(t, err)
+	require.True(t, ingested)
+	latest, ok = db.LatestSealedBlock()
+	require.True(t, ok)
+	require.Equal(t, opSepoliaLikeHeight+1, latest.Number)
+	require.Equal(t, []uint64{0, opSepoliaLikeHeight}, *asked,
+		"once anchored, the cursor is the latest sealed block")
+}
+
+// TestRemoteNodeContiguityAfterAnchor pins the other half of the rule: the height
+// freedom is exhausted by the anchor. Once history exists, a block at any height other
+// than latest+1 is rejected and nothing is sealed.
+func TestRemoteNodeContiguityAfterAnchor(t *testing.T) {
+	t.Parallel()
+	const blockTime = uint64(2)
+	chainID := eth.ChainIDFromUInt64(11155420)
+	chain := remotetest.New(remotetest.Config{
+		ChainID: chainID, BlockTime: blockTime, StartTimestamp: 1000,
+		FirstBlock: opSepoliaLikeHeight,
+	})
+
+	db, err := openLogsDB(testLogger(), chainID, t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	// The scripted adapter answers the anchor request honestly, then jumps a block.
+	served := chain.Block(opSepoliaLikeHeight)
+	adapter := &scriptedAdapter{chainID: chainID, next: func(after uint64) (*remote.FinalizedBlock, bool, error) {
+		if after == 0 {
+			return served, true, nil
+		}
+		// A gap: skipping straight from the anchor to anchor+2.
+		return chain.Block(after + 2), true, nil
+	}}
+	node := &remoteNode{log: testLogger(), adapter: adapter, db: db, poll: defaultRemotePollInterval}
+
+	ingested, err := node.ingestOnce(context.Background())
+	require.NoError(t, err)
+	require.True(t, ingested)
+
+	_, err = node.ingestOnce(context.Background())
+	require.ErrorContains(t, err, "non-contiguous")
+	latest, ok := db.LatestSealedBlock()
+	require.True(t, ok)
+	require.Equal(t, opSepoliaLikeHeight, latest.Number, "a rejected block must not be sealed")
+
+	// The same guard applies to a block below the head, not just above it.
+	adapter.next = func(after uint64) (*remote.FinalizedBlock, bool, error) {
+		return chain.Block(after), true, nil
+	}
+	_, err = node.ingestOnce(context.Background())
+	require.ErrorContains(t, err, "non-contiguous")
+}
+
+// TestRemoteNodeAnchorSurvivesRestart reopens the same LogsDB directory with a fresh
+// ingester: the anchor is durable, so the restarted node resumes from LatestSealedBlock
+// instead of re-anchoring somewhere else.
+func TestRemoteNodeAnchorSurvivesRestart(t *testing.T) {
+	t.Parallel()
+	const (
+		activation = uint64(1000)
+		blockTime  = uint64(2)
+	)
+	chainID := eth.ChainIDFromUInt64(11155420)
+	dir := filepath.Join(t.TempDir(), "logsdb")
+	cfg := remotetest.Config{
+		ChainID: chainID, BlockTime: blockTime, StartTimestamp: activation,
+		FirstBlock: opSepoliaLikeHeight,
+	}
+
+	node, _, db, asked := newRemoteNodeInDir(t, cfg, dir)
+	for i := 0; i < 2; i++ {
+		ingested, err := node.ingestOnce(context.Background())
+		require.NoError(t, err)
+		require.True(t, ingested)
+	}
+	require.Equal(t, []uint64{0, opSepoliaLikeHeight}, *asked)
+	require.NoError(t, db.Close())
+
+	// Restart: same directory, new DB handle, new ingester.
+	node2, chain2, db2, asked2 := newRemoteNodeInDir(t, cfg, dir)
+	latest, ok := db2.LatestSealedBlock()
+	require.True(t, ok, "sealed history must survive the restart")
+	require.Equal(t, opSepoliaLikeHeight+1, latest.Number)
+	first, err := db2.FirstSealedBlock()
+	require.NoError(t, err)
+	require.Equal(t, opSepoliaLikeHeight, first.Number, "the anchor is still the start of history")
+
+	ingested, err := node2.ingestOnce(context.Background())
+	require.NoError(t, err)
+	require.True(t, ingested)
+	require.Equal(t, []uint64{opSepoliaLikeHeight + 1}, *asked2,
+		"a restarted node resumes from its latest sealed block, never re-anchoring")
+
+	latest, ok = db2.LatestSealedBlock()
+	require.True(t, ok)
+	require.Equal(t, opSepoliaLikeHeight+2, latest.Number)
+
+	// Messages sealed before the restart are still referenceable afterwards.
+	seal, err := db2.Contains(messages.ContainsQuery{
+		BlockNum:  opSepoliaLikeHeight,
+		LogIdx:    0,
+		Timestamp: activation + blockTime,
+		Checksum:  chain2.ExpectedChecksum(opSepoliaLikeHeight, 0),
+	})
+	require.NoError(t, err)
+	require.Equal(t, opSepoliaLikeHeight, seal.Number)
+}
+
+// TestRemoteNodeIngestCycleDrains covers catch-up: one cycle must drain every block the
+// adapter is willing to serve, not one per tick. At one block per poll interval an
+// ingester could only match the remote chain's production rate and would never close a
+// gap opened by downtime.
+func TestRemoteNodeIngestCycleDrains(t *testing.T) {
+	t.Parallel()
+	const (
+		blockTime = uint64(2)
+		backlog   = uint64(10)
+	)
+	chainID := eth.ChainIDFromUInt64(11155420)
+	head := opSepoliaLikeHeight + backlog - 1
+	node, _, db, asked := newRemoteNodeInDir(t, remotetest.Config{
+		ChainID: chainID, BlockTime: blockTime, StartTimestamp: 1000,
+		FirstBlock: opSepoliaLikeHeight, Head: head,
+	}, t.TempDir())
+
+	require.NoError(t, node.ingestCycle(context.Background()))
+
+	latest, ok := db.LatestSealedBlock()
+	require.True(t, ok)
+	require.Equal(t, head, latest.Number, "one cycle must drain the whole backlog")
+	// backlog ingests plus the final request that reported nothing new.
+	require.Len(t, *asked, int(backlog)+1)
+
+	// A cycle with nothing to do is a single request and no error.
+	before := len(*asked)
+	require.NoError(t, node.ingestCycle(context.Background()))
+	require.Equal(t, head, mustLatest(t, db).Number)
+	require.Len(t, *asked, before+1)
+}
+
+// TestRemoteNodeIngestCycleRespectsCap keeps a cycle bounded: a chain that is arbitrarily
+// far ahead must not be drained in one unbounded burst, or shutdown latency and adapter
+// load become unbounded with it. Progress simply continues on the next tick.
+func TestRemoteNodeIngestCycleRespectsCap(t *testing.T) {
+	t.Parallel()
+	chainID := eth.ChainIDFromUInt64(11155420)
+	node, _, db, _ := newRemoteNodeInDir(t, remotetest.Config{
+		ChainID: chainID, BlockTime: 2, StartTimestamp: 1000,
+		FirstBlock: opSepoliaLikeHeight, // unbounded: always another block
+	}, t.TempDir())
+	node.maxPerCycle = 4
+
+	require.NoError(t, node.ingestCycle(context.Background()))
+	require.Equal(t, opSepoliaLikeHeight+3, mustLatest(t, db).Number, "capped at 4 blocks")
+
+	require.NoError(t, node.ingestCycle(context.Background()))
+	require.Equal(t, opSepoliaLikeHeight+7, mustLatest(t, db).Number, "the next cycle resumes")
+}
+
+// TestRemoteNodeIngestCycleStopsOnCancel makes sure a cancelled context ends the cycle
+// promptly rather than running to the cap.
+func TestRemoteNodeIngestCycleStopsOnCancel(t *testing.T) {
+	t.Parallel()
+	chainID := eth.ChainIDFromUInt64(11155420)
+	node, _, db, _ := newRemoteNodeInDir(t, remotetest.Config{
+		ChainID: chainID, BlockTime: 2, StartTimestamp: 1000,
+		FirstBlock: opSepoliaLikeHeight,
+	}, t.TempDir())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ingested, err := node.ingestOnce(ctx)
+	require.NoError(t, err)
+	require.True(t, ingested)
+	cancel()
+
+	require.ErrorIs(t, node.ingestCycle(ctx), context.Canceled)
+	require.Equal(t, opSepoliaLikeHeight, mustLatest(t, db).Number)
+}
+
+func mustLatest(t *testing.T, db LogsDB) eth.BlockID {
+	t.Helper()
+	latest, ok := db.LatestSealedBlock()
+	require.True(t, ok)
+	return latest
+}
+
+func TestAddRemoteNode(t *testing.T) {
+	// newInteropTestHarness calls t.Parallel() internally.
+	h := newInteropTestHarness(t).WithActivation(1000).WithChain(10, nil).Build()
+	require.NotNil(t, h.interop)
+
+	remoteID := eth.ChainIDFromUInt64(8453)
+	adapter := remote.NewHTTPAdapter(remoteID, "http://example.invalid", nil)
+
+	require.NoError(t, h.interop.AddRemoteNode(adapter))
+	require.Contains(t, h.interop.remoteNodes, remoteID)
+	require.Contains(t, h.interop.logsDBs, remoteID, "remote logsDB must be registered for executing-message validation to read it")
+
+	// Duplicate remote registration fails.
+	require.Error(t, h.interop.AddRemoteNode(adapter))
+
+	// A driven chain cannot also be a remote node.
+	require.Error(t, h.interop.AddRemoteNode(remote.NewHTTPAdapter(eth.ChainIDFromUInt64(10), "http://example.invalid", nil)))
+}
+
+// TestVerifyExecutingMessageReferencesRemoteNode is the end-to-end check: a driven chain
+// references a remote node's initiating message as an executing message, through the real
+// verifyExecutingMessage path (including the remote block-time fallback). The remote
+// node's messages arrive over HTTP from the test server.
+func TestVerifyExecutingMessageReferencesRemoteNode(t *testing.T) {
+	// newInteropTestHarness calls t.Parallel() internally.
+	const (
+		drivenChain = 10
+		remoteChain = 8453
+		activation  = uint64(1000)
+		blockTime   = uint64(2)
+	)
+	h := newInteropTestHarness(t).WithActivation(activation).WithChain(drivenChain, nil).Build()
+	require.NotNil(t, h.interop)
+
+	remoteID := eth.ChainIDFromUInt64(remoteChain)
+	chain := remotetest.New(remotetest.Config{
+		ChainID: remoteID, BlockTime: blockTime, MsgsPerBlock: 1, StartTimestamp: activation,
+	})
+	srv := httptest.NewServer(chain.Handler())
+	defer srv.Close()
+	require.NoError(t, h.interop.AddRemoteNode(remote.NewHTTPAdapter(remoteID, srv.URL, srv.Client())))
+
+	// Ingest one finalized block from the remote node (also populates the adapter's
+	// cached block time, used by the activation invariant below).
+	node := h.interop.remoteNodes[remoteID]
+	require.NotNil(t, node)
+	ingested, err := node.ingestOnce(context.Background())
+	require.NoError(t, err)
+	require.True(t, ingested)
+
+	const initBlock, initLogIdx = uint64(1), uint32(0)
+	initTimestamp := activation + blockTime // block 1 timestamp = 1002
+
+	execMsg := &messages.ExecutingMessage{
+		ChainID:   remoteID,
+		BlockNum:  initBlock,
+		LogIdx:    initLogIdx,
+		Timestamp: initTimestamp,
+		Checksum:  chain.ExpectedChecksum(initBlock, initLogIdx),
+	}
+	drivenID := eth.ChainIDFromUInt64(drivenChain)
+
+	// Positive: valid executing message referencing the remote node passes.
+	require.NoError(t, h.interop.verifyExecutingMessage(drivenID, initTimestamp+50, 0, execMsg, nil),
+		"valid executing message referencing a remote node must pass")
+
+	// Negative: a wrong checksum is a conflict.
+	bad := *execMsg
+	bad.Checksum = messages.MessageChecksum(common.HexToHash("0xdeadbeef"))
+	err = h.interop.verifyExecutingMessage(drivenID, initTimestamp+50, 0, &bad, nil)
+	require.ErrorIs(t, err, coreinterop.ErrConflict)
+
+	// Negative: referencing a block the remote node has not ingested yet fails.
+	future := *execMsg
+	future.BlockNum = 99
+	future.Timestamp = activation + 99*blockTime
+	future.Checksum = chain.ExpectedChecksum(99, 0)
+	require.Error(t, h.interop.verifyExecutingMessage(drivenID, future.Timestamp+50, 0, &future, nil),
+		"referencing a not-yet-ingested remote block must fail")
+}
+
+// TestVerifyExecutingMessageReferencesAnchoredRemoteNode is the previous test's case for
+// an anchored remote chain: a driven chain references an initiating message in a block
+// tens of millions of blocks past the remote chain's genesis, which is the only shape
+// available when the remote chain is a live public network. Nothing in the verification
+// path depends on the remote history being genesis-rooted.
+func TestVerifyExecutingMessageReferencesAnchoredRemoteNode(t *testing.T) {
+	// newInteropTestHarness calls t.Parallel() internally.
+	const (
+		drivenChain = 10
+		remoteChain = 11155420
+		activation  = uint64(1000)
+		blockTime   = uint64(2)
+	)
+	h := newInteropTestHarness(t).WithActivation(activation).WithChain(drivenChain, nil).Build()
+	require.NotNil(t, h.interop)
+
+	remoteID := eth.ChainIDFromUInt64(remoteChain)
+	chain := remotetest.New(remotetest.Config{
+		ChainID: remoteID, BlockTime: blockTime, MsgsPerBlock: 1,
+		StartTimestamp: activation, FirstBlock: opSepoliaLikeHeight,
+	})
+	srv := httptest.NewServer(chain.Handler())
+	defer srv.Close()
+	require.NoError(t, h.interop.AddRemoteNode(remote.NewHTTPAdapter(remoteID, srv.URL, srv.Client())))
+
+	node := h.interop.remoteNodes[remoteID]
+	require.NotNil(t, node)
+	require.Equal(t, defaultMaxBlocksPerCycle, node.maxPerCycle,
+		"AddRemoteNode must configure the per-cycle cap")
+	// Drain a small backlog in one cycle, the way a catching-up node does.
+	require.NoError(t, node.ingestCycle(context.Background()))
+	require.Equal(t, opSepoliaLikeHeight+uint64(defaultMaxBlocksPerCycle)-1,
+		mustLatest(t, h.interop.logsDBs[remoteID]).Number)
+
+	const initLogIdx = uint32(0)
+	initBlock := opSepoliaLikeHeight + 3
+	initTimestamp := activation + 4*blockTime // 4th block served
+
+	execMsg := &messages.ExecutingMessage{
+		ChainID:   remoteID,
+		BlockNum:  initBlock,
+		LogIdx:    initLogIdx,
+		Timestamp: initTimestamp,
+		Checksum:  chain.ExpectedChecksum(initBlock, initLogIdx),
+	}
+	drivenID := eth.ChainIDFromUInt64(drivenChain)
+
+	require.NoError(t, h.interop.verifyExecutingMessage(drivenID, initTimestamp+50, 0, execMsg, nil),
+		"an executing message referencing anchored remote history must verify")
+
+	bad := *execMsg
+	bad.Checksum = messages.MessageChecksum(common.HexToHash("0xdeadbeef"))
+	require.ErrorIs(t, h.interop.verifyExecutingMessage(drivenID, initTimestamp+50, 0, &bad, nil),
+		coreinterop.ErrConflict)
+
+	// A message from below the anchor cannot be verified: that history was never
+	// ingested, and the verifier must not accept it on faith.
+	belowAnchor := *execMsg
+	belowAnchor.BlockNum = opSepoliaLikeHeight - 1
+	belowAnchor.Checksum = chain.ExpectedChecksum(belowAnchor.BlockNum, 0)
+	require.Error(t, h.interop.verifyExecutingMessage(drivenID, initTimestamp+50, 0, &belowAnchor, nil),
+		"referencing pre-anchor history must fail")
+}

--- a/op-supernode/supernode/remote/adapter.go
+++ b/op-supernode/supernode/remote/adapter.go
@@ -1,0 +1,92 @@
+// Package remote provides the plugin boundary for ingesting initiating messages
+// from chains that the supernode does NOT drive.
+//
+// A driven chain is represented by an in-process virtual node that runs a full
+// op-node and seals that chain's logs into a LogsDB. A *remote* chain, by
+// contrast, is represented only by an [Adapter]: a small plugin that exposes the
+// chain's FINALIZED initiating messages, already normalized into the canonical
+// form the interop verifier needs. The supernode ingests those messages into a
+// LogsDB so the driven chains in the interop set can reference them as executing
+// messages — without the supernode running a consensus client for the remote
+// chain.
+//
+// This lets an operator plug in any external chain node software. The production
+// Adapter is [HTTPAdapter]: point it at a URL and the supernode polls that endpoint
+// for the chain's finalized initiating messages, so the wire protocol — not a Go
+// type — is the real plugin boundary (serve the right responses in any language and
+// you are done). The remotetest package provides a deterministic test server for it.
+package remote
+
+import (
+	"context"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+// InitiatingMessage is a single initiating (cross-chain) message emitted by a
+// remote chain, normalized to the minimum the interop verifier needs to make it
+// referenceable by an executing message on another chain. It is also the JSON wire
+// type a remote node serves (see [HTTPAdapter]).
+//
+// LogHash is the canonical content hash of the originating log — identical to
+// what messages.LogToLogHash produces for a real EVM log. The verifier derives
+// the referenceable checksum from (LogHash, block number, LogIndex, block
+// timestamp, chain ID).
+type InitiatingMessage struct {
+	// LogIndex is the position of this message's log within its block. Indices
+	// must be contiguous and start at 0: the verifier indexes messages at exactly
+	// these positions.
+	LogIndex uint32 `json:"logIndex"`
+	// LogHash is the canonical content hash of the originating log.
+	LogHash common.Hash `json:"logHash"`
+}
+
+// FinalizedBlock is one finalized block's worth of initiating messages from a
+// remote chain, and the JSON wire type a remote node serves. Because remote chains
+// are ingested finalized-only, blocks are assumed irreversible: there is no
+// reorg/rewind path for them.
+type FinalizedBlock struct {
+	Number     uint64      `json:"number"`
+	Hash       common.Hash `json:"hash"`
+	ParentHash common.Hash `json:"parentHash"`
+	Timestamp  uint64      `json:"timestamp"`
+	// Messages are the initiating messages in this block, ordered by ascending
+	// LogIndex starting at 0. May be empty (a block with no cross-chain messages).
+	Messages []InitiatingMessage `json:"messages"`
+}
+
+// Adapter is the plugin boundary: an implementation wraps any external chain node
+// software and exposes that chain's finalized initiating messages. An adapter is
+// only ever consulted by a single ingester goroutine, so implementations need not
+// be safe for concurrent use.
+type Adapter interface {
+	// ChainID identifies the remote chain. It must be a member of the interop
+	// dependency set for its messages to be referenceable.
+	ChainID() eth.ChainID
+
+	// BlockTime is the remote chain's block time in seconds. The verifier uses it
+	// for the interop activation invariant (a message must be at least one block
+	// past activation on its own chain).
+	BlockTime() uint64
+
+	// NextFinalized returns the next finalized block after block number `after`
+	// (i.e. block number after+1), or ok=false if that block is not finalized yet.
+	//
+	// after == 0 is the ANCHOR request: the supernode has no local history for this
+	// chain and asks where to start. The adapter may answer with a block at any
+	// height >= 1 — its chain's current finalized head, for instance — and that block
+	// becomes the anchor of the locally recorded history. It is the adapter's choice,
+	// and it must be stable across adapter restarts once the supernode has sealed
+	// history rooted at it. Block 0 is the implicit genesis and carries no messages,
+	// so it is never a valid answer.
+	//
+	// For after > 0 the adapter MUST return exactly block after+1 (or ok=false until
+	// it is finalized): the supernode enforces strict contiguity from the anchor
+	// onward and rejects any other height.
+	NextFinalized(ctx context.Context, after uint64) (blk *FinalizedBlock, ok bool, err error)
+
+	// Close releases any resources held by the adapter.
+	Close() error
+}

--- a/op-supernode/supernode/remote/http_adapter.go
+++ b/op-supernode/supernode/remote/http_adapter.go
@@ -1,0 +1,94 @@
+package remote
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync/atomic"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+// HTTPAdapter is the production [Adapter]: it reads a remote chain's finalized
+// initiating messages from an HTTP endpoint. Point it at any server that speaks the
+// remote-node protocol below — that server is the real plugin boundary, so a remote
+// chain can be backed by any node software, in any language, as long as it responds
+// correctly.
+//
+// Protocol:
+//
+//	GET {baseURL}/finalized?after={N}
+//	200 application/json: {"blockTime": <secs>, "block": <FinalizedBlock>|null}
+//	  - block is the finalized block with Number == N+1, or null if no block after N
+//	    is finalized yet (the client then waits and retries).
+//	  - N == 0 is the anchor request (the supernode has no history for this chain
+//	    yet): the server answers with the block it wants history to start at, at any
+//	    height >= 1, and must keep answering with that same block until the supernode
+//	    has ingested past it. See Adapter.NextFinalized.
+//	  - blockTime is the remote chain's block time in seconds (always present); it is
+//	    cached and surfaced via BlockTime for the interop activation invariant.
+type HTTPAdapter struct {
+	chainID   eth.ChainID
+	baseURL   string
+	client    *http.Client
+	blockTime atomic.Uint64
+}
+
+// finalizedResponse is the wire envelope returned by GET /finalized.
+type finalizedResponse struct {
+	BlockTime uint64          `json:"blockTime"`
+	Block     *FinalizedBlock `json:"block"`
+}
+
+var _ Adapter = (*HTTPAdapter)(nil)
+
+// NewHTTPAdapter builds an HTTPAdapter for the given chain and base URL. A nil client
+// uses http.DefaultClient.
+func NewHTTPAdapter(chainID eth.ChainID, baseURL string, client *http.Client) *HTTPAdapter {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	return &HTTPAdapter{
+		chainID: chainID,
+		baseURL: strings.TrimRight(baseURL, "/"),
+		client:  client,
+	}
+}
+
+func (a *HTTPAdapter) ChainID() eth.ChainID { return a.chainID }
+
+// BlockTime returns the remote chain's block time as last reported by the endpoint, or
+// 0 before the first successful response. Since a message can only be referenced after
+// its block has been ingested, a non-zero value is always available by validation time.
+func (a *HTTPAdapter) BlockTime() uint64 { return a.blockTime.Load() }
+
+func (a *HTTPAdapter) NextFinalized(ctx context.Context, after uint64) (*FinalizedBlock, bool, error) {
+	url := fmt.Sprintf("%s/finalized?after=%d", a.baseURL, after)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, false, fmt.Errorf("build request: %w", err)
+	}
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return nil, false, fmt.Errorf("GET %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, false, fmt.Errorf("GET %s: unexpected status %d", url, resp.StatusCode)
+	}
+	var out finalizedResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, false, fmt.Errorf("decode response from %s: %w", url, err)
+	}
+	if out.BlockTime > 0 {
+		a.blockTime.Store(out.BlockTime)
+	}
+	if out.Block == nil {
+		return nil, false, nil
+	}
+	return out.Block, true, nil
+}
+
+func (a *HTTPAdapter) Close() error { return nil }

--- a/op-supernode/supernode/remote/http_adapter_test.go
+++ b/op-supernode/supernode/remote/http_adapter_test.go
@@ -1,0 +1,40 @@
+package remote_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-supernode/supernode/remote"
+)
+
+func TestHTTPAdapterErrorOnNon200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	adapter := remote.NewHTTPAdapter(eth.ChainIDFromUInt64(10), srv.URL, srv.Client())
+	_, ok, err := adapter.NextFinalized(context.Background(), 0)
+	require.Error(t, err)
+	require.False(t, ok)
+}
+
+func TestHTTPAdapterNullBlockIsNotAnError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"blockTime":2,"block":null}`))
+	}))
+	defer srv.Close()
+
+	adapter := remote.NewHTTPAdapter(eth.ChainIDFromUInt64(10), srv.URL, srv.Client())
+	blk, ok, err := adapter.NextFinalized(context.Background(), 5)
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Nil(t, blk)
+	require.Equal(t, uint64(2), adapter.BlockTime(), "blockTime is cached even when no block is returned")
+}

--- a/op-supernode/supernode/remote/remotetest/server.go
+++ b/op-supernode/supernode/remote/remotetest/server.go
@@ -1,0 +1,191 @@
+// Package remotetest provides a deterministic HTTP server implementing the remote-node
+// protocol (see remote.HTTPAdapter), for use in tests. Production code never imports it;
+// it lets a test point a real remote.HTTPAdapter at an httptest.Server that serves a
+// fabricated finalized-block stream — "serve the right responses and you're good."
+package remotetest
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"net/http"
+	"strconv"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+
+	"github.com/ethereum-optimism/optimism/op-core/interop/messages"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-supernode/supernode/remote"
+)
+
+const (
+	defaultBlockTime    = uint64(2)
+	defaultMsgsPerBlock = 1
+)
+
+// Config configures a [Chain].
+type Config struct {
+	// ChainID of the simulated remote chain. Required.
+	ChainID eth.ChainID
+	// BlockTime in seconds, reported to the client. Defaults to 2 when zero.
+	BlockTime uint64
+	// MsgsPerBlock is the number of dummy initiating messages fabricated per block.
+	// Defaults to 1 when zero.
+	MsgsPerBlock int
+	// StartTimestamp anchors the simulated chain's clock: the first served block has
+	// timestamp StartTimestamp + BlockTime, and each later block adds BlockTime. Set
+	// this to the interop activation timestamp so the first block lands exactly one
+	// block past activation (the earliest referenceable point).
+	StartTimestamp uint64
+	// FirstBlock is the height served for the anchor request (after=0), i.e. where
+	// this chain offers to start history. Defaults to 1. Set it high to simulate a
+	// long-running chain whose finalized head is far past genesis — the case that
+	// forces the supernode to anchor rather than replay from block 1.
+	FirstBlock uint64
+	// Head, when non-zero, is the highest finalized block number: requests for a block
+	// beyond it get "block": null, so tests can exercise the "nothing new yet" path.
+	// Zero means the chain is unbounded (always has the next block).
+	Head uint64
+}
+
+// Chain is a deterministic fake remote chain. The same (ChainID, block, log index)
+// always maps to the same log hash and timestamp, so [Chain.ExpectedChecksum] reproduces
+// exactly the checksum the LogsDB recomputes when validating a referencing executing
+// message.
+type Chain struct {
+	cfg Config
+}
+
+// New builds a Chain, applying defaults for unset fields.
+func New(cfg Config) *Chain {
+	if cfg.BlockTime == 0 {
+		cfg.BlockTime = defaultBlockTime
+	}
+	if cfg.MsgsPerBlock <= 0 {
+		cfg.MsgsPerBlock = defaultMsgsPerBlock
+	}
+	if cfg.FirstBlock == 0 {
+		cfg.FirstBlock = 1
+	}
+	return &Chain{cfg: cfg}
+}
+
+func (c *Chain) BlockTime() uint64 { return c.cfg.BlockTime }
+
+// FirstBlock is the height this chain serves for the anchor request (after=0).
+func (c *Chain) FirstBlock() uint64 { return c.cfg.FirstBlock }
+
+// Handler returns an http.Handler implementing GET /finalized?after={N}. Wrap it in
+// httptest.NewServer and point a remote.HTTPAdapter at the server's URL.
+func (c *Chain) Handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/finalized", func(w http.ResponseWriter, r *http.Request) {
+		after, err := strconv.ParseUint(r.URL.Query().Get("after"), 10, 64)
+		if err != nil {
+			http.Error(w, "invalid 'after' query param", http.StatusBadRequest)
+			return
+		}
+		resp := struct {
+			BlockTime uint64                 `json:"blockTime"`
+			Block     *remote.FinalizedBlock `json:"block"`
+		}{BlockTime: c.cfg.BlockTime}
+
+		// after == 0 is the anchor request: answer with FirstBlock, wherever that is.
+		// Every later request is strictly contiguous.
+		n := after + 1
+		if after == 0 {
+			n = c.cfg.FirstBlock
+		}
+		if n >= c.cfg.FirstBlock && (c.cfg.Head == 0 || n <= c.cfg.Head) {
+			resp.Block = c.Block(n)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+	return mux
+}
+
+// Block returns the deterministic finalized block at the given height (>= 1).
+func (c *Chain) Block(n uint64) *remote.FinalizedBlock {
+	blk := &remote.FinalizedBlock{
+		Number:     n,
+		Hash:       c.blockHash(n),
+		ParentHash: c.parentHash(n),
+		Timestamp:  c.blockTimestamp(n),
+		Messages:   make([]remote.InitiatingMessage, 0, c.cfg.MsgsPerBlock),
+	}
+	for i := 0; i < c.cfg.MsgsPerBlock; i++ {
+		blk.Messages = append(blk.Messages, remote.InitiatingMessage{
+			LogIndex: uint32(i),
+			LogHash:  c.logHash(n, uint32(i)),
+		})
+	}
+	return blk
+}
+
+// ExpectedChecksum returns the message checksum an executing message must carry to
+// reference the dummy initiating message at (blockNum, logIdx). It mirrors exactly what
+// raftwallogdb.DB.Contains recomputes from the sealed log hash, block timestamp and
+// chain ID.
+func (c *Chain) ExpectedChecksum(blockNum uint64, logIdx uint32) messages.MessageChecksum {
+	return messages.ChecksumArgs{
+		BlockNumber: blockNum,
+		LogIndex:    logIdx,
+		Timestamp:   c.blockTimestamp(blockNum),
+		ChainID:     c.cfg.ChainID,
+		LogHash:     c.logHash(blockNum, logIdx),
+	}.Checksum()
+}
+
+// blockTimestamp places the first served block one block time past StartTimestamp,
+// whatever height that block sits at, so an anchored chain's timestamps stay in the
+// same relation to activation as a genesis-rooted one's.
+func (c *Chain) blockTimestamp(n uint64) uint64 {
+	return c.cfg.StartTimestamp + (n-c.cfg.FirstBlock+1)*c.cfg.BlockTime
+}
+
+func (c *Chain) blockHash(n uint64) common.Hash {
+	return c.tag("mock-remote-block", n, 0)
+}
+
+// parentHash links block n to its parent: the prior block's hash, so the LogsDB
+// parent-linkage invariants hold. At or below the first served block the parent is a
+// synthetic, non-zero hash standing in for history this chain does not serve.
+func (c *Chain) parentHash(n uint64) common.Hash {
+	if n <= c.cfg.FirstBlock {
+		return c.tag("mock-remote-genesis", 0, 0)
+	}
+	return c.blockHash(n - 1)
+}
+
+// logHash is the canonical content hash the remote node serves and the LogsDB stores.
+// It is derived from a fabricated (payloadHash, origin) preimage so a real CrossL2Inbox
+// executing-message log — which carries payloadHash and origin separately — can reference
+// it: messages.DecodeExecutingMessageLog recomputes exactly this hash.
+func (c *Chain) logHash(n uint64, logIdx uint32) common.Hash {
+	return messages.PayloadHashToLogHash(c.PayloadHash(n, logIdx), c.Origin(n, logIdx))
+}
+
+// Origin is the deterministic originating-contract address for the message at
+// (blockNum, logIdx). A referencing executing message must carry this address.
+func (c *Chain) Origin(blockNum uint64, logIdx uint32) common.Address {
+	return common.BytesToAddress(c.tag("mock-remote-origin", blockNum, uint64(logIdx)).Bytes())
+}
+
+// PayloadHash is the deterministic initiating-message payload hash for (blockNum, logIdx).
+// A referencing executing message carries this as the CrossL2Inbox event's indexed topic.
+func (c *Chain) PayloadHash(blockNum uint64, logIdx uint32) common.Hash {
+	return c.tag("mock-remote-payload", blockNum, uint64(logIdx))
+}
+
+// tag derives a deterministic, domain-separated hash from the chain ID and two numbers,
+// so distinct (domain, n, k) tuples never collide.
+func (c *Chain) tag(domain string, n, k uint64) common.Hash {
+	cid := c.cfg.ChainID.Bytes32()
+	buf := make([]byte, 0, len(domain)+len(cid)+16)
+	buf = append(buf, domain...)
+	buf = append(buf, cid[:]...)
+	buf = binary.BigEndian.AppendUint64(buf, n)
+	buf = binary.BigEndian.AppendUint64(buf, k)
+	return crypto.Keccak256Hash(buf)
+}

--- a/op-supernode/supernode/remote/remotetest/server_test.go
+++ b/op-supernode/supernode/remote/remotetest/server_test.go
@@ -1,0 +1,86 @@
+package remotetest_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-supernode/supernode/remote"
+	"github.com/ethereum-optimism/optimism/op-supernode/supernode/remote/remotetest"
+)
+
+// TestServerServesProtocol drives the test server through a real remote.HTTPAdapter and
+// confirms the round trip: contiguous, linked blocks; blockTime is reported; and a
+// bounded Head produces the "nothing new yet" (ok=false) response.
+func TestServerServesProtocol(t *testing.T) {
+	chain := remotetest.New(remotetest.Config{
+		ChainID:        eth.ChainIDFromUInt64(8453),
+		BlockTime:      2,
+		MsgsPerBlock:   3,
+		StartTimestamp: 1000,
+		Head:           2,
+	})
+	srv := httptest.NewServer(chain.Handler())
+	defer srv.Close()
+
+	adapter := remote.NewHTTPAdapter(eth.ChainIDFromUInt64(8453), srv.URL, srv.Client())
+
+	b1, ok, err := adapter.NextFinalized(context.Background(), 0)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, uint64(1), b1.Number)
+	require.Equal(t, uint64(1002), b1.Timestamp)
+	require.Len(t, b1.Messages, 3)
+	require.Equal(t, uint64(2), adapter.BlockTime(), "blockTime should be cached from the response")
+
+	b2, ok, err := adapter.NextFinalized(context.Background(), 1)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, b1.Hash, b2.ParentHash, "block 2 must link to block 1")
+
+	// Head == 2, so there is no block 3 yet.
+	_, ok, err = adapter.NextFinalized(context.Background(), 2)
+	require.NoError(t, err)
+	require.False(t, ok)
+}
+
+// TestServerAnchorsAtFirstBlock covers the anchor request against a chain whose history
+// starts far past genesis, the way a live public chain's does: after=0 gets FirstBlock,
+// and everything from there is strictly contiguous.
+func TestServerAnchorsAtFirstBlock(t *testing.T) {
+	const first = uint64(47_300_000)
+	chainID := eth.ChainIDFromUInt64(11155420)
+	chain := remotetest.New(remotetest.Config{
+		ChainID:        chainID,
+		BlockTime:      2,
+		MsgsPerBlock:   1,
+		StartTimestamp: 1000,
+		FirstBlock:     first,
+	})
+	srv := httptest.NewServer(chain.Handler())
+	defer srv.Close()
+
+	adapter := remote.NewHTTPAdapter(chainID, srv.URL, srv.Client())
+
+	anchor, ok, err := adapter.NextFinalized(context.Background(), 0)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, first, anchor.Number, "after=0 must be answered with the anchor")
+	require.Equal(t, uint64(1002), anchor.Timestamp, "the anchor sits one block past StartTimestamp")
+	require.NotEqual(t, common.Hash{}, anchor.ParentHash)
+
+	next, ok, err := adapter.NextFinalized(context.Background(), first)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, first+1, next.Number)
+	require.Equal(t, anchor.Hash, next.ParentHash, "blocks after the anchor stay linked")
+
+	// Nothing below the anchor is served.
+	_, ok, err = adapter.NextFinalized(context.Background(), first-10)
+	require.NoError(t, err)
+	require.False(t, ok)
+}

--- a/op-supernode/supernode/supernode.go
+++ b/op-supernode/supernode/supernode.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -23,6 +24,7 @@ import (
 	supernodeactivity "github.com/ethereum-optimism/optimism/op-supernode/supernode/activity/supernode"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/activity/superroot"
 	cc "github.com/ethereum-optimism/optimism/op-supernode/supernode/chain_container"
+	"github.com/ethereum-optimism/optimism/op-supernode/supernode/remote"
 	"github.com/ethereum-optimism/optimism/op-supernode/supernode/resources"
 	gethlog "github.com/ethereum/go-ethereum/log"
 	rpc "github.com/ethereum/go-ethereum/rpc"
@@ -127,6 +129,10 @@ func New(ctx context.Context, log gethlog.Logger, version string, commit string,
 		}
 		interopActivity = interop.New(log.New("activity", "interop"), *interopActivationTimestamp, msgExpiryWindow, s.chains, cfg.DataDir, s.l1Client, cfg.InteropLogBackfillDepth, s.supernodeMetrics)
 		verifiedReader = interopActivity
+
+		if err := registerRemoteNodes(log, interopActivity, cfg); err != nil {
+			return nil, fmt.Errorf("failed to register remote interop nodes: %w", err)
+		}
 	}
 
 	// Order in this slice governs Start/Stop ordering; interop is appended
@@ -159,6 +165,39 @@ func New(ctx context.Context, log gethlog.Logger, version string, commit string,
 		s.metrics = resources.NewMetricsService(log, cfg.MetricsConfig.ListenAddr, cfg.MetricsConfig.ListenPort, s.metricsFanIn)
 	}
 	return s, nil
+}
+
+// registerRemoteNodes attaches the configured remote interop nodes to the interop
+// activity. A remote node is a chain the supernode does not drive: the supernode polls
+// the configured URL (the remote-node HTTP protocol) for that chain's finalized
+// initiating messages so driven chains can reference them. The wire protocol is the
+// plugin boundary — any node software that serves it can back a remote chain.
+func registerRemoteNodes(log gethlog.Logger, act *interop.Interop, cfg *config.CLIConfig) error {
+	for _, spec := range cfg.RemoteNodes {
+		chainID, rawURL, err := parseRemoteNodeSpec(spec)
+		if err != nil {
+			return err
+		}
+		if err := act.AddRemoteNode(remote.NewHTTPAdapter(chainID, rawURL, nil)); err != nil {
+			return fmt.Errorf("remote node %s: %w", chainID, err)
+		}
+		log.Info("attached remote node", "chain", chainID, "url", rawURL)
+	}
+	return nil
+}
+
+// parseRemoteNodeSpec parses a "<chainID>=<url>" spec. It splits on the first '=' so URLs
+// may themselves contain '=' (e.g. query parameters).
+func parseRemoteNodeSpec(spec string) (eth.ChainID, string, error) {
+	eq := strings.IndexByte(spec, '=')
+	if eq <= 0 || eq == len(spec)-1 {
+		return eth.ChainID{}, "", fmt.Errorf("invalid --interop.remote-nodes entry %q, want <chainID>=<url>", spec)
+	}
+	id, err := strconv.ParseUint(spec[:eq], 10, 64)
+	if err != nil {
+		return eth.ChainID{}, "", fmt.Errorf("invalid chain ID in --interop.remote-nodes entry %q: %w", spec, err)
+	}
+	return eth.ChainIDFromUInt64(id), spec[eq+1:], nil
 }
 
 func resolveInteropActivationTimestamp(override *uint64, vnCfgs map[eth.ChainID]*opnodecfg.Config) (*uint64, error) {


### PR DESCRIPTION
This combines two previously-drafted features into the minimal "bones" of a private alt-DA chain that interops one-way with external finalized chains: keccak-committed alt-DA with no challenge contract, plus a way for a supernode to treat an external chain as a read-only member of its interop dependency set. Neither half is new work on its own — the point of putting them in one branch is that the combination is what a permissioned Validium that wants to read finalized messages from a public chain actually needs, and it is worth seeing the seam between them. Opened as a **draft for visibility and discussion, not for merge**.

## Commits

**1. `feat(op-alt-da): allow Keccak256 commitments without DAChallengeAddress`**

A revival of #19395 by @fakedev9999 (preserved as the commit author). It makes the DA challenge contract optional for Keccak256 commitments, so a permissioned Validium can keep the `keccak256(data) == commitment` verify-on-read that generic commitments give up, without standing up a challenge game. The guard on `fetchChallengeLogs` moves from commitment-type-based to address-based: challenge machinery is skipped exactly when `da_challenge_contract_address` is zero, and is untouched otherwise.

It also fixes the two op-node alt-DA derive tests that #19395 broke. `TestAltDADataSourceStall` and `TestAltDADataSourceInvalidData` build an `altda.Config` with no challenge contract address, so under the address-based guard the manager skips challenge-log lookups and the tests fail on unmet `FetchReceipts` expectations. They now get an explicit non-zero test challenge contract, so they keep exercising the challenge flow they were written for rather than being weakened.

**2. `feat(op-supernode): HTTP-backed remote interop nodes`**

A revival of draft #21479 (original author and co-author preserved). It adds a *remote node*: a member of the interop dependency set that the supernode does not drive. Rather than running a consensus client for that chain, the supernode polls an HTTP endpoint for its **finalized** initiating messages and seals them into that chain's LogsDB, so driven chains can reference them as executing messages exactly as they reference driven-chain messages. Finalized-only means there is no rewind path to implement. The wire protocol is the plugin boundary — `GET {url}/finalized?after={N}` — so the far side can be any server in any language; configured with `--interop.remote-nodes <chainID>=<url>`.

New in this branch, all of it forced by running the thing against a live public chain:

- **Start-height anchoring.** #21479 resumed from the LogsDB's latest sealed block and demanded strict contiguity from there, with an empty DB meaning "expect block 1" — unreachable for a chain whose finalized head is tens of millions of blocks past genesis. An empty LogsDB now accepts whatever height the adapter serves for `after=0` and seals it as the anchor of local history; contiguity is enforced from the anchor onward exactly as before. Nothing below the DB layer changed — the raft-wal store already keys by block number and records its own first block — and this mirrors how a driven chain's logsDB already starts at an arbitrary height via `--interop.log-backfill-depth`.
- **Ingestion drain with a per-cycle cap.** Ingestion ran once per tick and the tick is the remote chain's block time, so it could only ever match the chain's production rate; a node that fell behind on a 2s chain could never catch up. The loop now drains until the adapter returns null, capped per cycle to keep shutdown responsive and bound adapter load.
- **An env-gated live e2e** exercising the whole chain of custody — real server process against a real public chain, real `HTTPAdapter`, real ingester, real LogsDB — ending by asking `Contains` for a genuine on-chain log with the checksum an executing message would carry. Anchors at the wrong height, a logHash derived differently on the two sides, a log index shifted by a filtered log: none of those are visible in a test with fabricated blocks.

## Validation

Beyond the unit and engine-level tests, this exact combination was deployed as a live chain on Sepolia and exercised end to end: deposits through the portal, alt-DA keccak batch derivation with no challenge contract, live executing messages referencing **finalized OP Sepolia logs** delivered over the remote-node path, and withdrawals proven and finalized through super-root permissioned dispute games. No infrastructure or endpoint details are included here.

## Known gaps / future work

- The remote-node protocol has **no auth and no handshake**. It is a trusted-endpoint plugin seam as it stands; anything adversarial needs authentication and probably a version/chain-ID negotiation on connect.
- **Interop tx filter integration** is future work: admission-time validation of transactions whose executing messages reference a remote chain is served by a separate service, which does not know about remote nodes yet. Today the remote path is validated at block-building/verification time only.
- The test impact of #19395 is fixed in commit 1 rather than left for a follow-up, since the two commits are meant to be reviewable independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
