### PR TITLE
ci: use dev profile for PR image builds and never cancel develop builds

### DIFF
--- a/.github/workflows/build-images.apko.yaml
+++ b/.github/workflows/build-images.apko.yaml
@@ -90,7 +90,7 @@ jobs:
       source-submodules: ${{ matrix.source_submodules }}
       use-gha-cache: ${{ matrix.use_gha_cache }}
       cache-key-files: ${{ matrix.cache_key_files }}
-      cargo-profile: maxperf
+      cargo-profile: ${{ github.event_name == 'pull_request' && 'fast-build' || 'maxperf' }}
       build-version: ${{ matrix.build_version }}
 
   apko:

--- a/.github/workflows/build-images.apko.yaml
+++ b/.github/workflows/build-images.apko.yaml
@@ -32,8 +32,8 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   SOURCE_DATE_EPOCH: 0

--- a/melange/pipelines/cargo/build.yaml
+++ b/melange/pipelines/cargo/build.yaml
@@ -146,6 +146,10 @@ pipeline:
         run_wrap="mold -run"
       fi
 
+      export VERGEN_GIT_SHA="${VERGEN_GIT_SHA:-${GIT_COMMIT:-0000000000000000000000000000000000000000}}"
+      export VERGEN_GIT_DIRTY="${VERGEN_GIT_DIRTY:-false}"
+      export VERGEN_GIT_DESCRIBE="${VERGEN_GIT_DESCRIBE:-${GIT_VERSION:-${GIT_COMMIT:-unknown}}}"
+
       RUSTFLAGS="${{inputs.rustflags}}" $run_wrap cargo auditable build \
         $profile_flag $build_opts $jobs_flag
 


### PR DESCRIPTION
## Summary
Three related changes to the apko/melange image builds:
1. Restore the `pull_request` -> `fast-build` (dev) cargo profile. `develop`, tags, and the nightly schedule stay on `maxperf`.
2. Give every non-PR commit its own concurrency group so develop/tag/scheduled image builds always run to completion; only cancel superseded builds on PRs.
3. Feed reth build scripts the git metadata they need so cold melange builds don't fail.

## Why
**Profile** — PR image builds only validate that images compile and pass smoke tests; they don't need fat-LTO binaries. The profile was conditional until #21876 hardcoded it to `maxperf` (when it removed the PR trigger), and #22257 re-added PR builds without restoring the conditional. `fast-build` (`opt-level = 0`, `incremental`, `codegen-units = 256`) is far faster.

**Concurrency** — keying the group on `github.ref` put every develop push in one group; with `cancel-in-progress: false` the active build was protected, but GitHub keeps only one *pending* run per group, so each new merge dropped the previously-pending develop SHA and most post-merge commits never produced images. Keying per-SHA for non-PR events lets each develop/tag/scheduled commit finish; `cancel-in-progress` for PRs supersedes an in-flight PR build on a new push.

**Build-script fix** — `reth-node-core`'s build script reads `VERGEN_GIT_SHA/DIRTY/DESCRIBE` via `env::var()?` and aborts (`Error: NotPresent`) when they're missing. The melange sandbox has no `.git`, so `vergen_git2` can't populate them and every *cold* build fails; `maxperf` only passed because that build-script output was served from the warm cache (the same landmine would hit a cold maxperf build after a `Cargo.lock` bump). `cargo/build` now exports the three vars from the `GIT_*` metadata the workflow already injects, so vergen never needs git and cold builds of any profile succeed with real version strings.

## Changes
```diff
-      cargo-profile: maxperf
+      cargo-profile: ${{ github.event_name == 'pull_request' && 'fast-build' || 'maxperf' }}
```
```diff
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```
```diff
+      export VERGEN_GIT_SHA="${VERGEN_GIT_SHA:-${GIT_COMMIT:-0000000000000000000000000000000000000000}}"
+      export VERGEN_GIT_DIRTY="${VERGEN_GIT_DIRTY:-false}"
+      export VERGEN_GIT_DESCRIBE="${VERGEN_GIT_DESCRIBE:-${GIT_VERSION:-${GIT_COMMIT:-unknown}}}"
```

## Notes
Complementary to #22384 (build binaries once).
