### PR TITLE
kona-node: run conductor acceptance coverage

### DIFF
--- a/op-acceptance-tests/tests/base/conductor/cluster_startup_test.go
+++ b/op-acceptance-tests/tests/base/conductor/cluster_startup_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
-	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
 )
 
 // TestConductorClusterStartsWithOneActiveSequencer verifies the core HA
@@ -14,8 +13,6 @@ import (
 // sequencers stay stopped.
 func TestConductorClusterStartsWithOneActiveSequencer(gt *testing.T) {
 	t := devtest.ParallelT(gt)
-	sysgo.SkipOnKonaNode(t, "kona-node conductor support is tracked by #21906")
-
 	sys := presets.NewMinimalWithConductors(t)
 
 	sys.Conductors.AwaitOneActiveSequencer()

--- a/op-acceptance-tests/tests/base/conductor/disaster_recovery_test.go
+++ b/op-acceptance-tests/tests/base/conductor/disaster_recovery_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
-	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
 	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 	"github.com/ethereum-optimism/optimism/op-service/retry"
 )
@@ -18,8 +17,6 @@ import (
 // on a surviving node and force it to resume sequencing.
 func TestDisasterRecoveryLeaderOverride(gt *testing.T) {
 	t := devtest.ParallelT(gt)
-	sysgo.SkipOnKonaNode(t, "kona-node conductor support is tracked by #21906")
-
 	sys := presets.NewMinimalWithConductors(t)
 
 	leader := sys.Conductors.AwaitOneActiveSequencer()

--- a/op-acceptance-tests/tests/base/conductor/failover_test.go
+++ b/op-acceptance-tests/tests/base/conductor/failover_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
-	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
 	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 )
 
@@ -15,8 +14,6 @@ import (
 // sequencer takes over block production.
 func TestFailoverOnActiveSequencerFailure(gt *testing.T) {
 	t := devtest.ParallelT(gt)
-	sysgo.SkipOnKonaNode(t, "kona-node conductor support is tracked by #21906")
-
 	sys := presets.NewMinimalWithConductors(t, presets.WithConductorFastHealthChecks())
 
 	failedLeader := sys.Conductors.AwaitOneActiveSequencer()

--- a/op-acceptance-tests/tests/base/conductor/leadership_transfer_test.go
+++ b/op-acceptance-tests/tests/base/conductor/leadership_transfer_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
-	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
 	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 )
 
@@ -15,8 +14,6 @@ import (
 // leader's sequencer stops sequencing and the transfer target's starts.
 func TestLeadershipTransferMovesActiveSequencer(gt *testing.T) {
 	t := devtest.ParallelT(gt)
-	sysgo.SkipOnKonaNode(t, "kona-node conductor support is tracked by #21906")
-
 	sys := presets.NewMinimalWithConductors(t)
 
 	initialLeader := sys.Conductors.AwaitOneActiveSequencer()
@@ -45,8 +42,6 @@ func TestLeadershipTransferSelectsAnotherActiveSequencer(gt *testing.T) {
 // canonical chain.
 func TestUnsafeChainAdvancesAfterLeadershipTransfer(gt *testing.T) {
 	t := devtest.ParallelT(gt)
-	sysgo.SkipOnKonaNode(t, "kona-node conductor support is tracked by #21906")
-
 	sys := presets.NewMinimalWithConductors(t)
 
 	leader := sys.Conductors.AwaitLeader()

--- a/op-acceptance-tests/tests/base/conductor/leadership_transfer_test.go
+++ b/op-acceptance-tests/tests/base/conductor/leadership_transfer_test.go
@@ -32,8 +32,6 @@ func TestLeadershipTransferMovesActiveSequencer(gt *testing.T) {
 // transfer moves leadership and sequencing to another healthy voter.
 func TestLeadershipTransferSelectsAnotherActiveSequencer(gt *testing.T) {
 	t := devtest.ParallelT(gt)
-	sysgo.SkipOnKonaNode(t, "kona-node conductor support is tracked by #21906")
-
 	sys := presets.NewMinimalWithConductors(t)
 
 	leader := sys.Conductors.AwaitOneActiveSequencer()

--- a/op-acceptance-tests/tests/base/conductor/membership_test.go
+++ b/op-acceptance-tests/tests/base/conductor/membership_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-conductor/consensus"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
-	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
 )
 
 // TestConductorClusterMembershipChanges verifies an operator can take a
@@ -15,8 +14,6 @@ import (
 // change.
 func TestConductorClusterMembershipChanges(gt *testing.T) {
 	t := devtest.ParallelT(gt)
-	sysgo.SkipOnKonaNode(t, "kona-node conductor support is tracked by #21906")
-
 	sys := presets.NewMinimalWithConductors(t)
 
 	leader := sys.Conductors.AwaitLeader()
@@ -41,8 +38,6 @@ func TestConductorClusterMembershipChanges(gt *testing.T) {
 // untouched.
 func TestConductorRejectsStaleMembershipVersion(gt *testing.T) {
 	t := devtest.ParallelT(gt)
-	sysgo.SkipOnKonaNode(t, "kona-node conductor support is tracked by #21906")
-
 	sys := presets.NewMinimalWithConductors(t)
 
 	leader := sys.Conductors.AwaitLeader()

--- a/op-acceptance-tests/tests/base/conductor/proxy_test.go
+++ b/op-acceptance-tests/tests/base/conductor/proxy_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
-	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
 	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
 	"github.com/ethereum-optimism/optimism/op-service/retry"
 )
@@ -18,8 +17,6 @@ import (
 // requests to its sequencer, while a follower's conductor refuses them.
 func TestConductorProxyServesOnlyLeader(gt *testing.T) {
 	t := devtest.ParallelT(gt)
-	sysgo.SkipOnKonaNode(t, "kona-node conductor support is tracked by #21906")
-
 	sys := presets.NewMinimalWithConductors(t)
 
 	leader := sys.Conductors.AwaitOneActiveSequencer()

--- a/op-acceptance-tests/tests/base/conductor/sequencer_admin_test.go
+++ b/op-acceptance-tests/tests/base/conductor/sequencer_admin_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/presets"
-	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
 )
 
 // TestSequencerStopsAndRestartsAtPreviousHead verifies an operator can stop
@@ -13,8 +12,6 @@ import (
 // stop operation.
 func TestSequencerStopsAndRestartsAtPreviousHead(gt *testing.T) {
 	t := devtest.ParallelT(gt)
-	sysgo.SkipOnKonaNode(t, "kona-node admin RPC compatibility is tracked by #21906")
-
 	sys := presets.NewMinimalNoFaultProofs(t)
 	sys.L2CL.AdvancedUnsafe(1, 30)
 

--- a/op-acceptance-tests/tests/base/conductor/unsafe_payload_test.go
+++ b/op-acceptance-tests/tests/base/conductor/unsafe_payload_test.go
@@ -38,8 +38,6 @@ func TestPostedUnsafePayloadAdvancesVerifier(gt *testing.T) {
 // rejected synchronously instead of being acknowledged and dropped later.
 func TestPostedUnsafePayloadRejectsBadBlockHash(gt *testing.T) {
 	t := devtest.ParallelT(gt)
-	sysgo.SkipOnKonaNode(t, "kona-node admin RPC compatibility is tracked by #21906")
-
 	sys := newUnsafePayloadSystem(t)
 	sys.L2CL.AdvancedUnsafe(2, 30)
 

--- a/op-acceptance-tests/tests/base/conductor/unsafe_payload_test.go
+++ b/op-acceptance-tests/tests/base/conductor/unsafe_payload_test.go
@@ -26,8 +26,6 @@ func newUnsafePayloadSystem(t devtest.T) *presets.SingleChainMultiNode {
 // verifier.
 func TestPostedUnsafePayloadAdvancesVerifier(gt *testing.T) {
 	t := devtest.ParallelT(gt)
-	sysgo.SkipOnKonaNode(t, "kona-node admin RPC compatibility is tracked by #21906")
-
 	sys := newUnsafePayloadSystem(t)
 	sys.L2CL.AdvancedUnsafe(2, 30)
 

--- a/op-devstack/sysgo/l2_cl.go
+++ b/op-devstack/sysgo/l2_cl.go
@@ -24,6 +24,11 @@ type L2CLConfig struct {
 
 	IsSequencer bool
 
+	// ConductorRPC configures this node to use the conductor at the given RPC
+	// endpoint. Empty disables conductor integration.
+	ConductorRPC        string
+	ConductorRPCTimeout time.Duration
+
 	// EnableReqRespSync enables/disables the req-resp sync server (serving payloads to peers).
 	EnableReqRespSync bool
 

--- a/op-devstack/sysgo/mixed_runtime.go
+++ b/op-devstack/sysgo/mixed_runtime.go
@@ -552,6 +552,7 @@ func startMixedKonaNode(
 	elKey string,
 	isSequencer bool,
 	depSet coredepset.DependencySet,
+	extraEnv ...string,
 ) *KonaNode {
 	tempKonaDir := t.TempDirWithPrefix("l2-cl-kona-" + NewComponentTarget(clKey, l2Net.ChainID()).String())
 
@@ -614,6 +615,7 @@ func startMixedKonaNode(
 	} else {
 		envVars = append(envVars, "KONA_NODE_MODE=Validator")
 	}
+	envVars = append(envVars, extraEnv...)
 
 	execPath, err := rustbin.Spec{
 		SrcDir:  "rust/kona",

--- a/op-devstack/sysgo/singlechain_build.go
+++ b/op-devstack/sysgo/singlechain_build.go
@@ -183,6 +183,55 @@ func startL2CLForKey(
 	}
 }
 
+// startStoppedSequencerCL starts the env-selected sequencer CL in the stopped
+// state required while a conductor cluster is being assembled.
+func startStoppedSequencerCL(
+	t devtest.T,
+	keys devkeys.Keys,
+	l1Net *L1Network,
+	l2Net *L2Network,
+	l1EL L1ELNode,
+	l1CL *L1CLNode,
+	l2EL L2ELNode,
+	jwtSecret [32]byte,
+	key string,
+	l2CLOpts []L2CLOption,
+) L2CLNode {
+	switch devstackL2CLKind() {
+	case MixedL2CLKona:
+		konaCfg := DefaultL2CLConfig()
+		konaCfg.IsSequencer = true
+		target := NewComponentTarget(key, l2Net.ChainID())
+		for _, opt := range l2CLOpts {
+			if opt != nil {
+				opt.Apply(t, target, konaCfg)
+			}
+		}
+		extraEnv := []string{"KONA_NODE_SEQUENCER_STOPPED=true"}
+		if konaCfg.ConductorRPC != "" {
+			t.Require().Positive(konaCfg.ConductorRPCTimeout, "conductor RPC timeout must be positive")
+			t.Require().Zero(konaCfg.ConductorRPCTimeout%time.Second, "Kona conductor RPC timeout must use whole seconds")
+			extraEnv = append(extraEnv,
+				"KONA_NODE_CONDUCTOR_RPC="+konaCfg.ConductorRPC,
+				fmt.Sprintf("KONA_NODE_CONDUCTOR_RPC_TIMEOUT=%d", konaCfg.ConductorRPCTimeout/time.Second),
+			)
+		}
+		return startMixedKonaNode(
+			t, keys, l1Net, l2Net, l1EL, l1CL, l2EL, key, key, true, nil,
+			extraEnv...,
+		)
+	default: // op-node
+		return startL2CLNode(t, keys, l1Net, l2Net, l1EL, l1CL, l2EL, jwtSecret, l2CLNodeStartConfig{
+			Key:              key,
+			IsSequencer:      true,
+			NoDiscovery:      true,
+			EnableReqResp:    true,
+			L2CLOptions:      l2CLOpts,
+			SequencerStopped: true,
+		})
+	}
+}
+
 func startSequencerEL(t devtest.T, l2Net *L2Network, jwtPath string, jwtSecret [32]byte, identity *ELNodeIdentity, opts ...OpRethOption) L2ELNode {
 	return startL2ELForKey(t, l2Net, jwtPath, jwtSecret, "sequencer", identity, opts...)
 }
@@ -434,6 +483,14 @@ func startL2CLNode(
 		AltDA:                           altda.CLIConfig{},
 		IgnoreMissingPectraBlobSchedule: false,
 		ExperimentalOPStackAPI:          true,
+	}
+	if cfg.ConductorRPC != "" {
+		require.Positive(cfg.ConductorRPCTimeout, "conductor RPC timeout must be positive")
+		nodeCfg.ConductorEnabled = true
+		nodeCfg.ConductorRpcTimeout = cfg.ConductorRPCTimeout
+		nodeCfg.ConductorRpc = func(context.Context) (string, error) {
+			return cfg.ConductorRPC, nil
+		}
 	}
 	l2CL := &OpNode{
 		name:     startCfg.Key,

--- a/op-devstack/sysgo/singlechain_runtime.go
+++ b/op-devstack/sysgo/singlechain_runtime.go
@@ -141,14 +141,10 @@ func startStoppedSingleChainPrimary(
 	// Env-resolved options come first so an explicit binary from the test overrides the env one.
 	sequencerELOpts := append(append([]OpRethOption{}, ResolveMixedL2ELOpts(t)...), cfg.OpRethOptions...)
 	l2EL := startSequencerEL(t, world.L2Network, jwtPath, jwtSecret, NewELNodeIdentity(0), sequencerELOpts...)
-	l2CL := startL2CLNode(t, keys, world.L1Network, world.L2Network, l1EL, l1CL, l2EL, jwtSecret, l2CLNodeStartConfig{
-		Key:              "sequencer",
-		IsSequencer:      true,
-		NoDiscovery:      true,
-		EnableReqResp:    true,
-		L2CLOptions:      l2CLOptions,
-		SequencerStopped: true,
-	})
+	l2CL := startStoppedSequencerCL(
+		t, keys, world.L1Network, world.L2Network, l1EL, l1CL, l2EL, jwtSecret,
+		"sequencer", l2CLOptions,
+	)
 	return singleChainPrimaryRuntime{EL: l2EL, CL: l2CL}
 }
 

--- a/op-devstack/sysgo/singlechain_variants.go
+++ b/op-devstack/sysgo/singlechain_variants.go
@@ -5,12 +5,12 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
-	"sync/atomic"
 	"time"
 
 	bss "github.com/ethereum-optimism/optimism/op-batcher/batcher"
 	opconductor "github.com/ethereum-optimism/optimism/op-conductor/conductor"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/dial"
 	"github.com/ethereum-optimism/optimism/op-service/endpoint"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -18,10 +18,12 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/retry"
 	oprpc "github.com/ethereum-optimism/optimism/op-service/rpc"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
+	"github.com/ethereum-optimism/optimism/op-service/testutils/tcpproxy"
 	synctesterconfig "github.com/ethereum-optimism/optimism/op-sync-tester/config"
 	"github.com/ethereum-optimism/optimism/op-sync-tester/synctester"
 	stconf "github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/config"
 	sttypes "github.com/ethereum-optimism/optimism/op-sync-tester/synctester/backend/types"
+	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
 )
 
@@ -115,6 +117,26 @@ func NewMinimalWithConductorsRuntime(t devtest.T) *SingleChainRuntime {
 }
 
 func NewMinimalWithConductorsRuntimeWithConfig(t devtest.T, cfg PresetConfig) *SingleChainRuntime {
+	// The CL and conductor depend on each other's RPC endpoints. Allocate a
+	// stable proxy for each conductor before starting its CL, then attach the
+	// conductor once its dynamically allocated RPC port is known.
+	conductorRPCProxies := make(map[string]*tcpproxy.Proxy)
+	for _, name := range []string{"sequencer", "b", "c"} {
+		proxy := tcpproxy.New(t.Logger().New("proxy", "conductor-rpc", "name", name))
+		t.Require().NoError(proxy.Start())
+		t.Cleanup(func() {
+			_ = proxy.Close()
+		})
+		conductorRPCProxies[name] = proxy
+	}
+	conductorConfig := L2CLOptionFn(func(_ devtest.T, target ComponentTarget, nodeCfg *L2CLConfig) {
+		if proxy, ok := conductorRPCProxies[target.Name]; ok {
+			nodeCfg.ConductorRPC = "http://" + proxy.Addr()
+			nodeCfg.ConductorRPCTimeout = 5 * time.Second
+		}
+	})
+	cfg.GlobalL2CLOptions = append(append([]L2CLOption{}, cfg.GlobalL2CLOptions...), conductorConfig)
+
 	// Conductor tests only exercise sequencing leadership. They do not need a
 	// challenger, and rust e2e jobs do not build cannon artifacts.
 	runtime := newSingleChainRuntimeWithConfig(t, cfg, singleChainRuntimeSpec{
@@ -137,19 +159,16 @@ func NewMinimalWithConductorsRuntimeWithConfig(t devtest.T, cfg PresetConfig) *S
 	nodeVerifier := addSingleChainOpNode(t, runtime, "verifier", false, "", cfg.GlobalL2CLOptions...)
 
 	healthCheck := conductorHealthCheckConfig(cfg.ConductorFastHealthChecks)
-	primaryCL := runtime.L2CL.(*OpNode)
-	conductorA := startConductorNode(t, "sequencer", runtime.L2Network, primaryCL, runtime.L2EL, true, false, healthCheck)
-	conductorB := startConductorNode(t, "b", runtime.L2Network, nodeB.CL.(*OpNode), nodeB.EL, false, true, healthCheck)
-	conductorC := startConductorNode(t, "c", runtime.L2Network, nodeC.CL.(*OpNode), nodeC.EL, false, true, healthCheck)
+	conductorA := startConductorNode(t, "sequencer", runtime.L2Network, runtime.L2CL, conductorRPCProxies["sequencer"], runtime.L2EL, true, false, healthCheck)
+	conductorB := startConductorNode(t, "b", runtime.L2Network, nodeB.CL, conductorRPCProxies["b"], nodeB.EL, false, true, healthCheck)
+	conductorC := startConductorNode(t, "c", runtime.L2Network, nodeC.CL, conductorRPCProxies["c"], nodeC.EL, false, true, healthCheck)
 
 	// Mesh the sequencer CL nodes over p2p, as in a production HA deployment:
 	// the active sequencer gossips unsafe blocks to the followers, which keeps
 	// them close enough to the raft-committed head for the conductor to start
 	// them on leadership changes (op-conductor only backfills a single missing
 	// block). EL p2p is not needed — unsafe blocks reach the follower ELs via
-	// CL gossip and the engine API. Peering must happen after
-	// startConductorNode, which restarts each op-node and would drop earlier
-	// connections.
+	// CL gossip and the engine API.
 	connectSingleChainCLPeer(t, runtime.L2CL, nodeB.CL)
 	connectSingleChainCLPeer(t, runtime.L2CL, nodeC.CL)
 	connectSingleChainCLPeer(t, nodeB.CL, nodeC.CL)
@@ -159,9 +178,10 @@ func NewMinimalWithConductorsRuntimeWithConfig(t devtest.T, cfg PresetConfig) *S
 	startConductorCluster(
 		t,
 		conductorA,
-		primaryCL,
+		runtime.L2CL,
+		runtime.L2EL,
 		[]*Conductor{conductorB, conductorC},
-		[]*OpNode{nodeB.CL.(*OpNode), nodeC.CL.(*OpNode)},
+		[]L2CLNode{nodeB.CL, nodeC.CL},
 	)
 
 	// Match production HA deployments: downstream services use every
@@ -172,7 +192,7 @@ func NewMinimalWithConductorsRuntimeWithConfig(t devtest.T, cfg PresetConfig) *S
 		t.Require().NoError(runtime.L2Batcher.service.Stop(t.Ctx()), "failed to stop direct-endpoint batcher")
 	}
 	conductorEndpoints := []string{conductorA.HTTPEndpoint(), conductorB.HTTPEndpoint(), conductorC.HTTPEndpoint()}
-	runtime.L2Batcher = startMinimalBatcher(t, runtime.Keys, runtime.L2Network, runtime.L1EL, primaryCL, runtime.L2EL, append(cfg.BatcherOptions,
+	runtime.L2Batcher = startMinimalBatcher(t, runtime.Keys, runtime.L2Network, runtime.L1EL, runtime.L2CL, runtime.L2EL, append(cfg.BatcherOptions,
 		func(_ ComponentTarget, batcherCfg *bss.CLIConfig) {
 			batcherCfg.L2EthRpc = conductorEndpoints
 			batcherCfg.RollupRpc = conductorEndpoints
@@ -259,14 +279,10 @@ func addStoppedSingleChainSequencerNode(
 	jwtPath := runtime.L2EL.JWTPath()
 	jwtSecret := readJWTSecretFromPath(t, jwtPath)
 	l2EL := startL2ELForKey(t, runtime.L2Network, jwtPath, jwtSecret, name, NewELNodeIdentity(0), elOpts...)
-	l2CL := startL2CLNode(t, runtime.Keys, runtime.L1Network, runtime.L2Network, runtime.L1EL, runtime.L1CL, l2EL, jwtSecret, l2CLNodeStartConfig{
-		Key:              name,
-		IsSequencer:      true,
-		NoDiscovery:      true,
-		EnableReqResp:    true,
-		L2CLOptions:      l2Opts,
-		SequencerStopped: true,
-	})
+	l2CL := startStoppedSequencerCL(
+		t, runtime.Keys, runtime.L1Network, runtime.L2Network, runtime.L1EL, runtime.L1CL,
+		l2EL, jwtSecret, name, l2Opts,
+	)
 	node := newSingleChainNodeRuntime(name, true, l2EL, l2CL)
 	runtime.Nodes[name] = node
 	return node
@@ -353,7 +369,8 @@ func startConductorNode(
 	t devtest.T,
 	conductorName string,
 	l2Net *L2Network,
-	opNode *OpNode,
+	node L2CLNode,
+	conductorRPCProxy *tcpproxy.Proxy,
 	l2EL L2ELNode,
 	bootstrap bool,
 	paused bool,
@@ -363,25 +380,7 @@ func startConductorNode(
 	serverID := conductorName
 	require.NotEmpty(serverID, "conductor ID key cannot be empty")
 
-	var conductorRPCEndpoint atomic.Value
-	conductorRPCEndpoint.Store("")
-	opNode.cfg.ConductorEnabled = true
-	opNode.cfg.ConductorRpcTimeout = 5 * time.Second
-	opNode.cfg.ConductorRpc = func(ctx context.Context) (string, error) {
-		for {
-			if endpoint, _ := conductorRPCEndpoint.Load().(string); endpoint != "" {
-				return endpoint, nil
-			}
-			select {
-			case <-ctx.Done():
-				return "", ctx.Err()
-			case <-time.After(100 * time.Millisecond):
-			}
-		}
-	}
-	opNode.cfg.Driver.SequencerStopped = true
-	opNode.Stop()
-	opNode.Start()
+	require.NotNil(conductorRPCProxy, "conductor RPC proxy is required")
 
 	cfg := opconductor.Config{
 		ConsensusAddr:           "127.0.0.1",
@@ -395,7 +394,7 @@ func startConductorNode(
 		RaftTrailingLogs:        10240,
 		RaftHeartbeatTimeout:    1000 * time.Millisecond,
 		RaftLeaderLeaseTimeout:  500 * time.Millisecond,
-		NodeRPC:                 opNode.UserRPC(),
+		NodeRPC:                 node.UserRPC(),
 		ExecutionRPC:            l2EL.UserRPC(),
 		Paused:                  paused,
 		HealthCheck:             healthCheck,
@@ -433,16 +432,17 @@ func startConductorNode(
 		rpcEndpoint:       svc.HTTPEndpoint(),
 		service:           svc,
 	}
-	conductorRPCEndpoint.Store(svc.HTTPEndpoint())
+	conductorRPCProxy.SetUpstream(ProxyAddr(require, svc.HTTPEndpoint()))
 	return out
 }
 
 func startConductorCluster(
 	t devtest.T,
 	bootstrap *Conductor,
-	bootstrapNode *OpNode,
+	bootstrapNode L2CLNode,
+	bootstrapEL L2ELNode,
 	members []*Conductor,
-	memberNodes []*OpNode,
+	memberNodes []L2CLNode,
 ) {
 	require := t.Require()
 	require.Len(memberNodes, len(members), "each conductor member must have a sequencer node")
@@ -489,15 +489,18 @@ func startConductorCluster(
 	// head and cannot create competing forks before this point.
 	rollupClient, err := dial.DialRollupClientWithTimeout(ctx, t.Logger(), bootstrapNode.UserRPC())
 	require.NoError(err, "failed to dial bootstrap sequencer node")
-	initialStatus, err := rollupClient.SyncStatus(ctx)
-	require.NoError(err, "failed to fetch bootstrap sequencer sync status")
-	require.NoError(rollupClient.StartSequencer(ctx, initialStatus.UnsafeL2.Hash), "failed to start sequencing on bootstrap node")
+	execClient, err := ethclient.DialContext(ctx, bootstrapEL.UserRPC())
+	require.NoError(err, "failed to dial bootstrap execution node")
+	defer execClient.Close()
+	initialHead, err := execClient.HeaderByNumber(ctx, nil)
+	require.NoError(err, "failed to fetch bootstrap execution head")
+	require.NoError(rollupClient.StartSequencer(ctx, initialHead.Hash()), "failed to start sequencing on bootstrap node")
 	err = retry.Do0(ctx, 90, retry.Fixed(500*time.Millisecond), func() error {
 		status, err := rollupClient.SyncStatus(ctx)
 		if err != nil {
 			return err
 		}
-		if status.UnsafeL2.Number <= initialStatus.UnsafeL2.Number {
+		if status.UnsafeL2.Number <= bigs.Uint64Strict(initialHead.Number) {
 			return fmt.Errorf("bootstrap sequencer has not sealed a block yet, unsafe head at %d", status.UnsafeL2.Number)
 		}
 		return nil
@@ -560,7 +563,7 @@ func startConductorCluster(
 		require.NoErrorf(err, "conductor %s never became healthy", conductor.ServerID())
 	}
 
-	clusterNodes := append([]*OpNode{bootstrapNode}, memberNodes...)
+	clusterNodes := append([]L2CLNode{bootstrapNode}, memberNodes...)
 	clusterClients := make([]*sources.RollupClient, 0, len(clusterNodes))
 	for _, node := range clusterNodes {
 		client, err := dial.DialRollupClientWithTimeout(ctx, t.Logger(), node.UserRPC())

--- a/rust/kona/bin/node/src/flags/sequencer.rs
+++ b/rust/kona/bin/node/src/flags/sequencer.rs
@@ -72,7 +72,21 @@ impl SequencerArgs {
             sequencer_stopped: self.stopped,
             sequencer_recovery_mode: self.recover,
             conductor_rpc_url: self.conductor_rpc.clone(),
+            conductor_rpc_timeout: self.conductor_rpc_timeout,
             l1_conf_delay: self.l1_confs,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn conductor_rpc_timeout_is_included_in_service_config() {
+        let args =
+            SequencerArgs { conductor_rpc_timeout: Duration::from_secs(42), ..Default::default() };
+
+        assert_eq!(args.config().conductor_rpc_timeout, Duration::from_secs(42));
     }
 }

--- a/rust/kona/crates/node/engine/src/lib.rs
+++ b/rust/kona/crates/node/engine/src/lib.rs
@@ -40,11 +40,11 @@ extern crate tracing;
 
 mod task_queue;
 pub use task_queue::{
-    BuildSealCoupling, BuildTask, BuildTaskError, ConsolidateInput, ConsolidateTask,
-    ConsolidateTaskError, Engine, EngineBuildError, EngineResetError, EngineTask, EngineTaskError,
-    EngineTaskErrorSeverity, EngineTaskErrors, EngineTaskExt, FinalizeBlockId, FinalizeTask,
-    FinalizeTaskError, InsertTask, InsertTaskError, SealTask, SealTaskError, SynchronizeTask,
-    SynchronizeTaskError,
+    BuildSealCoupling, BuildTask, BuildTaskError, CanonicalizeTask, ConsolidateInput,
+    ConsolidateTask, ConsolidateTaskError, Engine, EngineBuildError, EngineResetError, EngineTask,
+    EngineTaskError, EngineTaskErrorSeverity, EngineTaskErrors, EngineTaskExt, FinalizeBlockId,
+    FinalizeTask, FinalizeTaskError, InsertTask, InsertTaskError, SealTask, SealTaskError,
+    SynchronizeTask, SynchronizeTaskError,
 };
 
 mod attributes;

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/insert/error.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/insert/error.rs
@@ -1,4 +1,5 @@
-//! Contains the error types for the [`InsertTask`](crate::InsertTask).
+//! Contains errors for the [`InsertTask`](crate::InsertTask) and
+//! [`CanonicalizeTask`](crate::CanonicalizeTask).
 
 use crate::{
     EngineTaskError, SynchronizeTaskError, task_queue::tasks::task::EngineTaskErrorSeverity,
@@ -10,7 +11,7 @@ use kona_protocol::{FromBlockError, L2BlockInfo};
 use op_alloy_rpc_types_engine::OpPayloadError;
 use tokio::sync::mpsc;
 
-/// An error that occurs when running the [`InsertTask`](crate::InsertTask).
+/// An error that occurs while inserting or canonicalizing a payload.
 #[derive(Debug, thiserror::Error)]
 pub enum InsertTaskError {
     /// Error converting a payload into a block.
@@ -47,8 +48,8 @@ pub enum InsertTaskError {
     /// The forkchoice update call to consolidate the block into the engine state failed.
     #[error(transparent)]
     ForkchoiceUpdateFailed(#[from] SynchronizeTaskError),
-    /// Failed to send the insertion result to the waiting caller.
-    #[error("Failed to send insertion result")]
+    /// Failed to send the canonicalization result to the waiting caller.
+    #[error("Failed to send canonicalization result")]
     MpscSend(#[from] Box<mpsc::error::SendError<Result<L2BlockInfo, Self>>>),
 }
 

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/insert/error.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/insert/error.rs
@@ -3,6 +3,7 @@
 use crate::{
     EngineTaskError, SynchronizeTaskError, task_queue::tasks::task::EngineTaskErrorSeverity,
 };
+use alloy_primitives::B256;
 use alloy_rpc_types_engine::PayloadStatusEnum;
 use alloy_transport::{RpcError, TransportErrorKind};
 use kona_protocol::{FromBlockError, L2BlockInfo};
@@ -15,6 +16,14 @@ pub enum InsertTaskError {
     /// Error converting a payload into a block.
     #[error(transparent)]
     FromBlockError(#[from] OpPayloadError),
+    /// A sequencer payload no longer extends the current unsafe head.
+    #[error("Payload parent {parent} does not match current unsafe head {unsafe_head}")]
+    StalePayload {
+        /// The parent hash of the payload being inserted.
+        parent: B256,
+        /// The current unsafe head hash.
+        unsafe_head: B256,
+    },
     /// Failed to insert new payload.
     #[error("Failed to insert new payload: {0}")]
     InsertFailed(RpcError<TransportErrorKind>),
@@ -38,9 +47,9 @@ impl EngineTaskError for InsertTaskError {
             Self::FromBlockError(_) | Self::L2BlockInfoConstruction(_) => {
                 EngineTaskErrorSeverity::Critical
             }
-            Self::InsertFailed(_) | Self::UnexpectedPayloadStatus(_) => {
-                EngineTaskErrorSeverity::Temporary
-            }
+            Self::StalePayload { .. } |
+            Self::InsertFailed(_) |
+            Self::UnexpectedPayloadStatus(_) => EngineTaskErrorSeverity::Temporary,
             Self::ForkchoiceUpdateFailed(inner) => inner.severity(),
             Self::MpscSend(_) => EngineTaskErrorSeverity::Critical,
         }

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/insert/error.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/insert/error.rs
@@ -24,6 +24,17 @@ pub enum InsertTaskError {
         /// The current unsafe head hash.
         unsafe_head: B256,
     },
+    /// Failed to walk the current unsafe chain while classifying an older payload.
+    #[error("Failed to walk unsafe chain ancestry: {0}")]
+    AncestryLookupFailed(RpcError<TransportErrorKind>),
+    /// A block needed to walk the current unsafe chain was unavailable.
+    #[error("Unsafe chain block {hash} at height {number} is unavailable")]
+    AncestorBlockNotFound {
+        /// Expected block hash.
+        hash: B256,
+        /// Expected block number.
+        number: u64,
+    },
     /// Failed to insert new payload.
     #[error("Failed to insert new payload: {0}")]
     InsertFailed(RpcError<TransportErrorKind>),
@@ -48,6 +59,8 @@ impl EngineTaskError for InsertTaskError {
                 EngineTaskErrorSeverity::Critical
             }
             Self::StalePayload { .. } |
+            Self::AncestryLookupFailed(_) |
+            Self::AncestorBlockNotFound { .. } |
             Self::InsertFailed(_) |
             Self::UnexpectedPayloadStatus(_) => EngineTaskErrorSeverity::Temporary,
             Self::ForkchoiceUpdateFailed(inner) => inner.severity(),

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/insert/error.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/insert/error.rs
@@ -5,8 +5,9 @@ use crate::{
 };
 use alloy_rpc_types_engine::PayloadStatusEnum;
 use alloy_transport::{RpcError, TransportErrorKind};
-use kona_protocol::FromBlockError;
+use kona_protocol::{FromBlockError, L2BlockInfo};
 use op_alloy_rpc_types_engine::OpPayloadError;
+use tokio::sync::mpsc;
 
 /// An error that occurs when running the [`InsertTask`](crate::InsertTask).
 #[derive(Debug, thiserror::Error)]
@@ -26,6 +27,9 @@ pub enum InsertTaskError {
     /// The forkchoice update call to consolidate the block into the engine state failed.
     #[error(transparent)]
     ForkchoiceUpdateFailed(#[from] SynchronizeTaskError),
+    /// Failed to send the insertion result to the waiting caller.
+    #[error("Failed to send insertion result")]
+    MpscSend(#[from] Box<mpsc::error::SendError<Result<L2BlockInfo, Self>>>),
 }
 
 impl EngineTaskError for InsertTaskError {
@@ -38,6 +42,7 @@ impl EngineTaskError for InsertTaskError {
                 EngineTaskErrorSeverity::Temporary
             }
             Self::ForkchoiceUpdateFailed(inner) => inner.severity(),
+            Self::MpscSend(_) => EngineTaskErrorSeverity::Critical,
         }
     }
 }

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/insert/mod.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/insert/mod.rs
@@ -1,7 +1,7 @@
-//! Task to insert an unsafe payload into the execution engine.
+//! Tasks to insert payloads into the execution engine.
 
 mod task;
-pub use task::InsertTask;
+pub use task::{CanonicalizeTask, InsertTask};
 
 mod error;
 pub use error::InsertTaskError;

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/insert/task.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/insert/task.rs
@@ -11,6 +11,7 @@ use kona_protocol::L2BlockInfo;
 use op_alloy_consensus::OpBlock;
 use op_alloy_rpc_types_engine::OpExecutionPayloadEnvelope;
 use std::{sync::Arc, time::Instant};
+use tokio::sync::mpsc;
 
 /// The task to insert a payload into the execution engine.
 #[derive(Debug, Clone)]
@@ -26,6 +27,8 @@ pub struct InsertTask<EngineClient_: EngineClient> {
     is_payload_safe: bool,
     /// Where to hand the decoded block once the engine has canonicalized it.
     block_sink: Arc<dyn ImportedBlockSink>,
+    /// Optional sender for callers that need to await canonicalization.
+    result_tx: Option<mpsc::Sender<Result<L2BlockInfo, InsertTaskError>>>,
 }
 
 impl<EngineClient_: EngineClient> InsertTask<EngineClient_> {
@@ -37,7 +40,39 @@ impl<EngineClient_: EngineClient> InsertTask<EngineClient_> {
         is_attributes_derived: bool,
         block_sink: Arc<dyn ImportedBlockSink>,
     ) -> Self {
-        Self { client, rollup_config, payload, is_payload_safe: is_attributes_derived, block_sink }
+        Self {
+            client,
+            rollup_config,
+            payload,
+            is_payload_safe: is_attributes_derived,
+            block_sink,
+            result_tx: None,
+        }
+    }
+
+    /// Configures a response channel for callers that need to await canonicalization.
+    pub fn with_result_sender(
+        mut self,
+        result_tx: mpsc::Sender<Result<L2BlockInfo, InsertTaskError>>,
+    ) -> Self {
+        self.result_tx = Some(result_tx);
+        self
+    }
+
+    /// Returns whether this task reports its result to a caller.
+    pub const fn has_result_sender(&self) -> bool {
+        self.result_tx.is_some()
+    }
+
+    /// Executes the insertion and sends its result to the waiting caller.
+    pub async fn execute_and_send(&self, state: &mut EngineState) -> Result<(), InsertTaskError> {
+        let result = self.execute(state).await;
+        self.result_tx
+            .as_ref()
+            .expect("result sender must be configured")
+            .send(result)
+            .await
+            .map_err(|err| InsertTaskError::MpscSend(Box::new(err)))
     }
 
     /// Checks the response of the `engine_newPayload` call.

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/insert/task.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/insert/task.rs
@@ -4,6 +4,7 @@ use crate::{
     EngineClient, EngineState, EngineTaskExt, ImportedBlockSink, InsertTaskError, SynchronizeTask,
     state::EngineSyncStateUpdate,
 };
+use alloy_eips::{BlockId, eip1898::RpcBlockHash};
 use alloy_rpc_types_engine::{ExecutionPayloadInputV2, PayloadStatusEnum};
 use async_trait::async_trait;
 use kona_genesis::RollupConfig;
@@ -29,8 +30,10 @@ pub struct InsertTask<EngineClient_: EngineClient> {
     block_sink: Arc<dyn ImportedBlockSink>,
     /// Optional sender for callers that need to await canonicalization.
     result_tx: Option<mpsc::Sender<Result<L2BlockInfo, InsertTaskError>>>,
-    /// Whether the payload must still extend the current unsafe head when this task executes.
+    /// Whether the payload must still extend or equal the current unsafe head when this executes.
     require_current_unsafe_parent: bool,
+    /// Whether insertion and forkchoice synchronization must both return `VALID`.
+    require_valid_payload_status: bool,
 }
 
 impl<EngineClient_: EngineClient> InsertTask<EngineClient_> {
@@ -50,6 +53,7 @@ impl<EngineClient_: EngineClient> InsertTask<EngineClient_> {
             block_sink,
             result_tx: None,
             require_current_unsafe_parent: false,
+            require_valid_payload_status: false,
         }
     }
 
@@ -62,9 +66,15 @@ impl<EngineClient_: EngineClient> InsertTask<EngineClient_> {
         self
     }
 
-    /// Requires the payload parent to match the current unsafe head when this task executes.
+    /// Requires the payload to extend or equal the current unsafe head when this task executes.
     pub const fn require_current_unsafe_parent(mut self) -> Self {
         self.require_current_unsafe_parent = true;
+        self
+    }
+
+    /// Requires both engine calls to return `VALID` before reporting successful insertion.
+    pub const fn require_valid_payload_status(mut self) -> Self {
+        self.require_valid_payload_status = true;
         self
     }
 
@@ -86,7 +96,8 @@ impl<EngineClient_: EngineClient> InsertTask<EngineClient_> {
 
     /// Checks the response of the `engine_newPayload` call.
     const fn check_new_payload_status(&self, status: &PayloadStatusEnum) -> bool {
-        matches!(status, PayloadStatusEnum::Valid | PayloadStatusEnum::Syncing)
+        matches!(status, PayloadStatusEnum::Valid) ||
+            (!self.require_valid_payload_status && matches!(status, PayloadStatusEnum::Syncing))
     }
 }
 
@@ -103,16 +114,64 @@ impl<EngineClient_: EngineClient> EngineTaskExt for InsertTask<EngineClient_> {
         // Form the new unsafe block ref from the execution payload.
         let payload = self.payload.clone();
         if self.require_current_unsafe_parent {
-            let parent = payload.clone().into_parts().0.parent_hash();
-            let unsafe_head = state.sync_state.unsafe_head().block_info.hash;
-            if parent != unsafe_head {
+            let execution_payload = payload.clone().into_parts().0;
+            let parent = execution_payload.parent_hash();
+            let payload_hash = execution_payload.block_hash();
+            let unsafe_head = state.sync_state.unsafe_head();
+            if parent != unsafe_head.block_info.hash && payload_hash != unsafe_head.block_info.hash
+            {
+                let payload_number = execution_payload.block_number();
+                if payload_number < unsafe_head.block_info.number {
+                    let mut ancestor_hash = unsafe_head.block_info.parent_hash;
+                    let mut ancestor_number = unsafe_head.block_info.number - 1;
+                    while ancestor_number > payload_number {
+                        let block = self
+                            .client
+                            .get_l2_block(BlockId::Hash(RpcBlockHash::from_hash(
+                                ancestor_hash,
+                                Some(false),
+                            )))
+                            .await
+                            .map_err(InsertTaskError::AncestryLookupFailed)?
+                            .ok_or(InsertTaskError::AncestorBlockNotFound {
+                                hash: ancestor_hash,
+                                number: ancestor_number,
+                            })?;
+                        ancestor_hash = block.header.inner.parent_hash;
+                        ancestor_number -= 1;
+                    }
+                    if ancestor_hash == payload_hash {
+                        if self.require_valid_payload_status {
+                            SynchronizeTask::new(
+                                Arc::clone(&self.client),
+                                self.rollup_config.clone(),
+                                EngineSyncStateUpdate::default(),
+                            )
+                            .require_valid_payload_status()
+                            .execute(state)
+                            .await?;
+                        }
+                        info!(
+                            target: "engine",
+                            %payload_hash,
+                            payload_number,
+                            unsafe_head = %unsafe_head.block_info.hash,
+                            "Retained sequencer payload is already an unsafe-chain ancestor"
+                        );
+                        return Ok(unsafe_head);
+                    }
+                }
+
                 info!(
                     target: "engine",
                     %parent,
-                    %unsafe_head,
+                    unsafe_head = %unsafe_head.block_info.hash,
                     "Dropping stale sequencer payload before insertion"
                 );
-                return Err(InsertTaskError::StalePayload { parent, unsafe_head });
+                return Err(InsertTaskError::StalePayload {
+                    parent,
+                    unsafe_head: unsafe_head.block_info.hash,
+                });
             }
         }
 
@@ -153,7 +212,7 @@ impl<EngineClient_: EngineClient> EngineTaskExt for InsertTask<EngineClient_> {
                 .map_err(InsertTaskError::L2BlockInfoConstruction)?;
 
         // Send a FCU to canonicalize the imported block.
-        SynchronizeTask::new(
+        let mut synchronize = SynchronizeTask::new(
             Arc::clone(&self.client),
             self.rollup_config.clone(),
             EngineSyncStateUpdate {
@@ -162,9 +221,11 @@ impl<EngineClient_: EngineClient> EngineTaskExt for InsertTask<EngineClient_> {
                 safe_head: self.is_payload_safe.then_some(new_unsafe_ref),
                 ..Default::default()
             },
-        )
-        .execute(state)
-        .await?;
+        );
+        if self.require_valid_payload_status {
+            synchronize = synchronize.require_valid_payload_status();
+        }
+        synchronize.execute(state).await?;
 
         // The block is now canonical, so anything reading the L2 chain locally can rely on it.
         self.block_sink.block_imported(block, new_unsafe_ref);
@@ -192,7 +253,10 @@ mod tests {
         test_utils::{TestEngineStateBuilder, test_block_info, test_engine_client_builder},
     };
     use alloy_primitives::{Address, B256, Bloom, Bytes, U256};
-    use alloy_rpc_types_engine::ExecutionPayloadV1;
+    use alloy_rpc_types_engine::{ExecutionPayloadV1, PayloadStatus, PayloadStatusEnum};
+    use alloy_rpc_types_eth::{Block as RpcBlock, BlockTransactions, Header as RpcHeader};
+    use op_alloy_rpc_types::Transaction;
+    use rstest::rstest;
 
     fn test_payload(parent_hash: B256) -> OpExecutionPayloadEnvelope {
         OpExecutionPayloadEnvelope::V1(ExecutionPayloadV1 {
@@ -214,8 +278,109 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn strict_insert_revalidates_syncing_payload_already_at_unsafe_head() {
+        let client = Arc::new(
+            test_engine_client_builder()
+                .with_new_payload_v1_response(PayloadStatus::from_status(
+                    PayloadStatusEnum::Syncing,
+                ))
+                .build(),
+        );
+        let task = InsertTask::new(
+            client,
+            Arc::new(RollupConfig::default()),
+            // The payload is already the default state's unsafe head even though its parent is
+            // not.
+            test_payload(B256::repeat_byte(1)),
+            false,
+            Arc::new(NoopBlockSink),
+        )
+        .require_valid_payload_status();
+
+        let err = task.execute(&mut EngineState::default()).await.unwrap_err();
+        assert!(matches!(
+            err,
+            InsertTaskError::UnexpectedPayloadStatus(PayloadStatusEnum::Syncing)
+        ));
+    }
+
+    #[derive(Debug)]
+    enum OlderPayloadOutcome {
+        Complete,
+        Conflict,
+        Retry,
+    }
+
+    #[rstest]
+    #[case::matching_ancestor(true, PayloadStatusEnum::Valid, OlderPayloadOutcome::Complete)]
+    #[case::conflicting_block(false, PayloadStatusEnum::Valid, OlderPayloadOutcome::Conflict)]
+    #[case::syncing_ancestor(true, PayloadStatusEnum::Syncing, OlderPayloadOutcome::Retry)]
+    #[tokio::test]
+    async fn checked_insert_classifies_older_payload_against_unsafe_chain(
+        #[case] is_ancestor: bool,
+        #[case] forkchoice_status: PayloadStatusEnum,
+        #[case] expected: OlderPayloadOutcome,
+    ) {
+        let payload_hash = B256::repeat_byte(2);
+        let intermediate_header = RpcHeader::new(alloy_consensus::Header {
+            parent_hash: if is_ancestor { payload_hash } else { B256::repeat_byte(3) },
+            number: 2,
+            ..Default::default()
+        });
+        let intermediate_hash = intermediate_header.hash;
+        let intermediate_block =
+            RpcBlock::new(intermediate_header, BlockTransactions::Full(Vec::<Transaction>::new()));
+        let payload = match test_payload(B256::repeat_byte(1)) {
+            OpExecutionPayloadEnvelope::V1(mut payload) => {
+                payload.block_hash = payload_hash;
+                OpExecutionPayloadEnvelope::V1(payload)
+            }
+            _ => unreachable!("test payload is V1"),
+        };
+        let mut unsafe_head = test_block_info(3);
+        unsafe_head.block_info.parent_hash = intermediate_hash;
+        let mut state = TestEngineStateBuilder::new().with_unsafe_head(unsafe_head).build();
+        let block_id = BlockId::Hash(RpcBlockHash::from_hash(intermediate_hash, Some(false)));
+        let client = Arc::new(
+            test_engine_client_builder()
+                .with_l2_block(block_id, intermediate_block)
+                .with_fork_choice_updated_v3_response(
+                    alloy_rpc_types_engine::ForkchoiceUpdated::new(PayloadStatus::from_status(
+                        forkchoice_status,
+                    )),
+                )
+                .build(),
+        );
+        let task = InsertTask::new(
+            client,
+            Arc::new(RollupConfig::default()),
+            payload,
+            false,
+            Arc::new(NoopBlockSink),
+        )
+        .require_current_unsafe_parent()
+        .require_valid_payload_status();
+
+        let result = task.execute(&mut state).await;
+        match expected {
+            OlderPayloadOutcome::Complete => assert_eq!(result.unwrap(), unsafe_head),
+            OlderPayloadOutcome::Conflict => {
+                assert!(matches!(result, Err(InsertTaskError::StalePayload { .. })));
+            }
+            OlderPayloadOutcome::Retry => assert!(matches!(
+                result,
+                Err(InsertTaskError::ForkchoiceUpdateFailed(
+                    crate::SynchronizeTaskError::UnexpectedPayloadStatus(
+                        PayloadStatusEnum::Syncing
+                    )
+                ))
+            )),
+        }
+    }
+
+    #[tokio::test]
     async fn checked_insert_rejects_payload_that_no_longer_extends_unsafe_head() {
-        let unsafe_head = test_block_info(10);
+        let unsafe_head = test_block_info(0);
         let stale_parent = B256::ZERO;
         assert_ne!(stale_parent, unsafe_head.hash());
         let mut state = TestEngineStateBuilder::new().with_unsafe_head(unsafe_head).build();

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/insert/task.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/insert/task.rs
@@ -1,5 +1,6 @@
-//! A task to insert an unsafe payload into the execution engine.
+//! Tasks to insert payloads into the execution engine.
 
+use super::super::synchronize::CanonicalizeForkchoiceTask;
 use crate::{
     EngineClient, EngineState, EngineTaskExt, ImportedBlockSink, InsertTaskError, SynchronizeTask,
     state::EngineSyncStateUpdate,
@@ -28,12 +29,15 @@ pub struct InsertTask<EngineClient_: EngineClient> {
     is_payload_safe: bool,
     /// Where to hand the decoded block once the engine has canonicalized it.
     block_sink: Arc<dyn ImportedBlockSink>,
-    /// Optional sender for callers that need to await canonicalization.
-    result_tx: Option<mpsc::Sender<Result<L2BlockInfo, InsertTaskError>>>,
-    /// Whether the payload must still extend or equal the current unsafe head when this executes.
-    require_current_unsafe_parent: bool,
-    /// Whether insertion and forkchoice synchronization must both return `VALID`.
-    require_valid_payload_status: bool,
+}
+
+/// Canonicalizes a sealed, conductor-approved payload under sequencing safety constraints.
+#[derive(Debug, Clone)]
+pub struct CanonicalizeTask<EngineClient_: EngineClient> {
+    /// Common payload insertion data and operations.
+    insertion: InsertTask<EngineClient_>,
+    /// Where to send the canonicalization result.
+    result_tx: mpsc::Sender<Result<L2BlockInfo, InsertTaskError>>,
 }
 
 impl<EngineClient_: EngineClient> InsertTask<EngineClient_> {
@@ -45,138 +49,15 @@ impl<EngineClient_: EngineClient> InsertTask<EngineClient_> {
         is_attributes_derived: bool,
         block_sink: Arc<dyn ImportedBlockSink>,
     ) -> Self {
-        Self {
-            client,
-            rollup_config,
-            payload,
-            is_payload_safe: is_attributes_derived,
-            block_sink,
-            result_tx: None,
-            require_current_unsafe_parent: false,
-            require_valid_payload_status: false,
-        }
+        Self { client, rollup_config, payload, is_payload_safe: is_attributes_derived, block_sink }
     }
 
-    /// Configures a response channel for callers that need to await canonicalization.
-    pub fn with_result_sender(
-        mut self,
-        result_tx: mpsc::Sender<Result<L2BlockInfo, InsertTaskError>>,
-    ) -> Self {
-        self.result_tx = Some(result_tx);
-        self
-    }
-
-    /// Requires the payload to extend or equal the current unsafe head when this task executes.
-    pub const fn require_current_unsafe_parent(mut self) -> Self {
-        self.require_current_unsafe_parent = true;
-        self
-    }
-
-    /// Requires both engine calls to return `VALID` before reporting successful insertion.
-    pub const fn require_valid_payload_status(mut self) -> Self {
-        self.require_valid_payload_status = true;
-        self
-    }
-
-    /// Returns whether this task reports its result to a caller.
-    pub const fn has_result_sender(&self) -> bool {
-        self.result_tx.is_some()
-    }
-
-    /// Executes the insertion and sends its result to the waiting caller.
-    pub async fn execute_and_send(&self, state: &mut EngineState) -> Result<(), InsertTaskError> {
-        let result = self.execute(state).await;
-        self.result_tx
-            .as_ref()
-            .expect("result sender must be configured")
-            .send(result)
-            .await
-            .map_err(|err| InsertTaskError::MpscSend(Box::new(err)))
-    }
-
-    /// Checks the response of the `engine_newPayload` call.
-    const fn check_new_payload_status(&self, status: &PayloadStatusEnum) -> bool {
-        matches!(status, PayloadStatusEnum::Valid) ||
-            (!self.require_valid_payload_status && matches!(status, PayloadStatusEnum::Syncing))
-    }
-}
-
-#[async_trait]
-impl<EngineClient_: EngineClient> EngineTaskExt for InsertTask<EngineClient_> {
-    type Output = L2BlockInfo;
-
-    type Error = InsertTaskError;
-
-    async fn execute(&self, state: &mut EngineState) -> Result<L2BlockInfo, InsertTaskError> {
-        let time_start = Instant::now();
-
-        // Insert the new payload.
-        // Form the new unsafe block ref from the execution payload.
-        let payload = self.payload.clone();
-        if self.require_current_unsafe_parent {
-            let execution_payload = payload.clone().into_parts().0;
-            let parent = execution_payload.parent_hash();
-            let payload_hash = execution_payload.block_hash();
-            let unsafe_head = state.sync_state.unsafe_head();
-            if parent != unsafe_head.block_info.hash && payload_hash != unsafe_head.block_info.hash
-            {
-                let payload_number = execution_payload.block_number();
-                if payload_number < unsafe_head.block_info.number {
-                    let mut ancestor_hash = unsafe_head.block_info.parent_hash;
-                    let mut ancestor_number = unsafe_head.block_info.number - 1;
-                    while ancestor_number > payload_number {
-                        let block = self
-                            .client
-                            .get_l2_block(BlockId::Hash(RpcBlockHash::from_hash(
-                                ancestor_hash,
-                                Some(false),
-                            )))
-                            .await
-                            .map_err(InsertTaskError::AncestryLookupFailed)?
-                            .ok_or(InsertTaskError::AncestorBlockNotFound {
-                                hash: ancestor_hash,
-                                number: ancestor_number,
-                            })?;
-                        ancestor_hash = block.header.inner.parent_hash;
-                        ancestor_number -= 1;
-                    }
-                    if ancestor_hash == payload_hash {
-                        if self.require_valid_payload_status {
-                            SynchronizeTask::new(
-                                Arc::clone(&self.client),
-                                self.rollup_config.clone(),
-                                EngineSyncStateUpdate::default(),
-                            )
-                            .require_valid_payload_status()
-                            .execute(state)
-                            .await?;
-                        }
-                        info!(
-                            target: "engine",
-                            %payload_hash,
-                            payload_number,
-                            unsafe_head = %unsafe_head.block_info.hash,
-                            "Retained sequencer payload is already an unsafe-chain ancestor"
-                        );
-                        return Ok(unsafe_head);
-                    }
-                }
-
-                info!(
-                    target: "engine",
-                    %parent,
-                    unsafe_head = %unsafe_head.block_info.hash,
-                    "Dropping stale sequencer payload before insertion"
-                );
-                return Err(InsertTaskError::StalePayload {
-                    parent,
-                    unsafe_head: unsafe_head.block_info.hash,
-                });
-            }
-        }
-
+    /// Submits the payload to the execution layer and returns its status and request duration.
+    async fn submit_payload(
+        &self,
+    ) -> Result<(PayloadStatusEnum, std::time::Duration), InsertTaskError> {
         let insert_time_start = Instant::now();
-        let response = match payload.clone() {
+        let response = match self.payload.clone() {
             OpExecutionPayloadEnvelope::V1(payload) => self.client.new_payload_v1(payload).await,
             OpExecutionPayloadEnvelope::V2(payload) => {
                 let payload_input = ExecutionPayloadInputV2 {
@@ -193,26 +74,148 @@ impl<EngineClient_: EngineClient> EngineTaskExt for InsertTask<EngineClient_> {
             }
         };
 
-        // Check the `engine_newPayload` response.
-        let response = match response {
-            Ok(resp) => resp,
-            Err(e) => {
-                warn!(target: "engine", "Failed to insert new payload: {e}");
-                return Err(InsertTaskError::InsertFailed(e));
+        match response {
+            Ok(response) => Ok((response.status, insert_time_start.elapsed())),
+            Err(err) => {
+                warn!(target: "engine", "Failed to insert new payload: {err}");
+                Err(InsertTaskError::InsertFailed(err))
             }
-        };
-        if !self.check_new_payload_status(&response.status) {
-            return Err(InsertTaskError::UnexpectedPayloadStatus(response.status));
         }
-        let insert_duration = insert_time_start.elapsed();
+    }
 
-        let block: OpBlock = payload.try_into_block().map_err(InsertTaskError::FromBlockError)?;
-        let new_unsafe_ref =
-            L2BlockInfo::from_block_and_genesis(&block, &self.rollup_config.genesis)
-                .map_err(InsertTaskError::L2BlockInfoConstruction)?;
+    /// Decodes the payload and derives its L2 block information.
+    fn decode_payload(&self) -> Result<(OpBlock, L2BlockInfo), InsertTaskError> {
+        let block: OpBlock =
+            self.payload.clone().try_into_block().map_err(InsertTaskError::FromBlockError)?;
+        let block_info = L2BlockInfo::from_block_and_genesis(&block, &self.rollup_config.genesis)
+            .map_err(InsertTaskError::L2BlockInfoConstruction)?;
+        Ok((block, block_info))
+    }
 
-        // Send a FCU to canonicalize the imported block.
-        let mut synchronize = SynchronizeTask::new(
+    /// Reports a successfully canonicalized block to downstream consumers and metrics.
+    fn complete_import(
+        &self,
+        block: OpBlock,
+        block_info: L2BlockInfo,
+        time_start: Instant,
+        insert_duration: std::time::Duration,
+    ) {
+        self.block_sink.block_imported(block, block_info);
+
+        info!(
+            target: "engine",
+            hash = %block_info.block_info.hash,
+            number = block_info.block_info.number,
+            total_duration = ?time_start.elapsed(),
+            insert_duration = ?insert_duration,
+            "Inserted new unsafe block"
+        );
+    }
+}
+
+impl<EngineClient_: EngineClient> CanonicalizeTask<EngineClient_> {
+    /// Creates a task for canonicalizing a conductor-approved payload.
+    pub const fn new(
+        client: Arc<EngineClient_>,
+        rollup_config: Arc<RollupConfig>,
+        payload: OpExecutionPayloadEnvelope,
+        block_sink: Arc<dyn ImportedBlockSink>,
+        result_tx: mpsc::Sender<Result<L2BlockInfo, InsertTaskError>>,
+    ) -> Self {
+        Self {
+            insertion: InsertTask::new(client, rollup_config, payload, false, block_sink),
+            result_tx,
+        }
+    }
+
+    /// Executes canonicalization and sends its result to the waiting sequencer.
+    pub async fn execute_and_send(&self, state: &mut EngineState) -> Result<(), InsertTaskError> {
+        let result = self.execute(state).await;
+        self.result_tx.send(result).await.map_err(|err| InsertTaskError::MpscSend(Box::new(err)))
+    }
+
+    /// Returns the current head when the retained payload is already on the unsafe chain.
+    ///
+    /// Conflicting payloads are rejected, while ancestry lookup failures remain retryable so the
+    /// sequencer keeps the exact conductor-approved payload.
+    async fn classify_retained_payload(
+        &self,
+        state: &mut EngineState,
+    ) -> Result<Option<L2BlockInfo>, InsertTaskError> {
+        let execution_payload = self.insertion.payload.clone().into_parts().0;
+        let parent = execution_payload.parent_hash();
+        let payload_hash = execution_payload.block_hash();
+        let payload_number = execution_payload.block_number();
+        let unsafe_head = state.sync_state.unsafe_head();
+
+        if parent == unsafe_head.block_info.hash || payload_hash == unsafe_head.block_info.hash {
+            return Ok(None);
+        }
+
+        if payload_number < unsafe_head.block_info.number {
+            let mut ancestor_hash = unsafe_head.block_info.parent_hash;
+            let mut ancestor_number = unsafe_head.block_info.number - 1;
+            while ancestor_number > payload_number {
+                let block = self
+                    .insertion
+                    .client
+                    .get_l2_block(BlockId::Hash(RpcBlockHash::from_hash(
+                        ancestor_hash,
+                        Some(false),
+                    )))
+                    .await
+                    .map_err(InsertTaskError::AncestryLookupFailed)?
+                    .ok_or(InsertTaskError::AncestorBlockNotFound {
+                        hash: ancestor_hash,
+                        number: ancestor_number,
+                    })?;
+                ancestor_hash = block.header.inner.parent_hash;
+                ancestor_number -= 1;
+            }
+
+            if ancestor_hash == payload_hash {
+                CanonicalizeForkchoiceTask::new(
+                    Arc::clone(&self.insertion.client),
+                    self.insertion.rollup_config.clone(),
+                    EngineSyncStateUpdate::default(),
+                )
+                .execute(state)
+                .await?;
+                info!(
+                    target: "engine",
+                    %payload_hash,
+                    payload_number,
+                    unsafe_head = %unsafe_head.block_info.hash,
+                    "Retained sequencer payload is already an unsafe-chain ancestor"
+                );
+                return Ok(Some(unsafe_head));
+            }
+        }
+
+        info!(
+            target: "engine",
+            %parent,
+            unsafe_head = %unsafe_head.block_info.hash,
+            "Dropping stale sequencer payload before insertion"
+        );
+        Err(InsertTaskError::StalePayload { parent, unsafe_head: unsafe_head.block_info.hash })
+    }
+}
+
+#[async_trait]
+impl<EngineClient_: EngineClient> EngineTaskExt for InsertTask<EngineClient_> {
+    type Output = L2BlockInfo;
+    type Error = InsertTaskError;
+
+    async fn execute(&self, state: &mut EngineState) -> Result<Self::Output, Self::Error> {
+        let time_start = Instant::now();
+        let (status, insert_duration) = self.submit_payload().await?;
+        if !matches!(status, PayloadStatusEnum::Valid | PayloadStatusEnum::Syncing) {
+            return Err(InsertTaskError::UnexpectedPayloadStatus(status));
+        }
+
+        let (block, new_unsafe_ref) = self.decode_payload()?;
+        SynchronizeTask::new(
             Arc::clone(&self.client),
             self.rollup_config.clone(),
             EngineSyncStateUpdate {
@@ -221,26 +224,41 @@ impl<EngineClient_: EngineClient> EngineTaskExt for InsertTask<EngineClient_> {
                 safe_head: self.is_payload_safe.then_some(new_unsafe_ref),
                 ..Default::default()
             },
-        );
-        if self.require_valid_payload_status {
-            synchronize = synchronize.require_valid_payload_status();
+        )
+        .execute(state)
+        .await?;
+
+        self.complete_import(block, new_unsafe_ref, time_start, insert_duration);
+        Ok(new_unsafe_ref)
+    }
+}
+
+#[async_trait]
+impl<EngineClient_: EngineClient> EngineTaskExt for CanonicalizeTask<EngineClient_> {
+    type Output = L2BlockInfo;
+    type Error = InsertTaskError;
+
+    async fn execute(&self, state: &mut EngineState) -> Result<Self::Output, Self::Error> {
+        let time_start = Instant::now();
+        if let Some(unsafe_head) = self.classify_retained_payload(state).await? {
+            return Ok(unsafe_head);
         }
-        synchronize.execute(state).await?;
 
-        // The block is now canonical, so anything reading the L2 chain locally can rely on it.
-        self.block_sink.block_imported(block, new_unsafe_ref);
+        let (status, insert_duration) = self.insertion.submit_payload().await?;
+        if !matches!(status, PayloadStatusEnum::Valid) {
+            return Err(InsertTaskError::UnexpectedPayloadStatus(status));
+        }
 
-        let total_duration = time_start.elapsed();
+        let (block, new_unsafe_ref) = self.insertion.decode_payload()?;
+        CanonicalizeForkchoiceTask::new(
+            Arc::clone(&self.insertion.client),
+            self.insertion.rollup_config.clone(),
+            EngineSyncStateUpdate { unsafe_head: Some(new_unsafe_ref), ..Default::default() },
+        )
+        .execute(state)
+        .await?;
 
-        info!(
-            target: "engine",
-            hash = %new_unsafe_ref.block_info.hash,
-            number = new_unsafe_ref.block_info.number,
-            total_duration = ?total_duration,
-            insert_duration = ?insert_duration,
-            "Inserted new unsafe block"
-        );
-
+        self.insertion.complete_import(block, new_unsafe_ref, time_start, insert_duration);
         Ok(new_unsafe_ref)
     }
 }
@@ -278,7 +296,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn strict_insert_revalidates_syncing_payload_already_at_unsafe_head() {
+    async fn canonicalization_revalidates_syncing_payload_already_at_unsafe_head() {
         let client = Arc::new(
             test_engine_client_builder()
                 .with_new_payload_v1_response(PayloadStatus::from_status(
@@ -286,16 +304,16 @@ mod tests {
                 ))
                 .build(),
         );
-        let task = InsertTask::new(
+        let (result_tx, _result_rx) = mpsc::channel(1);
+        let task = CanonicalizeTask::new(
             client,
             Arc::new(RollupConfig::default()),
             // The payload is already the default state's unsafe head even though its parent is
             // not.
             test_payload(B256::repeat_byte(1)),
-            false,
             Arc::new(NoopBlockSink),
-        )
-        .require_valid_payload_status();
+            result_tx,
+        );
 
         let err = task.execute(&mut EngineState::default()).await.unwrap_err();
         assert!(matches!(
@@ -316,7 +334,7 @@ mod tests {
     #[case::conflicting_block(false, PayloadStatusEnum::Valid, OlderPayloadOutcome::Conflict)]
     #[case::syncing_ancestor(true, PayloadStatusEnum::Syncing, OlderPayloadOutcome::Retry)]
     #[tokio::test]
-    async fn checked_insert_classifies_older_payload_against_unsafe_chain(
+    async fn canonicalization_classifies_older_payload_against_unsafe_chain(
         #[case] is_ancestor: bool,
         #[case] forkchoice_status: PayloadStatusEnum,
         #[case] expected: OlderPayloadOutcome,
@@ -351,15 +369,14 @@ mod tests {
                 )
                 .build(),
         );
-        let task = InsertTask::new(
+        let (result_tx, _result_rx) = mpsc::channel(1);
+        let task = CanonicalizeTask::new(
             client,
             Arc::new(RollupConfig::default()),
             payload,
-            false,
             Arc::new(NoopBlockSink),
-        )
-        .require_current_unsafe_parent()
-        .require_valid_payload_status();
+            result_tx,
+        );
 
         let result = task.execute(&mut state).await;
         match expected {
@@ -379,19 +396,19 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn checked_insert_rejects_payload_that_no_longer_extends_unsafe_head() {
+    async fn canonicalization_rejects_payload_that_no_longer_extends_unsafe_head() {
         let unsafe_head = test_block_info(0);
         let stale_parent = B256::ZERO;
         assert_ne!(stale_parent, unsafe_head.hash());
         let mut state = TestEngineStateBuilder::new().with_unsafe_head(unsafe_head).build();
-        let task = InsertTask::new(
+        let (result_tx, _result_rx) = mpsc::channel(1);
+        let task = CanonicalizeTask::new(
             Arc::new(test_engine_client_builder().build()),
             Arc::new(RollupConfig::default()),
             test_payload(stale_parent),
-            false,
             Arc::new(NoopBlockSink),
-        )
-        .require_current_unsafe_parent();
+            result_tx,
+        );
 
         let err = task.execute(&mut state).await.unwrap_err();
         assert!(matches!(

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/insert/task.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/insert/task.rs
@@ -29,6 +29,8 @@ pub struct InsertTask<EngineClient_: EngineClient> {
     block_sink: Arc<dyn ImportedBlockSink>,
     /// Optional sender for callers that need to await canonicalization.
     result_tx: Option<mpsc::Sender<Result<L2BlockInfo, InsertTaskError>>>,
+    /// Whether the payload must still extend the current unsafe head when this task executes.
+    require_current_unsafe_parent: bool,
 }
 
 impl<EngineClient_: EngineClient> InsertTask<EngineClient_> {
@@ -47,6 +49,7 @@ impl<EngineClient_: EngineClient> InsertTask<EngineClient_> {
             is_payload_safe: is_attributes_derived,
             block_sink,
             result_tx: None,
+            require_current_unsafe_parent: false,
         }
     }
 
@@ -56,6 +59,12 @@ impl<EngineClient_: EngineClient> InsertTask<EngineClient_> {
         result_tx: mpsc::Sender<Result<L2BlockInfo, InsertTaskError>>,
     ) -> Self {
         self.result_tx = Some(result_tx);
+        self
+    }
+
+    /// Requires the payload parent to match the current unsafe head when this task executes.
+    pub const fn require_current_unsafe_parent(mut self) -> Self {
+        self.require_current_unsafe_parent = true;
         self
     }
 
@@ -93,6 +102,20 @@ impl<EngineClient_: EngineClient> EngineTaskExt for InsertTask<EngineClient_> {
         // Insert the new payload.
         // Form the new unsafe block ref from the execution payload.
         let payload = self.payload.clone();
+        if self.require_current_unsafe_parent {
+            let parent = payload.clone().into_parts().0.parent_hash();
+            let unsafe_head = state.sync_state.unsafe_head().block_info.hash;
+            if parent != unsafe_head {
+                info!(
+                    target: "engine",
+                    %parent,
+                    %unsafe_head,
+                    "Dropping stale sequencer payload before insertion"
+                );
+                return Err(InsertTaskError::StalePayload { parent, unsafe_head });
+            }
+        }
+
         let insert_time_start = Instant::now();
         let response = match payload.clone() {
             OpExecutionPayloadEnvelope::V1(payload) => self.client.new_payload_v1(payload).await,
@@ -158,5 +181,58 @@ impl<EngineClient_: EngineClient> EngineTaskExt for InsertTask<EngineClient_> {
         );
 
         Ok(new_unsafe_ref)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        EngineTaskExt, NoopBlockSink,
+        test_utils::{TestEngineStateBuilder, test_block_info, test_engine_client_builder},
+    };
+    use alloy_primitives::{Address, B256, Bloom, Bytes, U256};
+    use alloy_rpc_types_engine::ExecutionPayloadV1;
+
+    fn test_payload(parent_hash: B256) -> OpExecutionPayloadEnvelope {
+        OpExecutionPayloadEnvelope::V1(ExecutionPayloadV1 {
+            parent_hash,
+            fee_recipient: Address::ZERO,
+            state_root: B256::ZERO,
+            receipts_root: B256::ZERO,
+            logs_bloom: Bloom::ZERO,
+            prev_randao: B256::ZERO,
+            block_number: 1,
+            gas_limit: 30_000_000,
+            gas_used: 0,
+            timestamp: 2,
+            extra_data: Bytes::new(),
+            base_fee_per_gas: U256::from(1),
+            block_hash: B256::ZERO,
+            transactions: Vec::new(),
+        })
+    }
+
+    #[tokio::test]
+    async fn checked_insert_rejects_payload_that_no_longer_extends_unsafe_head() {
+        let unsafe_head = test_block_info(10);
+        let stale_parent = B256::ZERO;
+        assert_ne!(stale_parent, unsafe_head.hash());
+        let mut state = TestEngineStateBuilder::new().with_unsafe_head(unsafe_head).build();
+        let task = InsertTask::new(
+            Arc::new(test_engine_client_builder().build()),
+            Arc::new(RollupConfig::default()),
+            test_payload(stale_parent),
+            false,
+            Arc::new(NoopBlockSink),
+        )
+        .require_current_unsafe_parent();
+
+        let err = task.execute(&mut state).await.unwrap_err();
+        assert!(matches!(
+            err,
+            InsertTaskError::StalePayload { parent, unsafe_head: actual }
+                if parent == stale_parent && actual == unsafe_head.hash()
+        ));
     }
 }

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/mod.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/mod.rs
@@ -9,7 +9,7 @@ mod synchronize;
 pub use synchronize::{SynchronizeTask, SynchronizeTaskError};
 
 mod insert;
-pub use insert::{InsertTask, InsertTaskError};
+pub use insert::{CanonicalizeTask, InsertTask, InsertTaskError};
 
 mod build;
 pub use build::{BuildTask, BuildTaskError, EngineBuildError};

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/seal/task.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/seal/task.rs
@@ -55,6 +55,8 @@ pub struct SealTask<EngineClient_: EngineClient> {
     pub is_attributes_derived: bool,
     /// How this seal is coupled to the build that produced `payload_id`.
     pub coupling: BuildSealCoupling,
+    /// Whether to canonicalize the payload as part of the seal operation.
+    pub canonicalize: bool,
     /// An optional sender to convey success/failure result of the built
     /// [`OpExecutionPayloadEnvelope`] after the block has been built, imported, and canonicalized
     /// or the [`SealTaskError`] that occurred during processing.
@@ -298,9 +300,13 @@ impl<EngineClient_: EngineClient> EngineTaskExt for SealTask<EngineClient_> {
                 "Seal attributes parent does not match unsafe head, returning rebuild error"
             );
             Err(SealTaskError::UnsafeHeadChangedSinceBuild)
-        } else {
-            // Seal the block and import it into the engine.
+        } else if self.canonicalize {
+            // Derived blocks and fallback payloads are safe to canonicalize atomically.
             self.seal_and_canonicalize_block(state).await
+        } else {
+            // Sequencer payloads must pass their external conductor check before canonicalization.
+            self.seal_payload(&self.cfg, &self.engine, self.payload_id, self.attributes.clone())
+                .await
         };
 
         self.send_channel_result_or_get_error(res).await?;

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/seal/task_test.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/seal/task_test.rs
@@ -54,6 +54,7 @@ async fn unsafe_head_check_variants(
         attributes,
         false,
         coupling,
+        true,
         with_channel.then_some(tx),
         Arc::new(crate::NoopBlockSink),
     );

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/synchronize/mod.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/synchronize/mod.rs
@@ -1,6 +1,7 @@
 //! Task and its associated types for the forkchoice engine update.
 
 mod task;
+pub(crate) use task::CanonicalizeForkchoiceTask;
 pub use task::SynchronizeTask;
 
 mod error;

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/synchronize/task.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/synchronize/task.rs
@@ -18,8 +18,8 @@ use tokio::time::Instant;
 ///
 /// ## Usage Patterns
 ///
-/// - **Internal Synchronization**: Called by [`InsertTask`], [`ConsolidateTask`], and
-///   [`FinalizeTask`]
+/// - **Internal Synchronization**: Called by [`InsertTask`], [`CanonicalizeTask`],
+///   [`ConsolidateTask`], and [`FinalizeTask`]
 /// - **Engine Reset**: Used during engine resets to establish initial forkchoice state
 /// - **Safe Head Updates**: Synchronizes safe and finalized head changes
 ///
@@ -30,6 +30,7 @@ use tokio::time::Instant;
 /// forkchoice management in most user scenarios.
 ///
 /// [`InsertTask`]: crate::InsertTask
+/// [`CanonicalizeTask`]: crate::CanonicalizeTask
 /// [`ConsolidateTask`]: crate::ConsolidateTask  
 /// [`FinalizeTask`]: crate::FinalizeTask
 /// [`BuildTask`]: crate::BuildTask
@@ -41,81 +42,109 @@ pub struct SynchronizeTask<EngineClient_: EngineClient> {
     pub rollup: Arc<RollupConfig>,
     /// The sync state update to apply to the engine state.
     pub state_update: EngineSyncStateUpdate,
-    /// Whether a `VALID` response is required instead of accepting `SYNCING`.
-    require_valid_payload_status: bool,
 }
 
-impl<EngineClient_: EngineClient> SynchronizeTask<EngineClient_> {
-    /// Creates a forkchoice synchronization task.
-    pub const fn new(
-        client: Arc<EngineClient_>,
-        rollup: Arc<RollupConfig>,
-        state_update: EngineSyncStateUpdate,
-    ) -> Self {
-        Self { client, rollup, state_update, require_valid_payload_status: false }
+/// Forkchoice synchronization used as the final validation barrier for a conductor-approved
+/// payload.
+#[derive(Debug, Clone)]
+pub(crate) struct CanonicalizeForkchoiceTask<EngineClient_: EngineClient>(
+    SynchronizeTask<EngineClient_>,
+);
+
+trait SynchronizationMode {
+    fn unchanged_state_is_complete(
+        current_state: &crate::EngineSyncState,
+        new_state: &crate::EngineSyncState,
+    ) -> bool;
+
+    fn check_payload_status(
+        state: &mut EngineState,
+        status: &PayloadStatusEnum,
+    ) -> Result<(), SynchronizeTaskError>;
+}
+
+#[derive(Debug)]
+struct ElSyncMode;
+
+impl SynchronizationMode for ElSyncMode {
+    fn unchanged_state_is_complete(
+        current_state: &crate::EngineSyncState,
+        new_state: &crate::EngineSyncState,
+    ) -> bool {
+        current_state != &Default::default() && current_state == new_state
     }
 
-    /// Requires the execution layer to return `VALID` before applying the state update.
-    pub const fn require_valid_payload_status(mut self) -> Self {
-        self.require_valid_payload_status = true;
-        self
-    }
-
-    /// Checks the response of the `engine_forkchoiceUpdated` call, and updates the sync status if
-    /// necessary.
-    fn check_forkchoice_updated_status(
-        &self,
+    fn check_payload_status(
         state: &mut EngineState,
         status: &PayloadStatusEnum,
     ) -> Result<(), SynchronizeTaskError> {
         match status {
             PayloadStatusEnum::Valid => {
-                if !state.el_sync_finished {
-                    info!(
-                        target: "engine",
-                        "Finished execution layer sync."
-                    );
-                    state.el_sync_finished = true;
-                }
-
+                mark_el_sync_finished(state);
                 Ok(())
             }
-            PayloadStatusEnum::Syncing if !self.require_valid_payload_status => {
-                // If we're not building a new payload, we're driving EL sync.
+            PayloadStatusEnum::Syncing => {
                 debug!(target: "engine", "Attempting to update forkchoice state while EL syncing");
                 Ok(())
             }
-            s => {
-                // Other codes are not expected.
-                Err(SynchronizeTaskError::UnexpectedPayloadStatus(s.clone()))
-            }
+            status => Err(SynchronizeTaskError::UnexpectedPayloadStatus(status.clone())),
         }
     }
 }
 
-#[async_trait]
-impl<EngineClient_: EngineClient> EngineTaskExt for SynchronizeTask<EngineClient_> {
-    type Output = ();
-    type Error = SynchronizeTaskError;
+#[derive(Debug)]
+struct CanonicalizationMode;
 
-    async fn execute(&self, state: &mut EngineState) -> Result<Self::Output, SynchronizeTaskError> {
+impl SynchronizationMode for CanonicalizationMode {
+    fn unchanged_state_is_complete(
+        _current_state: &crate::EngineSyncState,
+        _new_state: &crate::EngineSyncState,
+    ) -> bool {
+        false
+    }
+
+    fn check_payload_status(
+        state: &mut EngineState,
+        status: &PayloadStatusEnum,
+    ) -> Result<(), SynchronizeTaskError> {
+        match status {
+            PayloadStatusEnum::Valid => {
+                mark_el_sync_finished(state);
+                Ok(())
+            }
+            status => Err(SynchronizeTaskError::UnexpectedPayloadStatus(status.clone())),
+        }
+    }
+}
+
+fn mark_el_sync_finished(state: &mut EngineState) {
+    if !state.el_sync_finished {
+        info!(target: "engine", "Finished execution layer sync.");
+        state.el_sync_finished = true;
+    }
+}
+
+impl<EngineClient_: EngineClient> SynchronizeTask<EngineClient_> {
+    /// Creates a forkchoice synchronization task that may drive execution-layer sync.
+    pub const fn new(
+        client: Arc<EngineClient_>,
+        rollup: Arc<RollupConfig>,
+        state_update: EngineSyncStateUpdate,
+    ) -> Self {
+        Self { client, rollup, state_update }
+    }
+
+    async fn execute_with_mode<Mode: SynchronizationMode>(
+        &self,
+        state: &mut EngineState,
+    ) -> Result<(), SynchronizeTaskError> {
         // Apply the sync state update to the engine state.
         let new_sync_state = state.sync_state.apply_update(self.state_update);
 
-        // Check if a forkchoice update is not needed, return early.
-        // A forkchoice update is not needed if...
-        // 1. The engine state is not default (initial forkchoice state has been emitted), and
-        // 2. The new sync state is the same as the current sync state (no changes to the sync
-        //    state).
-        //
-        // NOTE:
-        // We shouldn't retry the synchronize task there. Since the `sync_state` is only updated
-        // inside the `SynchronizeTask` (except inside the ConsolidateTask, when the block is not
-        // the last in the batch) - the engine will get stuck retrying the `SynchronizeTask`
-        if !self.require_valid_payload_status &&
-            state.sync_state != Default::default() &&
-            state.sync_state == new_sync_state
-        {
+        // A normal synchronization with no state change does not need another FCU. Canonicalizing
+        // a conductor-approved payload deliberately bypasses this shortcut: its caller needs a
+        // fresh VALID response before retiring the retained payload.
+        if Mode::unchanged_state_is_complete(&state.sync_state, &new_sync_state) {
             debug!(target: "engine", ?new_sync_state, "No forkchoice update needed");
             return Ok(());
         }
@@ -156,7 +185,7 @@ impl<EngineClient_: EngineClient> EngineTaskExt for SynchronizeTask<EngineClient
             error
         })?;
 
-        self.check_forkchoice_updated_status(state, &valid_response.payload_status.status)?;
+        Mode::check_payload_status(state, &valid_response.payload_status.status)?;
 
         // Apply the new sync state to the engine state.
         state.sync_state = new_sync_state;
@@ -171,6 +200,36 @@ impl<EngineClient_: EngineClient> EngineTaskExt for SynchronizeTask<EngineClient
         );
 
         Ok(())
+    }
+}
+
+impl<EngineClient_: EngineClient> CanonicalizeForkchoiceTask<EngineClient_> {
+    pub(crate) const fn new(
+        client: Arc<EngineClient_>,
+        rollup: Arc<RollupConfig>,
+        state_update: EngineSyncStateUpdate,
+    ) -> Self {
+        Self(SynchronizeTask::new(client, rollup, state_update))
+    }
+}
+
+#[async_trait]
+impl<EngineClient_: EngineClient> EngineTaskExt for SynchronizeTask<EngineClient_> {
+    type Output = ();
+    type Error = SynchronizeTaskError;
+
+    async fn execute(&self, state: &mut EngineState) -> Result<Self::Output, SynchronizeTaskError> {
+        self.execute_with_mode::<ElSyncMode>(state).await
+    }
+}
+
+#[async_trait]
+impl<EngineClient_: EngineClient> EngineTaskExt for CanonicalizeForkchoiceTask<EngineClient_> {
+    type Output = ();
+    type Error = SynchronizeTaskError;
+
+    async fn execute(&self, state: &mut EngineState) -> Result<Self::Output, SynchronizeTaskError> {
+        self.0.execute_with_mode::<CanonicalizationMode>(state).await
     }
 }
 
@@ -191,12 +250,11 @@ mod tests {
                 ))
                 .build(),
         );
-        let task = SynchronizeTask::new(
+        let task = CanonicalizeForkchoiceTask::new(
             client,
             Arc::new(RollupConfig::default()),
             EngineSyncStateUpdate { unsafe_head: Some(unsafe_head), ..Default::default() },
-        )
-        .require_valid_payload_status();
+        );
 
         let err = task.execute(&mut state).await.unwrap_err();
         assert!(matches!(

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/synchronize/task.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/synchronize/task.rs
@@ -5,7 +5,6 @@ use crate::{
 };
 use alloy_rpc_types_engine::{INVALID_FORK_CHOICE_STATE_ERROR, PayloadStatusEnum};
 use async_trait::async_trait;
-use derive_more::Constructor;
 use kona_genesis::RollupConfig;
 use std::sync::Arc;
 use tokio::time::Instant;
@@ -34,7 +33,7 @@ use tokio::time::Instant;
 /// [`ConsolidateTask`]: crate::ConsolidateTask  
 /// [`FinalizeTask`]: crate::FinalizeTask
 /// [`BuildTask`]: crate::BuildTask
-#[derive(Debug, Clone, Constructor)]
+#[derive(Debug, Clone)]
 pub struct SynchronizeTask<EngineClient_: EngineClient> {
     /// The engine client.
     pub client: Arc<EngineClient_>,
@@ -42,9 +41,26 @@ pub struct SynchronizeTask<EngineClient_: EngineClient> {
     pub rollup: Arc<RollupConfig>,
     /// The sync state update to apply to the engine state.
     pub state_update: EngineSyncStateUpdate,
+    /// Whether a `VALID` response is required instead of accepting `SYNCING`.
+    require_valid_payload_status: bool,
 }
 
 impl<EngineClient_: EngineClient> SynchronizeTask<EngineClient_> {
+    /// Creates a forkchoice synchronization task.
+    pub const fn new(
+        client: Arc<EngineClient_>,
+        rollup: Arc<RollupConfig>,
+        state_update: EngineSyncStateUpdate,
+    ) -> Self {
+        Self { client, rollup, state_update, require_valid_payload_status: false }
+    }
+
+    /// Requires the execution layer to return `VALID` before applying the state update.
+    pub const fn require_valid_payload_status(mut self) -> Self {
+        self.require_valid_payload_status = true;
+        self
+    }
+
     /// Checks the response of the `engine_forkchoiceUpdated` call, and updates the sync status if
     /// necessary.
     fn check_forkchoice_updated_status(
@@ -64,7 +80,7 @@ impl<EngineClient_: EngineClient> SynchronizeTask<EngineClient_> {
 
                 Ok(())
             }
-            PayloadStatusEnum::Syncing => {
+            PayloadStatusEnum::Syncing if !self.require_valid_payload_status => {
                 // If we're not building a new payload, we're driving EL sync.
                 debug!(target: "engine", "Attempting to update forkchoice state while EL syncing");
                 Ok(())
@@ -96,7 +112,10 @@ impl<EngineClient_: EngineClient> EngineTaskExt for SynchronizeTask<EngineClient
         // We shouldn't retry the synchronize task there. Since the `sync_state` is only updated
         // inside the `SynchronizeTask` (except inside the ConsolidateTask, when the block is not
         // the last in the batch) - the engine will get stuck retrying the `SynchronizeTask`
-        if state.sync_state != Default::default() && state.sync_state == new_sync_state {
+        if !self.require_valid_payload_status &&
+            state.sync_state != Default::default() &&
+            state.sync_state == new_sync_state
+        {
             debug!(target: "engine", ?new_sync_state, "No forkchoice update needed");
             return Ok(());
         }
@@ -152,5 +171,38 @@ impl<EngineClient_: EngineClient> EngineTaskExt for SynchronizeTask<EngineClient
         );
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::{TestEngineStateBuilder, test_block_info, test_engine_client_builder};
+    use alloy_rpc_types_engine::{ForkchoiceUpdated, PayloadStatus};
+
+    #[tokio::test]
+    async fn strict_synchronization_revalidates_unchanged_syncing_head() {
+        let unsafe_head = test_block_info(1);
+        let mut state = TestEngineStateBuilder::new().with_unsafe_head(unsafe_head).build();
+        let client = Arc::new(
+            test_engine_client_builder()
+                .with_fork_choice_updated_v3_response(ForkchoiceUpdated::new(
+                    PayloadStatus::from_status(PayloadStatusEnum::Syncing),
+                ))
+                .build(),
+        );
+        let task = SynchronizeTask::new(
+            client,
+            Arc::new(RollupConfig::default()),
+            EngineSyncStateUpdate { unsafe_head: Some(unsafe_head), ..Default::default() },
+        )
+        .require_valid_payload_status();
+
+        let err = task.execute(&mut state).await.unwrap_err();
+        assert!(matches!(
+            err,
+            SynchronizeTaskError::UnexpectedPayloadStatus(PayloadStatusEnum::Syncing)
+        ));
+        assert_eq!(state.sync_state.unsafe_head(), unsafe_head);
     }
 }

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/task.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/task.rs
@@ -111,6 +111,9 @@ impl<EngineClient_: EngineClient> EngineTask<EngineClient_> {
     /// Executes the task without consuming it.
     async fn execute_inner(&self, state: &mut EngineState) -> Result<(), EngineTaskErrors> {
         match self {
+            Self::Insert(task) if task.has_result_sender() => {
+                task.execute_and_send(state).await?;
+            }
             Self::Insert(task) => match task.execute(state).await {
                 // INVALID is terminal for an externally sourced unsafe payload. Drop it so the
                 // queue can process competing or subsequent payloads instead of retrying forever.

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/task.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/task.rs
@@ -2,7 +2,7 @@
 //!
 //! [`Engine`]: crate::Engine
 
-use super::{BuildTask, ConsolidateTask, FinalizeTask, InsertTask};
+use super::{BuildTask, CanonicalizeTask, ConsolidateTask, FinalizeTask, InsertTask};
 use crate::{
     BuildTaskError, ConsolidateTaskError, EngineClient, EngineState, FinalizeTaskError,
     InsertTaskError,
@@ -93,6 +93,8 @@ impl EngineTaskError for EngineTaskErrors {
 /// [`Engine`]: crate::Engine
 #[derive(Debug, Clone)]
 pub enum EngineTask<EngineClient_: EngineClient> {
+    /// Canonicalizes a sealed, conductor-approved payload.
+    Canonicalize(Box<CanonicalizeTask<EngineClient_>>),
     /// Inserts an unsafe payload into the execution engine.
     Insert(Box<InsertTask<EngineClient_>>),
     /// Begins building a new block with the given attributes, producing a new payload ID.
@@ -111,9 +113,7 @@ impl<EngineClient_: EngineClient> EngineTask<EngineClient_> {
     /// Executes the task without consuming it.
     async fn execute_inner(&self, state: &mut EngineState) -> Result<(), EngineTaskErrors> {
         match self {
-            Self::Insert(task) if task.has_result_sender() => {
-                task.execute_and_send(state).await?;
-            }
+            Self::Canonicalize(task) => task.execute_and_send(state).await?,
             Self::Insert(task) => match task.execute(state).await {
                 // INVALID is terminal for an externally sourced unsafe payload. Drop it so the
                 // queue can process competing or subsequent payloads instead of retrying forever.
@@ -138,7 +138,7 @@ impl<EngineClient_: EngineClient> EngineTask<EngineClient_> {
 
     const fn task_metrics_label(&self) -> &'static str {
         match self {
-            Self::Insert(_) => crate::Metrics::INSERT_TASK_LABEL,
+            Self::Canonicalize(_) | Self::Insert(_) => crate::Metrics::INSERT_TASK_LABEL,
             Self::Consolidate(_) => crate::Metrics::CONSOLIDATE_TASK_LABEL,
             Self::Build(_) => crate::Metrics::BUILD_TASK_LABEL,
             Self::Seal(_) => crate::Metrics::SEAL_TASK_LABEL,
@@ -151,7 +151,7 @@ impl<EngineClient_: EngineClient> PartialEq for EngineTask<EngineClient_> {
     fn eq(&self, other: &Self) -> bool {
         matches!(
             (self, other),
-            (Self::Insert(_), Self::Insert(_)) |
+            (Self::Canonicalize(_) | Self::Insert(_), Self::Canonicalize(_) | Self::Insert(_),) |
                 (Self::Build(_), Self::Build(_)) |
                 (Self::Seal(_), Self::Seal(_)) |
                 (Self::Consolidate(_), Self::Consolidate(_)) |
@@ -182,8 +182,8 @@ impl<EngineClient_: EngineClient> Ord for EngineTask<EngineClient_> {
         //   via derivation.
         // - Finalize tasks have the lowest priority, as they only update finalized status.
         match (self, other) {
-            // Same variant cases
-            (Self::Insert(_), Self::Insert(_)) |
+            // Tasks with the same priority
+            (Self::Canonicalize(_) | Self::Insert(_), Self::Canonicalize(_) | Self::Insert(_)) |
             (Self::Consolidate(_), Self::Consolidate(_)) |
             (Self::Build(_), Self::Build(_)) |
             (Self::Seal(_), Self::Seal(_)) |
@@ -197,9 +197,9 @@ impl<EngineClient_: EngineClient> Ord for EngineTask<EngineClient_> {
             (Self::Build(_), _) => Ordering::Greater,
             (_, Self::Build(_)) => Ordering::Less,
 
-            // InsertUnsafe tasks are prioritized over Consolidate and Finalize tasks
-            (Self::Insert(_), _) => Ordering::Greater,
-            (_, Self::Insert(_)) => Ordering::Less,
+            // Payload insertion tasks are prioritized over Consolidate and Finalize tasks.
+            (Self::Canonicalize(_) | Self::Insert(_), _) => Ordering::Greater,
+            (_, Self::Canonicalize(_) | Self::Insert(_)) => Ordering::Less,
 
             // Consolidate tasks are prioritized over Finalize tasks
             (Self::Consolidate(_), _) => Ordering::Greater,
@@ -325,6 +325,45 @@ mod tests {
             &[(imported_hash, 0)],
             "a successfully imported block must reach the sink"
         );
+    }
+
+    #[tokio::test]
+    async fn canonicalization_task_reports_validated_payload() {
+        let payload = ExecutionPayloadV1::from_block_slow(&Block::<OpTxEnvelope>::default());
+        let envelope = OpExecutionPayloadEnvelope::V1(payload);
+        let imported: op_alloy_consensus::OpBlock =
+            envelope.clone().try_into_block().expect("payload converts to a block");
+        let imported_hash = imported.header.hash_slow();
+        let config = Arc::new(RollupConfig {
+            genesis: kona_genesis::ChainGenesis {
+                l2: alloy_eips::BlockNumHash { hash: imported_hash, number: 0 },
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        let valid = || PayloadStatus::from_status(PayloadStatusEnum::Valid);
+        let client = Arc::new(
+            MockEngineClient::builder()
+                .with_config(config.clone())
+                .with_new_payload_v1_response(valid())
+                .with_fork_choice_updated_v3_response(
+                    alloy_rpc_types_engine::ForkchoiceUpdated::new(valid()),
+                )
+                .build(),
+        );
+        let (result_tx, mut result_rx) = tokio::sync::mpsc::channel(1);
+        let task = EngineTask::Canonicalize(Box::new(CanonicalizeTask::new(
+            client,
+            config,
+            envelope,
+            Arc::new(crate::NoopBlockSink),
+            result_tx,
+        )));
+
+        task.execute(&mut EngineState::default()).await.unwrap();
+
+        let result = result_rx.recv().await.expect("canonicalization result was sent").unwrap();
+        assert_eq!(result.block_info.hash, imported_hash);
     }
 
     #[tokio::test]

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/util.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/util.rs
@@ -60,6 +60,7 @@ pub(in crate::task_queue) async fn build_and_seal<EngineClient_: EngineClient>(
         attributes,
         is_attributes_derived,
         BuildSealCoupling::Atomic,
+        true,
         None,
         block_sink,
     )

--- a/rust/kona/crates/node/rpc/src/admin.rs
+++ b/rust/kona/crates/node/rpc/src/admin.rs
@@ -82,14 +82,14 @@ where
             .map_err(|_| ErrorObject::from(ErrorCode::InternalError))
     }
 
-    async fn admin_start_sequencer(&self) -> RpcResult<()> {
+    async fn admin_start_sequencer(&self, head: B256) -> RpcResult<()> {
         // If the sequencer is not enabled (mode runs in validator mode), return an error.
         let Some(ref sequencer_client) = self.sequencer_admin_client else {
             return Err(ErrorObject::from(ErrorCode::MethodNotFound));
         };
 
         sequencer_client
-            .start_sequencer()
+            .start_sequencer(head)
             .await
             .map_err(|_| ErrorObject::from(ErrorCode::InternalError))
     }

--- a/rust/kona/crates/node/rpc/src/admin.rs
+++ b/rust/kona/crates/node/rpc/src/admin.rs
@@ -88,10 +88,9 @@ where
             return Err(ErrorObject::from(ErrorCode::MethodNotFound));
         };
 
-        sequencer_client
-            .start_sequencer(head)
-            .await
-            .map_err(|_| ErrorObject::from(ErrorCode::InternalError))
+        sequencer_client.start_sequencer(head).await.map_err(|err| {
+            ErrorObject::owned(ErrorCode::InternalError.code(), err.to_string(), None::<()>)
+        })
     }
 
     async fn admin_stop_sequencer(&self) -> RpcResult<B256> {

--- a/rust/kona/crates/node/rpc/src/admin.rs
+++ b/rust/kona/crates/node/rpc/src/admin.rs
@@ -2,13 +2,14 @@
 
 use crate::{AdminApiServer, SequencerAdminAPIClient};
 use alloy_primitives::B256;
+use alloy_rpc_types_engine::PayloadError;
 use async_trait::async_trait;
 use core::fmt::Debug;
 use jsonrpsee::{
     core::RpcResult,
     types::{ErrorCode, ErrorObject},
 };
-use op_alloy_rpc_types_engine::OpExecutionPayloadEnvelope;
+use op_alloy_rpc_types_engine::{OpExecutionPayloadEnvelope, OpPayloadError};
 
 /// The query types to the network actor for the admin api.
 #[derive(Debug)]
@@ -64,6 +65,17 @@ where
         payload: OpExecutionPayloadEnvelope,
     ) -> RpcResult<()> {
         kona_macros::inc!(gauge, kona_gossip::Metrics::RPC_CALLS, "method" => "admin_postUnsafePayload");
+        payload.check_block_hash().map_err(|err| {
+            let message = match &err {
+                OpPayloadError::Eth(PayloadError::BlockHash { execution, consensus }) => {
+                    format!(
+                        "payload has bad block hash: {consensus}, actual block hash is: {execution}"
+                    )
+                }
+                _ => format!("invalid payload: {err}"),
+            };
+            ErrorObject::owned(ErrorCode::InvalidParams.code(), message, None::<()>)
+        })?;
         self.network_sender
             .send(NetworkAdminQuery::PostUnsafePayload { payload })
             .await

--- a/rust/kona/crates/node/rpc/src/client.rs
+++ b/rust/kona/crates/node/rpc/src/client.rs
@@ -46,8 +46,8 @@ pub trait SequencerAdminAPIClient: Send + Sync + Debug {
     /// Check if in recovery mode.
     async fn is_recovery_mode(&self) -> Result<bool, SequencerAdminAPIError>;
 
-    /// Start the sequencer.
-    async fn start_sequencer(&self) -> Result<(), SequencerAdminAPIError>;
+    /// Start the sequencer from the expected unsafe head.
+    async fn start_sequencer(&self, head: B256) -> Result<(), SequencerAdminAPIError>;
 
     /// Stop the sequencer.
     async fn stop_sequencer(&self) -> Result<B256, SequencerAdminAPIError>;

--- a/rust/kona/crates/node/rpc/src/jsonrpsee.rs
+++ b/rust/kona/crates/node/rpc/src/jsonrpsee.rs
@@ -175,9 +175,9 @@ pub trait AdminApi {
     #[method(name = "sequencerActive")]
     async fn admin_sequencer_active(&self) -> RpcResult<bool>;
 
-    /// Starts the sequencer.
+    /// Starts the sequencer from the expected unsafe head.
     #[method(name = "startSequencer")]
-    async fn admin_start_sequencer(&self) -> RpcResult<()>;
+    async fn admin_start_sequencer(&self, head: B256) -> RpcResult<()>;
 
     /// Stops the sequencer.
     #[method(name = "stopSequencer")]

--- a/rust/kona/crates/node/service/src/actors/engine/actor.rs
+++ b/rust/kona/crates/node/service/src/actors/engine/actor.rs
@@ -1,6 +1,6 @@
 use crate::{
     BuildRequest, EngineClientError, EngineDerivationClient, EngineError, NodeActor, ResetRequest,
-    SealRequest,
+    SealRequest, actors::engine::CanonicalizeRequest,
 };
 use async_trait::async_trait;
 use kona_derive::{ResetSignal, Signal};
@@ -28,8 +28,10 @@ pub enum EngineActorRequest {
     ProcessUnsafeL2Block(Box<OpExecutionPayloadEnvelope>),
     /// Request to reset the forkchoice.
     Reset(Box<ResetRequest>),
-    /// Request to seal a block.
+    /// Request to seal a block without canonicalizing it.
     Seal(Box<SealRequest>),
+    /// Request to canonicalize a sealed block.
+    Canonicalize(Box<CanonicalizeRequest>),
 }
 
 /// Responsible for managing the operations sent to the execution layer's Engine API. To accomplish
@@ -302,10 +304,23 @@ where
                     // The payload is not derived in this case.
                     false,
                     BuildSealCoupling::Detached,
+                    false,
                     Some(result_tx),
                     Arc::clone(&self.block_sink),
                 )));
                 self.engine.enqueue(task);
+            }
+            EngineActorRequest::Canonicalize(request) => {
+                let CanonicalizeRequest { payload, result_tx } = *request;
+                let task = InsertTask::new(
+                    self.client.clone(),
+                    self.rollup.clone(),
+                    payload,
+                    false,
+                    Arc::clone(&self.block_sink),
+                )
+                .with_result_sender(result_tx);
+                self.engine.enqueue(EngineTask::Insert(Box::new(task)));
             }
         }
 

--- a/rust/kona/crates/node/service/src/actors/engine/actor.rs
+++ b/rust/kona/crates/node/service/src/actors/engine/actor.rs
@@ -5,9 +5,9 @@ use crate::{
 use async_trait::async_trait;
 use kona_derive::{ResetSignal, Signal};
 use kona_engine::{
-    BuildSealCoupling, BuildTask, ConsolidateInput, ConsolidateTask, Engine, EngineClient,
-    EngineTask, EngineTaskError, EngineTaskErrorSeverity, FinalizeBlockId, FinalizeTask,
-    ImportedBlockSink, InsertTask, SealTask,
+    BuildSealCoupling, BuildTask, CanonicalizeTask, ConsolidateInput, ConsolidateTask, Engine,
+    EngineClient, EngineTask, EngineTaskError, EngineTaskErrorSeverity, FinalizeBlockId,
+    FinalizeTask, ImportedBlockSink, InsertTask, SealTask,
 };
 use kona_genesis::RollupConfig;
 use kona_protocol::L2BlockInfo;
@@ -312,17 +312,14 @@ where
             }
             EngineActorRequest::Canonicalize(request) => {
                 let CanonicalizeRequest { payload, result_tx } = *request;
-                let task = InsertTask::new(
+                let task = CanonicalizeTask::new(
                     self.client.clone(),
                     self.rollup.clone(),
                     payload,
-                    false,
                     Arc::clone(&self.block_sink),
-                )
-                .require_current_unsafe_parent()
-                .require_valid_payload_status()
-                .with_result_sender(result_tx);
-                self.engine.enqueue(EngineTask::Insert(Box::new(task)));
+                    result_tx,
+                );
+                self.engine.enqueue(EngineTask::Canonicalize(Box::new(task)));
             }
         }
 

--- a/rust/kona/crates/node/service/src/actors/engine/actor.rs
+++ b/rust/kona/crates/node/service/src/actors/engine/actor.rs
@@ -320,6 +320,7 @@ where
                     Arc::clone(&self.block_sink),
                 )
                 .require_current_unsafe_parent()
+                .require_valid_payload_status()
                 .with_result_sender(result_tx);
                 self.engine.enqueue(EngineTask::Insert(Box::new(task)));
             }

--- a/rust/kona/crates/node/service/src/actors/engine/actor.rs
+++ b/rust/kona/crates/node/service/src/actors/engine/actor.rs
@@ -319,6 +319,7 @@ where
                     false,
                     Arc::clone(&self.block_sink),
                 )
+                .require_current_unsafe_parent()
                 .with_result_sender(result_tx);
                 self.engine.enqueue(EngineTask::Insert(Box::new(task)));
             }

--- a/rust/kona/crates/node/service/src/actors/engine/mod.rs
+++ b/rust/kona/crates/node/service/src/actors/engine/mod.rs
@@ -14,8 +14,8 @@ pub use error::EngineError;
 
 mod request;
 pub use request::{
-    BuildRequest, EngineClientError, EngineClientResult, EngineRpcRequest, ResetRequest,
-    SealRequest,
+    BuildRequest, CanonicalizeRequest, EngineClientError, EngineClientResult, EngineRpcRequest,
+    ResetRequest, SealRequest,
 };
 
 mod rpc_actor;

--- a/rust/kona/crates/node/service/src/actors/engine/request.rs
+++ b/rust/kona/crates/node/service/src/actors/engine/request.rs
@@ -1,6 +1,6 @@
 use alloy_rpc_types_engine::PayloadId;
-use kona_engine::{BuildTaskError, EngineQueries, SealTaskError};
-use kona_protocol::OpAttributesWithParent;
+use kona_engine::{BuildTaskError, EngineQueries, InsertTaskError, SealTaskError};
+use kona_protocol::{L2BlockInfo, OpAttributesWithParent};
 use op_alloy_rpc_types_engine::OpExecutionPayloadEnvelope;
 use thiserror::Error;
 use tokio::sync::mpsc;
@@ -56,7 +56,7 @@ pub struct ResetRequest {
     pub result_tx: mpsc::Sender<EngineClientResult<()>>,
 }
 
-/// A request to seal and canonicalize a payload.
+/// A request to seal a payload without canonicalizing it.
 /// Contains the `PayloadId`, attributes, and a channel to send back the result.
 #[derive(Debug)]
 pub struct SealRequest {
@@ -66,4 +66,13 @@ pub struct SealRequest {
     pub attributes: OpAttributesWithParent,
     /// The channel on which the result, successful or not, will be sent.
     pub result_tx: mpsc::Sender<Result<OpExecutionPayloadEnvelope, SealTaskError>>,
+}
+
+/// A request to canonicalize a payload after an external safety check has completed.
+#[derive(Debug)]
+pub struct CanonicalizeRequest {
+    /// The sealed payload to canonicalize.
+    pub payload: OpExecutionPayloadEnvelope,
+    /// The channel on which the result will be sent.
+    pub result_tx: mpsc::Sender<Result<L2BlockInfo, InsertTaskError>>,
 }

--- a/rust/kona/crates/node/service/src/actors/engine/request.rs
+++ b/rust/kona/crates/node/service/src/actors/engine/request.rs
@@ -28,6 +28,10 @@ pub enum EngineClientError {
     #[error(transparent)]
     SealError(#[from] SealTaskError),
 
+    /// An error occurred canonicalizing a sealed payload.
+    #[error(transparent)]
+    CanonicalizeError(InsertTaskError),
+
     /// An error occurred performing the reset.
     #[error("An error occurred performing the reset: {0}.")]
     ResetForkchoiceError(String),

--- a/rust/kona/crates/node/service/src/actors/mod.rs
+++ b/rust/kona/crates/node/service/src/actors/mod.rs
@@ -7,9 +7,9 @@ pub use traits::NodeActor;
 
 mod engine;
 pub use engine::{
-    BuildRequest, EngineActor, EngineActorRequest, EngineClientError, EngineClientResult,
-    EngineConfig, EngineDerivationClient, EngineError, EngineRpcActor, EngineRpcRequest,
-    QueuedEngineDerivationClient, ResetRequest, SealRequest,
+    BuildRequest, CanonicalizeRequest, EngineActor, EngineActorRequest, EngineClientError,
+    EngineClientResult, EngineConfig, EngineDerivationClient, EngineError, EngineRpcActor,
+    EngineRpcRequest, QueuedEngineDerivationClient, ResetRequest, SealRequest,
 };
 
 pub(crate) mod rpc;

--- a/rust/kona/crates/node/service/src/actors/rpc/sequencer_rpc_client.rs
+++ b/rust/kona/crates/node/service/src/actors/rpc/sequencer_rpc_client.rs
@@ -45,12 +45,12 @@ impl SequencerAdminAPIClient for QueuedSequencerAdminAPIClient {
         rx.await.map_err(|_| SequencerAdminAPIError::ResponseError)?
     }
 
-    async fn start_sequencer(&self) -> Result<(), SequencerAdminAPIError> {
+    async fn start_sequencer(&self, head: B256) -> Result<(), SequencerAdminAPIError> {
         let (tx, rx) = oneshot::channel();
 
-        self.request_tx.send(SequencerAdminQuery::StartSequencer(tx)).await.map_err(|_| {
-            SequencerAdminAPIError::RequestError("request channel closed".to_string())
-        })?;
+        self.request_tx.send(SequencerAdminQuery::StartSequencer(head, tx)).await.map_err(
+            |_| SequencerAdminAPIError::RequestError("request channel closed".to_string()),
+        )?;
         rx.await.map_err(|_| SequencerAdminAPIError::ResponseError)?
     }
 

--- a/rust/kona/crates/node/service/src/actors/sequencer/actor.rs
+++ b/rust/kona/crates/node/service/src/actors/sequencer/actor.rs
@@ -32,7 +32,7 @@ use tokio::{select, sync::mpsc, time::Interval};
 
 /// The handle to a block that has been started but not sealed.
 #[derive(Debug)]
-pub(super) struct UnsealedPayloadHandle {
+struct UnsealedPayloadHandle {
     /// The [`PayloadId`] of the unsealed payload.
     pub payload_id: PayloadId,
     /// The [`OpAttributesWithParent`] used to start block building.
@@ -88,7 +88,7 @@ pub struct SequencerActor<
     /// Ticker that paces block-building attempts.
     build_ticker: Interval,
     /// The handle for the payload built on the previous tick that is waiting to be sealed.
-    pub(super) next_payload_to_seal: Option<UnsealedPayloadHandle>,
+    next_payload_to_seal: Option<UnsealedPayloadHandle>,
     /// Duration of the most recent seal operation, used to back-pressure the build ticker.
     last_seal_duration: Duration,
     /// Whether the one-shot startup work (metrics + initial engine reset) has run.
@@ -172,7 +172,7 @@ where
 
     /// Sends a seal request to seal the provided [`UnsealedPayloadHandle`], committing and
     /// gossiping the resulting block, if one is built.
-    pub(super) async fn seal_and_commit_payload_if_applicable(
+    async fn seal_and_commit_payload_if_applicable(
         &self,
         unsealed_payload_handle: &UnsealedPayloadHandle,
     ) -> Result<(), SequencerActorError> {
@@ -212,7 +212,7 @@ where
     }
 
     /// Handles a block-building tick.
-    pub(super) async fn handle_build_tick(&mut self) -> Result<(), SequencerActorError> {
+    async fn handle_build_tick(&mut self) -> Result<(), SequencerActorError> {
         // Move the pending payload out of self so the &mut self call below doesn't conflict with
         // the &self read of self.next_payload_to_seal.
         let pending = self.next_payload_to_seal.take();
@@ -266,7 +266,7 @@ where
 
     /// Starts building an L2 block by creating and populating payload attributes referencing the
     /// correct L1 origin block and sending them to the block engine.
-    pub(super) async fn build_unsealed_payload(
+    async fn build_unsealed_payload(
         &mut self,
     ) -> Result<Option<UnsealedPayloadHandle>, SequencerActorError> {
         let unsafe_head = self.engine_client.get_unsafe_head().await?;
@@ -558,3 +558,7 @@ fn is_seal_task_err_fatal(err: &SealTaskError) -> bool {
         SealTaskError::ClockWentBackwards => true,
     }
 }
+
+#[cfg(test)]
+#[path = "tests/actor_test.rs"]
+mod tests;

--- a/rust/kona/crates/node/service/src/actors/sequencer/actor.rs
+++ b/rust/kona/crates/node/service/src/actors/sequencer/actor.rs
@@ -88,7 +88,7 @@ pub struct SequencerActor<
     /// Ticker that paces block-building attempts.
     build_ticker: Interval,
     /// The handle for the payload built on the previous tick that is waiting to be sealed.
-    next_payload_to_seal: Option<UnsealedPayloadHandle>,
+    pub(super) next_payload_to_seal: Option<UnsealedPayloadHandle>,
     /// Duration of the most recent seal operation, used to back-pressure the build ticker.
     last_seal_duration: Duration,
     /// Whether the one-shot startup work (metrics + initial engine reset) has run.
@@ -209,6 +209,59 @@ where
             .schedule_execution_payload_gossip(payload)
             .await
             .map_err(Into::into)
+    }
+
+    /// Handles a block-building tick.
+    pub(super) async fn handle_build_tick(&mut self) -> Result<(), SequencerActorError> {
+        // Move the pending payload out of self so the &mut self call below doesn't conflict with
+        // the &self read of self.next_payload_to_seal.
+        let pending = self.next_payload_to_seal.take();
+        match self.seal_last_and_start_next(pending.as_ref()).await {
+            Ok(res) => {
+                self.next_payload_to_seal = res.unsealed_payload_handle;
+                self.last_seal_duration = res.seal_duration;
+            }
+            Err(SequencerActorError::Conductor(err)) => {
+                // Match op-node's temporary-error behavior: retain the build so the same payload
+                // can be sealed and committed again after a short backoff.
+                error!(target: "sequencer", ?err, "Failed to commit unsafe payload to conductor; backing off sequencer");
+                self.next_payload_to_seal = pending;
+                self.build_ticker.reset_after(Duration::from_secs(1));
+                return Ok(());
+            }
+            Err(SequencerActorError::EngineError(EngineClientError::SealError(err))) => {
+                if is_seal_task_err_fatal(&err) {
+                    error!(target: "sequencer", err=?err, "Critical seal task error occurred");
+                    return Err(SequencerActorError::EngineError(EngineClientError::SealError(
+                        err,
+                    )));
+                }
+                self.next_payload_to_seal = None;
+            }
+            Err(other_err) => {
+                error!(target: "sequencer", err = ?other_err, "Unexpected error building or sealing payload");
+                return Err(other_err);
+            }
+        }
+
+        if let Some(payload) = self.next_payload_to_seal.as_ref() {
+            let next_block_seconds = payload
+                .attributes_with_parent
+                .parent()
+                .block_info
+                .timestamp
+                .saturating_add(self.rollup_config.block_time);
+            // Next block time is last + block_time - time it takes to seal.
+            let next_block_time =
+                UNIX_EPOCH + Duration::from_secs(next_block_seconds) - self.last_seal_duration;
+            match next_block_time.duration_since(SystemTime::now()) {
+                Ok(duration) => self.build_ticker.reset_after(duration),
+                Err(_) => self.build_ticker.reset_immediately(),
+            };
+        } else {
+            self.build_ticker.reset_immediately();
+        }
+        Ok(())
     }
 
     /// Starts building an L2 block by creating and populating payload attributes referencing the
@@ -471,41 +524,7 @@ where
                 Ok(())
             }
             // The sequencer must be active to build new blocks.
-            _ = self.build_ticker.tick(), if self.is_active => {
-                // Move the pending payload out of self so the &mut self call below doesn't conflict
-                // with the &self read of self.next_payload_to_seal.
-                let pending = self.next_payload_to_seal.take();
-                match self.seal_last_and_start_next(pending.as_ref()).await {
-                    Ok(res) => {
-                        self.next_payload_to_seal = res.unsealed_payload_handle;
-                        self.last_seal_duration = res.seal_duration;
-                    }
-                    Err(SequencerActorError::EngineError(EngineClientError::SealError(err))) => {
-                        if is_seal_task_err_fatal(&err) {
-                            error!(target: "sequencer", err=?err, "Critical seal task error occurred");
-                            return Err(SequencerActorError::EngineError(EngineClientError::SealError(err)));
-                        }
-                        self.next_payload_to_seal = None;
-                    }
-                    Err(other_err) => {
-                        error!(target: "sequencer", err = ?other_err, "Unexpected error building or sealing payload");
-                        return Err(other_err);
-                    }
-                }
-
-                if let Some(payload) = self.next_payload_to_seal.as_ref() {
-                    let next_block_seconds = payload.attributes_with_parent.parent().block_info.timestamp.saturating_add(self.rollup_config.block_time);
-                    // next block time is last + block_time - time it takes to seal.
-                    let next_block_time = UNIX_EPOCH + Duration::from_secs(next_block_seconds) - self.last_seal_duration;
-                    match next_block_time.duration_since(SystemTime::now()) {
-                        Ok(duration) => self.build_ticker.reset_after(duration),
-                        Err(_) => self.build_ticker.reset_immediately(),
-                    };
-                } else {
-                    self.build_ticker.reset_immediately();
-                }
-                Ok(())
-            }
+            _ = self.build_ticker.tick(), if self.is_active => self.handle_build_tick().await,
         }
     }
 }

--- a/rust/kona/crates/node/service/src/actors/sequencer/actor.rs
+++ b/rust/kona/crates/node/service/src/actors/sequencer/actor.rs
@@ -172,7 +172,7 @@ where
 
     /// Sends a seal request to seal the provided [`UnsealedPayloadHandle`], committing and
     /// gossiping the resulting block, if one is built.
-    async fn seal_and_commit_payload_if_applicable(
+    pub(super) async fn seal_and_commit_payload_if_applicable(
         &self,
         unsealed_payload_handle: &UnsealedPayloadHandle,
     ) -> Result<(), SequencerActorError> {
@@ -181,7 +181,7 @@ where
         // Send the seal request to the engine to seal the unsealed block.
         let payload = self
             .engine_client
-            .seal_and_canonicalize_block(
+            .seal_block(
                 unsealed_payload_handle.payload_id,
                 unsealed_payload_handle.attributes_with_parent.clone(),
             )
@@ -196,12 +196,14 @@ where
         // If the conductor is available, commit the payload to it.
         if let Some(conductor) = &self.conductor {
             let _conductor_commitment_start = Instant::now();
-            if let Err(err) = conductor.commit_unsafe_payload(&payload).await {
+            conductor.commit_unsafe_payload(&payload).await.inspect_err(|err| {
                 error!(target: "sequencer", ?err, "Failed to commit unsafe payload to conductor");
-            }
+            })?;
 
             update_conductor_commitment_duration_metrics(_conductor_commitment_start.elapsed());
         }
+
+        self.engine_client.canonicalize_block(payload.clone()).await?;
 
         self.unsafe_payload_gossip_client
             .schedule_execution_payload_gossip(payload)
@@ -523,9 +525,9 @@ fn is_seal_task_err_fatal(err: &SealTaskError) -> bool {
                 SynchronizeTaskError::InvalidForkchoiceState |
                 SynchronizeTaskError::UnexpectedPayloadStatus(_) => false,
             },
-            InsertTaskError::FromBlockError(_) | InsertTaskError::L2BlockInfoConstruction(_) => {
-                true
-            }
+            InsertTaskError::FromBlockError(_) |
+            InsertTaskError::L2BlockInfoConstruction(_) |
+            InsertTaskError::MpscSend(_) => true,
             InsertTaskError::InsertFailed(_) | InsertTaskError::UnexpectedPayloadStatus(_) => false,
         },
         SealTaskError::GetPayloadFailed(_) |

--- a/rust/kona/crates/node/service/src/actors/sequencer/actor.rs
+++ b/rust/kona/crates/node/service/src/actors/sequencer/actor.rs
@@ -17,7 +17,7 @@ use crate::{
         },
     },
 };
-use alloy_rpc_types_engine::PayloadId;
+use alloy_rpc_types_engine::{PayloadId, PayloadStatusEnum};
 use async_trait::async_trait;
 use kona_derive::{AttributesBuilder, PipelineErrorKind};
 use kona_engine::{InsertTaskError, SealTaskError, SynchronizeTaskError};
@@ -42,8 +42,10 @@ struct UnsealedPayloadHandle {
 /// Work retained between block-building ticks.
 #[derive(Debug)]
 enum PendingPayload {
-    /// An engine build that has not yet been accepted by the conductor.
+    /// An engine build that has not yet been sealed.
     Unsealed(Box<UnsealedPayloadHandle>),
+    /// The exact sealed payload whose conductor commitment is not yet acknowledged.
+    Sealed(Box<OpExecutionPayloadEnvelope>),
     /// The exact payload accepted by the conductor but not yet canonicalized locally.
     Committed(Box<OpExecutionPayloadEnvelope>),
 }
@@ -146,8 +148,8 @@ where
         }
     }
 
-    /// Seals an engine build and commits the exact payload to the conductor.
-    async fn seal_and_commit_payload(
+    /// Seals an engine build without making it canonical.
+    async fn seal_payload(
         &self,
         unsealed_payload_handle: &UnsealedPayloadHandle,
     ) -> Result<OpExecutionPayloadEnvelope, SequencerActorError> {
@@ -164,16 +166,31 @@ where
         update_total_transactions_sequenced(
             unsealed_payload_handle.attributes_with_parent.count_transactions(),
         );
-
-        if let Some(conductor) = &self.conductor {
-            let conductor_commitment_start = Instant::now();
-            conductor.commit_unsafe_payload(&payload).await.inspect_err(|err| {
-                error!(target: "sequencer", ?err, "Failed to commit unsafe payload to conductor");
-            })?;
-            update_conductor_commitment_duration_metrics(conductor_commitment_start.elapsed());
-        }
-
         Ok(payload)
+    }
+
+    /// Commits a sealed payload, retaining the exact envelope if acknowledgement fails.
+    async fn commit_payload_or_backoff(
+        &mut self,
+        payload: Box<OpExecutionPayloadEnvelope>,
+    ) -> Option<Box<OpExecutionPayloadEnvelope>> {
+        let Some(conductor) = &self.conductor else {
+            return Some(payload);
+        };
+
+        let conductor_commitment_start = Instant::now();
+        match conductor.commit_unsafe_payload(&payload).await {
+            Ok(()) => {
+                update_conductor_commitment_duration_metrics(conductor_commitment_start.elapsed());
+                Some(payload)
+            }
+            Err(err) => {
+                error!(target: "sequencer", ?err, "Failed to commit unsafe payload to conductor; backing off sequencer");
+                self.pending_payload = Some(PendingPayload::Sealed(payload));
+                self.build_ticker.reset_after(Duration::from_secs(1));
+                None
+            }
+        }
     }
 
     /// Canonicalizes a conductor-approved payload and then publishes it to peers.
@@ -194,19 +211,8 @@ where
         let committed_payload = match pending {
             Some(PendingPayload::Unsealed(unsealed)) => {
                 let seal_start = Instant::now();
-                match self.seal_and_commit_payload(&unsealed).await {
-                    Ok(payload) => {
-                        self.last_seal_duration = seal_start.elapsed();
-                        Some(Box::new(payload))
-                    }
-                    Err(SequencerActorError::Conductor(err)) => {
-                        // Match op-node's temporary-error behavior: retain the build so the same
-                        // payload can be sealed and committed again after a short backoff.
-                        error!(target: "sequencer", ?err, "Failed to commit unsafe payload to conductor; backing off sequencer");
-                        self.pending_payload = Some(PendingPayload::Unsealed(unsealed));
-                        self.build_ticker.reset_after(Duration::from_secs(1));
-                        return Ok(());
-                    }
+                let payload = match self.seal_payload(&unsealed).await {
+                    Ok(payload) => Box::new(payload),
                     Err(SequencerActorError::EngineError(EngineClientError::SealError(err))) => {
                         if is_seal_task_err_fatal(&err) {
                             error!(target: "sequencer", ?err, "Critical seal task error occurred");
@@ -219,7 +225,18 @@ where
                         error!(target: "sequencer", err = ?other_err, "Unexpected error sealing payload");
                         return Err(other_err);
                     }
-                }
+                };
+                self.last_seal_duration = seal_start.elapsed();
+                let Some(payload) = self.commit_payload_or_backoff(payload).await else {
+                    return Ok(());
+                };
+                Some(payload)
+            }
+            Some(PendingPayload::Sealed(payload)) => {
+                let Some(payload) = self.commit_payload_or_backoff(payload).await else {
+                    return Ok(());
+                };
+                Some(payload)
             }
             Some(PendingPayload::Committed(payload)) => Some(payload),
             None => None,
@@ -238,7 +255,11 @@ where
                         return Ok(());
                     }
                     CanonicalizationErrorAction::DropStale => {
-                        warn!(target: "sequencer", ?err, "Dropping stale conductor-approved payload");
+                        if self.conductor.is_some() {
+                            error!(target: "sequencer", ?err, "Conductor-approved payload became stale; stopping to prevent a conflicting same-height replacement");
+                            return Err(EngineClientError::CanonicalizeError(err).into());
+                        }
+                        warn!(target: "sequencer", ?err, "Dropping stale payload");
                         self.build_ticker.reset_immediately();
                         return Ok(());
                     }
@@ -554,13 +575,18 @@ enum CanonicalizationErrorAction {
 const fn canonicalization_error_action(err: &InsertTaskError) -> CanonicalizationErrorAction {
     match err {
         InsertTaskError::StalePayload { .. } => CanonicalizationErrorAction::DropStale,
-        InsertTaskError::InsertFailed(_) | InsertTaskError::UnexpectedPayloadStatus(_) => {
-            CanonicalizationErrorAction::Retry
+        InsertTaskError::UnexpectedPayloadStatus(PayloadStatusEnum::Invalid { .. }) => {
+            CanonicalizationErrorAction::Fatal
         }
+        InsertTaskError::AncestryLookupFailed(_) |
+        InsertTaskError::AncestorBlockNotFound { .. } |
+        InsertTaskError::InsertFailed(_) |
+        InsertTaskError::UnexpectedPayloadStatus(_) => CanonicalizationErrorAction::Retry,
         InsertTaskError::ForkchoiceUpdateFailed(err) => match err {
-            SynchronizeTaskError::FinalizedAheadOfUnsafe(_, _) => {
-                CanonicalizationErrorAction::Fatal
-            }
+            SynchronizeTaskError::FinalizedAheadOfUnsafe(_, _) |
+            SynchronizeTaskError::UnexpectedPayloadStatus(PayloadStatusEnum::Invalid {
+                ..
+            }) => CanonicalizationErrorAction::Fatal,
             SynchronizeTaskError::ForkchoiceUpdateFailed(_) |
             SynchronizeTaskError::InvalidForkchoiceState |
             SynchronizeTaskError::UnexpectedPayloadStatus(_) => CanonicalizationErrorAction::Retry,
@@ -590,6 +616,8 @@ fn is_seal_task_err_fatal(err: &SealTaskError) -> bool {
             InsertTaskError::L2BlockInfoConstruction(_) |
             InsertTaskError::MpscSend(_) => true,
             InsertTaskError::StalePayload { .. } |
+            InsertTaskError::AncestryLookupFailed(_) |
+            InsertTaskError::AncestorBlockNotFound { .. } |
             InsertTaskError::InsertFailed(_) |
             InsertTaskError::UnexpectedPayloadStatus(_) => false,
         },

--- a/rust/kona/crates/node/service/src/actors/sequencer/actor.rs
+++ b/rust/kona/crates/node/service/src/actors/sequencer/actor.rs
@@ -23,7 +23,7 @@ use kona_derive::{AttributesBuilder, PipelineErrorKind};
 use kona_engine::{InsertTaskError, SealTaskError, SynchronizeTaskError};
 use kona_genesis::RollupConfig;
 use kona_protocol::{BlockInfo, L2BlockInfo, OpAttributesWithParent};
-use op_alloy_rpc_types_engine::OpPayloadAttributes;
+use op_alloy_rpc_types_engine::{OpExecutionPayloadEnvelope, OpPayloadAttributes};
 use std::{
     sync::Arc,
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
@@ -34,19 +34,18 @@ use tokio::{select, sync::mpsc, time::Interval};
 #[derive(Debug)]
 struct UnsealedPayloadHandle {
     /// The [`PayloadId`] of the unsealed payload.
-    pub payload_id: PayloadId,
+    payload_id: PayloadId,
     /// The [`OpAttributesWithParent`] used to start block building.
-    pub attributes_with_parent: OpAttributesWithParent,
+    attributes_with_parent: OpAttributesWithParent,
 }
 
-/// The return payload of the `seal_last_and_start_next` function. This allows the sequencer
-/// to make an informed decision about when to seal and build the next block.
+/// Work retained between block-building ticks.
 #[derive(Debug)]
-struct SealLastStartNextResult {
-    /// The [`UnsealedPayloadHandle`] that was built.
-    pub unsealed_payload_handle: Option<UnsealedPayloadHandle>,
-    /// How long it took to execute the seal operation.
-    pub seal_duration: Duration,
+enum PendingPayload {
+    /// An engine build that has not yet been accepted by the conductor.
+    Unsealed(Box<UnsealedPayloadHandle>),
+    /// The exact payload accepted by the conductor but not yet canonicalized locally.
+    Committed(Box<OpExecutionPayloadEnvelope>),
 }
 
 /// The [`SequencerActor`] is responsible for building L2 blocks on top of the current unsafe head
@@ -87,8 +86,8 @@ pub struct SequencerActor<
 
     /// Ticker that paces block-building attempts.
     build_ticker: Interval,
-    /// The handle for the payload built on the previous tick that is waiting to be sealed.
-    next_payload_to_seal: Option<UnsealedPayloadHandle>,
+    /// The payload work to resume on the next block-building tick.
+    pending_payload: Option<PendingPayload>,
     /// Duration of the most recent seal operation, used to back-pressure the build ticker.
     last_seal_duration: Duration,
     /// Whether the one-shot startup work (metrics + initial engine reset) has run.
@@ -141,44 +140,18 @@ where
             rollup_config,
             unsafe_payload_gossip_client,
             build_ticker,
-            next_payload_to_seal: None,
+            pending_payload: None,
             last_seal_duration: Duration::from_secs(0),
             started: false,
         }
     }
 
-    /// Seals and commits the last pending block, if one exists and starts the build job for the
-    /// next L2 block, on top of the current unsafe head.
-    ///
-    /// If a new block was started, it will return the associated [`UnsealedPayloadHandle`] so
-    /// that it may be sealed and committed in a future call to this function.
-    async fn seal_last_and_start_next(
-        &mut self,
-        payload_to_seal: Option<&UnsealedPayloadHandle>,
-    ) -> Result<SealLastStartNextResult, SequencerActorError> {
-        let seal_duration = match payload_to_seal {
-            Some(to_seal) => {
-                let seal_start = Instant::now();
-                self.seal_and_commit_payload_if_applicable(to_seal).await?;
-                seal_start.elapsed()
-            }
-            None => Duration::default(),
-        };
-
-        let unsealed_payload_handle = self.build_unsealed_payload().await?;
-
-        Ok(SealLastStartNextResult { unsealed_payload_handle, seal_duration })
-    }
-
-    /// Sends a seal request to seal the provided [`UnsealedPayloadHandle`], committing and
-    /// gossiping the resulting block, if one is built.
-    async fn seal_and_commit_payload_if_applicable(
+    /// Seals an engine build and commits the exact payload to the conductor.
+    async fn seal_and_commit_payload(
         &self,
         unsealed_payload_handle: &UnsealedPayloadHandle,
-    ) -> Result<(), SequencerActorError> {
+    ) -> Result<OpExecutionPayloadEnvelope, SequencerActorError> {
         let seal_request_start = Instant::now();
-
-        // Send the seal request to the engine to seal the unsealed block.
         let payload = self
             .engine_client
             .seal_block(
@@ -188,63 +161,102 @@ where
             .await?;
 
         update_seal_duration_metrics(seal_request_start.elapsed());
+        update_total_transactions_sequenced(
+            unsealed_payload_handle.attributes_with_parent.count_transactions(),
+        );
 
-        let payload_transaction_count =
-            unsealed_payload_handle.attributes_with_parent.count_transactions();
-        update_total_transactions_sequenced(payload_transaction_count);
-
-        // If the conductor is available, commit the payload to it.
         if let Some(conductor) = &self.conductor {
-            let _conductor_commitment_start = Instant::now();
+            let conductor_commitment_start = Instant::now();
             conductor.commit_unsafe_payload(&payload).await.inspect_err(|err| {
                 error!(target: "sequencer", ?err, "Failed to commit unsafe payload to conductor");
             })?;
-
-            update_conductor_commitment_duration_metrics(_conductor_commitment_start.elapsed());
+            update_conductor_commitment_duration_metrics(conductor_commitment_start.elapsed());
         }
 
-        self.engine_client.canonicalize_block(payload.clone()).await?;
+        Ok(payload)
+    }
 
+    /// Canonicalizes a conductor-approved payload and then publishes it to peers.
+    async fn canonicalize_and_gossip_payload(
+        &self,
+        payload: &OpExecutionPayloadEnvelope,
+    ) -> Result<(), SequencerActorError> {
+        self.engine_client.canonicalize_block(payload.clone()).await?;
         self.unsafe_payload_gossip_client
-            .schedule_execution_payload_gossip(payload)
+            .schedule_execution_payload_gossip(payload.clone())
             .await
             .map_err(Into::into)
     }
 
     /// Handles a block-building tick.
     async fn handle_build_tick(&mut self) -> Result<(), SequencerActorError> {
-        // Move the pending payload out of self so the &mut self call below doesn't conflict with
-        // the &self read of self.next_payload_to_seal.
-        let pending = self.next_payload_to_seal.take();
-        match self.seal_last_and_start_next(pending.as_ref()).await {
-            Ok(res) => {
-                self.next_payload_to_seal = res.unsealed_payload_handle;
-                self.last_seal_duration = res.seal_duration;
-            }
-            Err(SequencerActorError::Conductor(err)) => {
-                // Match op-node's temporary-error behavior: retain the build so the same payload
-                // can be sealed and committed again after a short backoff.
-                error!(target: "sequencer", ?err, "Failed to commit unsafe payload to conductor; backing off sequencer");
-                self.next_payload_to_seal = pending;
-                self.build_ticker.reset_after(Duration::from_secs(1));
-                return Ok(());
-            }
-            Err(SequencerActorError::EngineError(EngineClientError::SealError(err))) => {
-                if is_seal_task_err_fatal(&err) {
-                    error!(target: "sequencer", err=?err, "Critical seal task error occurred");
-                    return Err(SequencerActorError::EngineError(EngineClientError::SealError(
-                        err,
-                    )));
+        let pending = self.pending_payload.take();
+        let committed_payload = match pending {
+            Some(PendingPayload::Unsealed(unsealed)) => {
+                let seal_start = Instant::now();
+                match self.seal_and_commit_payload(&unsealed).await {
+                    Ok(payload) => {
+                        self.last_seal_duration = seal_start.elapsed();
+                        Some(Box::new(payload))
+                    }
+                    Err(SequencerActorError::Conductor(err)) => {
+                        // Match op-node's temporary-error behavior: retain the build so the same
+                        // payload can be sealed and committed again after a short backoff.
+                        error!(target: "sequencer", ?err, "Failed to commit unsafe payload to conductor; backing off sequencer");
+                        self.pending_payload = Some(PendingPayload::Unsealed(unsealed));
+                        self.build_ticker.reset_after(Duration::from_secs(1));
+                        return Ok(());
+                    }
+                    Err(SequencerActorError::EngineError(EngineClientError::SealError(err))) => {
+                        if is_seal_task_err_fatal(&err) {
+                            error!(target: "sequencer", ?err, "Critical seal task error occurred");
+                            return Err(EngineClientError::SealError(err).into());
+                        }
+                        self.build_ticker.reset_immediately();
+                        return Ok(());
+                    }
+                    Err(other_err) => {
+                        error!(target: "sequencer", err = ?other_err, "Unexpected error sealing payload");
+                        return Err(other_err);
+                    }
                 }
-                self.next_payload_to_seal = None;
             }
-            Err(other_err) => {
-                error!(target: "sequencer", err = ?other_err, "Unexpected error building or sealing payload");
-                return Err(other_err);
+            Some(PendingPayload::Committed(payload)) => Some(payload),
+            None => None,
+        };
+
+        if let Some(payload) = committed_payload {
+            match self.canonicalize_and_gossip_payload(&payload).await {
+                Ok(()) => {}
+                Err(SequencerActorError::EngineError(EngineClientError::CanonicalizeError(
+                    err,
+                ))) => match canonicalization_error_action(&err) {
+                    CanonicalizationErrorAction::Retry => {
+                        error!(target: "sequencer", ?err, "Failed to canonicalize conductor-approved payload; backing off sequencer");
+                        self.pending_payload = Some(PendingPayload::Committed(payload));
+                        self.build_ticker.reset_after(Duration::from_secs(1));
+                        return Ok(());
+                    }
+                    CanonicalizationErrorAction::DropStale => {
+                        warn!(target: "sequencer", ?err, "Dropping stale conductor-approved payload");
+                        self.build_ticker.reset_immediately();
+                        return Ok(());
+                    }
+                    CanonicalizationErrorAction::Fatal => {
+                        return Err(EngineClientError::CanonicalizeError(err).into());
+                    }
+                },
+                Err(other_err) => {
+                    error!(target: "sequencer", err = ?other_err, "Unexpected error canonicalizing or gossiping payload");
+                    return Err(other_err);
+                }
             }
         }
 
-        if let Some(payload) = self.next_payload_to_seal.as_ref() {
+        self.pending_payload =
+            self.build_unsealed_payload().await?.map(Box::new).map(PendingPayload::Unsealed);
+
+        if let Some(PendingPayload::Unsealed(payload)) = self.pending_payload.as_ref() {
             let next_block_seconds = payload
                 .attributes_with_parent
                 .parent()
@@ -529,6 +541,36 @@ where
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CanonicalizationErrorAction {
+    /// Retry the exact conductor-approved payload after a backoff.
+    Retry,
+    /// Drop a payload whose parent is no longer the unsafe head.
+    DropStale,
+    /// Stop the node because retrying cannot recover safely.
+    Fatal,
+}
+
+const fn canonicalization_error_action(err: &InsertTaskError) -> CanonicalizationErrorAction {
+    match err {
+        InsertTaskError::StalePayload { .. } => CanonicalizationErrorAction::DropStale,
+        InsertTaskError::InsertFailed(_) | InsertTaskError::UnexpectedPayloadStatus(_) => {
+            CanonicalizationErrorAction::Retry
+        }
+        InsertTaskError::ForkchoiceUpdateFailed(err) => match err {
+            SynchronizeTaskError::FinalizedAheadOfUnsafe(_, _) => {
+                CanonicalizationErrorAction::Fatal
+            }
+            SynchronizeTaskError::ForkchoiceUpdateFailed(_) |
+            SynchronizeTaskError::InvalidForkchoiceState |
+            SynchronizeTaskError::UnexpectedPayloadStatus(_) => CanonicalizationErrorAction::Retry,
+        },
+        InsertTaskError::FromBlockError(_) |
+        InsertTaskError::L2BlockInfoConstruction(_) |
+        InsertTaskError::MpscSend(_) => CanonicalizationErrorAction::Fatal,
+    }
+}
+
 // Determines whether the provided [`SealTaskError`] is fatal for the sequencer.
 //
 // NB: We could use `err.severity()`, but that gives EngineActor control over this classification.
@@ -547,7 +589,9 @@ fn is_seal_task_err_fatal(err: &SealTaskError) -> bool {
             InsertTaskError::FromBlockError(_) |
             InsertTaskError::L2BlockInfoConstruction(_) |
             InsertTaskError::MpscSend(_) => true,
-            InsertTaskError::InsertFailed(_) | InsertTaskError::UnexpectedPayloadStatus(_) => false,
+            InsertTaskError::StalePayload { .. } |
+            InsertTaskError::InsertFailed(_) |
+            InsertTaskError::UnexpectedPayloadStatus(_) => false,
         },
         SealTaskError::GetPayloadFailed(_) |
         SealTaskError::HoloceneInvalidFlush |

--- a/rust/kona/crates/node/service/src/actors/sequencer/admin_api_impl.rs
+++ b/rust/kona/crates/node/service/src/actors/sequencer/admin_api_impl.rs
@@ -10,8 +10,8 @@ use tokio::sync::oneshot;
 pub enum SequencerAdminQuery {
     /// A query to check if the sequencer is active.
     SequencerActive(oneshot::Sender<Result<bool, SequencerAdminAPIError>>),
-    /// A query to start the sequencer.
-    StartSequencer(oneshot::Sender<Result<(), SequencerAdminAPIError>>),
+    /// A query to start the sequencer from the expected unsafe head.
+    StartSequencer(B256, oneshot::Sender<Result<(), SequencerAdminAPIError>>),
     /// A query to stop the sequencer.
     StopSequencer(oneshot::Sender<Result<B256, SequencerAdminAPIError>>),
     /// A query to check if the conductor is enabled.
@@ -57,8 +57,8 @@ where
                     warn!(target: "sequencer", "Failed to send response for is_sequencer_active query");
                 }
             }
-            SequencerAdminQuery::StartSequencer(tx) => {
-                if tx.send(self.start_sequencer().await).is_err() {
+            SequencerAdminQuery::StartSequencer(head, tx) => {
+                if tx.send(self.start_sequencer(head).await).is_err() {
                     warn!(target: "sequencer", "Failed to send response for start_sequencer query");
                 }
             }
@@ -111,7 +111,10 @@ where
     }
 
     /// Starts the sequencer in an idempotent fashion.
-    pub(super) async fn start_sequencer(&mut self) -> Result<(), SequencerAdminAPIError> {
+    pub(super) async fn start_sequencer(
+        &mut self,
+        _head: B256,
+    ) -> Result<(), SequencerAdminAPIError> {
         if self.is_active {
             info!(target: "sequencer", "received request to start sequencer, but it is already started");
             return Ok(());

--- a/rust/kona/crates/node/service/src/actors/sequencer/admin_api_impl.rs
+++ b/rust/kona/crates/node/service/src/actors/sequencer/admin_api_impl.rs
@@ -110,7 +110,8 @@ where
         Ok(self.in_recovery_mode)
     }
 
-    /// Starts the sequencer in an idempotent fashion after validating the expected unsafe head.
+    /// Starts the sequencer in an idempotent fashion after validating conductor leadership and
+    /// the expected unsafe head.
     pub(super) async fn start_sequencer(
         &mut self,
         head: B256,
@@ -118,6 +119,19 @@ where
         if self.is_active {
             info!(target: "sequencer", "received request to start sequencer, but it is already started");
             return Ok(());
+        }
+
+        if let Some(conductor) = &self.conductor {
+            let is_leader = conductor.leader().await.map_err(|err| {
+                SequencerAdminAPIError::RequestError(format!(
+                    "sequencer leader check failed: {err}"
+                ))
+            })?;
+            if !is_leader {
+                return Err(SequencerAdminAPIError::RequestError(
+                    "sequencer is not the leader, aborting".to_string(),
+                ));
+            }
         }
 
         let unsafe_head = self.engine_client.get_unsafe_head().await.map_err(|err| {

--- a/rust/kona/crates/node/service/src/actors/sequencer/admin_api_impl.rs
+++ b/rust/kona/crates/node/service/src/actors/sequencer/admin_api_impl.rs
@@ -110,14 +110,24 @@ where
         Ok(self.in_recovery_mode)
     }
 
-    /// Starts the sequencer in an idempotent fashion.
+    /// Starts the sequencer in an idempotent fashion after validating the expected unsafe head.
     pub(super) async fn start_sequencer(
         &mut self,
-        _head: B256,
+        head: B256,
     ) -> Result<(), SequencerAdminAPIError> {
         if self.is_active {
             info!(target: "sequencer", "received request to start sequencer, but it is already started");
             return Ok(());
+        }
+
+        let unsafe_head = self.engine_client.get_unsafe_head().await.map_err(|err| {
+            SequencerAdminAPIError::RequestError(format!("failed to get unsafe head: {err}"))
+        })?;
+        if unsafe_head.hash() != head {
+            return Err(SequencerAdminAPIError::RequestError(format!(
+                "block hash does not match: head {}, received {head}",
+                unsafe_head.hash()
+            )));
         }
 
         info!(target: "sequencer", "Starting sequencer");

--- a/rust/kona/crates/node/service/src/actors/sequencer/admin_api_impl.rs
+++ b/rust/kona/crates/node/service/src/actors/sequencer/admin_api_impl.rs
@@ -96,26 +96,23 @@ where
     }
 
     /// Returns whether the sequencer is active.
-    pub(super) async fn is_sequencer_active(&self) -> Result<bool, SequencerAdminAPIError> {
+    async fn is_sequencer_active(&self) -> Result<bool, SequencerAdminAPIError> {
         Ok(self.is_active)
     }
 
     /// Returns whether the conductor is enabled.
-    pub(super) async fn is_conductor_enabled(&self) -> Result<bool, SequencerAdminAPIError> {
+    async fn is_conductor_enabled(&self) -> Result<bool, SequencerAdminAPIError> {
         Ok(self.conductor.is_some())
     }
 
     /// Returns whether the node is in recovery mode.
-    pub(super) async fn in_recovery_mode(&self) -> Result<bool, SequencerAdminAPIError> {
+    async fn in_recovery_mode(&self) -> Result<bool, SequencerAdminAPIError> {
         Ok(self.in_recovery_mode)
     }
 
     /// Starts the sequencer in an idempotent fashion after validating conductor leadership and
     /// the expected unsafe head.
-    pub(super) async fn start_sequencer(
-        &mut self,
-        head: B256,
-    ) -> Result<(), SequencerAdminAPIError> {
+    async fn start_sequencer(&mut self, head: B256) -> Result<(), SequencerAdminAPIError> {
         if self.is_active {
             info!(target: "sequencer", "received request to start sequencer, but it is already started");
             return Ok(());
@@ -153,7 +150,7 @@ where
     }
 
     /// Stops the sequencer in an idempotent fashion.
-    pub(super) async fn stop_sequencer(&mut self) -> Result<B256, SequencerAdminAPIError> {
+    async fn stop_sequencer(&mut self) -> Result<B256, SequencerAdminAPIError> {
         info!(target: "sequencer", "Stopping sequencer");
         self.is_active = false;
 
@@ -168,10 +165,7 @@ where
     }
 
     /// Sets the recovery mode of the sequencer in an idempotent fashion.
-    pub(super) async fn set_recovery_mode(
-        &mut self,
-        is_active: bool,
-    ) -> Result<(), SequencerAdminAPIError> {
+    async fn set_recovery_mode(&mut self, is_active: bool) -> Result<(), SequencerAdminAPIError> {
         self.in_recovery_mode = is_active;
         info!(target: "sequencer", is_active, "Updated recovery mode");
 
@@ -182,7 +176,7 @@ where
 
     /// Overrides the leader, if the conductor is enabled.
     /// If not, an error will be returned.
-    pub(super) async fn override_leader(&mut self) -> Result<(), SequencerAdminAPIError> {
+    async fn override_leader(&mut self) -> Result<(), SequencerAdminAPIError> {
         let Some(conductor) = self.conductor.as_mut() else {
             return Err(SequencerAdminAPIError::LeaderOverrideError(
                 "No conductor configured".to_string(),
@@ -200,7 +194,7 @@ where
         Ok(())
     }
 
-    pub(super) async fn reset_derivation_pipeline(&self) -> Result<(), SequencerAdminAPIError> {
+    async fn reset_derivation_pipeline(&self) -> Result<(), SequencerAdminAPIError> {
         info!(target: "sequencer", "Resetting derivation pipeline");
         self.engine_client.reset_engine_forkchoice().await.map_err(|e| {
             error!(target: "sequencer", err=?e, "Failed to reset engine forkchoice");
@@ -208,3 +202,7 @@ where
         })
     }
 }
+
+#[cfg(test)]
+#[path = "tests/admin_api_impl_test.rs"]
+mod tests;

--- a/rust/kona/crates/node/service/src/actors/sequencer/conductor.rs
+++ b/rust/kona/crates/node/service/src/actors/sequencer/conductor.rs
@@ -2,7 +2,13 @@ use alloy_rpc_client::ReqwestClient;
 use alloy_transport::{RpcError, TransportErrorKind};
 use async_trait::async_trait;
 use op_alloy_rpc_types_engine::OpExecutionPayloadEnvelope;
-use std::fmt::Debug;
+use std::{
+    fmt::Debug,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+};
 use url::Url;
 
 /// Trait for interacting with the conductor service.
@@ -18,15 +24,20 @@ pub trait Conductor: Debug + Send + Sync {
         payload: &OpExecutionPayloadEnvelope,
     ) -> Result<(), ConductorError>;
 
-    /// Override the leader of the conductor.
+    /// Check if this node is the conductor leader.
+    async fn leader(&self) -> Result<bool, ConductorError>;
+
+    /// Locally override conductor leadership for disaster recovery.
     async fn override_leader(&self) -> Result<(), ConductorError>;
 }
 
 /// A client for communicating with the conductor service via RPC
 #[derive(Debug, Clone)]
 pub struct ConductorClient {
-    /// The inner RPC provider
+    /// The inner RPC provider.
     rpc: ReqwestClient,
+    /// Local disaster-recovery override. When set, conductor interactions are bypassed.
+    override_leader: Arc<AtomicBool>,
 }
 
 #[async_trait]
@@ -36,12 +47,23 @@ impl Conductor for ConductorClient {
         &self,
         payload: &OpExecutionPayloadEnvelope,
     ) -> Result<(), ConductorError> {
+        if self.override_leader.load(Ordering::Relaxed) {
+            return Ok(());
+        }
         self.rpc.request("conductor_commitUnsafePayload", [payload]).await.map_err(Into::into)
     }
 
-    /// Override the leader of the conductor.
+    async fn leader(&self) -> Result<bool, ConductorError> {
+        if self.override_leader.load(Ordering::Relaxed) {
+            return Ok(true);
+        }
+        self.rpc.request("conductor_leader", ()).await.map_err(Into::into)
+    }
+
+    /// Override conductor interactions locally, matching op-node's disaster-recovery behavior.
     async fn override_leader(&self) -> Result<(), ConductorError> {
-        self.rpc.request("conductor_overrideLeader", ()).await.map_err(Into::into)
+        self.override_leader.store(true, Ordering::Relaxed);
+        Ok(())
     }
 }
 
@@ -49,12 +71,12 @@ impl ConductorClient {
     /// Creates a new conductor client using HTTP transport
     pub fn new_http(url: Url) -> Self {
         let rpc = ReqwestClient::new_http(url);
-        Self { rpc }
+        Self { rpc, override_leader: Arc::new(AtomicBool::new(false)) }
     }
 
     /// Check if the node is a leader of the conductor.
     pub async fn leader(&self) -> Result<bool, ConductorError> {
-        self.rpc.request("conductor_leader", ()).await.map_err(Into::into)
+        Conductor::leader(self).await
     }
 
     /// Check if the conductor is active.

--- a/rust/kona/crates/node/service/src/actors/sequencer/conductor.rs
+++ b/rust/kona/crates/node/service/src/actors/sequencer/conductor.rs
@@ -13,15 +13,15 @@ use std::{
 };
 use url::Url;
 
-/// Number of conductor RPC attempts, matching op-node.
-const CONDUCTOR_RPC_MAX_ATTEMPTS: usize = 2;
+/// Number of conductor RPC retries after the initial attempt, matching op-node's two attempts.
+const CONDUCTOR_RPC_MAX_RETRIES: usize = 1;
 /// Delay between conductor RPC attempts, matching op-node.
 const CONDUCTOR_RPC_RETRY_DELAY: Duration = Duration::from_millis(50);
 
 fn conductor_rpc_backoff() -> ConstantBuilder {
     ConstantBuilder::default()
         .with_delay(CONDUCTOR_RPC_RETRY_DELAY)
-        .with_max_times(CONDUCTOR_RPC_MAX_ATTEMPTS)
+        .with_max_times(CONDUCTOR_RPC_MAX_RETRIES)
 }
 
 /// Trait for interacting with the conductor service.
@@ -139,7 +139,12 @@ pub enum ConductorError {
 mod tests {
     use super::*;
     use jsonrpsee::{RpcModule, server::ServerBuilder, types::ErrorObjectOwned};
-    use std::{io::Read, net::TcpListener, sync::atomic::AtomicUsize, thread};
+    use std::{
+        io::Read,
+        net::TcpListener,
+        sync::{atomic::AtomicUsize, mpsc},
+        thread,
+    };
 
     #[tokio::test]
     async fn conductor_request_retries_once() {
@@ -169,14 +174,39 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn conductor_request_stops_after_two_attempts() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let server = ServerBuilder::default().build("127.0.0.1:0").await.unwrap();
+        let addr = server.local_addr().unwrap();
+        let mut module = RpcModule::new(attempts.clone());
+        module
+            .register_async_method("conductor_leader", |_, attempts, _| async move {
+                attempts.fetch_add(1, Ordering::Relaxed);
+                Err::<bool, _>(ErrorObjectOwned::owned(-32000, "persistent failure", None::<()>))
+            })
+            .unwrap();
+        let handle = server.start(module);
+
+        let client = ConductorClient::new_http_with_timeout(
+            Url::parse(&format!("http://{addr}")).unwrap(),
+            Duration::from_secs(1),
+        );
+        assert!(client.leader().await.is_err());
+        assert_eq!(attempts.load(Ordering::Relaxed), 2);
+
+        handle.stop().unwrap();
+    }
+
+    #[tokio::test]
     async fn conductor_request_honors_timeout() {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let addr = listener.local_addr().unwrap();
-        thread::spawn(move || {
+        let (release_tx, release_rx) = mpsc::channel::<()>();
+        let server = thread::spawn(move || {
             let (mut stream, _) = listener.accept().unwrap();
             let mut request = [0_u8; 1024];
             let _ = stream.read(&mut request);
-            thread::park_timeout(Duration::from_secs(1));
+            let _ = release_rx.recv();
         });
 
         let client = ConductorClient::new_http_with_timeout(
@@ -187,5 +217,7 @@ mod tests {
         assert!(
             matches!(err, ConductorError::Timeout(duration) if duration == Duration::from_millis(20))
         );
+        drop(release_tx);
+        server.join().unwrap();
     }
 }

--- a/rust/kona/crates/node/service/src/actors/sequencer/conductor.rs
+++ b/rust/kona/crates/node/service/src/actors/sequencer/conductor.rs
@@ -1,6 +1,7 @@
 use alloy_rpc_client::ReqwestClient;
 use alloy_transport::{RpcError, TransportErrorKind};
 use async_trait::async_trait;
+use backon::{ConstantBuilder, Retryable};
 use op_alloy_rpc_types_engine::OpExecutionPayloadEnvelope;
 use std::{
     fmt::Debug,
@@ -11,6 +12,17 @@ use std::{
     time::Duration,
 };
 use url::Url;
+
+/// Number of conductor RPC attempts, matching op-node.
+const CONDUCTOR_RPC_MAX_ATTEMPTS: usize = 2;
+/// Delay between conductor RPC attempts, matching op-node.
+const CONDUCTOR_RPC_RETRY_DELAY: Duration = Duration::from_millis(50);
+
+fn conductor_rpc_backoff() -> ConstantBuilder {
+    ConstantBuilder::default()
+        .with_delay(CONDUCTOR_RPC_RETRY_DELAY)
+        .with_max_times(CONDUCTOR_RPC_MAX_ATTEMPTS)
+}
 
 /// Trait for interacting with the conductor service.
 ///
@@ -55,7 +67,8 @@ impl Conductor for ConductorClient {
         }
         tokio::time::timeout(
             self.rpc_timeout,
-            self.rpc.request("conductor_commitUnsafePayload", [payload]),
+            (|| self.rpc.request("conductor_commitUnsafePayload", [payload]))
+                .retry(conductor_rpc_backoff()),
         )
         .await
         .map_err(|_| ConductorError::Timeout(self.rpc_timeout))?
@@ -66,10 +79,13 @@ impl Conductor for ConductorClient {
         if self.override_leader.load(Ordering::Relaxed) {
             return Ok(true);
         }
-        tokio::time::timeout(self.rpc_timeout, self.rpc.request("conductor_leader", ()))
-            .await
-            .map_err(|_| ConductorError::Timeout(self.rpc_timeout))?
-            .map_err(Into::into)
+        tokio::time::timeout(
+            self.rpc_timeout,
+            (|| self.rpc.request("conductor_leader", ())).retry(conductor_rpc_backoff()),
+        )
+        .await
+        .map_err(|_| ConductorError::Timeout(self.rpc_timeout))?
+        .map_err(Into::into)
     }
 
     /// Override conductor interactions locally, matching op-node's disaster-recovery behavior.
@@ -98,10 +114,13 @@ impl ConductorClient {
 
     /// Check if the conductor is active.
     pub async fn conductor_active(&self) -> Result<bool, ConductorError> {
-        tokio::time::timeout(self.rpc_timeout, self.rpc.request("conductor_active", ()))
-            .await
-            .map_err(|_| ConductorError::Timeout(self.rpc_timeout))?
-            .map_err(Into::into)
+        tokio::time::timeout(
+            self.rpc_timeout,
+            (|| self.rpc.request("conductor_active", ())).retry(conductor_rpc_backoff()),
+        )
+        .await
+        .map_err(|_| ConductorError::Timeout(self.rpc_timeout))?
+        .map_err(Into::into)
     }
 }
 
@@ -119,7 +138,35 @@ pub enum ConductorError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::{io::Read, net::TcpListener, thread};
+    use jsonrpsee::{RpcModule, server::ServerBuilder, types::ErrorObjectOwned};
+    use std::{io::Read, net::TcpListener, sync::atomic::AtomicUsize, thread};
+
+    #[tokio::test]
+    async fn conductor_request_retries_once() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let server = ServerBuilder::default().build("127.0.0.1:0").await.unwrap();
+        let addr = server.local_addr().unwrap();
+        let mut module = RpcModule::new(attempts.clone());
+        module
+            .register_async_method("conductor_leader", |_, attempts, _| async move {
+                if attempts.fetch_add(1, Ordering::Relaxed) == 0 {
+                    Err(ErrorObjectOwned::owned(-32000, "temporary failure", None::<()>))
+                } else {
+                    Ok(true)
+                }
+            })
+            .unwrap();
+        let handle = server.start(module);
+
+        let client = ConductorClient::new_http_with_timeout(
+            Url::parse(&format!("http://{addr}")).unwrap(),
+            Duration::from_secs(1),
+        );
+        assert!(client.leader().await.unwrap());
+        assert_eq!(attempts.load(Ordering::Relaxed), 2);
+
+        handle.stop().unwrap();
+    }
 
     #[tokio::test]
     async fn conductor_request_honors_timeout() {

--- a/rust/kona/crates/node/service/src/actors/sequencer/conductor.rs
+++ b/rust/kona/crates/node/service/src/actors/sequencer/conductor.rs
@@ -8,6 +8,7 @@ use std::{
         Arc,
         atomic::{AtomicBool, Ordering},
     },
+    time::Duration,
 };
 use url::Url;
 
@@ -38,6 +39,8 @@ pub struct ConductorClient {
     rpc: ReqwestClient,
     /// Local disaster-recovery override. When set, conductor interactions are bypassed.
     override_leader: Arc<AtomicBool>,
+    /// Maximum duration of an RPC request to the conductor.
+    rpc_timeout: Duration,
 }
 
 #[async_trait]
@@ -50,14 +53,23 @@ impl Conductor for ConductorClient {
         if self.override_leader.load(Ordering::Relaxed) {
             return Ok(());
         }
-        self.rpc.request("conductor_commitUnsafePayload", [payload]).await.map_err(Into::into)
+        tokio::time::timeout(
+            self.rpc_timeout,
+            self.rpc.request("conductor_commitUnsafePayload", [payload]),
+        )
+        .await
+        .map_err(|_| ConductorError::Timeout(self.rpc_timeout))?
+        .map_err(Into::into)
     }
 
     async fn leader(&self) -> Result<bool, ConductorError> {
         if self.override_leader.load(Ordering::Relaxed) {
             return Ok(true);
         }
-        self.rpc.request("conductor_leader", ()).await.map_err(Into::into)
+        tokio::time::timeout(self.rpc_timeout, self.rpc.request("conductor_leader", ()))
+            .await
+            .map_err(|_| ConductorError::Timeout(self.rpc_timeout))?
+            .map_err(Into::into)
     }
 
     /// Override conductor interactions locally, matching op-node's disaster-recovery behavior.
@@ -68,10 +80,15 @@ impl Conductor for ConductorClient {
 }
 
 impl ConductorClient {
-    /// Creates a new conductor client using HTTP transport
+    /// Creates a new conductor client using HTTP transport and the default timeout.
     pub fn new_http(url: Url) -> Self {
+        Self::new_http_with_timeout(url, Duration::from_secs(1))
+    }
+
+    /// Creates a new conductor client using HTTP transport and the provided timeout.
+    pub fn new_http_with_timeout(url: Url, rpc_timeout: Duration) -> Self {
         let rpc = ReqwestClient::new_http(url);
-        Self { rpc, override_leader: Arc::new(AtomicBool::new(false)) }
+        Self { rpc, override_leader: Arc::new(AtomicBool::new(false)), rpc_timeout }
     }
 
     /// Check if the node is a leader of the conductor.
@@ -81,7 +98,10 @@ impl ConductorClient {
 
     /// Check if the conductor is active.
     pub async fn conductor_active(&self) -> Result<bool, ConductorError> {
-        self.rpc.request("conductor_active", ()).await.map_err(Into::into)
+        tokio::time::timeout(self.rpc_timeout, self.rpc.request("conductor_active", ()))
+            .await
+            .map_err(|_| ConductorError::Timeout(self.rpc_timeout))?
+            .map_err(Into::into)
     }
 }
 
@@ -91,4 +111,34 @@ pub enum ConductorError {
     /// An error occurred while making an RPC call to the conductor.
     #[error("RPC error: {0}")]
     Rpc(#[from] RpcError<TransportErrorKind>),
+    /// A conductor RPC request exceeded its configured timeout.
+    #[error("conductor RPC request timed out after {0:?}")]
+    Timeout(Duration),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{io::Read, net::TcpListener, thread};
+
+    #[tokio::test]
+    async fn conductor_request_honors_timeout() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0_u8; 1024];
+            let _ = stream.read(&mut request);
+            thread::park_timeout(Duration::from_secs(1));
+        });
+
+        let client = ConductorClient::new_http_with_timeout(
+            Url::parse(&format!("http://{addr}")).unwrap(),
+            Duration::from_millis(20),
+        );
+        let err = client.leader().await.unwrap_err();
+        assert!(
+            matches!(err, ConductorError::Timeout(duration) if duration == Duration::from_millis(20))
+        );
+    }
 }

--- a/rust/kona/crates/node/service/src/actors/sequencer/config.rs
+++ b/rust/kona/crates/node/service/src/actors/sequencer/config.rs
@@ -2,12 +2,16 @@
 //!
 //! [`SequencerActor`]: super::SequencerActor
 
+use std::time::Duration;
 use url::Url;
+
+/// Default timeout for conductor RPC requests.
+const DEFAULT_CONDUCTOR_RPC_TIMEOUT: Duration = Duration::from_secs(1);
 
 /// Configuration for the [`SequencerActor`].
 ///
 /// [`SequencerActor`]: super::SequencerActor
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SequencerConfig {
     /// Whether or not the sequencer is enabled at startup.
     pub sequencer_stopped: bool,
@@ -15,6 +19,20 @@ pub struct SequencerConfig {
     pub sequencer_recovery_mode: bool,
     /// The [`Url`] for the conductor RPC endpoint. If [`Some`], enables the conductor service.
     pub conductor_rpc_url: Option<Url>,
+    /// Timeout for each conductor RPC request.
+    pub conductor_rpc_timeout: Duration,
     /// The confirmation delay for the sequencer.
     pub l1_conf_delay: u64,
+}
+
+impl Default for SequencerConfig {
+    fn default() -> Self {
+        Self {
+            sequencer_stopped: false,
+            sequencer_recovery_mode: false,
+            conductor_rpc_url: None,
+            conductor_rpc_timeout: DEFAULT_CONDUCTOR_RPC_TIMEOUT,
+            l1_conf_delay: 0,
+        }
+    }
 }

--- a/rust/kona/crates/node/service/src/actors/sequencer/engine_client.rs
+++ b/rust/kona/crates/node/service/src/actors/sequencer/engine_client.rs
@@ -1,10 +1,13 @@
 use crate::{
     EngineClientError, EngineClientResult,
-    actors::engine::{BuildRequest, EngineActorRequest, ResetRequest, SealRequest},
+    actors::engine::{
+        BuildRequest, CanonicalizeRequest, EngineActorRequest, ResetRequest, SealRequest,
+    },
 };
 use alloy_rpc_types_engine::PayloadId;
 use async_trait::async_trait;
 use derive_more::Constructor;
+use kona_engine::SealTaskError;
 use kona_protocol::{L2BlockInfo, OpAttributesWithParent};
 use op_alloy_rpc_types_engine::OpExecutionPayloadEnvelope;
 use std::fmt::Debug;
@@ -27,15 +30,18 @@ pub trait SequencerEngineClient: Debug + Send + Sync {
         attributes: OpAttributesWithParent,
     ) -> EngineClientResult<PayloadId>;
 
-    /// Seals and canonicalizes a previously started block.
-    ///
-    /// Takes a `PayloadId` from a previous `start_build_block` call and returns
-    /// the finalized execution payload envelope.
-    async fn seal_and_canonicalize_block(
+    /// Seals a previously started block without making it canonical.
+    async fn seal_block(
         &self,
         payload_id: PayloadId,
         attributes: OpAttributesWithParent,
     ) -> EngineClientResult<OpExecutionPayloadEnvelope>;
+
+    /// Canonicalizes a sealed block after external safety checks have completed.
+    async fn canonicalize_block(
+        &self,
+        payload: OpExecutionPayloadEnvelope,
+    ) -> EngineClientResult<()>;
 
     /// Returns the current unsafe head [`L2BlockInfo`].
     async fn get_unsafe_head(&self) -> EngineClientResult<L2BlockInfo>;
@@ -104,7 +110,7 @@ impl SequencerEngineClient for QueuedSequencerEngineClient {
         })
     }
 
-    async fn seal_and_canonicalize_block(
+    async fn seal_block(
         &self,
         payload_id: PayloadId,
         attributes: OpAttributesWithParent,
@@ -135,5 +141,33 @@ impl SequencerEngineClient for QueuedSequencerEngineClient {
                 Err(EngineClientError::ResponseError("response channel closed.".to_string()))
             }
         }
+    }
+
+    async fn canonicalize_block(
+        &self,
+        payload: OpExecutionPayloadEnvelope,
+    ) -> EngineClientResult<()> {
+        let (result_tx, mut result_rx) = mpsc::channel(1);
+
+        trace!(target: "sequencer", "Sending canonicalize request to engine.");
+        self.engine_actor_request_tx
+            .send(EngineActorRequest::Canonicalize(Box::new(CanonicalizeRequest {
+                payload,
+                result_tx,
+            })))
+            .await
+            .map_err(|_| EngineClientError::RequestError("request channel closed.".to_string()))?;
+
+        result_rx
+            .recv()
+            .await
+            .ok_or_else(|| {
+                error!(target: "block_engine", "Failed to receive canonicalization result");
+                EngineClientError::ResponseError("response channel closed.".to_string())
+            })?
+            .map_err(|err| {
+                EngineClientError::SealError(SealTaskError::PayloadInsertionFailed(Box::new(err)))
+            })?;
+        Ok(())
     }
 }

--- a/rust/kona/crates/node/service/src/actors/sequencer/engine_client.rs
+++ b/rust/kona/crates/node/service/src/actors/sequencer/engine_client.rs
@@ -7,7 +7,6 @@ use crate::{
 use alloy_rpc_types_engine::PayloadId;
 use async_trait::async_trait;
 use derive_more::Constructor;
-use kona_engine::SealTaskError;
 use kona_protocol::{L2BlockInfo, OpAttributesWithParent};
 use op_alloy_rpc_types_engine::OpExecutionPayloadEnvelope;
 use std::fmt::Debug;
@@ -165,9 +164,7 @@ impl SequencerEngineClient for QueuedSequencerEngineClient {
                 error!(target: "block_engine", "Failed to receive canonicalization result");
                 EngineClientError::ResponseError("response channel closed.".to_string())
             })?
-            .map_err(|err| {
-                EngineClientError::SealError(SealTaskError::PayloadInsertionFailed(Box::new(err)))
-            })?;
+            .map_err(EngineClientError::CanonicalizeError)?;
         Ok(())
     }
 }

--- a/rust/kona/crates/node/service/src/actors/sequencer/error.rs
+++ b/rust/kona/crates/node/service/src/actors/sequencer/error.rs
@@ -1,5 +1,6 @@
 use crate::{
-    L1OriginSelectorError, UnsafePayloadGossipClientError, actors::engine::EngineClientError,
+    ConductorError, L1OriginSelectorError, UnsafePayloadGossipClientError,
+    actors::engine::EngineClientError,
 };
 use kona_derive::PipelineErrorKind;
 use kona_engine::BuildTaskError;
@@ -22,6 +23,9 @@ pub enum SequencerActorError {
     /// An error occurred while attempting to build a payload.
     #[error(transparent)]
     BuildError(#[from] BuildTaskError),
+    /// An error occurred committing a payload to the conductor.
+    #[error("An error occurred while committing a payload to the conductor: {0}")]
+    Conductor(#[from] ConductorError),
     /// An error occurred while attempting to schedule unsafe payload gossip.
     #[error("An error occurred while attempting to schedule unsafe payload gossip: {0}")]
     PayloadGossip(#[from] UnsafePayloadGossipClientError),

--- a/rust/kona/crates/node/service/src/actors/sequencer/tests/actor_test.rs
+++ b/rust/kona/crates/node/service/src/actors/sequencer/tests/actor_test.rs
@@ -115,6 +115,28 @@ async fn test_rejected_conductor_commit_is_not_canonicalized_or_gossiped() {
 }
 
 #[tokio::test]
+async fn test_rejected_conductor_commit_backs_off_without_stopping_actor() {
+    let mut engine = MockSequencerEngineClient::new();
+    engine.expect_seal_block().times(1).return_once(|_, _| Ok(test_payload()));
+    engine.expect_canonicalize_block().times(0);
+
+    let mut conductor = MockConductor::new();
+    conductor
+        .expect_commit_unsafe_payload()
+        .times(1)
+        .return_once(|_| Err(ConductorError::Rpc(RpcError::local_usage_str("leadership lost"))));
+
+    let mut actor = test_actor();
+    actor.engine_client = engine;
+    actor.conductor = Some(conductor);
+    actor.unsafe_payload_gossip_client.expect_schedule_execution_payload_gossip().times(0);
+    actor.next_payload_to_seal = Some(test_unsealed_payload());
+
+    assert!(actor.handle_build_tick().await.is_ok());
+    assert!(actor.next_payload_to_seal.is_some(), "pending build must be retained for retry");
+}
+
+#[tokio::test]
 async fn test_accepted_conductor_commit_is_canonicalized_before_gossip() {
     let mut sequence = Sequence::new();
     let mut engine = MockSequencerEngineClient::new();

--- a/rust/kona/crates/node/service/src/actors/sequencer/tests/actor_test.rs
+++ b/rust/kona/crates/node/service/src/actors/sequencer/tests/actor_test.rs
@@ -8,7 +8,7 @@ use crate::{
     },
 };
 use alloy_primitives::{Address, B256, Bloom, Bytes, U256};
-use alloy_rpc_types_engine::{ExecutionPayloadV1, PayloadId};
+use alloy_rpc_types_engine::{ExecutionPayloadV1, PayloadId, PayloadStatusEnum};
 use alloy_transport::RpcError;
 use kona_derive::{BuilderError, PipelineErrorKind, test_utils::TestAttributesBuilder};
 use kona_engine::{InsertTaskError, SynchronizeTaskError};
@@ -92,13 +92,13 @@ fn test_unsealed_payload() -> UnsealedPayloadHandle {
 
 #[tokio::test]
 async fn test_rejected_conductor_commit_is_not_canonicalized_or_gossiped() {
+    let payload = test_payload();
     let mut sequence = Sequence::new();
     let mut engine = MockSequencerEngineClient::new();
-    engine
-        .expect_seal_block()
-        .times(1)
-        .in_sequence(&mut sequence)
-        .return_once(|_, _| Ok(test_payload()));
+    engine.expect_seal_block().times(1).in_sequence(&mut sequence).return_once({
+        let payload = payload.clone();
+        move |_, _| Ok(payload)
+    });
     engine.expect_canonicalize_block().times(0);
 
     let mut conductor = MockConductor::new();
@@ -106,26 +106,6 @@ async fn test_rejected_conductor_commit_is_not_canonicalized_or_gossiped() {
         .expect_commit_unsafe_payload()
         .times(1)
         .in_sequence(&mut sequence)
-        .return_once(|_| Err(ConductorError::Rpc(RpcError::local_usage_str("leadership lost"))));
-
-    let mut actor = test_actor();
-    actor.engine_client = engine;
-    actor.conductor = Some(conductor);
-    actor.unsafe_payload_gossip_client.expect_schedule_execution_payload_gossip().times(0);
-
-    assert!(actor.seal_and_commit_payload(&test_unsealed_payload()).await.is_err());
-}
-
-#[tokio::test]
-async fn test_rejected_conductor_commit_backs_off_without_stopping_actor() {
-    let mut engine = MockSequencerEngineClient::new();
-    engine.expect_seal_block().times(1).return_once(|_, _| Ok(test_payload()));
-    engine.expect_canonicalize_block().times(0);
-
-    let mut conductor = MockConductor::new();
-    conductor
-        .expect_commit_unsafe_payload()
-        .times(1)
         .return_once(|_| Err(ConductorError::Rpc(RpcError::local_usage_str("leadership lost"))));
 
     let mut actor = test_actor();
@@ -135,10 +115,82 @@ async fn test_rejected_conductor_commit_backs_off_without_stopping_actor() {
     actor.pending_payload = Some(PendingPayload::Unsealed(Box::new(test_unsealed_payload())));
 
     assert!(actor.handle_build_tick().await.is_ok());
-    assert!(
-        matches!(actor.pending_payload, Some(PendingPayload::Unsealed(_))),
-        "pending build must be retained for retry"
-    );
+    match actor.pending_payload.as_ref() {
+        Some(PendingPayload::Sealed(retained)) => assert_eq!(retained.as_ref(), &payload),
+        other => panic!("expected exact sealed payload to be retained, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_failed_conductor_commit_retries_exact_sealed_payload() {
+    let payload = test_payload();
+    let mut sequence = Sequence::new();
+    let mut engine = MockSequencerEngineClient::new();
+    engine.expect_seal_block().times(1).in_sequence(&mut sequence).return_once({
+        let payload = payload.clone();
+        move |_, _| Ok(payload)
+    });
+    engine
+        .expect_canonicalize_block()
+        .withf({
+            let payload = payload.clone();
+            move |actual| actual == &payload
+        })
+        .times(1)
+        .return_once(|_| Ok(()));
+    engine.expect_get_unsafe_head().times(1).return_once(|| Ok(L2BlockInfo::default()));
+    engine.expect_reset_engine_forkchoice().times(1).return_once(|| Ok(()));
+
+    let mut conductor = MockConductor::new();
+    conductor
+        .expect_commit_unsafe_payload()
+        .withf({
+            let payload = payload.clone();
+            move |actual| actual == &payload
+        })
+        .times(1)
+        .in_sequence(&mut sequence)
+        .return_once(|_| Err(ConductorError::Rpc(RpcError::local_usage_str("response lost"))));
+    conductor
+        .expect_commit_unsafe_payload()
+        .withf({
+            let payload = payload.clone();
+            move |actual| actual == &payload
+        })
+        .times(1)
+        .in_sequence(&mut sequence)
+        .return_once(|_| Ok(()));
+
+    let mut origin_selector = MockOriginSelector::new();
+    origin_selector
+        .expect_next_l1_origin()
+        .times(1)
+        .return_once(|head, _| Err(L1OriginSelectorError::OriginNotFound(head.l1_origin.hash)));
+
+    let mut actor = test_actor();
+    actor.engine_client = engine;
+    actor.conductor = Some(conductor);
+    actor.origin_selector = origin_selector;
+    actor
+        .unsafe_payload_gossip_client
+        .expect_schedule_execution_payload_gossip()
+        .withf({
+            let payload = payload.clone();
+            move |actual| actual == &payload
+        })
+        .times(1)
+        .in_sequence(&mut sequence)
+        .return_once(|_| Ok(()));
+    actor.pending_payload = Some(PendingPayload::Unsealed(Box::new(test_unsealed_payload())));
+
+    assert!(actor.handle_build_tick().await.is_ok());
+    match actor.pending_payload.as_ref() {
+        Some(PendingPayload::Sealed(retained)) => assert_eq!(retained.as_ref(), &payload),
+        other => panic!("expected exact sealed payload to be retained, got {other:?}"),
+    }
+
+    assert!(actor.handle_build_tick().await.is_ok());
+    assert!(actor.pending_payload.is_none());
 }
 
 #[tokio::test]
@@ -205,8 +257,12 @@ async fn test_temporary_canonicalization_failure_retries_exact_committed_payload
 fn transient_new_payload_and_forkchoice_errors_retry_committed_payload() {
     let errors = [
         InsertTaskError::InsertFailed(RpcError::local_usage_str("new payload unavailable")),
+        InsertTaskError::UnexpectedPayloadStatus(PayloadStatusEnum::Accepted),
         InsertTaskError::ForkchoiceUpdateFailed(SynchronizeTaskError::ForkchoiceUpdateFailed(
             RpcError::local_usage_str("forkchoice unavailable"),
+        )),
+        InsertTaskError::ForkchoiceUpdateFailed(SynchronizeTaskError::UnexpectedPayloadStatus(
+            PayloadStatusEnum::Accepted,
         )),
     ];
 
@@ -215,8 +271,48 @@ fn transient_new_payload_and_forkchoice_errors_retry_committed_payload() {
     }
 }
 
+#[test]
+fn permanently_invalid_new_payload_and_forkchoice_statuses_are_fatal() {
+    let errors = [
+        InsertTaskError::UnexpectedPayloadStatus(PayloadStatusEnum::Invalid {
+            validation_error: "invalid payload".to_string(),
+        }),
+        InsertTaskError::ForkchoiceUpdateFailed(SynchronizeTaskError::UnexpectedPayloadStatus(
+            PayloadStatusEnum::Invalid { validation_error: "invalid forkchoice".to_string() },
+        )),
+    ];
+
+    for err in errors {
+        assert_eq!(canonicalization_error_action(&err), CanonicalizationErrorAction::Fatal);
+    }
+}
+
 #[tokio::test]
-async fn test_stale_committed_payload_is_dropped_without_gossip() {
+async fn invalid_conductor_approved_payload_stops_instead_of_retrying() {
+    let payload = test_payload();
+    let mut engine = MockSequencerEngineClient::new();
+    engine.expect_canonicalize_block().times(1).return_once(|_| {
+        Err(crate::EngineClientError::CanonicalizeError(InsertTaskError::UnexpectedPayloadStatus(
+            PayloadStatusEnum::Invalid { validation_error: "invalid payload".to_string() },
+        )))
+    });
+
+    let mut actor = test_actor();
+    actor.engine_client = engine;
+    actor.unsafe_payload_gossip_client.expect_schedule_execution_payload_gossip().times(0);
+    actor.pending_payload = Some(PendingPayload::Committed(Box::new(payload)));
+
+    assert!(matches!(
+        actor.handle_build_tick().await,
+        Err(SequencerActorError::EngineError(crate::EngineClientError::CanonicalizeError(
+            InsertTaskError::UnexpectedPayloadStatus(PayloadStatusEnum::Invalid { .. })
+        )))
+    ));
+    assert!(actor.pending_payload.is_none(), "invalid payload must not be retained for retry");
+}
+
+#[tokio::test]
+async fn test_stale_payload_without_conductor_is_dropped_without_gossip() {
     let payload = test_payload();
     let mut engine = MockSequencerEngineClient::new();
     engine.expect_canonicalize_block().times(1).return_once(|_| {
@@ -232,6 +328,32 @@ async fn test_stale_committed_payload_is_dropped_without_gossip() {
     actor.pending_payload = Some(PendingPayload::Committed(Box::new(payload)));
 
     assert!(actor.handle_build_tick().await.is_ok());
+    assert!(actor.pending_payload.is_none());
+}
+
+#[tokio::test]
+async fn stale_conductor_approved_payload_stops_before_building_replacement() {
+    let payload = test_payload();
+    let mut engine = MockSequencerEngineClient::new();
+    engine.expect_canonicalize_block().times(1).return_once(|_| {
+        Err(crate::EngineClientError::CanonicalizeError(InsertTaskError::StalePayload {
+            parent: B256::ZERO,
+            unsafe_head: B256::repeat_byte(1),
+        }))
+    });
+
+    let mut actor = test_actor();
+    actor.engine_client = engine;
+    actor.conductor = Some(MockConductor::new());
+    actor.unsafe_payload_gossip_client.expect_schedule_execution_payload_gossip().times(0);
+    actor.pending_payload = Some(PendingPayload::Committed(Box::new(payload)));
+
+    assert!(matches!(
+        actor.handle_build_tick().await,
+        Err(SequencerActorError::EngineError(crate::EngineClientError::CanonicalizeError(
+            InsertTaskError::StalePayload { .. }
+        )))
+    ));
     assert!(actor.pending_payload.is_none());
 }
 
@@ -264,6 +386,7 @@ async fn test_accepted_conductor_commit_is_canonicalized_before_gossip() {
         .in_sequence(&mut sequence)
         .return_once(|_| Ok(()));
 
-    let payload = actor.seal_and_commit_payload(&test_unsealed_payload()).await.unwrap();
+    let payload = actor.seal_payload(&test_unsealed_payload()).await.unwrap();
+    let payload = actor.commit_payload_or_backoff(Box::new(payload)).await.unwrap();
     assert!(actor.canonicalize_and_gossip_payload(&payload).await.is_ok());
 }

--- a/rust/kona/crates/node/service/src/actors/sequencer/tests/actor_test.rs
+++ b/rust/kona/crates/node/service/src/actors/sequencer/tests/actor_test.rs
@@ -1,12 +1,18 @@
 #[cfg(test)]
 use crate::{
-    SequencerActorError,
+    ConductorError, SequencerActorError,
     actors::{
-        MockOriginSelector, MockSequencerEngineClient, sequencer::tests::test_util::test_actor,
+        MockConductor, MockOriginSelector, MockSequencerEngineClient,
+        sequencer::{actor::UnsealedPayloadHandle, tests::test_util::test_actor},
     },
 };
+use alloy_primitives::{Address, B256, Bloom, Bytes, U256};
+use alloy_rpc_types_engine::{ExecutionPayloadV1, PayloadId};
+use alloy_transport::RpcError;
 use kona_derive::{BuilderError, PipelineErrorKind, test_utils::TestAttributesBuilder};
-use kona_protocol::{BlockInfo, L2BlockInfo};
+use kona_protocol::{BlockInfo, L2BlockInfo, OpAttributesWithParent};
+use mockall::Sequence;
+use op_alloy_rpc_types_engine::{OpExecutionPayloadEnvelope, OpPayloadAttributes};
 use rstest::rstest;
 
 #[rstest]
@@ -49,4 +55,93 @@ async fn test_build_unsealed_payload_prepare_payload_attributes_error(
     } else {
         assert!(result.is_ok());
     }
+}
+
+fn test_payload() -> OpExecutionPayloadEnvelope {
+    OpExecutionPayloadEnvelope::V1(ExecutionPayloadV1 {
+        parent_hash: B256::ZERO,
+        fee_recipient: Address::ZERO,
+        state_root: B256::ZERO,
+        receipts_root: B256::ZERO,
+        logs_bloom: Bloom::ZERO,
+        prev_randao: B256::ZERO,
+        block_number: 1,
+        gas_limit: 30_000_000,
+        gas_used: 0,
+        timestamp: 2,
+        extra_data: Bytes::new(),
+        base_fee_per_gas: U256::from(1),
+        block_hash: B256::ZERO,
+        transactions: Vec::new(),
+    })
+}
+
+fn test_unsealed_payload() -> UnsealedPayloadHandle {
+    UnsealedPayloadHandle {
+        payload_id: PayloadId::default(),
+        attributes_with_parent: OpAttributesWithParent::new(
+            OpPayloadAttributes::default(),
+            L2BlockInfo::default(),
+            None,
+            false,
+        ),
+    }
+}
+
+#[tokio::test]
+async fn test_rejected_conductor_commit_is_not_canonicalized_or_gossiped() {
+    let mut sequence = Sequence::new();
+    let mut engine = MockSequencerEngineClient::new();
+    engine
+        .expect_seal_block()
+        .times(1)
+        .in_sequence(&mut sequence)
+        .return_once(|_, _| Ok(test_payload()));
+    engine.expect_canonicalize_block().times(0);
+
+    let mut conductor = MockConductor::new();
+    conductor
+        .expect_commit_unsafe_payload()
+        .times(1)
+        .in_sequence(&mut sequence)
+        .return_once(|_| Err(ConductorError::Rpc(RpcError::local_usage_str("leadership lost"))));
+
+    let mut actor = test_actor();
+    actor.engine_client = engine;
+    actor.conductor = Some(conductor);
+    actor.unsafe_payload_gossip_client.expect_schedule_execution_payload_gossip().times(0);
+
+    assert!(actor.seal_and_commit_payload_if_applicable(&test_unsealed_payload()).await.is_err());
+}
+
+#[tokio::test]
+async fn test_accepted_conductor_commit_is_canonicalized_before_gossip() {
+    let mut sequence = Sequence::new();
+    let mut engine = MockSequencerEngineClient::new();
+    engine
+        .expect_seal_block()
+        .times(1)
+        .in_sequence(&mut sequence)
+        .return_once(|_, _| Ok(test_payload()));
+
+    let mut conductor = MockConductor::new();
+    conductor
+        .expect_commit_unsafe_payload()
+        .times(1)
+        .in_sequence(&mut sequence)
+        .return_once(|_| Ok(()));
+
+    engine.expect_canonicalize_block().times(1).in_sequence(&mut sequence).return_once(|_| Ok(()));
+
+    let mut actor = test_actor();
+    actor.engine_client = engine;
+    actor.conductor = Some(conductor);
+    actor
+        .unsafe_payload_gossip_client
+        .expect_schedule_execution_payload_gossip()
+        .times(1)
+        .in_sequence(&mut sequence)
+        .return_once(|_| Ok(()));
+
+    assert!(actor.seal_and_commit_payload_if_applicable(&test_unsealed_payload()).await.is_ok());
 }

--- a/rust/kona/crates/node/service/src/actors/sequencer/tests/actor_test.rs
+++ b/rust/kona/crates/node/service/src/actors/sequencer/tests/actor_test.rs
@@ -1,6 +1,7 @@
+use super::{CanonicalizationErrorAction, PendingPayload, canonicalization_error_action};
 #[cfg(test)]
 use crate::{
-    ConductorError, SequencerActorError,
+    ConductorError, L1OriginSelectorError, SequencerActorError,
     actors::{
         MockConductor, MockOriginSelector, MockSequencerEngineClient,
         sequencer::{actor::UnsealedPayloadHandle, tests::test_util::test_actor},
@@ -10,6 +11,7 @@ use alloy_primitives::{Address, B256, Bloom, Bytes, U256};
 use alloy_rpc_types_engine::{ExecutionPayloadV1, PayloadId};
 use alloy_transport::RpcError;
 use kona_derive::{BuilderError, PipelineErrorKind, test_utils::TestAttributesBuilder};
+use kona_engine::{InsertTaskError, SynchronizeTaskError};
 use kona_protocol::{BlockInfo, L2BlockInfo, OpAttributesWithParent};
 use mockall::Sequence;
 use op_alloy_rpc_types_engine::{OpExecutionPayloadEnvelope, OpPayloadAttributes};
@@ -111,7 +113,7 @@ async fn test_rejected_conductor_commit_is_not_canonicalized_or_gossiped() {
     actor.conductor = Some(conductor);
     actor.unsafe_payload_gossip_client.expect_schedule_execution_payload_gossip().times(0);
 
-    assert!(actor.seal_and_commit_payload_if_applicable(&test_unsealed_payload()).await.is_err());
+    assert!(actor.seal_and_commit_payload(&test_unsealed_payload()).await.is_err());
 }
 
 #[tokio::test]
@@ -130,10 +132,107 @@ async fn test_rejected_conductor_commit_backs_off_without_stopping_actor() {
     actor.engine_client = engine;
     actor.conductor = Some(conductor);
     actor.unsafe_payload_gossip_client.expect_schedule_execution_payload_gossip().times(0);
-    actor.next_payload_to_seal = Some(test_unsealed_payload());
+    actor.pending_payload = Some(PendingPayload::Unsealed(Box::new(test_unsealed_payload())));
 
     assert!(actor.handle_build_tick().await.is_ok());
-    assert!(actor.next_payload_to_seal.is_some(), "pending build must be retained for retry");
+    assert!(
+        matches!(actor.pending_payload, Some(PendingPayload::Unsealed(_))),
+        "pending build must be retained for retry"
+    );
+}
+
+#[tokio::test]
+async fn test_temporary_canonicalization_failure_retries_exact_committed_payload() {
+    let payload = test_payload();
+    let mut sequence = Sequence::new();
+    let mut engine = MockSequencerEngineClient::new();
+    engine.expect_seal_block().times(1).return_once({
+        let payload = payload.clone();
+        move |_, _| Ok(payload)
+    });
+    engine.expect_canonicalize_block().times(1).in_sequence(&mut sequence).return_once(|_| {
+        Err(crate::EngineClientError::CanonicalizeError(InsertTaskError::InsertFailed(
+            RpcError::local_usage_str("temporary engine failure"),
+        )))
+    });
+    engine
+        .expect_canonicalize_block()
+        .withf({
+            let payload = payload.clone();
+            move |actual| actual == &payload
+        })
+        .times(1)
+        .in_sequence(&mut sequence)
+        .return_once(|_| Ok(()));
+    engine.expect_get_unsafe_head().times(1).return_once(|| Ok(L2BlockInfo::default()));
+    engine.expect_reset_engine_forkchoice().times(1).return_once(|| Ok(()));
+
+    let mut conductor = MockConductor::new();
+    conductor.expect_commit_unsafe_payload().times(1).return_once(|_| Ok(()));
+
+    let mut origin_selector = MockOriginSelector::new();
+    origin_selector
+        .expect_next_l1_origin()
+        .times(1)
+        .return_once(|head, _| Err(L1OriginSelectorError::OriginNotFound(head.l1_origin.hash)));
+
+    let mut actor = test_actor();
+    actor.engine_client = engine;
+    actor.conductor = Some(conductor);
+    actor.origin_selector = origin_selector;
+    actor
+        .unsafe_payload_gossip_client
+        .expect_schedule_execution_payload_gossip()
+        .withf({
+            let payload = payload.clone();
+            move |actual| actual == &payload
+        })
+        .times(1)
+        .return_once(|_| Ok(()));
+    actor.pending_payload = Some(PendingPayload::Unsealed(Box::new(test_unsealed_payload())));
+
+    assert!(actor.handle_build_tick().await.is_ok());
+    match actor.pending_payload.as_ref() {
+        Some(PendingPayload::Committed(retained)) => assert_eq!(retained.as_ref(), &payload),
+        other => panic!("expected exact committed payload to be retained, got {other:?}"),
+    }
+
+    assert!(actor.handle_build_tick().await.is_ok());
+    assert!(actor.pending_payload.is_none());
+}
+
+#[test]
+fn transient_new_payload_and_forkchoice_errors_retry_committed_payload() {
+    let errors = [
+        InsertTaskError::InsertFailed(RpcError::local_usage_str("new payload unavailable")),
+        InsertTaskError::ForkchoiceUpdateFailed(SynchronizeTaskError::ForkchoiceUpdateFailed(
+            RpcError::local_usage_str("forkchoice unavailable"),
+        )),
+    ];
+
+    for err in errors {
+        assert_eq!(canonicalization_error_action(&err), CanonicalizationErrorAction::Retry);
+    }
+}
+
+#[tokio::test]
+async fn test_stale_committed_payload_is_dropped_without_gossip() {
+    let payload = test_payload();
+    let mut engine = MockSequencerEngineClient::new();
+    engine.expect_canonicalize_block().times(1).return_once(|_| {
+        Err(crate::EngineClientError::CanonicalizeError(InsertTaskError::StalePayload {
+            parent: B256::ZERO,
+            unsafe_head: B256::repeat_byte(1),
+        }))
+    });
+
+    let mut actor = test_actor();
+    actor.engine_client = engine;
+    actor.unsafe_payload_gossip_client.expect_schedule_execution_payload_gossip().times(0);
+    actor.pending_payload = Some(PendingPayload::Committed(Box::new(payload)));
+
+    assert!(actor.handle_build_tick().await.is_ok());
+    assert!(actor.pending_payload.is_none());
 }
 
 #[tokio::test]
@@ -165,5 +264,6 @@ async fn test_accepted_conductor_commit_is_canonicalized_before_gossip() {
         .in_sequence(&mut sequence)
         .return_once(|_| Ok(()));
 
-    assert!(actor.seal_and_commit_payload_if_applicable(&test_unsealed_payload()).await.is_ok());
+    let payload = actor.seal_and_commit_payload(&test_unsealed_payload()).await.unwrap();
+    assert!(actor.canonicalize_and_gossip_payload(&payload).await.is_ok());
 }

--- a/rust/kona/crates/node/service/src/actors/sequencer/tests/admin_api_impl_test.rs
+++ b/rust/kona/crates/node/service/src/actors/sequencer/tests/admin_api_impl_test.rs
@@ -103,10 +103,10 @@ async fn test_start_sequencer(
     // start the sequencer
     let result = async {
         match via_channel {
-            false => actor.start_sequencer().await,
+            false => actor.start_sequencer(B256::ZERO).await,
             true => {
                 let (tx, rx) = oneshot::channel();
-                actor.handle_admin_query(SequencerAdminQuery::StartSequencer(tx)).await;
+                actor.handle_admin_query(SequencerAdminQuery::StartSequencer(B256::ZERO, tx)).await;
                 rx.await.unwrap()
             }
         }
@@ -370,7 +370,7 @@ async fn test_handle_admin_query_resilient_to_dropped_receiver() {
     {
         // immediately drop receiver
         let (tx, _rx) = oneshot::channel();
-        queries.push(SequencerAdminQuery::StartSequencer(tx));
+        queries.push(SequencerAdminQuery::StartSequencer(B256::ZERO, tx));
     }
     {
         // immediately drop receiver

--- a/rust/kona/crates/node/service/src/actors/sequencer/tests/admin_api_impl_test.rs
+++ b/rust/kona/crates/node/service/src/actors/sequencer/tests/admin_api_impl_test.rs
@@ -134,6 +134,20 @@ async fn test_start_sequencer(
 }
 
 #[tokio::test]
+async fn test_start_sequencer_requires_conductor_leadership() {
+    let mut conductor = MockConductor::new();
+    conductor.expect_leader().times(1).return_once(|| Ok(false));
+
+    let mut actor = test_actor();
+    actor.conductor = Some(conductor);
+    actor.is_active = false;
+
+    let err = actor.start_sequencer(B256::ZERO).await.unwrap_err();
+    assert!(err.to_string().contains("sequencer is not the leader"));
+    assert!(!actor.is_active);
+}
+
+#[tokio::test]
 async fn test_start_sequencer_validates_unsafe_head() {
     let unsafe_head = L2BlockInfo {
         block_info: BlockInfo { hash: B256::from([1u8; 32]), ..Default::default() },

--- a/rust/kona/crates/node/service/src/actors/sequencer/tests/admin_api_impl_test.rs
+++ b/rust/kona/crates/node/service/src/actors/sequencer/tests/admin_api_impl_test.rs
@@ -92,7 +92,18 @@ async fn test_start_sequencer(
     #[values(true, false)] already_started: bool,
     #[values(true, false)] via_channel: bool,
 ) {
+    let unsafe_head = L2BlockInfo {
+        block_info: BlockInfo { hash: B256::from([1u8; 32]), ..Default::default() },
+        ..Default::default()
+    };
+    let expected_hash = unsafe_head.hash();
+    let mut client = MockSequencerEngineClient::new();
+    if !already_started {
+        client.expect_get_unsafe_head().times(1).return_once(move || Ok(unsafe_head));
+    }
+
     let mut actor = test_actor();
+    actor.engine_client = client;
     actor.is_active = already_started;
 
     // verify starting state
@@ -103,10 +114,12 @@ async fn test_start_sequencer(
     // start the sequencer
     let result = async {
         match via_channel {
-            false => actor.start_sequencer(B256::ZERO).await,
+            false => actor.start_sequencer(expected_hash).await,
             true => {
                 let (tx, rx) = oneshot::channel();
-                actor.handle_admin_query(SequencerAdminQuery::StartSequencer(B256::ZERO, tx)).await;
+                actor
+                    .handle_admin_query(SequencerAdminQuery::StartSequencer(expected_hash, tx))
+                    .await;
                 rx.await.unwrap()
             }
         }
@@ -118,6 +131,24 @@ async fn test_start_sequencer(
     let result = actor.is_sequencer_active().await;
     assert!(result.is_ok());
     assert!(result.unwrap());
+}
+
+#[tokio::test]
+async fn test_start_sequencer_validates_unsafe_head() {
+    let unsafe_head = L2BlockInfo {
+        block_info: BlockInfo { hash: B256::from([1u8; 32]), ..Default::default() },
+        ..Default::default()
+    };
+    let mut client = MockSequencerEngineClient::new();
+    client.expect_get_unsafe_head().times(1).return_once(move || Ok(unsafe_head));
+
+    let mut actor = test_actor();
+    actor.engine_client = client;
+    actor.is_active = false;
+
+    let err = actor.start_sequencer(B256::ZERO).await.unwrap_err();
+    assert!(err.to_string().contains("block hash does not match"));
+    assert!(!actor.is_active);
 }
 
 #[rstest]

--- a/rust/kona/crates/node/service/src/actors/sequencer/tests/mod.rs
+++ b/rust/kona/crates/node/service/src/actors/sequencer/tests/mod.rs
@@ -1,4 +1,1 @@
-mod actor_test;
-mod admin_api_impl_test;
-
-mod test_util;
+pub(super) mod test_util;

--- a/rust/kona/crates/node/service/src/actors/sequencer/tests/test_util.rs
+++ b/rust/kona/crates/node/service/src/actors/sequencer/tests/test_util.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use tokio::sync::mpsc;
 
 // Returns a test SequencerActor with mocks that can be used or overridden.
-pub(crate) fn test_actor() -> SequencerActor<
+pub(in crate::actors::sequencer) fn test_actor() -> SequencerActor<
     TestAttributesBuilder,
     MockConductor,
     MockOriginSelector,

--- a/rust/kona/crates/node/service/src/lib.rs
+++ b/rust/kona/crates/node/service/src/lib.rs
@@ -16,7 +16,7 @@ pub use service::{
 
 mod actors;
 pub use actors::{
-    BlockStream, BuildRequest, Conductor, ConductorClient, ConductorError,
+    BlockStream, BuildRequest, CanonicalizeRequest, Conductor, ConductorClient, ConductorError,
     DelayedL1OriginSelectorProvider, DelegateDerivationActor, DerivationActor,
     DerivationActorRequest, DerivationClientError, DerivationClientResult,
     DerivationDelegateClient, DerivationDelegateClientError, DerivationDelegateProvider,

--- a/rust/kona/crates/node/service/src/service/node.rs
+++ b/rust/kona/crates/node/service/src/service/node.rs
@@ -357,8 +357,9 @@ impl RollupNode {
         let delayed_origin_selector =
             L1OriginSelector::new(self.config.clone(), delayed_l1_provider);
 
-        let conductor =
-            self.sequencer_config.conductor_rpc_url.clone().map(ConductorClient::new_http);
+        let conductor = self.sequencer_config.conductor_rpc_url.clone().map(|url| {
+            ConductorClient::new_http_with_timeout(url, self.sequencer_config.conductor_rpc_timeout)
+        });
 
         let sequencer_engine_client =
             QueuedSequencerEngineClient { engine_actor_request_tx, unsafe_head_rx };


### PR DESCRIPTION
## Overview

Stacked on #22244.

Run the conductor and conductor-relevant sequencer admin-RPC acceptance coverage against real kona-node processes as well as op-node. Commits are split by the behavior they unlock:

1. **Cluster lifecycle** — startup, failover, proxy, membership, and all leadership-transfer coverage.
2. **Sequencer handoffs** — targeted leadership transfer and direct stop/restart coverage.
3. **Disaster recovery** — leader override coverage.
4. **Unsafe payload injection** — run the valid `admin_postUnsafePayload` path against Kona.
5. **Malformed payload rejection** — synchronously validate block hashes before enqueueing admin payloads.

Each commit removes only the Kona skips for the tests it unlocks. Tests and assertions remain shared between op-node and kona-node.

## Testing

- all affected coverage-preservation tests pass against op-node/op-reth and Kona/op-reth
- `just lint-go`
- `cargo test -p kona-rpc -p kona-node-service`
- `cargo clippy -p kona-rpc -p kona-node-service -p kona-node --all-targets --all-features -- -D warnings`
- compile checks for conductor acceptance, DSL, sysgo, and retained op-e2e coverage

Closes #22262
