### PR TITLE
kona-sp1: expand super-root acceptance coverage

### DIFF
--- a/.circleci/continue/rust-e2e.yml
+++ b/.circleci/continue/rust-e2e.yml
@@ -313,7 +313,7 @@ jobs:
               cargo nextest run --package kona-sp1-proposer \
               real_elf_agg_vkey_matches_vkeys_toml_prestate
       - run:
-          name: Run SP1 super-range ELF smoke
+          name: Run SP1 super-root ELF acceptance
           no_output_timeout: 30m
           command: |
             ROOT_DIR="$(pwd)"
@@ -325,15 +325,19 @@ jobs:
             export DEVSTACK_L2EL_KIND=op-reth
             export RUST_BINARY_PATH_OP_RETH="$ROOT_DIR/rust/target/release/op-reth"
             export RUST_BINARY_PATH_KONA_HOST="$ROOT_DIR/rust/target/release/kona-host"
-            export KONA_SP1_SUPER_RANGE_ELF_EXECUTOR_PATH="$ROOT_DIR/.circleci-cache/rust-binaries/kona-sp1-super-range-executor"
+            export RUST_BINARY_PATH_KONA_SP1_PROPOSER="$ROOT_DIR/rust/target/release/kona-sp1-proposer"
+            export KONA_SP1_SUPER_RANGE_ELF_EXECUTOR_PATH="$ROOT_DIR/rust/target/release/kona-sp1-super-range-executor"
             export KONA_SP1_ELF_DIR="$ROOT_DIR/rust/kona/sp1/elf"
 
             test -x "$RUST_BINARY_PATH_OP_RETH"
             test -x "$RUST_BINARY_PATH_KONA_HOST"
+            test -x "$RUST_BINARY_PATH_KONA_SP1_PROPOSER"
             test -x "$KONA_SP1_SUPER_RANGE_ELF_EXECUTOR_PATH"
             test -x "$ROOT_DIR/cannon/bin/cannon"
             test -s "$ROOT_DIR/rust/kona/prestate-artifacts-cannon-interop/prestate.bin.gz"
             test -s "$KONA_SP1_ELF_DIR/super-range-elf"
+            test -s "$KONA_SP1_ELF_DIR/super-aggregation-elf"
+            test -s "$KONA_SP1_ELF_DIR/vkeys.toml"
 
             gotestsum \
               --format=testname \
@@ -341,9 +345,17 @@ jobs:
               --jsonfile="$LOG_DIR/go-test.json" \
               -- \
               -count=1 \
-              -timeout=30m \
-              -run '^TestSP1SuperRangeELFExecutionValidCrossChainMessageSmoke$' \
+              -parallel=1 \
+              -timeout=60m \
               ./op-acceptance-tests/tests/interop/proofs/sp1
+
+            go test -list '^TestDeploymentUsesSuperAggregationVKey$' \
+              ./op-acceptance-tests/tests/proofs/zk | grep -Fxq TestDeploymentUsesSuperAggregationVKey
+            go test \
+              -count=1 \
+              -timeout=30m \
+              -run '^TestDeploymentUsesSuperAggregationVKey$' \
+              ./op-acceptance-tests/tests/proofs/zk
       - go-save-cache:
           namespace: sp1-super-range-elf-smoke
       - store_test_results:
@@ -467,17 +479,12 @@ workflows:
           requires:
             - prep-go-modules
       - rust-build-binary:
-          # The default Rust workspace members include both op-reth and kona-host,
-          # which the shared proofs preset starts or configures.
+          # The workspace release build includes op-reth, kona-host, the SP1
+          # proposer, and the super-range executor used by this job.
           name: sp1-elf-smoke-rust-binaries
           directory: rust
           profile: release
           persist_to_workspace: true
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-            - sccache-gcs-optimism
-      - rust-build-sp1-super-range-executor:
-          name: sp1-elf-smoke-executor
           context:
             - circleci-repo-readonly-authenticated-github-token
             - sccache-gcs-optimism
@@ -503,7 +510,6 @@ workflows:
             - prep-superchain
             - contracts-bedrock-build
             - sp1-elf-smoke-rust-binaries
-            - sp1-elf-smoke-executor
             - kona-build-sp1-elfs
             - cannon-prestate
             - go-binaries-for-sysgo

--- a/docs/ai/fault-proofs.md
+++ b/docs/ai/fault-proofs.md
@@ -21,6 +21,9 @@ contracts.
   L2 state. It executes blocks via `op-revm`/`op-alloy` through `kona-executor`, not op-reth.
 - **Dispute game**: an on-chain bisection game to resolve output root disputes.
 - **Preimage oracle**: the mechanism for the VM to load external data (L1 blocks, L2 state).
+- **Kona-SP1 acceptance boundary**: tests exercise the shipping super-root path through the
+  `super-range` and `super-aggregation` programs. A single chain is represented by a dependency
+  set of size one; the output-root-only programs are not acceptance targets.
 
 ## Invariants
 

--- a/op-acceptance-tests/README.md
+++ b/op-acceptance-tests/README.md
@@ -50,6 +50,25 @@ The `just` wrapper computes defaults from available CPUs:
 
 Override them with `ACCEPTANCE_TEST_JOBS`, `ACCEPTANCE_TEST_PARALLEL`, and `ACCEPTANCE_TEST_TIMEOUT`.
 
