### PR TITLE
ci: bump factory pin so tag builds reuse the develop cache

### DIFF
--- a/.github/workflows/build-images.apko.yaml
+++ b/.github/workflows/build-images.apko.yaml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Plan melange, apko, and smoke matrices
         id: plan
-        uses: ethereum-optimism/factory/actions/apko-plan@9f80f67c23ba5ff05dff9e4265f74bbd58e9b012
+        uses: ethereum-optimism/factory/actions/apko-plan@12411827f96e70e564f1b459a1c50bd6e3bd6199
         with:
           config: .github/images.apko.json
 
@@ -77,7 +77,7 @@ jobs:
       id-token: write
       attestations: write
       artifact-metadata: write
-    uses: ethereum-optimism/factory/.github/workflows/melange-build.yaml@9f80f67c23ba5ff05dff9e4265f74bbd58e9b012
+    uses: ethereum-optimism/factory/.github/workflows/melange-build.yaml@12411827f96e70e564f1b459a1c50bd6e3bd6199
     with:
       stack: ${{ matrix.stack }}
       arch: ${{ matrix.arch }}
@@ -110,7 +110,7 @@ jobs:
       attestations: write
       artifact-metadata: write
       actions: read
-    uses: ethereum-optimism/factory/.github/workflows/apko-publish.yaml@9f80f67c23ba5ff05dff9e4265f74bbd58e9b012
+    uses: ethereum-optimism/factory/.github/workflows/apko-publish.yaml@12411827f96e70e564f1b459a1c50bd6e3bd6199
     with:
       service: ${{ matrix.service }}
       needs-melange-apks: ${{ matrix.needs_melange_apks }}
@@ -133,7 +133,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: ethereum-optimism/factory/.github/workflows/apko-smoke-test.yaml@9f80f67c23ba5ff05dff9e4265f74bbd58e9b012
+    uses: ethereum-optimism/factory/.github/workflows/apko-smoke-test.yaml@12411827f96e70e564f1b459a1c50bd6e3bd6199
     with:
       service: ${{ matrix.service }}
       registry: us-docker.pkg.dev/oplabs-tools-artifacts/images


### PR DESCRIPTION
## Summary
Bump the `ethereum-optimism/factory` pin to pull in ethereum-optimism/factory#56, which lets tag refs **restore (read-only)** the default-branch melange cache instead of building cold.

Bumps all four factory reusable-workflow/action pins in `build-images.apko.yaml` (`apko-plan`, `melange-build`, `apko-publish`, `apko-smoke-test`) to the same new `main` commit (`12411827`).

## Why
Tag/release image builds currently run with no cache (tag refs fell into the `untrusted-ref` bucket), so a release is a full cold `maxperf` compile (~50 min). With #56, tags read the warm develop cache and recompile only the delta — cutting emergency-release turnaround toward ~35 min or less.

Tags only ever **read** the cache (never write), so there's no cache-poisoning vector.
