### PR TITLE
op-acceptance-tests: enable ZK dispute-game withdrawal

### DIFF
--- a/op-acceptance-tests/tests/base/withdrawal/withdrawal_test_helper.go
+++ b/op-acceptance-tests/tests/base/withdrawal/withdrawal_test_helper.go
@@ -2,15 +2,19 @@ package withdrawal
 
 import (
 	"testing"
+	"time"
 
 	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-core/devfeatures"
 	opforks "github.com/ethereum-optimism/optimism/op-core/forks"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl/proofs"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
 	ps "github.com/ethereum-optimism/optimism/op-proposer/proposer"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/common"
 )
 
 func withdrawalOpts(gameType gameTypes.GameType, extra ...presets.Option) []presets.Option {
@@ -42,22 +46,60 @@ func newSystem(t devtest.T, gameType gameTypes.GameType, extra ...presets.Option
 	return presets.NewMinimal(t, withdrawalOpts(gameType, extra...)...)
 }
 
+type withdrawalTestEnv struct {
+	bridge      *dsl.StandardBridge
+	factory     *proofs.DisputeGameFactory
+	anchor      *dsl.AnchorStateRegistry
+	funderL1    *dsl.FunderEOA
+	l2EL        *dsl.L2ELNode
+	advanceTime func(time.Duration)
+}
+
+func newWithdrawalTestEnv(t devtest.T, gameType gameTypes.GameType, extra ...presets.Option) withdrawalTestEnv {
+	if gameType == gameTypes.ZKDisputeGameType {
+		opts := []presets.Option{
+			presets.WithZK(),
+			presets.WithZKProposerOption(sysgo.WithZKFastFinality()),
+			presets.WithFinalizationPeriodSeconds(1),
+			presets.WithProofMaturityDelaySeconds(2),
+		}
+		sys := presets.NewSimpleInterop(t, append(opts, extra...)...)
+		return withdrawalTestEnv{
+			bridge:      sys.StandardBridge(sys.L2ChainA),
+			factory:     sys.DisputeGameFactory(),
+			anchor:      sys.AnchorStateRegistry(sys.L2ChainA),
+			funderL1:    sys.FunderL1,
+			l2EL:        sys.L2ELA,
+			advanceTime: sys.AdvanceTime,
+		}
+	}
+
+	sys := newSystem(t, gameType, extra...)
+	return withdrawalTestEnv{
+		bridge:      sys.StandardBridge(),
+		factory:     sys.DisputeGameFactory(),
+		anchor:      sys.AnchorStateRegistry(),
+		funderL1:    sys.FunderL1,
+		l2EL:        sys.L2EL,
+		advanceTime: sys.AdvanceTime,
+	}
+}
+
 func TestWithdrawal(gt *testing.T, gameType gameTypes.GameType, extra ...presets.Option) {
 	t := devtest.ParallelT(gt)
 	if gameType == gameTypes.SuperPermissionedGameType || gameType == gameTypes.SuperCannonKonaGameType {
 		// TODO(#21861): Enable this when kona-node supports superroot_atTimestamp
 		sysgo.SkipOnKonaNode(t, "super-root proposals require op-node superroot RPC")
 	}
-	sys := newSystem(t, gameType, extra...)
-
-	bridge := sys.StandardBridge()
+	env := newWithdrawalTestEnv(t, gameType, extra...)
+	bridge := env.bridge
 	bridge.VerifyRespectedGameType(gameType)
 
 	initialL1Balance := eth.OneThirdEther
 
 	// l1User and l2User share same private key
-	l1User := sys.FunderL1.NewFundedEOA(initialL1Balance)
-	l2User := l1User.AsEL(sys.L2EL) // Only receives funds via the deposit
+	l1User := env.funderL1.NewFundedEOA(initialL1Balance)
+	l2User := l1User.AsEL(env.l2EL) // Only receives funds via the deposit
 	depositAmount := eth.OneTenthEther
 	withdrawalAmount := eth.OneHundredthEther
 
@@ -72,25 +114,50 @@ func TestWithdrawal(gt *testing.T, gameType gameTypes.GameType, extra ...presets
 	withdrawal := bridge.InitiateWithdrawal(withdrawalAmount, l2User)
 	expectedL2UserBalance = expectedL2UserBalance.Sub(withdrawalAmount).Sub(withdrawal.InitiateGasCost())
 	l2User.VerifyBalanceExact(expectedL2UserBalance)
-	game := sys.DisputeGameFactory().WaitForGame()
-	t.Require().Equal(gameType, game.GameType())
+	var game *proofs.FaultDisputeGame
+	if gameType != gameTypes.ZKDisputeGameType {
+		game = env.factory.WaitForGame()
+		t.Require().Equal(gameType, game.GameType())
+	}
 
 	withdrawal.Prove(l1User)
 	expectedL1UserBalance = expectedL1UserBalance.Sub(withdrawal.ProveGasCost())
 	l1User.VerifyBalanceExact(expectedL1UserBalance)
 
-	// Advance time until game is resolvable
-	sys.AdvanceTime(bridge.GameResolutionDelay())
-	withdrawal.WaitForDisputeGameResolved()
+	var zkGame *proofs.ZKGame
+	if gameType == gameTypes.ZKDisputeGameType {
+		gameIndex := withdrawal.ProvenDisputeGameIndex()
+		t.Require().True(gameIndex.IsInt64(), "proven dispute game index must fit in int64: %s", gameIndex)
+		t.Require().GreaterOrEqual(gameIndex.Int64(), int64(0), "proven dispute game index must not be negative")
+		zkGame = env.factory.WaitForZKGameAtIndex(gameIndex.Int64())
+		deadline := zkGame.ClaimData().Deadline
+		zkGame.WaitForGameStatus(gameTypes.GameStatusDefenderWon)
+		claimData := zkGame.ClaimData()
+		t.Require().NotEqual(common.Address{}, claimData.Prover, "fast-finality proposer must submit an accepted proof")
+		t.Require().Less(zkGame.ResolvedAt(), deadline, "proven ZK game must resolve before its challenge deadline")
+		env.advanceTime(max(bridge.WithdrawalDelay(), bridge.DisputeGameFinalityDelay()) + time.Second)
+	} else {
+		// Advance time until game is resolvable
+		env.advanceTime(bridge.GameResolutionDelay())
+		withdrawal.WaitForDisputeGameResolved()
 
-	// Advance time to when game finalization and proof finalization delay has expired
-	sys.AdvanceTime(max(bridge.WithdrawalDelay()-bridge.GameResolutionDelay(), bridge.DisputeGameFinalityDelay()))
+		// Advance time to when game finalization and proof finalization delay has expired
+		env.advanceTime(max(bridge.WithdrawalDelay()-bridge.GameResolutionDelay(), bridge.DisputeGameFinalityDelay()))
+	}
 
-	t.Logger().Info("Attempting to finalize", "proofMaturity", bridge.WithdrawalDelay(), "gameResolutionDelay", bridge.GameResolutionDelay(), "gameFinalityDelay", bridge.DisputeGameFinalityDelay())
+	if gameType == gameTypes.ZKDisputeGameType {
+		t.Logger().Info("Attempting to finalize", "proofMaturity", bridge.WithdrawalDelay(), "gameFinalityDelay", bridge.DisputeGameFinalityDelay())
+	} else {
+		t.Logger().Info("Attempting to finalize", "proofMaturity", bridge.WithdrawalDelay(), "gameResolutionDelay", bridge.GameResolutionDelay(), "gameFinalityDelay", bridge.DisputeGameFinalityDelay())
+	}
 	withdrawal.Finalize(l1User)
 	expectedL1UserBalance = expectedL1UserBalance.Sub(withdrawal.FinalizeGasCost()).Add(withdrawalAmount)
 	l1User.VerifyBalanceExact(expectedL1UserBalance)
-	sys.AnchorStateRegistry().WaitForAnchorRootAtLeast(game)
+	if zkGame != nil {
+		env.anchor.WaitForAnchorRootAtLeast(zkGame)
+	} else {
+		env.anchor.WaitForAnchorRootAtLeast(game)
+	}
 }
 
 // TestWithdrawalAfterUpgrade is like TestWithdrawal but waits for the given fork to activate

--- a/op-acceptance-tests/tests/proofs/super/withdrawal_test.go
+++ b/op-acceptance-tests/tests/proofs/super/withdrawal_test.go
@@ -16,10 +16,5 @@ func TestSuperCannonKonaWithdrawal(gt *testing.T) {
 }
 
 func TestZKDisputeGameWithdrawal(gt *testing.T) {
-	// TODO(#22174): the single-chain withdrawal preset cannot install the
-	// ZK game type; devstack bring-up fails in UpgradeOPChain.s.sol before
-	// any proposer runs. Unskip once the single-chain runtime supports the
-	// ZK game type (or the withdrawal helper gains a supernode preset).
-	gt.Skip("single-chain withdrawal preset cannot install the ZK game type (#22174)")
 	withdrawal.TestWithdrawal(gt, gameTypes.ZKDisputeGameType)
 }

--- a/op-devstack/dsl/bridge.go
+++ b/op-devstack/dsl/bridge.go
@@ -387,6 +387,11 @@ func bridgeGameSequenceAndOutputRoot(game bindings.GameSearchResult, gameType ga
 		return new(big.Int).SetBytes(game.ExtraData[:32]), game.RootClaim, true, nil
 	case gameTypes.SuperCannonKonaGameType, gameTypes.SuperPermissionedGameType:
 		return bridgeSuperRootChainOutput(game.ExtraData, l2ChainID)
+	case gameTypes.ZKDisputeGameType:
+		if len(game.ExtraData) < 4 {
+			return nil, common.Hash{}, false, fmt.Errorf("ZK game extra data is %d bytes, need at least 4-byte parent index", len(game.ExtraData))
+		}
+		return bridgeSuperRootChainOutput(game.ExtraData[4:], l2ChainID)
 	default:
 		return nil, common.Hash{}, false, fmt.Errorf("unsupported game type: %v", gameType)
 	}
@@ -431,6 +436,12 @@ func (w *Withdrawal) InitiateGasCost() eth.ETH {
 func (w *Withdrawal) ProveGasCost() eth.ETH {
 	w.require.NotNil(w.proveReceipt, "Must have proven withdrawal before calculating gas cost")
 	return w.bridge.gasCost(w.proveReceipt, w.bridge.l1Client.EthClient())
+}
+
+func (w *Withdrawal) ProvenDisputeGameIndex() *big.Int {
+	w.require.NotNil(w.proveReceipt, "Must have proven withdrawal before reading dispute game index")
+	w.require.NotNil(w.proveParams.DisputeGameIndex, "Proven withdrawal is missing dispute game index")
+	return new(big.Int).Set(w.proveParams.DisputeGameIndex)
 }
 
 func (w *Withdrawal) FinalizeGasCost() eth.ETH {

--- a/op-devstack/dsl/bridge_test.go
+++ b/op-devstack/dsl/bridge_test.go
@@ -1,0 +1,98 @@
+package dsl
+
+import (
+	"encoding/binary"
+	"math"
+	"math/big"
+	"testing"
+
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/txintent/bindings"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBridgeGameSequenceAndOutputRootZK(t *testing.T) {
+	chainID := uint64(10)
+	outputRoot := eth.Bytes32{0: 0xaa}
+	superRoot := eth.NewSuperV1(1234, eth.ChainIDAndOutput{
+		ChainID: eth.ChainIDFromUInt64(chainID),
+		Output:  outputRoot,
+	}).Marshal()
+	extraData := make([]byte, 4+len(superRoot))
+	binary.BigEndian.PutUint32(extraData, math.MaxUint32)
+	copy(extraData[4:], superRoot)
+
+	sequence, actualRoot, ok, err := bridgeGameSequenceAndOutputRoot(
+		bindings.GameSearchResult{ExtraData: extraData},
+		gameTypes.ZKDisputeGameType,
+		new(big.Int).SetUint64(chainID),
+	)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, uint64(1234), bigs.Uint64Strict(sequence))
+	require.Equal(t, common.Hash(outputRoot), actualRoot)
+}
+
+func TestBridgeGameSequenceAndOutputRootZKRejectsInvalidExtraData(t *testing.T) {
+	invalid := map[string][]byte{
+		"empty":         nil,
+		"one byte":      make([]byte, 1),
+		"two bytes":     make([]byte, 2),
+		"three bytes":   make([]byte, 3),
+		"prefix only":   make([]byte, 4),
+		"invalid proof": append(make([]byte, 4), 0xff),
+	}
+
+	for name, extraData := range invalid {
+		t.Run(name, func(t *testing.T) {
+			sequence, outputRoot, ok, err := bridgeGameSequenceAndOutputRoot(
+				bindings.GameSearchResult{ExtraData: extraData},
+				gameTypes.ZKDisputeGameType,
+				big.NewInt(10),
+			)
+			require.Error(t, err)
+			require.Nil(t, sequence)
+			require.Equal(t, common.Hash{}, outputRoot)
+			require.False(t, ok)
+		})
+	}
+}
+
+func TestBridgeGameSequenceAndOutputRootZKMissingChain(t *testing.T) {
+	superRoot := eth.NewSuperV1(1234, eth.ChainIDAndOutput{
+		ChainID: eth.ChainIDFromUInt64(10),
+		Output:  eth.Bytes32{0: 0xaa},
+	}).Marshal()
+	extraData := append(make([]byte, 4), superRoot...)
+
+	sequence, outputRoot, ok, err := bridgeGameSequenceAndOutputRoot(
+		bindings.GameSearchResult{ExtraData: extraData},
+		gameTypes.ZKDisputeGameType,
+		big.NewInt(11),
+	)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1234), bigs.Uint64Strict(sequence))
+	require.Equal(t, common.Hash{}, outputRoot)
+	require.False(t, ok)
+}
+
+func TestWithdrawalProvenDisputeGameIndexReturnsCopy(t *testing.T) {
+	dt := devtest.SerialT(t)
+	stored := big.NewInt(7)
+	withdrawal := &Withdrawal{
+		commonImpl:   commonFromT(dt),
+		proveParams:  ProvenWithdrawalParameters{DisputeGameIndex: stored},
+		proveReceipt: &types.Receipt{},
+	}
+
+	actual := withdrawal.ProvenDisputeGameIndex()
+	require.Equal(t, int64(7), actual.Int64())
+	require.NotSame(t, stored, actual)
+	actual.SetInt64(8)
+	require.Equal(t, int64(7), withdrawal.ProvenDisputeGameIndex().Int64())
+}


### PR DESCRIPTION
## Summary

Closes #22174 

Enable the ZK dispute-game withdrawal acceptance test using the existing SimpleInterop ZK topology with fast finality. The bridge now decodes the type-10 parent-index prefix and tracks the exact covering game selected by the withdrawal proof.

The test verifies the full flow:

1. Deposit ETH to L2, initiate a withdrawal, and check exact balances and gas costs.
2. Prove the withdrawal against the selected ZK super-root game.
3. Exercise the proposer mock-proof path through the configured mock verifier, then require a nonzero prover and DefenderWon resolution before the original challenge deadline.
4. Satisfy proof maturity and game finality, finalize the withdrawal, verify the final L1 balance, and require the anchor to reach the proven root or a canonical successor.

## Test plan

- Full op-devstack DSL unit suite.
- ZK, SuperPermissioned, and SuperCannon Kona withdrawal acceptance scenarios.
- Go vet and compile checks for the affected acceptance packages.