+### Kona-SP1 super-root coverage
+
+The canonical coverage tiers and proof-boundary definitions live in the
+[`rust/kona/sp1` README](../rust/kona/sp1/README.md#acceptance-coverage). The acceptance packages
+are:
+
+```bash
+# Required native-core coverage.
+RUST_JIT_BUILD=1 go test -count=1 -timeout=60m \
+  ./tests/interop/proofs/serial \
+  ./tests/interop/proofs-singlechain
+
+# Scheduled full-ELF coverage, after building the ELFs and executor.
+KONA_SP1_ELF_DIR="$PWD/../rust/kona/sp1/elf" \
+KONA_SP1_SUPER_RANGE_ELF_EXECUTOR_PATH="$PWD/../rust/target/release/kona-sp1-super-range-executor" \
+RUST_JIT_BUILD=1 go test -count=1 -parallel=1 -timeout=120m \
+  ./tests/interop/proofs/sp1
+```
+
 ## Logging
 
 When invoked with `go test`, devstack acceptance tests support configuring logging via CLI flags and environment variables:
@@ -62,7 +81,7 @@ When invoked with `go test`, devstack acceptance tests support configuring loggi
 Example:
 
 ```bash
-LOG_LEVEL=info go test -v ./op-acceptance-tests/tests/interop/message/... -run TestInteropHappyTx
+LOG_LEVEL=info go test -v ./tests/interop/message/... -run TestInteropHappyTx
 ```
 
 ## Adding Tests

--- a/op-acceptance-tests/tests/interop/proofs-singlechain/interop_fault_proofs_test.go
+++ b/op-acceptance-tests/tests/interop/proofs-singlechain/interop_fault_proofs_test.go
@@ -1,6 +1,7 @@
 package proofs_singlechain
 
 import (
+	"os"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/sdm/sdmtest"
@@ -12,11 +13,19 @@ import (
 func TestInteropSingleChainFaultProofs(gt *testing.T) {
 	t := devtest.SerialT(gt)
 	sys := presets.NewSingleChainInterop(t)
-	sfp.RunSingleChainSuperFaultProofSmokeTest(t, sys)
+	sfp.RunSingleChainSuperFaultProofSmokeTest(t, sys, proofRunners()...)
 }
 
 func TestInteropSingleChainFaultProofsWithSDM(gt *testing.T) {
 	t := devtest.SerialT(gt)
 	sys := sdmtest.NewFixtureSingleChainFaultProofSystem(t)
 	sfp.RunSingleChainSuperFaultProofSDMSmokeTest(t, sys)
+}
+
+func proofRunners() []sfp.ProofRunner {
+	runners := []sfp.ProofRunner{sfp.NewKonaProofRunner()}
+	if os.Getenv("RUST_BINARY_PATH_KONA_SP1_SUPER_RANGE_EXECUTOR") != "" || os.Getenv("RUST_JIT_BUILD") != "" {
+		runners = append(runners, sfp.NewSP1NativeProofRunner())
+	}
+	return runners
 }

--- a/op-acceptance-tests/tests/interop/proofs/sp1/super_range_elf_test.go
+++ b/op-acceptance-tests/tests/interop/proofs/sp1/super_range_elf_test.go
@@ -2,6 +2,7 @@ package sp1
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	sfp "github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/superfaultproofs"
@@ -9,15 +10,44 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 )
 
-const konaSP1SuperRangeELFExecutorPathEnv = "KONA_SP1_SUPER_RANGE_ELF_EXECUTOR_PATH"
+const (
+	konaSP1SuperRangeELFExecutorPathEnv = "KONA_SP1_SUPER_RANGE_ELF_EXECUTOR_PATH"
+	konaSP1ELFDirEnv                    = "KONA_SP1_ELF_DIR"
+)
 
 func TestSP1SuperRangeELFExecutionValidCrossChainMessageSmoke(gt *testing.T) {
 	t := devtest.SerialT(gt)
-	executorPath := os.Getenv(konaSP1SuperRangeELFExecutorPathEnv)
-	if executorPath == "" {
-		t.Skip("kona-sp1 super-range ELF executor not provided; set " + konaSP1SuperRangeELFExecutorPathEnv)
-	}
+	executorPath := requireSP1FullELF(t)
 
 	sys := presets.NewSimpleInterop(t)
 	sfp.RunConsolidateValidCrossChainMessageTest(t, sys, sfp.NewSP1FullProofRunner(executorPath))
+}
+
+func TestSP1SuperRangeELFExecutionSingleChainSmoke(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	executorPath := requireSP1FullELF(t)
+
+	sys := presets.NewSingleChainInterop(t)
+	sfp.RunSingleChainSuperFaultProofSmokeTest(t, sys, sfp.NewSP1FullProofRunner(executorPath))
+}
+
+func requireSP1FullELF(t devtest.T) string {
+	executorPath := os.Getenv(konaSP1SuperRangeELFExecutorPathEnv)
+	elfDir := os.Getenv(konaSP1ELFDirEnv)
+	if executorPath == "" && elfDir == "" {
+		t.Skip("kona-sp1 full-ELF execution not configured; set " + konaSP1SuperRangeELFExecutorPathEnv)
+	}
+
+	t.Require().NotEmpty(executorPath, konaSP1SuperRangeELFExecutorPathEnv+" must be set when "+konaSP1ELFDirEnv+" is set")
+	executorInfo, err := os.Stat(executorPath)
+	t.Require().NoError(err, "stat kona-sp1 super-range ELF executor")
+	t.Require().False(executorInfo.IsDir(), "kona-sp1 super-range ELF executor must be a file")
+	t.Require().NotZero(executorInfo.Mode().Perm()&0o111, "kona-sp1 super-range ELF executor must be executable")
+
+	t.Require().NotEmpty(elfDir, konaSP1ELFDirEnv+" must be set for full-ELF execution")
+	elfInfo, err := os.Stat(filepath.Join(elfDir, "super-range-elf"))
+	t.Require().NoError(err, "stat kona-sp1 super-range ELF")
+	t.Require().False(elfInfo.IsDir(), "kona-sp1 super-range ELF must be a file")
+	t.Require().Positive(elfInfo.Size(), "kona-sp1 super-range ELF must not be empty")
+	return executorPath
 }

--- a/op-acceptance-tests/tests/superfaultproofs/activation_boundary.go
+++ b/op-acceptance-tests/tests/superfaultproofs/activation_boundary.go
@@ -95,9 +95,9 @@ func RunInteropActivationBoundaryTest(t devtest.T, sys *presets.SimpleInterop, r
 		},
 	}
 
-	runScenarioProofs(t, sys, &scenarioProofData{
+	runScenarioProofs(t, &sys.SingleChainInterop, chains, &scenarioProofData{
 		fpvmTransitions:    tests,
 		fpvmStartTimestamp: startTimestamp,
-		zkCheckpoint:       newZKCheckpointForRunners(t, sys, endTimestamp, false, runners),
+		zkCheckpoint:       newZKCheckpointForRunners(t, &sys.SingleChainInterop, endTimestamp, false, runners),
 	}, runners...)
 }

--- a/op-acceptance-tests/tests/superfaultproofs/intrablock.go
+++ b/op-acceptance-tests/tests/superfaultproofs/intrablock.go
@@ -195,10 +195,10 @@ func RunIntraBlockConsolidationTest(t devtest.T, sys *presets.SimpleInterop, tc 
 		})
 	}
 
