### PR TITLE
op-e2e: stabilize AutoDA market ordering

### DIFF
--- a/op-e2e/e2eutils/geth/engine_helpers_test.go
+++ b/op-e2e/e2eutils/geth/engine_helpers_test.go
@@ -70,15 +70,32 @@ func TestFakePoSAdvancesAmsterdamChain(t *testing.T) {
 	require.NoError(t, err)
 
 	logicalClock := clock.NewAdvancingClock()
-	instance, _, err := InitL1(1, 64, l1Genesis, logicalClock, t.TempDir(), noOpBeacon{})
+	instance, fakePoS, err := InitL1(1, 64, l1Genesis, logicalClock, t.TempDir(), noOpBeacon{})
+	require.NoError(t, err)
+	pausedAtBlock1, err := fakePoS.PauseAtBlock(1)
 	require.NoError(t, err)
 	require.NoError(t, instance.Node.Start())
 	t.Cleanup(func() { require.NoError(t, instance.Close()) })
 
 	logicalClock.AdvanceTime(2 * time.Second)
-	require.Eventually(t, func() bool {
-		return instance.Backend.BlockChain().CurrentBlock().Number.Cmp(big.NewInt(1)) >= 0
-	}, 10*time.Second, 100*time.Millisecond)
+	select {
+	case <-pausedAtBlock1:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for fake PoS to pause at block 1")
+	}
+	require.Equal(t, big.NewInt(1), instance.Backend.BlockChain().CurrentBlock().Number)
+
+	pausedAtBlock2, err := fakePoS.PauseAtBlock(2)
+	require.NoError(t, err)
+	logicalClock.AdvanceTime(10 * time.Second)
+	require.Equal(t, big.NewInt(1), instance.Backend.BlockChain().CurrentBlock().Number)
+	require.NoError(t, fakePoS.Resume())
+	select {
+	case <-pausedAtBlock2:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for fake PoS to pause at block 2")
+	}
+	require.Equal(t, big.NewInt(2), instance.Backend.BlockChain().CurrentBlock().Number)
 }
 
 type noOpBeacon struct{}

--- a/op-e2e/e2eutils/geth/fakepos.go
+++ b/op-e2e/e2eutils/geth/fakepos.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math/big"
 	"math/rand"
+	"sync"
 	"time"
 
 	"github.com/ethereum/go-ethereum"
