### PR TITLE
alloy-op-evm,kona: apply SDM post-exec refunds exactly once

### DIFF
--- a/rust/alloy-op-evm/src/block/mod.rs
+++ b/rust/alloy-op-evm/src/block/mod.rs
@@ -566,6 +566,11 @@ where
         Ok(refund)
     }
 
+    /// Applies the post-exec refund to `total_gas_spent` so `tx_gas_used()` reports canonical gas.
+    ///
+    /// The EVM refund counter stays unchanged to avoid subtracting the refund twice. If the
+    /// EIP-7623 floor binds, `tx_gas_used()` remains clamped and may exceed canonical gas; whether
+    /// SDM rebates can reduce gas below that floor remains an open spec question.
     const fn canonicalize_result_gas(
         result: &mut ExecutionResult<E::HaltReason>,
         post_exec_refund: u64,
@@ -575,12 +580,9 @@ where
         }
 
         match result {
-            ExecutionResult::Success { gas, .. } => {
-                *gas = gas
-                    .with_total_gas_spent(gas.total_gas_spent().saturating_sub(post_exec_refund))
-                    .with_refunded(gas.inner_refunded().saturating_add(post_exec_refund));
-            }
-            ExecutionResult::Revert { gas, .. } | ExecutionResult::Halt { gas, .. } => {
+            ExecutionResult::Success { gas, .. } |
+            ExecutionResult::Revert { gas, .. } |
+            ExecutionResult::Halt { gas, .. } => {
                 *gas = gas
                     .with_total_gas_spent(gas.total_gas_spent().saturating_sub(post_exec_refund));
             }

--- a/rust/alloy-op-evm/src/block/tests/structural_tests.rs
+++ b/rust/alloy-op-evm/src/block/tests/structural_tests.rs
@@ -129,6 +129,45 @@ impl PostExecRefundInspector for FixedRefundPolicy {
 }
 
 #[test]
+fn canonicalized_result_gas_applies_refund_exactly_once() {
+    let mut db = prepare_observer_db();
+    let receipt_builder = OpAlloyReceiptBuilder::default();
+    let hardforks = OpChainHardforks::op_mainnet();
+    let mut executor =
+        build_policy_executor::<FixedRefundPolicy>(&mut db, &receipt_builder, &hardforks);
+
+    let output = executor
+        .execute_transaction_without_commit(&observer_test_tx())
+        .expect("refunded workload executes");
+
+    let refund = output.post_exec.as_ref().expect("refund adjustment present").refund;
+    assert_eq!(refund, 1);
+    let gas = output.inner.result.result.gas();
+    // The EIP-7623 floor must stay below the refunded gas, or `tx_gas_used()` would pin at
+    // the floor and mask a double-subtracted refund.
+    assert!(
+        output.evm_gas_used.saturating_sub(2 * refund) > gas.floor_gas(),
+        "workload too cheap to distinguish a double-subtracted refund from the floor"
+    );
+    assert_eq!(output.canonical_gas_used, output.evm_gas_used - refund);
+
+    // The exposed ExecutionResult must agree with the canonical gas the block accounts:
+    // the refund applied exactly once, not twice.
+    assert_eq!(
+        gas.tx_gas_used(),
+        output.canonical_gas_used,
+        "canonicalized result gas must equal canonical_gas_used"
+    );
+    // The refund must lower `total_gas_spent`, not inflate the EVM's own refund counter —
+    // this workload earns no EVM refund, so any value here is SDM leakage.
+    assert_eq!(gas.inner_refunded(), 0, "post-exec refund folded into the EVM refund counter");
+
+    let canonical_gas_used = output.canonical_gas_used;
+    executor.commit_transaction(output);
+    assert_eq!(executor.gas_used, canonical_gas_used, "block must accumulate canonical gas");
+}
+
+#[test]
 fn fixed_policy_producer_verifier_roundtrip() {
     let tx = observer_test_tx();
     let mut producer_db = prepare_observer_db();

--- a/rust/alloy-op-evm/src/tx.rs
+++ b/rust/alloy-op-evm/src/tx.rs
@@ -254,7 +254,17 @@ impl FromRecoveredTx<TxPostExec> for OpTx {
 
 impl FromTxWithEncoded<TxPostExec> for OpTx {
     fn from_encoded_tx(tx: &TxPostExec, caller: Address, encoded: Bytes) -> Self {
-        let base = TxEnv { tx_type: tx.ty(), caller, kind: tx.kind(), ..Default::default() };
+        // Mirror the 0x7D fields instead of inheriting unrelated `TxEnv` defaults. Preserving its
+        // zero gas limit also ensures accidental execution fails intrinsic gas validation.
+        let base = TxEnv {
+            tx_type: tx.ty(),
+            caller,
+            kind: tx.kind(),
+            gas_limit: tx.gas_limit(),
+            chain_id: tx.chain_id(),
+            data: tx.input().clone(),
+            ..Default::default()
+        };
         Self(OpTransaction { base, enveloped_tx: Some(encoded), deposit: Default::default() })
     }
 }
@@ -270,5 +280,29 @@ impl TransactionEnvMut for OpTx {
 
     fn set_access_list(&mut self, access_list: alloy_eips::eip2930::AccessList) {
         self.0.base.access_list = access_list;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec;
+    use op_alloy::consensus::{SDMGasEntry, build_post_exec_tx};
+
+    #[test]
+    fn post_exec_tx_env_mirrors_transaction() {
+        let tx = build_post_exec_tx(7, vec![SDMGasEntry { index: 0, gas_refund: 42 }]);
+        let env = OpTx::from_encoded_tx(&tx, Address::ZERO, tx.encoded_2718().into());
+
+        let expected = TxEnv {
+            tx_type: tx.ty(),
+            caller: Address::ZERO,
+            kind: tx.kind(),
+            gas_limit: tx.gas_limit(),
+            chain_id: tx.chain_id(),
+            data: tx.input().clone(),
+            ..Default::default()
+        };
+        assert_eq!(env.0.base, expected);
     }
 }

--- a/rust/kona/bin/client/src/fpvm_evm/tx.rs
+++ b/rust/kona/bin/client/src/fpvm_evm/tx.rs
@@ -226,7 +226,41 @@ impl FromRecoveredTx<TxPostExec> for FpvmOpTx {
 
 impl FromTxWithEncoded<TxPostExec> for FpvmOpTx {
     fn from_encoded_tx(tx: &TxPostExec, caller: Address, encoded: Bytes) -> Self {
-        let base = TxEnv { tx_type: tx.ty(), caller, kind: tx.kind(), ..Default::default() };
+        // Mirror the 0x7D fields instead of inheriting unrelated `TxEnv` defaults. Preserving its
+        // zero gas limit also ensures accidental execution fails intrinsic gas validation.
+        let base = TxEnv {
+            tx_type: tx.ty(),
+            caller,
+            kind: tx.kind(),
+            gas_limit: tx.gas_limit(),
+            chain_id: tx.chain_id(),
+            data: tx.input().clone(),
+            ..Default::default()
+        };
         Self(OpTransaction { base, enveloped_tx: Some(encoded), deposit: Default::default() })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec;
+    use op_alloy_consensus::{SDMGasEntry, build_post_exec_tx};
+
+    #[test]
+    fn post_exec_tx_env_mirrors_transaction() {
+        let tx = build_post_exec_tx(7, vec![SDMGasEntry { index: 0, gas_refund: 42 }]);
+        let env = FpvmOpTx::from_encoded_tx(&tx, Address::ZERO, tx.encoded_2718().into());
+
+        let expected = TxEnv {
+            tx_type: tx.ty(),
+            caller: Address::ZERO,
+            kind: tx.kind(),
+            gas_limit: tx.gas_limit(),
+            chain_id: tx.chain_id(),
+            data: tx.input().clone(),
+            ..Default::default()
+        };
+        assert_eq!(env.0.base, expected);
     }
 }


### PR DESCRIPTION
## Summary

Fix SDM post-exec gas accounting so the refund is reflected exactly once in the exposed execution result.

This code path is currently exercised only by op-rbuilder. This is not a bug that we are currently hitting in production.

Previously, successful transactions both reduced `total_gas_spent` and increased the EVM refund counter. Since `tx_gas_used()` subtracts the refund counter itself, this applied the SDM refund twice.

This change:

- applies the SDM refund only to `total_gas_spent`
- leaves the EVM-native refund counter unchanged
- preserves the EIP-7623 floor-gas behavior
- populates 0x7D transaction environments from the transaction fields in both alloy-op-evm and the Kona FPVM, preserving their zero gas limit so accidental execution fails validation
- adds regression tests for result gas accounting and 0x7D transaction environments

Fixes https://github.com/ethereum-optimism/protocol-team/issues/278

## Tests

- `cargo nextest run --package alloy-op-evm`
- `cargo nextest run --package kona-client post_exec_tx_env_mirrors_transaction`
- `cargo clippy --package alloy-op-evm --all-targets --all-features -- -D warnings`