-	runScenarioProofs(t, sys, &scenarioProofData{
+	runScenarioProofs(t, &sys.SingleChainInterop, chains, &scenarioProofData{
 		fpvmTransitions:    tests,
 		fpvmStartTimestamp: startTimestamp,
-		zkCheckpoint:       newZKCheckpointForRunners(t, sys, endTimestamp, tc.ExpectReplacement, runners),
+		zkCheckpoint:       newZKCheckpointForRunners(t, &sys.SingleChainInterop, endTimestamp, tc.ExpectReplacement, runners),
 	}, runners...)
 }
 

--- a/op-acceptance-tests/tests/superfaultproofs/proof_runner.go
+++ b/op-acceptance-tests/tests/superfaultproofs/proof_runner.go
@@ -50,7 +50,7 @@ func NewSP1NativeProofRunner() ProofRunner {
 	return sp1ProofRunner{nativeCore: true}
 }
 
-// NewSP1FullProofRunner constructs the opt-in full-ELF runner used by the single smoke test.
+// NewSP1FullProofRunner constructs the opt-in runner used by the full-ELF smoke tests.
 func NewSP1FullProofRunner(executorPath string) ProofRunner {
 	return sp1ProofRunner{executorPath: executorPath}
 }

--- a/op-acceptance-tests/tests/superfaultproofs/proof_runner.go
+++ b/op-acceptance-tests/tests/superfaultproofs/proof_runner.go
@@ -17,7 +17,7 @@ import (
 // ProofRunner executes the proof checks attached to one shared interop scenario.
 // Implementations are constructed here so scenario internals remain private.
 type ProofRunner interface {
-	run(t devtest.T, sys *presets.SimpleInterop, data *scenarioProofData)
+	run(t devtest.T, sys *presets.SingleChainInterop, chains []*chain, data *scenarioProofData)
 }
 
 type scenarioProofData struct {
@@ -55,12 +55,12 @@ func NewSP1FullProofRunner(executorPath string) ProofRunner {
 	return sp1ProofRunner{executorPath: executorPath}
 }
 
-func runScenarioProofs(t devtest.T, sys *presets.SimpleInterop, data *scenarioProofData, runners ...ProofRunner) {
+func runScenarioProofs(t devtest.T, sys *presets.SingleChainInterop, chains []*chain, data *scenarioProofData, runners ...ProofRunner) {
 	if len(runners) == 0 {
 		runners = []ProofRunner{NewKonaProofRunner()}
 	}
 	for _, runner := range runners {
-		runner.run(t, sys, data)
+		runner.run(t, sys, chains, data)
 	}
 }
 
@@ -73,7 +73,7 @@ func hasSP1Runner(runners []ProofRunner) bool {
 	return false
 }
 
-func (konaProofRunner) run(t devtest.T, sys *presets.SimpleInterop, data *scenarioProofData) {
+func (konaProofRunner) run(t devtest.T, sys *presets.SingleChainInterop, _ []*chain, data *scenarioProofData) {
 	t.Require().NotEmpty(data.fpvmTransitions, "Kona runner requires FPVM transition cases")
 	challengerCfg := sys.L2ChainA.Escape().L2Challengers()[0].Config()
 	gameDepth := sys.DisputeGameFactory().GameImpl(gameTypes.SuperCannonKonaGameType).SplitDepth()
@@ -90,7 +90,7 @@ func (konaProofRunner) run(t devtest.T, sys *presets.SimpleInterop, data *scenar
 	}
 }
 
-func (r sp1ProofRunner) run(t devtest.T, sys *presets.SimpleInterop, data *scenarioProofData) {
+func (r sp1ProofRunner) run(t devtest.T, sys *presets.SingleChainInterop, chains []*chain, data *scenarioProofData) {
 	executorPath := r.executorPath
 	if r.nativeCore {
 		var err error
@@ -114,7 +114,7 @@ func (r sp1ProofRunner) run(t devtest.T, sys *presets.SimpleInterop, data *scena
 		checkpoint := data.zkCheckpoint
 		validateZKCheckpoint(t, sys, checkpoint)
 		cfg := sys.L2ChainA.Escape().L2Challengers()[0].Config().CannonKona
-		args := superRangeExecutorArgs(t, sys, cfg, checkpoint.trustedL1Head, checkpoint.endTimestamp)
+		args := superRangeExecutorArgs(t, sys, chains, cfg, checkpoint.trustedL1Head, checkpoint.endTimestamp)
 		if r.nativeCore {
 			args = append(args, "--native-core")
 		}
@@ -126,7 +126,7 @@ func (r sp1ProofRunner) run(t devtest.T, sys *presets.SimpleInterop, data *scena
 	})
 }
 
-func newZKCheckpoint(t devtest.T, sys *presets.SimpleInterop, endTimestamp uint64, expectReplacement bool) *zkCheckpoint {
+func newZKCheckpoint(t devtest.T, sys *presets.SingleChainInterop, endTimestamp uint64, expectReplacement bool) *zkCheckpoint {
 	resp := sys.SuperRoots.SuperRootAtTimestamp(endTimestamp)
 	t.Require().NotNil(resp.Data, "expected verified super-root data at timestamp %d", endTimestamp)
 	return &zkCheckpoint{
@@ -138,7 +138,7 @@ func newZKCheckpoint(t devtest.T, sys *presets.SimpleInterop, endTimestamp uint6
 
 func newZKCheckpointForRunners(
 	t devtest.T,
-	sys *presets.SimpleInterop,
+	sys *presets.SingleChainInterop,
 	endTimestamp uint64,
 	expectReplacement bool,
 	runners []ProofRunner,
@@ -149,7 +149,7 @@ func newZKCheckpointForRunners(
 	return newZKCheckpoint(t, sys, endTimestamp, expectReplacement)
 }
 
-func validateZKCheckpoint(t devtest.T, sys *presets.SimpleInterop, checkpoint *zkCheckpoint) {
+func validateZKCheckpoint(t devtest.T, sys *presets.SingleChainInterop, checkpoint *zkCheckpoint) {
 	resp := sys.SuperRoots.SuperRootAtTimestamp(checkpoint.endTimestamp)
 	t.Require().NotNil(resp.Data, "expected verified super-root data at timestamp %d", checkpoint.endTimestamp)
 	t.Require().Equal(checkpoint.trustedL1Head, resp.Data.VerifiedRequiredL1,
@@ -212,21 +212,24 @@ func validateZKCheckpoint(t devtest.T, sys *presets.SimpleInterop, checkpoint *z
 
 func superRangeExecutorArgs(
 	t devtest.T,
-	sys *presets.SimpleInterop,
+	sys *presets.SingleChainInterop,
+	chains []*chain,
 	cfg vm.Config,
 	l1Head eth.BlockID,
 	endTimestamp uint64,
 ) []string {
+	t.Require().Len(chains, 2, "SP1 super-range requires exactly two chains")
 	t.Require().Len(cfg.RollupConfigPaths, 2, "SP1 super-range requires both rollup configs")
 	t.Require().NotEmpty(cfg.DepsetConfigPath, "SP1 super-range requires a dependency-set config")
+	l2NodeAddresses := make([]string, len(chains))
+	for i, chain := range chains {
+		l2NodeAddresses[i] = chain.EL.Escape().UserRPC()
+	}
 	args := []string{
 		"--supernode-address", sys.SuperRoots.UserRPC(),
 		"--l1-node-address", sys.L1EL.Escape().UserRPC(),
 		"--l1-beacon-address", sys.L1CL.BeaconHTTPAddr(),
-		"--l2-node-addresses", strings.Join([]string{
-			sys.L2ELA.Escape().UserRPC(),
-			sys.L2ELB.Escape().UserRPC(),
-		}, ","),
+		"--l2-node-addresses", strings.Join(l2NodeAddresses, ","),
 		"--l1-head", l1Head.Hash.Hex(),
 		"--end-timestamp", strconv.FormatUint(endTimestamp, 10),
 		"--rollup-config-paths", strings.Join(cfg.RollupConfigPaths, ","),

--- a/op-acceptance-tests/tests/superfaultproofs/proof_runner.go
+++ b/op-acceptance-tests/tests/superfaultproofs/proof_runner.go
@@ -112,7 +112,7 @@ func (r sp1ProofRunner) run(t devtest.T, sys *presets.SingleChainInterop, chains
 	}
 	t.Run(name, func(t devtest.T) {
 		checkpoint := data.zkCheckpoint
-		validateZKCheckpoint(t, sys, checkpoint)
+		validateZKCheckpoint(t, sys, chains, checkpoint)
 		cfg := sys.L2ChainA.Escape().L2Challengers()[0].Config().CannonKona
 		args := superRangeExecutorArgs(t, sys, chains, cfg, checkpoint.trustedL1Head, checkpoint.endTimestamp)
 		if r.nativeCore {
@@ -149,13 +149,19 @@ func newZKCheckpointForRunners(
 	return newZKCheckpoint(t, sys, endTimestamp, expectReplacement)
 }
 
-func validateZKCheckpoint(t devtest.T, sys *presets.SingleChainInterop, checkpoint *zkCheckpoint) {
+func validateZKCheckpoint(t devtest.T, sys *presets.SingleChainInterop, chains []*chain, checkpoint *zkCheckpoint) {
 	resp := sys.SuperRoots.SuperRootAtTimestamp(checkpoint.endTimestamp)
 	t.Require().NotNil(resp.Data, "expected verified super-root data at timestamp %d", checkpoint.endTimestamp)
 	t.Require().Equal(checkpoint.trustedL1Head, resp.Data.VerifiedRequiredL1,
 		"verified required L1 changed for timestamp %d", checkpoint.endTimestamp)
-	t.Require().NotEmpty(resp.ChainIDs, "dependency set must contain at least one chain")
-	t.Require().Len(resp.OptimisticAtTimestamp, len(resp.ChainIDs),
+	expectedChainIDs := make([]eth.ChainID, len(chains))
+	for i, chain := range chains {
+		expectedChainIDs[i] = chain.ID
+	}
+	t.Require().NotEmpty(expectedChainIDs, "dependency set must contain at least one chain")
+	t.Require().Equal(expectedChainIDs, resp.ChainIDs,
+		"checkpoint dependency-set chains must match the proof system")
+	t.Require().Len(resp.OptimisticAtTimestamp, len(expectedChainIDs),
 		"every dependency-set chain must have an optimistic output")
 
 	verified, ok := resp.Data.Super.(*eth.SuperV1)
@@ -164,12 +170,11 @@ func validateZKCheckpoint(t devtest.T, sys *presets.SingleChainInterop, checkpoi
 		return
 	}
 	t.Require().Equal(checkpoint.endTimestamp, verified.Timestamp)
-	t.Require().Len(verified.Chains, len(resp.ChainIDs),
+	t.Require().Len(verified.Chains, len(expectedChainIDs),
 		"verified super root must contain every dependency-set chain")
-
-	verifiedRoots := make(map[eth.ChainID]eth.Bytes32, len(verified.Chains))
-	for _, output := range verified.Chains {
-		verifiedRoots[output.ChainID] = output.Output
+	for i, output := range verified.Chains {
+		t.Require().Equal(expectedChainIDs[i], output.ChainID,
+			"verified super-root chains must match the proof system")
 	}
 	trustedL1 := sys.L1EL.BlockRefByNumber(checkpoint.trustedL1Head.Number)
 	t.Require().Equal(checkpoint.trustedL1Head.Hash, trustedL1.Hash,
@@ -179,7 +184,7 @@ func validateZKCheckpoint(t devtest.T, sys *presets.SingleChainInterop, checkpoi
 	}
 
 	replacements := 0
-	for _, chainID := range resp.ChainIDs {
+	for i, chainID := range expectedChainIDs {
 		optimistic, exists := resp.OptimisticAtTimestamp[chainID]
 		t.Require().Truef(exists, "missing optimistic output for chain %s", chainID)
 		if !exists {
@@ -197,9 +202,7 @@ func validateZKCheckpoint(t devtest.T, sys *presets.SingleChainInterop, checkpoi
 		}
 		t.Require().Equalf(optimistic.RequiredL1.Hash, canonicalHash,
 			"optimistic output for chain %s is not supported by the trusted L1 chain", chainID)
-		verifiedRoot, exists := verifiedRoots[chainID]
-		t.Require().Truef(exists, "verified super root missing chain %s", chainID)
-		if optimistic.OutputRoot != verifiedRoot {
+		if optimistic.OutputRoot != verified.Chains[i].Output {
 			replacements++
 		}
 	}
@@ -218,8 +221,8 @@ func superRangeExecutorArgs(
 	l1Head eth.BlockID,
 	endTimestamp uint64,
 ) []string {
-	t.Require().Len(chains, 2, "SP1 super-range requires exactly two chains")
-	t.Require().Len(cfg.RollupConfigPaths, 2, "SP1 super-range requires both rollup configs")
+	t.Require().NotEmpty(chains, "SP1 super-range requires at least one chain")
+	t.Require().Len(cfg.RollupConfigPaths, len(chains), "SP1 super-range requires one rollup config per chain")
 	t.Require().NotEmpty(cfg.DepsetConfigPath, "SP1 super-range requires a dependency-set config")
 	l2NodeAddresses := make([]string, len(chains))
 	for i, chain := range chains {

--- a/op-acceptance-tests/tests/superfaultproofs/singlechain.go
+++ b/op-acceptance-tests/tests/superfaultproofs/singlechain.go
@@ -2,7 +2,6 @@ package superfaultproofs
 
 import (
 	sdmpkg "github.com/ethereum-optimism/optimism/op-chain-ops/pkg/sdm"
-	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
@@ -13,7 +12,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/txplan"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/crypto"
 )
 
 // singleChain bundles the DSL handles for the single L2 chain in a SingleChainInterop system.
@@ -31,21 +29,26 @@ func singleChainFrom(sys *presets.SingleChainInterop) *chain {
 // RunSingleChainSuperFaultProofSmokeTest is a minimal smoke test for single-chain super fault proofs.
 // It verifies that the super-root transition works correctly when the dependency set has only one chain.
 // The test stops the batcher, waits for the safe head to stall, then resumes batching and verifies
-// a basic set of valid/invalid transitions through both the FPP and challenger trace provider.
-func RunSingleChainSuperFaultProofSmokeTest(t devtest.T, sys *presets.SingleChainInterop) {
-	runSingleChainSuperFaultProofSmokeTest(t, sys, prepareDefaultSingleChainTarget)
+// a basic set of valid/invalid transitions through the selected proof runners.
+func RunSingleChainSuperFaultProofSmokeTest(t devtest.T, sys *presets.SingleChainInterop, runners ...ProofRunner) {
+	runSingleChainSuperFaultProofSmokeTest(t, sys, prepareDefaultSingleChainTarget, runners...)
 }
 
 // RunSingleChainSuperFaultProofSDMSmokeTest verifies the same single-chain super-root transition
 // while the disputed block contains an SDM PostExec tx. This proves kona-host super --native can
 // derive interop batches whose L2 payload includes SDM's synthetic post-exec transaction.
-func RunSingleChainSuperFaultProofSDMSmokeTest(t devtest.T, sys *presets.SingleChainInterop) {
-	runSingleChainSuperFaultProofSmokeTest(t, sys, prepareSDMSingleChainTarget)
+func RunSingleChainSuperFaultProofSDMSmokeTest(t devtest.T, sys *presets.SingleChainInterop, runners ...ProofRunner) {
+	runSingleChainSuperFaultProofSmokeTest(t, sys, prepareSDMSingleChainTarget, runners...)
 }
 
 type singleChainTargetFn func(t devtest.T, sys *presets.SingleChainInterop, c *chain, chains []*chain) (startTimestamp uint64, endTimestamp uint64, targetBlock uint64)
 
-func runSingleChainSuperFaultProofSmokeTest(t devtest.T, sys *presets.SingleChainInterop, prepareTarget singleChainTargetFn) {
+func runSingleChainSuperFaultProofSmokeTest(
+	t devtest.T,
+	sys *presets.SingleChainInterop,
+	prepareTarget singleChainTargetFn,
+	runners ...ProofRunner,
+) {
 	t.Require().NotNil(sys.SuperRoots, "supernode is required for this test")
 
 	c := singleChainFrom(sys)
@@ -154,19 +157,11 @@ func runSingleChainSuperFaultProofSmokeTest(t devtest.T, sys *presets.SingleChai
 		},
 	}
 
-	challengerCfg := sys.L2ChainA.Escape().L2Challengers()[0].Config()
-	gameDepth := sys.DisputeGameFactory().GameImpl(gameTypes.SuperCannonKonaGameType).SplitDepth()
-
-	for _, test := range tests {
-		t.Run(test.Name+"-fpp", func(t devtest.T) {
-			runKonaInteropProgram(t, challengerCfg.CannonKona, test.L1Head.Hash,
-				test.AgreedClaim, crypto.Keccak256Hash(test.DisputedClaim),
-				test.ClaimTimestamp, test.ExpectValid)
-		})
-		t.Run(test.Name+"-challenger", func(t devtest.T) {
-			runChallengerProviderTest(t, sys.SuperRoots.QueryAPI(), gameDepth, startTimestamp, test.ClaimTimestamp, test)
-		})
-	}
+	runScenarioProofs(t, sys, chains, &scenarioProofData{
+		fpvmTransitions:    tests,
+		fpvmStartTimestamp: startTimestamp,
+		zkCheckpoint:       newZKCheckpointForRunners(t, sys, endTimestamp, false, runners),
+	}, runners...)
 }
 
 func prepareDefaultSingleChainTarget(t devtest.T, _ *presets.SingleChainInterop, c *chain, chains []*chain) (uint64, uint64, uint64) {

--- a/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
+++ b/op-acceptance-tests/tests/superfaultproofs/superfaultproofs.go
@@ -956,10 +956,10 @@ func runFaultProofTest(t devtest.T, sys *presets.SimpleInterop, runners ...Proof
 		chains, end, endNext, endTimestamp, l1HeadCurrent,
 		firstOptimisticNext, secondOptimisticNext)...)
 
-	runScenarioProofs(t, sys, &scenarioProofData{
+	runScenarioProofs(t, &sys.SingleChainInterop, chains, &scenarioProofData{
 		fpvmTransitions:    tests,
 		fpvmStartTimestamp: startTimestamp,
-		zkCheckpoint:       newZKCheckpointForRunners(t, sys, zkEndTimestamp, false, runners),
+		zkCheckpoint:       newZKCheckpointForRunners(t, &sys.SingleChainInterop, zkEndTimestamp, false, runners),
 	}, runners...)
 }
 
@@ -1112,10 +1112,10 @@ func RunConsolidateValidCrossChainMessageTest(t devtest.T, sys *presets.SimpleIn
 		},
 	}
 
-	runScenarioProofs(t, sys, &scenarioProofData{
+	runScenarioProofs(t, &sys.SingleChainInterop, chains, &scenarioProofData{
 		fpvmTransitions:    tests,
 		fpvmStartTimestamp: startTimestamp,
-		zkCheckpoint:       newZKCheckpointForRunners(t, sys, endTimestamp, false, runners),
+		zkCheckpoint:       newZKCheckpointForRunners(t, &sys.SingleChainInterop, endTimestamp, false, runners),
 	}, runners...)
 }
 
@@ -1267,10 +1267,10 @@ func RunInvalidBlockTest(t devtest.T, sys *presets.SimpleInterop, runners ...Pro
 		},
 	}
 
-	runScenarioProofs(t, sys, &scenarioProofData{
+	runScenarioProofs(t, &sys.SingleChainInterop, chains, &scenarioProofData{
 		fpvmTransitions:    tests,
 		fpvmStartTimestamp: startTimestamp,
-		zkCheckpoint:       newZKCheckpointForRunners(t, sys, endTimestamp, true, runners),
+		zkCheckpoint:       newZKCheckpointForRunners(t, &sys.SingleChainInterop, endTimestamp, true, runners),
 	}, runners...)
 }
 
@@ -1399,10 +1399,10 @@ func RunMessageExpiryTest(t devtest.T, sys *presets.SimpleInterop, msgExpiryWind
 		},
 	}
 
-	runScenarioProofs(t, sys, &scenarioProofData{
+	runScenarioProofs(t, &sys.SingleChainInterop, chains, &scenarioProofData{
 		fpvmTransitions:    tests,
 		fpvmStartTimestamp: startTimestamp,
-		zkCheckpoint:       newZKCheckpointForRunners(t, sys, endTimestamp, true, runners),
+		zkCheckpoint:       newZKCheckpointForRunners(t, &sys.SingleChainInterop, endTimestamp, true, runners),
 	}, runners...)
 }
 
@@ -1462,10 +1462,10 @@ func RunDepositMessageTest(t devtest.T, sys *presets.SimpleInterop, runners ...P
 		},
 	}
 
-	runScenarioProofs(t, sys, &scenarioProofData{
+	runScenarioProofs(t, &sys.SingleChainInterop, chains, &scenarioProofData{
 		fpvmTransitions:    tests,
 		fpvmStartTimestamp: startTimestamp,
-		zkCheckpoint:       newZKCheckpointForRunners(t, sys, endTimestamp, false, runners),
+		zkCheckpoint:       newZKCheckpointForRunners(t, &sys.SingleChainInterop, endTimestamp, false, runners),
 	}, runners...)
 }
 
@@ -1543,9 +1543,9 @@ func RunDepositMessageInvalidExecutionTest(t devtest.T, sys *presets.SimpleInter
 		},
 	}
 
-	runScenarioProofs(t, sys, &scenarioProofData{
+	runScenarioProofs(t, &sys.SingleChainInterop, chains, &scenarioProofData{
 		fpvmTransitions:    tests,
 		fpvmStartTimestamp: startTimestamp,
-		zkCheckpoint:       newZKCheckpointForRunners(t, sys, endTimestamp, true, runners),
+		zkCheckpoint:       newZKCheckpointForRunners(t, &sys.SingleChainInterop, endTimestamp, true, runners),
 	}, runners...)
 }

--- a/rust/kona/sp1/README.md
+++ b/rust/kona/sp1/README.md
@@ -78,6 +78,36 @@ The directory must contain `chainList.json`, `configs.json`, and `depsets.json`.
 Those files are compiled into the kona crates used by the guest programs, so
 custom configs produce different ELFs and verification-key hashes.
 
+## Acceptance coverage
+
+Kona-SP1 acceptance coverage targets the shipping super-root path: `super-range` and
+`super-aggregation`, for both multi-chain interop and a single-chain dependency set of size one.
+
+| Tier | Coverage | Boundary |
+|---|---|---|
+| Required native core | Existing two-chain scenarios and one canonical single-chain scenario collect real witnesses and replay the shared range/consolidation cores. | Does not load the zkVM ELF. |
+| Scheduled full ELF | One valid cross-chain transition and one canonical single-chain transition execute `super-range-elf`. | Exercises ELF input/output and zkVM patches, but does not generate a proof. |
+| Required lifecycle | The proposer and challenger assemble real child outputs and aggregation inputs, then submit mock proof bytes through `SP1PlonkAdapter` backed by `MockSP1Verifier`. | Exercises the onchain lifecycle without production proof verification. |
+| Guest and artifact | Guest tests validate single-chain aggregation, child ordering, and `SUPER_RANGE_VKEY`; scheduled checks bind the built aggregation vkey to the deployed prestate. | Does not generate a recursive aggregation proof. |
+
+Run the native and full-ELF acceptance packages from the repository root after building the
+standard acceptance dependencies:
+
+```bash
+RUST_JIT_BUILD=1 go test -count=1 -timeout=60m \
+  ./op-acceptance-tests/tests/interop/proofs/serial \
+  ./op-acceptance-tests/tests/interop/proofs-singlechain
+
+cd rust/kona/sp1 && just build-elfs-native && just build-super-range-executor && cd ../../..
+KONA_SP1_ELF_DIR="$PWD/rust/kona/sp1/elf" \
+KONA_SP1_SUPER_RANGE_ELF_EXECUTOR_PATH="$PWD/rust/target/release/kona-sp1-super-range-executor" \
+RUST_JIT_BUILD=1 go test -count=1 -parallel=1 -timeout=120m \
+  ./op-acceptance-tests/tests/interop/proofs/sp1
+```
+
+Real recursive proof generation, SPN credentials, and production verifier proof-byte validation
+remain network-proving concerns rather than deterministic acceptance-test coverage.
+
 ## CI TODOs
 
 TODO(#18326): the monorepo's CircleCI runs the

--- a/rust/kona/sp1/crates/client/src/test_utils.rs
+++ b/rust/kona/sp1/crates/client/src/test_utils.rs
@@ -83,3 +83,35 @@ pub fn valid_aggregation_inputs() -> SuperAggregationInputs {
         ],
     }
 }
+
+/// Returns the canonical valid single-chain fixture for super-aggregation tests.
+pub fn valid_single_chain_aggregation_inputs() -> SuperAggregationInputs {
+    let starting_super_root_proof = SuperRootProof::new(99, vec![output(10, 0x01)]);
+    let starting_root_hash =
+        hash_super_root_proof(&starting_super_root_proof).expect("starting root hashes");
+    let final_super_root = B256::from([0x44; 32]);
+    let timestamp_100 = vec![optimistic(10, 0x11, 0x12)];
+
+    SuperAggregationInputs {
+        l1_head: B256::from([0x99; 32]),
+        starting_root_hash,
+        starting_super_root_proof,
+        root_claim: final_super_root,
+        l2_sequence_number: 100,
+        prover: address!("0x1234567890123456789012345678901234567890"),
+        range_outputs: vec![SuperRangeOutputs {
+            span: TimestampSpan::new(100, 100).expect("valid span"),
+            l1_head: B256::from([0x99; 32]),
+            previous_super_roots: vec![starting_root_hash],
+            transitions: vec![SuperRangeTransition {
+                timestamp: 100,
+                optimistic_block: timestamp_100[0],
+            }],
+        }],
+        consolidation_outputs: vec![SuperConsolidationOutputs {
+            span: TimestampSpan::new(100, 100).expect("valid span"),
+            previous_super_root: starting_root_hash,
+            transitions: vec![consolidation_transition(100, timestamp_100, 0x44)],
+        }],
+    }
+}

--- a/rust/kona/sp1/programs/super-aggregation/src/main.rs
+++ b/rust/kona/sp1/programs/super-aggregation/src/main.rs
@@ -58,7 +58,10 @@ fn interop_public_values_digest(output: &SuperInteropOutputs) -> [u8; 32] {
 
 #[cfg(test)]
 mod tests {
-    use kona_sp1_client_utils::{super_root::SuperRootError, test_utils::valid_aggregation_inputs};
+    use kona_sp1_client_utils::{
+        super_root::SuperRootError,
+        test_utils::{valid_aggregation_inputs, valid_single_chain_aggregation_inputs},
+    };
     use sha2::{Digest, Sha256};
 
     use super::{aggregate, consolidation_public_values_digest, range_public_values_digest};
@@ -105,6 +108,25 @@ mod tests {
                 (kona_sp1_range_vkeys::SUPER_RANGE_VKEY, CONSOLIDATION_DIGESTS[0]),
                 (kona_sp1_range_vkeys::SUPER_RANGE_VKEY, CONSOLIDATION_DIGESTS[1]),
             ]
+        );
+    }
+
+    #[test]
+    fn aggregation_accepts_single_chain_dependency_set() {
+        let inputs = valid_single_chain_aggregation_inputs();
+        let mut calls = Vec::new();
+
+        let public_values = aggregate(&inputs, |vkey, digest| calls.push((*vkey, *digest)))
+            .expect("valid single-chain aggregation succeeds");
+
+        assert_eq!(public_values, inputs.zk_dispute_game_public_values());
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[0].0, kona_sp1_range_vkeys::SUPER_RANGE_VKEY);
+        assert_eq!(calls[0].1, range_public_values_digest(&inputs.range_outputs[0]));
+        assert_eq!(calls[1].0, kona_sp1_range_vkeys::SUPER_RANGE_VKEY);
+        assert_eq!(
+            calls[1].1,
+            consolidation_public_values_digest(&inputs.consolidation_outputs[0])
         );
     }
 


### PR DESCRIPTION
## Summary

- Generalize the super-fault-proof runner from the two-chain preset to an ordered dependency set of one or more chains.
- Cover the shipping super-range path for a dependency set of size one in native SP1 and full-ELF execution.
- Add a size-one super-aggregation guest test and strengthen the scheduled real-artifact boundary.
- Reuse the scheduled Rust workspace build for the SP1 proposer and executor instead of compiling the executor in a second job.

This covers only super roots through the super-range and super-aggregation programs. The output-root-only range path is outside this PR. Related to #18326.

## Local and CI behavior

The existing environment-gated `proofRunners()` behavior is preserved. A normal local acceptance run uses Kona only. Setting `RUST_JIT_BUILD` or `RUST_BINARY_PATH_KONA_SP1_SUPER_RANGE_EXECUTOR` opts into SP1 native; required CI already exports the executor path, so it runs both the existing multi-chain scenarios and the new size-one scenario through SP1.

Full-ELF execution remains scheduled and opt-in through `KONA_SP1_SUPER_RANGE_ELF_EXECUTOR_PATH` plus `KONA_SP1_ELF_DIR`.

## How to review

Review the three commits in order:

1. `2a2f559d32` decouples runner internals from `SimpleInterop` by passing the shared `SingleChainInterop` base and ordered chain list. It deliberately preserves the existing exact-two assertion and runner-selection behavior.
2. `46e33db633` relaxes the executor adapter to one or more chains, validates checkpoint chain identity and ordering, routes the existing single-chain smoke scenario through the shared runner, and adds native SP1 only when the existing environment opt-in is present.
3. `15ab59c522` adds multi-chain and size-one full-ELF smoke coverage, verifies size-one super-aggregation inputs, and updates scheduled CI and documentation.

## CI simplification

The scheduled `rust-build-binary` invocation already performs a workspace release build, which produces and persists `op-reth`, `kona-host`, `kona-sp1-proposer`, and `kona-sp1-super-range-executor`. This PR removes the separate executor build job and consumes the executor from that workspace artifact, avoiding duplicated compilation and one workflow dependency.

The 32 GB scheduled job then preflights the real proposer, executor, ELFs, and vkeys; runs the dedicated full-ELF Go package serially for both chain cardinalities; and checks that the built super-aggregation vkey reaches the deployed ZK game prestate.

## Test plan

- Focused Go compilation and vet for affected acceptance packages.
- `TestInteropSingleChainFaultProofs` with `RUST_JIT_BUILD=1`, including `SP1NativeCore`.
- Size-one super-aggregation guest test.
- Full SP1 guest lint/test suite and full-ELF smoke coverage.
- Merged CircleCI validation, scheduled-workflow processing, and decision-tree checks.