@@ -49,6 +50,12 @@ type FakePoS struct {
 	beacon Beacon
 
 	config *params.ChainConfig
+
+	pauseMu      sync.Mutex
+	pauseAt      uint64
+	pauseReached chan struct{}
+	paused       bool
+	resumeCh     chan struct{}
 }
 
 type Backend interface {
@@ -84,6 +91,67 @@ func NewFakePoS(backend Backend, engineAPI EngineAPI, c clock.Clock, logger log.
 		engineAPI:         engineAPI,
 		beacon:            beacon,
 		config:            config,
+		resumeCh:          make(chan struct{}, 1),
+	}
+}
+
+// PauseAtBlock configures the block producer to pause immediately after block
+// number is made canonical. The returned channel closes when the pause has
+// taken effect.
+func (f *FakePoS) PauseAtBlock(number uint64) (<-chan struct{}, error) {
+	f.pauseMu.Lock()
+	defer f.pauseMu.Unlock()
+	if f.pauseAt != 0 {
+		return nil, fmt.Errorf("L1 block producer already configured to pause at block %d", f.pauseAt)
+	}
+
+	head, err := f.eth.HeaderByNumber(context.Background(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("get L1 head before configuring pause: %w", err)
+	}
+	headNumber := bigs.Uint64Strict(head.Number)
+	if headNumber >= number {
+		return nil, fmt.Errorf("cannot pause at L1 block %d: current head is %d", number, headNumber)
+	}
+
+	f.pauseAt = number
+	f.pauseReached = make(chan struct{})
+	return f.pauseReached, nil
+}
+
+// Resume resumes block production after a configured pause has taken effect.
+func (f *FakePoS) Resume() error {
+	f.pauseMu.Lock()
+	if !f.paused {
+		f.pauseMu.Unlock()
+		return errors.New("L1 block producer is not paused")
+	}
+	f.paused = false
+	f.pauseMu.Unlock()
+	f.resumeCh <- struct{}{}
+	return nil
+}
+
+// pauseIfConfigured returns true if the subscription context ended while the
+// block producer was paused.
+func (f *FakePoS) pauseIfConfigured(ctx context.Context, number uint64) bool {
+	f.pauseMu.Lock()
+	if f.pauseAt != number {
+		f.pauseMu.Unlock()
+		return false
+	}
+	reached := f.pauseReached
+	f.pauseAt = 0
+	f.pauseReached = nil
+	f.paused = true
+	f.pauseMu.Unlock()
+	close(reached)
+
+	select {
+	case <-f.resumeCh:
+		return false
+	case <-ctx.Done():
+		return true
 	}
 }
 
@@ -308,6 +376,9 @@ func (f *FakePoS) Start() error {
 				// The EL doesn't really care about the value,
 				// but it's nice to mock something consistent with the CL specs.
 				f.withdrawalsIndex += uint64(len(withdrawals))
+				if f.pauseIfConfigured(ctx, bigs.Uint64Strict(nextHeight)) {
+					return nil
+				}
 			case <-ctx.Done():
 				return nil
 			}

--- a/op-e2e/system/da/eip4844_test.go
+++ b/op-e2e/system/da/eip4844_test.go
@@ -38,6 +38,30 @@ import (
 // Update to Prague if L1 changes to Prague and we need more blobs in multi-blob tests.
 var maxBlobsPerBlock = params.DefaultCancunBlobConfig.Max
 
+func findBatcherTxTypes(txs []*types.Transaction, inbox common.Address, expectedType uint8) (foundExpected, foundOther bool) {
+	for _, tx := range txs {
+		if tx.To() == nil || tx.To().Cmp(inbox) != 0 {
+			continue
+		}
+		if tx.Type() == expectedType {
+			foundExpected = true
+			continue
+		}
+		foundOther = true
+	}
+	return foundExpected, foundOther
+}
+
+func TestFindBatcherTxTypesInspectsTransactionsAfterExpectedType(t *testing.T) {
+	inbox := common.Address{0xff}
+	expected := types.NewTx(&types.DynamicFeeTx{To: &inbox})
+	unexpected := types.NewTx(&types.AccessListTx{To: &inbox})
+
+	foundExpected, foundOther := findBatcherTxTypes([]*types.Transaction{expected, unexpected}, inbox, expected.Type())
+	require.True(t, foundExpected)
+	require.True(t, foundOther)
+}
+
 // TestSystem4844E2E* run the SystemE2E test with 4844 enabled on L1, and active on the rollup in
 // the op-batcher and verifier.  It submits a txpool-blocking transaction before running
 // each test to ensure the batcher is able to clear it.
@@ -265,7 +289,10 @@ func TestBatcherAutoDA(t *testing.T) {
 	cfg.DisableProposer = true // disable L2 output submission for this test
 	cfg.DisableTxForwarder = true
 	cfg.DisableBatcher = true // disable batcher because we start it manually later
-	sys, err := cfg.Start(t)
+
+	// System startup may include an external L2 EL. Pause L1 immediately after
+	// block 2 so variable startup duration cannot mutate the initial fee market.
+	sys, err := cfg.Start(t, e2esys.WithL1BlockPauseAtBlock2())
 	require.NoError(t, err, "Error starting up system")
 	log := testlog.Logger(t, log.LevelInfo)
 	log.Info("genesis", "l2", sys.RollupConfig.Genesis.L2, "l1", sys.RollupConfig.Genesis.L1, "l2_time", sys.RollupConfig.Genesis.L2Time)
@@ -292,35 +319,47 @@ func TestBatcherAutoDA(t *testing.T) {
 	}
 	requireEventualBatcherTxType := func(txType uint8, timeout time.Duration, strict bool) {
 		var foundOtherTxType bool
-		require.Eventually(t, func() bool {
-			b, err := l1Client.BlockByNumber(ctx, nil)
-			require.NoError(t, err)
-			for _, tx := range b.Transactions() {
-				if tx.To() == nil || tx.To().Cmp(cfg.DeployConfig.BatchInboxAddress) != 0 {
-					continue
-				}
-				if typ := tx.Type(); typ == txType {
-					return true
-				} else if strict {
-					foundOtherTxType = true
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			var content struct {
+				Pending map[string]*types.Transaction `json:"pending"`
+				Queued  map[string]*types.Transaction `json:"queued"`
+			}
+			err := l1Client.Client().CallContext(ctx, &content, "txpool_contentFrom", cfg.Secrets.Addresses().Batcher)
+			require.NoError(ct, err)
+			txs := make([]*types.Transaction, 0, len(content.Pending)+len(content.Queued))
+			for _, txGroup := range []map[string]*types.Transaction{content.Pending, content.Queued} {
+				for _, tx := range txGroup {
+					txs = append(txs, tx)
 				}
 			}
-			return false
-		}, timeout, time.Second, "expected batcher tx type didn't arrive")
+			latest, err := l1Client.BlockByNumber(ctx, nil)
+			require.NoError(ct, err)
+			txs = append(txs, latest.Transactions()...)
+			foundExpected, foundOther := findBatcherTxTypes(txs, cfg.DeployConfig.BatchInboxAddress, txType)
+			if strict && foundOther {
+				foundOtherTxType = true
+			}
+			assert.True(ct, foundExpected, "expected batcher tx type didn't arrive")
+		}, timeout, 100*time.Millisecond)
 		require.False(t, foundOtherTxType, "unexpected batcher tx type found")
 	}
 
-	// Check markets are set up as expected.
-	// There is a race condition where the batcher might already
-	// impact the markets before we query the feeRatio. Therefore
-	// the L1GenesisBlockExcessBlobGas above is tuned so that
-	// the feeRatio remains above 41.0 even after the market begins to
-	// change:
-	// initially:     feeRatio = 43.67449956483899
-	// after block 3: feeRatio = 42.65440079562407 (using geth.WaitForBlock(big.NewInt(3), l1Client))
-
+	// L1 is paused at block 2 until the test explicitly resumes it, so this
+	// observes the intended initial market.
 	_, _, _, feeRatio := mustGetFees()
 	require.Greater(t, feeRatio, 41.0, "expected feeRatio to be greater than 41 (calldata should be cheaper, even with Pectra)")
+
+	// Let the rollup nodes observe one post-start L1 head, then pause again while
+	// the initial batch is selected. The fee ratio remains in the
+	// calldata-cheaper range at block 3.
+	pausedAtBlock3, err := sys.PauseL1AtBlock(3)
+	require.NoError(t, err)
+	require.NoError(t, sys.ResumeL1())
+	select {
+	case <-pausedAtBlock3:
+	case <-ctx.Done():
+		require.NoError(t, ctx.Err(), "waiting for L1 to pause at block 3")
+	}
 
 	// Market manipulations:
 	// Send deposit transactions in a loop to shore up L1 base fee
@@ -337,10 +376,11 @@ func TestBatcherAutoDA(t *testing.T) {
 		txs = append(txs, tx)
 	}
 
-	// At this point, we didn't wait on any blocks yet, so we can check that
-	// the first batcher tx used calldata.
+	// L1 is still paused, so inspect the pending batcher transaction before it
+	// can be mined and confirm the initial selection used calldata.
 	require.NoError(t, sys.BatchSubmitter.TestDriver().StartBatchSubmitting())
 	requireEventualBatcherTxType(types.DynamicFeeTxType, 8*time.Second, true)
+	require.NoError(t, sys.ResumeL1())
 
 	// Now wait for txs to confirm on L1:
 	t.Logf("Confirming %d txs on L1...", numTxs)

--- a/op-e2e/system/e2esys/setup.go
+++ b/op-e2e/system/e2esys/setup.go
@@ -397,6 +397,7 @@ type System struct {
 	// Note that this time travel may occur in a single block, creating a very large difference in the Time
 	// on sequential blocks.
 	TimeTravelClock *clock.AdvancingClock
+	l1Miner         *geth.FakePoS
 
 	t      *testing.T
 	closed atomic.Bool
@@ -427,6 +428,19 @@ func (sys *System) AdvanceTime(d time.Duration) {
 	if sys.TimeTravelClock != nil {
 		sys.TimeTravelClock.AdvanceTime(d)
 	}
+}
+
+// PauseL1AtBlock configures the fake L1 block producer to pause immediately
+// after the requested block is made canonical. The returned channel closes
+// when the pause has taken effect.
+func (sys *System) PauseL1AtBlock(block uint64) (<-chan struct{}, error) {
+	return sys.l1Miner.PauseAtBlock(block)
+}
+
+// ResumeL1 resumes a fake L1 block producer paused by PauseL1AtBlock or
+// WithL1BlockPauseAtBlock2.
+func (sys *System) ResumeL1() error {
+	return sys.l1Miner.Resume()
 }
 
 func (sys *System) L1BeaconEndpoint() endpoint.RestHTTP {
@@ -559,15 +573,25 @@ type StartOption struct {
 
 	// Batcher CLIConfig modifications to apply before starting the batcher.
 	BatcherMod func(*bss.CLIConfig)
+
+	pauseL1AtBlock2 bool
 }
 
 type startOptions struct {
-	opts map[string]SystemConfigHook
+	opts            map[string]SystemConfigHook
+	pauseL1AtBlock2 bool
 }
 
 func parseStartOptions(_opts []StartOption) (startOptions, error) {
 	opts := make(map[string]SystemConfigHook)
+	var pauseL1AtBlock2 bool
 	for _, opt := range _opts {
+		if opt.pauseL1AtBlock2 {
+			if pauseL1AtBlock2 {
+				return startOptions{}, errors.New("duplicate L1 block 2 pause option")
+			}
+			pauseL1AtBlock2 = true
+		}
 		if _, ok := opts[opt.Key+":"+opt.Role]; ok {
 			return startOptions{}, fmt.Errorf("duplicate option for key %s and role %s", opt.Key, opt.Role)
 		}
@@ -575,8 +599,16 @@ func parseStartOptions(_opts []StartOption) (startOptions, error) {
 	}
 
 	return startOptions{
-		opts: opts,
+		opts:            opts,
+		pauseL1AtBlock2: pauseL1AtBlock2,
 	}, nil
+}
+
+// WithL1BlockPauseAtBlock2 pauses the fake L1 block producer immediately after
+// block 2 is made canonical. Start does not return until the pause takes
+// effect, and tests can resume the producer with System.ResumeL1.
+func WithL1BlockPauseAtBlock2() StartOption {
+	return StartOption{Key: "pauseL1AtBlock2", pauseL1AtBlock2: true}
 }
 
 func WithBatcherCompressionAlgo(ca derive.CompressionAlgo) StartOption {
@@ -605,6 +637,10 @@ func (s *startOptions) Get(key, role string) (SystemConfigHook, bool) {
 }
 
 func (cfg SystemConfig) Start(t *testing.T, startOpts ...StartOption) (*System, error) {
+	return cfg.start(t, nil, startOpts...)
+}
+
+func (cfg SystemConfig) start(t *testing.T, wrapL1Block2PauseWait func(<-chan struct{}) <-chan struct{}, startOpts ...StartOption) (*System, error) {
 	parsedStartOpts, err := parseStartOptions(startOpts)
 	if err != nil {
 		return nil, err
@@ -766,11 +802,19 @@ func (cfg SystemConfig) Start(t *testing.T, startOpts ...StartOption) (*System, 
 	sys.L1BeaconAPIAddr = endpoint.RestHTTPURL(beaconApiAddr)
 
 	// Initialize nodes
-	l1Geth, _, err := geth.InitL1(
+	l1Geth, l1Miner, err := geth.InitL1(
 		cfg.DeployConfig.L1BlockTime, cfg.L1FinalizedDistance, l1Genesis, clk,
 		path.Join(cfg.BlobsPath, "l1_el"), bcn, cfg.GethOptions[RoleL1]...)
 	if err != nil {
 		return nil, err
+	}
+	sys.l1Miner = l1Miner
+	var l1Block2PauseReached <-chan struct{}
+	if parsedStartOpts.pauseL1AtBlock2 {
+		l1Block2PauseReached, err = l1Miner.PauseAtBlock(2)
+		if err != nil {
+			return nil, err
+		}
 	}
 	sys.EthInstances[RoleL1] = l1Geth
 	err = l1Geth.Node.Start()
@@ -780,7 +824,7 @@ func (cfg SystemConfig) Start(t *testing.T, startOpts ...StartOption) (*System, 
 
 	sysLogger := testlog.Logger(t, log.LevelInfo).New("role", "system")
 
-	l1UpCtx, l1UpCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	l1UpCtx, l1UpCancel := context.WithTimeout(t.Context(), 30*time.Second)
 	defer l1UpCancel()
 	if err := wait.ForNodeUp(l1UpCtx, sys.NodeClient(RoleL1), sysLogger); err != nil {
 		return nil, fmt.Errorf("l1 never came up: %w", err)
@@ -836,6 +880,18 @@ func (cfg SystemConfig) Start(t *testing.T, startOpts ...StartOption) (*System, 
 	_, err = geth.WaitForBlock(big.NewInt(2), l1Client)
 	if err != nil {
 		return nil, fmt.Errorf("waiting for blocks: %w", err)
+	}
+	if l1Block2PauseReached != nil {
+		if wrapL1Block2PauseWait != nil {
+			l1Block2PauseReached = wrapL1Block2PauseWait(l1Block2PauseReached)
+		}
+		l1PauseCtx, l1PauseCancel := context.WithTimeout(t.Context(), 30*time.Second)
+		defer l1PauseCancel()
+		select {
+		case <-l1Block2PauseReached:
+		case <-l1PauseCtx.Done():
+			return nil, fmt.Errorf("waiting for L1 block producer to pause: %w", l1PauseCtx.Err())
+		}
 	}
 
 	sys.Mocknet = mocknet.New()

--- a/op-e2e/system/e2esys/setup_test.go
+++ b/op-e2e/system/e2esys/setup_test.go
@@ -1,0 +1,62 @@
+package e2esys
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/services"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSystemStartWaitsForL1BlockPause(t *testing.T) {
+	cfg := DefaultSystemConfig(t, WithL2ELKind(services.ELKindOpGeth))
+	cfg.Nodes = nil
+
+	realAcknowledgement := make(chan (<-chan struct{}), 1)
+	gatedAcknowledgement := make(chan struct{})
+	pause := WithL1BlockPauseAtBlock2()
+	pauseWait := func(reached <-chan struct{}) <-chan struct{} {
+		realAcknowledgement <- reached
+		return gatedAcknowledgement
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	handshakeComplete := make(chan struct{})
+	defer func() {
+		cancel()
+		<-handshakeComplete
+	}()
+	sendCompleted := make(chan struct{})
+	go func() {
+		defer close(handshakeComplete)
+		var reached <-chan struct{}
+		select {
+		case reached = <-realAcknowledgement:
+		case <-ctx.Done():
+			return
+		}
+		select {
+		case <-reached:
+		case <-ctx.Done():
+			return
+		}
+		select {
+		case gatedAcknowledgement <- struct{}{}:
+			close(sendCompleted)
+		case <-ctx.Done():
+		}
+	}()
+
+	sys, err := cfg.start(t, pauseWait, pause)
+	require.NoError(t, err)
+	select {
+	case <-sendCompleted:
+	case <-ctx.Done():
+		require.NoError(t, ctx.Err(), "completing the real and gated L1 pause acknowledgements")
+	}
+	block, err := sys.NodeClient(RoleL1).BlockNumber(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, uint64(2), block)
+	require.NoError(t, sys.ResumeL1())
+}


### PR DESCRIPTION
Closes #22379

## Summary

- add synchronized FakePoS pause/resume controls that acknowledge after the target L1 block is canonical
- pause L1 at blocks 2 and 3 so TestBatcherAutoDA observes the intended fee market and pending calldata batch independent of startup time
- cover startup acknowledgement and strict batch transaction-type inspection

## Test plan

- TestBatcherAutoDA with op-geth and op-reth, including 20 repeated op-reth runs
- focused FakePoS and startup acknowledgement tests, including race stress
- just lint-go