### PR TITLE
ci: remove mold linker from Rust builds

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -695,12 +695,7 @@ commands:
               # build alone would omit crates other workspace members need).
               cargo fetch --locked
             fi
-            # Use the mold linker (pinned via mise; also present in ci-base-clang)
-            # to cut final link time. `mold -run` intercepts the linker at exec
-            # time, so it needs no RUSTFLAGS change and does not perturb the sccache
-            # compile-cache key. The CI env is controlled, so a missing mold must
-            # fail loudly rather than silently falling back to the default linker.
-            mold -run cargo build $PROFILE $TARGET $PACKAGE $FEATURES $BINARY
+            cargo build $PROFILE $TARGET $PACKAGE $FEATURES $BINARY
           no_output_timeout: 30m
       - when:
           condition: << parameters.save_cache >>

--- a/melange/op-stack-rust.yaml
+++ b/melange/op-stack-rust.yaml
@@ -34,8 +34,6 @@ environment:
       - protobuf-dev
       - clang-19
       - libclang-cpp-19
-      # opt-in mold linking when the cargo/build pipeline uses it.
-      - mold
   environment:
     # The workflow selects MELANGE_CARGO_PROFILE for the main rust/ workspace:
     # fast-build for PRs and maxperf for develop/tag builds. CARGO_HOME and

--- a/melange/pipelines/cargo/build.yaml
+++ b/melange/pipelines/cargo/build.yaml
@@ -135,12 +135,7 @@ pipeline:
         jobs_flag="--jobs ${{inputs.jobs}}"
       fi
 
-      run_wrap=""
-      if command -v mold >/dev/null 2>&1; then
-        run_wrap="mold -run"
-      fi
-
-      RUSTFLAGS="${{inputs.rustflags}}" $run_wrap cargo auditable build \
+      RUSTFLAGS="${{inputs.rustflags}}" cargo auditable build \
         $profile_flag $build_opts $jobs_flag
 
       if [ -n "${{inputs.output}}" ]; then

--- a/mise.toml
+++ b/mise.toml
@@ -22,11 +22,6 @@ make = "4.4.1"
 
 svm-rs = "0.5.19"
 
-# Fast linker used for Rust link steps in CI (see .circleci rust-build). Linux
-# only: mold ships no macOS build, so gate on os to keep `mise install` green on
-# developer Macs. Pinned here so CI's linker version is fixed and reproducible.
-mold = { version = "2.41.0", os = ["linux"] }
-
 # Rust tooling
 "github:crate-ci/cargo-release" = { version = "1.1.2" }
 

--- a/ops/docker/ci-base-clang/Dockerfile
+++ b/ops/docker/ci-base-clang/Dockerfile
@@ -22,7 +22,6 @@ RUN apt-get -o Acquire::Retries=8 update \
       clang \
       llvm-dev \
       libclang-dev \
-      mold \
       protobuf-compiler \
       libprotobuf-dev \
  && apt clean \


### PR DESCRIPTION
## Description

Removes the mold linker from CI Rust builds. Mold was added in #21208 (installed in the `ci-base-clang` image) and wired into the CircleCI build in #22042, but it is now obsolete: since Rust 1.90, `rust-lld` is the default linker on `x86_64-unknown-linux-gnu` (we pin 1.95), so the default toolchain already links fast without an extra pinned tool.

Changes:
- `.circleci/continue/main.yml`: drop the `mold -run` wrapper from the `rust-build` command (the job split from #22042 is kept — only the linker part is removed)
- `mise.toml`: drop the Linux-only mold pin
- `ops/docker/ci-base-clang/Dockerfile`: drop the mold apt package (takes effect on the next image rebuild; the currently pinned digest is unaffected)
- `melange/op-stack-rust.yaml` + `melange/pipelines/cargo/build.yaml`: drop the mold package and the opt-in `mold -run` wrapper from the apko/melange Rust builds

Not touched: `rust/op-reth/flake.nix` still uses mold in its nix dev shell — that predates these PRs and is developer tooling rather than CI, so it is left as-is.

Validation: `merge-configs.sh` + `circleci config validate` (private orb stubbed) and `circleci config process` with release params pass; `test-decision-tree.sh` passes (20/20).

🤖 Generated with [Claude Code](https://claude.com/claude-code)