### PR TITLE
kona-engine: reset on invalid derived payloads

### DIFF
--- a/docs/public-docs/node-operators/kona-node/design/engine.mdx
+++ b/docs/public-docs/node-operators/kona-node/design/engine.mdx
@@ -190,14 +190,10 @@ pub struct EngineState {
     pub sync_state: EngineSyncState,
     /// Whether or not the EL has finished syncing.
     pub el_sync_finished: bool,
-    /// Tracks when the rollup node changes the forkchoice to restore a
-    /// previously known unsafe chain (e.g. an unsafe reorg caused by an
-    /// invalid span batch).
-    pub need_fcu_call_backup_unsafe_reorg: bool,
 }
 ```
 
-The unsafe, safe, and finalized heads live in the nested `EngineSyncState`. State updates are communicated through watch channels, enabling reactive programming patterns across the system.
+The unsafe, safe, and finalized heads live in the nested `EngineSyncState`. State updates are communicated through watch channels, enabling reactive programming patterns across the system. If the execution layer marks a derived payload `INVALID`, the engine and derivation pipeline reset instead of retrying the same task indefinitely.
 
 ## Integration with kona-node
 

--- a/op-acceptance-tests/tests/derivation/invalid_span_batch_test.go
+++ b/op-acceptance-tests/tests/derivation/invalid_span_batch_test.go
@@ -1,0 +1,90 @@
+package derivation
+
+import (
+	"math/big"
+	"testing"
+	"time"
+
+	bss "github.com/ethereum-optimism/optimism/op-batcher/batcher"
+	"github.com/ethereum-optimism/optimism/op-core/forks"
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+	safety "github.com/ethereum-optimism/optimism/op-service/eth/safety"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+// TestValidatorRecoversFromInvalidSpanBatch verifies a validator recovers after its execution
+// layer rejects derived attributes from a span batch. The acceptance suite runs this test with
+// both op-node and kona-node through DEVSTACK_L2CL_KIND.
+func TestValidatorRecoversFromInvalidSpanBatch(gt *testing.T) {
+	t := devtest.ParallelT(gt)
+	activationDelta := uint64(1)
+	var engineFault *sysgo.EngineFaultProxy
+	sys := presets.NewSingleChainMultiNodeWithoutP2PWithoutCheck(t,
+		presets.WithDeployerOptions(
+			sysgo.WithHardforkSequentialActivation(forks.Ecotone, forks.Ecotone, &activationDelta),
+		),
+		presets.WithBatcherOption(func(_ sysgo.ComponentTarget, cfg *bss.CLIConfig) {
+			cfg.Stopped = true
+		}),
+		presets.WithGlobalL2CLOption(sysgo.L2CLSequencerMaxSafeLag(6)),
+		presets.WithGlobalL2CLOption(sysgo.L2CLOptionFn(func(p devtest.T, target sysgo.ComponentTarget, cfg *sysgo.L2CLConfig) {
+			if target.Name != "b" {
+				return
+			}
+			sysgo.L2CLEngineRPCProxy(func(engineRPC string) string {
+				engineFault = sysgo.StartEngineFaultProxy(p, target.String(), engineRPC)
+				return engineFault.URL()
+			}).Apply(p, target, cfg)
+		})),
+	)
+
+	t.Require().NotNil(engineFault)
+	sys.L2CL.Reached(safety.LocalUnsafe, 6, 30)
+	originalHeadHash := sys.L2CL.StopSequencer()
+	originalHead := sys.L2EL.BlockRefByHash(originalHeadHash)
+	validPrefix := sys.L2EL.BlockRefByNumber(originalHead.Number - 1)
+	// Feed every prefix block explicitly so the test does not depend on P2P peer-connection
+	// timing. Leave the validator one block behind so deriving the invalid final block exercises
+	// the force-build path.
+	for blockNumber := uint64(1); blockNumber <= validPrefix.Number; blockNumber++ {
+		sys.L2CLB.SignalTarget(sys.L2EL, blockNumber)
+	}
+	sys.L2CLB.ReachedRef(safety.LocalUnsafe, validPrefix.ID(), 30)
+
+	// Diverge from the original unsafe chain at the penultimate block. The transaction only needs
+	// to make the derived attributes differ; it is signed independently of the EL and need not be
+	// accepted by the sequencer's tx pool.
+	divergentKey, err := crypto.GenerateKey()
+	t.Require().NoError(err)
+	divergentAddr := crypto.PubkeyToAddress(divergentKey.PublicKey)
+	divergentTx, err := types.SignNewTx(divergentKey, types.LatestSigner(sys.L2Chain.Escape().ChainConfig()), &types.DynamicFeeTx{
+		ChainID:   sys.L2Chain.ChainID().ToBig(),
+		Nonce:     0,
+		GasTipCap: big.NewInt(1_000_000_000),
+		GasFeeCap: big.NewInt(2_000_000_000),
+		Gas:       21_000,
+		To:        &divergentAddr,
+	})
+	t.Require().NoError(err)
+	validBatch := sys.L2Chain.NewSpanBatch(1, originalHead.Number)
+	invalidBatch := sys.L2Chain.NewSpanBatch(1, originalHead.Number,
+		dsl.WithSpanBatchTransaction(originalHead.Number-1, divergentTx))
+
+	engineFault.InvalidateNextForkchoiceWithAttributes()
+	invalidBatch.Submit()
+	t.Require().Eventually(func() bool {
+		return engineFault.InvalidForkchoiceCount() == 1
+	}, 30*time.Second, 100*time.Millisecond, "validator must process the injected INVALID response")
+	// Reject the same final attributes again if the client retries them unchanged. The fixed client
+	// resets instead; the old kona-node loops on this response and never reaches the valid batch.
+	engineFault.ReinjectLastInvalidForkchoiceWithAttributes()
+
+	// The rejected final block must restore the backed-up original unsafe branch. A subsequent
+	// valid batch then proves derivation can continue and promote that branch to local-safe.
+	validBatch.Submit()
+	sys.L2CLB.ReachedRef(safety.LocalSafe, originalHead.ID(), 30)
+}

--- a/op-devstack/dsl/span_batch.go
+++ b/op-devstack/dsl/span_batch.go
@@ -1,0 +1,121 @@
+package dsl
+
+import (
+	"bytes"
+	"errors"
+	"io"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	deriveparams "github.com/ethereum-optimism/optimism/op-node/rollup/derive/params"
+	"github.com/ethereum-optimism/optimism/op-service/txplan"
+)
+
+const spanBatchMaxL1TxSize = 120_000
+
+type spanBatchConfig struct {
+	transactions map[uint64][]*types.Transaction
+}
+
+// SpanBatchOption configures a span batch built by [L2Network.NewSpanBatch].
+type SpanBatchOption func(*spanBatchConfig)
+
+// WithSpanBatchTransaction appends tx to the selected source block.
+func WithSpanBatchTransaction(blockNumber uint64, tx *types.Transaction) SpanBatchOption {
+	return func(cfg *spanBatchConfig) {
+		if cfg.transactions == nil {
+			cfg.transactions = make(map[uint64][]*types.Transaction)
+		}
+		cfg.transactions[blockNumber] = append(cfg.transactions[blockNumber], tx)
+	}
+}
+
+// SpanBatch is a prepared span batch that can be submitted after its source L2 blocks are reorged.
+type SpanBatch struct {
+	commonImpl
+	batcher *EOA
+	inbox   common.Address
+	frames  [][]byte
+	start   uint64
+	end     uint64
+}
+
+// NewSpanBatch prepares a span batch from the canonical L2 blocks in the inclusive [start, end]
+// range. Preparing and submitting are separate so a test can retain one version while another
+// version reorgs its source blocks out of the canonical chain.
+func (n *L2Network) NewSpanBatch(start, end uint64, opts ...SpanBatchOption) *SpanBatch {
+	cfg := spanBatchConfig{}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	n.require.GreaterOrEqual(start, uint64(1), "span batch cannot include the L2 genesis block")
+	n.require.GreaterOrEqual(end, start, "span batch end must not precede start")
+	for blockNumber, txs := range cfg.transactions {
+		n.require.GreaterOrEqual(blockNumber, start, "transaction block must be in the span batch")
+		n.require.LessOrEqual(blockNumber, end, "transaction block must be in the span batch")
+		for _, tx := range txs {
+			n.require.NotNil(tx, "span batch transaction must not be nil")
+		}
+	}
+
+	rollupCfg := n.inner.RollupConfig()
+	channel, err := derive.NewSpanChannelOut(
+		spanBatchMaxL1TxSize,
+		derive.Zlib,
+		rollup.NewChainSpec(rollupCfg),
+	)
+	n.require.NoError(err, "must create span batch channel")
+
+	for blockNumber := start; blockNumber <= end; blockNumber++ {
+		payload := n.primaryEL.PayloadByNumber(blockNumber)
+		for _, tx := range cfg.transactions[blockNumber] {
+			encoded, err := tx.MarshalBinary()
+			n.require.NoError(err, "must encode span batch transaction")
+			payload.ExecutionPayload.Transactions = append(payload.ExecutionPayload.Transactions, encoded)
+		}
+		_, err = channel.AddBlock(rollupCfg, payload.ExecutionPayload)
+		n.require.NoError(err, "must add L2 block %d to span batch", blockNumber)
+	}
+	n.require.NoError(channel.Close(), "must close span batch channel")
+
+	var frames [][]byte
+	for {
+		frame := new(bytes.Buffer)
+		frame.WriteByte(deriveparams.DerivationVersion0)
+		_, err := channel.OutputFrame(frame, spanBatchMaxL1TxSize-1)
+		frames = append(frames, frame.Bytes())
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		n.require.NoError(err, "must output span batch frame")
+	}
+
+	batcherKey := n.inner.Keys().Secret(devkeys.BatcherRole.Key(n.ChainID().ToBig()))
+	inbox := rollupCfg.BatchInboxAddress
+	return &SpanBatch{
+		commonImpl: commonFromT(n.t),
+		batcher:    NewKey(n.t, batcherKey).User(n.primaryL1),
+		inbox:      inbox,
+		frames:     frames,
+		start:      start,
+		end:        end,
+	}
+}
+
+// Submit posts every prepared frame to L1 from the configured batcher account and waits for each
+// transaction to be included.
+func (b *SpanBatch) Submit() {
+	b.log.Info("Submitting prepared span batch", "start", b.start, "end", b.end, "frames", len(b.frames))
+	for i, frame := range b.frames {
+		b.log.Info("Submitting span batch frame", "frame", i, "size", len(frame))
+		b.batcher.Transact(
+			b.batcher.Plan(),
+			txplan.WithTo(&b.inbox),
+			txplan.WithData(frame),
+		)
+	}
+}

--- a/op-devstack/sysgo/engine_fault_proxy.go
+++ b/op-devstack/sysgo/engine_fault_proxy.go
@@ -1,0 +1,145 @@
+package sysgo
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum/go-ethereum/beacon/engine"
+)
+
+// EngineFaultProxy is an Engine API reverse proxy that can return INVALID for the next
+// forkchoiceUpdated request carrying payload attributes. It is intended for recovery tests that
+// need to exercise the CL's handling of an EL-rejected derived payload deterministically.
+type EngineFaultProxy struct {
+	addr string
+
+	mu                         sync.Mutex
+	invalidForkchoiceArmed     bool
+	invalidForkchoiceCount     uint64
+	lastInvalidForkchoiceAttrs []byte
+}
+
+// StartEngineFaultProxy starts a passthrough Engine API proxy in front of targetURL.
+func StartEngineFaultProxy(p devtest.T, name, targetURL string) *EngineFaultProxy {
+	targetURL = strings.Replace(targetURL, "ws://", "http://", 1)
+	target, err := url.Parse(targetURL)
+	p.Require().NoError(err, "invalid engine fault proxy target URL %q", targetURL)
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	p.Require().NoError(err, "failed to listen for engine fault proxy %s", name)
+
+	proxy := &EngineFaultProxy{addr: "http://" + listener.Addr().String()}
+	rp := httputil.NewSingleHostReverseProxy(target)
+	server := &http.Server{
+		ReadHeaderTimeout: 5 * time.Second,
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			r.Body = io.NopCloser(bytes.NewReader(body))
+
+			if proxy.shouldInvalidateForkchoice(body) {
+				var req struct {
+					JSONRPC string          `json:"jsonrpc"`
+					ID      json.RawMessage `json:"id"`
+				}
+				if err := json.Unmarshal(body, &req); err != nil {
+					http.Error(w, err.Error(), http.StatusBadRequest)
+					return
+				}
+				validationError := "injected invalid derived payload"
+				response := struct {
+					JSONRPC string                    `json:"jsonrpc"`
+					ID      json.RawMessage           `json:"id"`
+					Result  engine.ForkChoiceResponse `json:"result"`
+				}{
+					JSONRPC: req.JSONRPC,
+					ID:      req.ID,
+					Result: engine.ForkChoiceResponse{PayloadStatus: engine.PayloadStatusV1{
+						Status:          engine.INVALID,
+						ValidationError: &validationError,
+					}},
+				}
+				w.Header().Set("Content-Type", "application/json")
+				p.Require().NoError(json.NewEncoder(w).Encode(response))
+				return
+			}
+
+			rp.ServeHTTP(w, r)
+		}),
+	}
+	go func() {
+		if err := server.Serve(listener); err != nil && err != http.ErrServerClosed {
+			p.Logger().Error("Engine fault proxy stopped", "name", name, "err", err)
+		}
+	}()
+	p.Cleanup(func() {
+		_ = server.Close()
+	})
+	return proxy
+}
+
+// URL returns the HTTP endpoint that an L2 CL should use as its Engine API endpoint.
+func (p *EngineFaultProxy) URL() string {
+	return p.addr
+}
+
+// InvalidateNextForkchoiceWithAttributes arms one injected INVALID response.
+func (p *EngineFaultProxy) InvalidateNextForkchoiceWithAttributes() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.invalidForkchoiceArmed = true
+}
+
+// ReinjectLastInvalidForkchoiceWithAttributes arms one INVALID response matching the payload
+// attributes of the previously injected request.
+func (p *EngineFaultProxy) ReinjectLastInvalidForkchoiceWithAttributes() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.invalidForkchoiceArmed = true
+}
+
+// InvalidForkchoiceCount returns the number of injected INVALID responses.
+func (p *EngineFaultProxy) InvalidForkchoiceCount() uint64 {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.invalidForkchoiceCount
+}
+
+func (p *EngineFaultProxy) shouldInvalidateForkchoice(body []byte) bool {
+	var req struct {
+		Method string            `json:"method"`
+		Params []json.RawMessage `json:"params"`
+	}
+	if err := json.Unmarshal(body, &req); err != nil ||
+		!strings.HasPrefix(req.Method, "engine_forkchoiceUpdatedV") ||
+		len(req.Params) < 2 ||
+		bytes.Equal(bytes.TrimSpace(req.Params[1]), []byte("null")) {
+		return false
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if !p.invalidForkchoiceArmed {
+		return false
+	}
+	attrs := bytes.TrimSpace(req.Params[1])
+	if p.lastInvalidForkchoiceAttrs != nil && !bytes.Equal(p.lastInvalidForkchoiceAttrs, attrs) {
+		return false
+	}
+	p.invalidForkchoiceArmed = false
+	p.invalidForkchoiceCount++
+	p.lastInvalidForkchoiceAttrs = append(p.lastInvalidForkchoiceAttrs[:0], attrs...)
+	return true
+}

--- a/op-devstack/sysgo/l2_cl.go
+++ b/op-devstack/sysgo/l2_cl.go
@@ -38,6 +38,9 @@ type L2CLConfig struct {
 	// SequencerMaxSafeLag caps the gap between unsafe and safe L2 heads;
 	// the sequencer stalls block production when the gap is exceeded. 0 disables.
 	SequencerMaxSafeLag uint64
+
+	// EngineRPCProxy may wrap the L2 EL Engine API endpoint. It runs after the endpoint is resolved.
+	EngineRPCProxy func(engineRPC string) string
 }
 
 func L2CLSequencer() L2CLOption {
@@ -49,6 +52,13 @@ func L2CLSequencer() L2CLOption {
 func L2CLFollowSource(source string) L2CLOption {
 	return L2CLOptionFn(func(p devtest.T, _ ComponentTarget, cfg *L2CLConfig) {
 		cfg.FollowSource = source
+	})
+}
+
+// L2CLEngineRPCProxy wraps the resolved Engine API endpoint used by matching L2 CLs.
+func L2CLEngineRPCProxy(proxy func(engineRPC string) string) L2CLOption {
+	return L2CLOptionFn(func(p devtest.T, _ ComponentTarget, cfg *L2CLConfig) {
+		cfg.EngineRPCProxy = proxy
 	})
 }
 

--- a/op-devstack/sysgo/mixed_runtime.go
+++ b/op-devstack/sysgo/mixed_runtime.go
@@ -565,6 +565,7 @@ func startMixedKonaNode(
 	elKey string,
 	isSequencer bool,
 	depSet coredepset.DependencySet,
+	l2CLOpts ...L2CLOption,
 ) *KonaNode {
 	tempKonaDir := t.TempDirWithPrefix("l2-cl-kona-" + NewComponentTarget(clKey, l2Net.ChainID()).String())
 
@@ -580,10 +581,22 @@ func startMixedKonaNode(
 	t.Require().NoError(err, "must write l1 chain config")
 	t.Require().NoError(os.WriteFile(tempL1CfgPath, l1CfgData, 0o640))
 
+	cfg := DefaultL2CLConfig()
+	cfg.IsSequencer = isSequencer
+	for _, opt := range l2CLOpts {
+		if opt != nil {
+			opt.Apply(t, NewComponentTarget(clKey, l2Net.ChainID()), cfg)
+		}
+	}
+	engineRPC := l2EL.EngineRPC()
+	if cfg.EngineRPCProxy != nil {
+		engineRPC = cfg.EngineRPCProxy(engineRPC)
+	}
+
 	envVars := []string{
 		"KONA_NODE_L1_ETH_RPC=" + l1EL.UserRPC(),
 		"KONA_NODE_L1_BEACON=" + l1CL.beaconHTTPAddr,
-		"KONA_NODE_L2_ENGINE_RPC=" + strings.ReplaceAll(l2EL.EngineRPC(), "ws://", "http://"),
+		"KONA_NODE_L2_ENGINE_RPC=" + strings.ReplaceAll(engineRPC, "ws://", "http://"),
 		"KONA_NODE_L2_ENGINE_AUTH=" + l2EL.JWTPath(),
 		"KONA_NODE_ROLLUP_CONFIG=" + tempRollupCfgPath,
 		"KONA_NODE_L1_CHAIN_CONFIG=" + tempL1CfgPath,

--- a/op-devstack/sysgo/singlechain_build.go
+++ b/op-devstack/sysgo/singlechain_build.go
@@ -171,7 +171,7 @@ func startL2CLForKey(
 ) L2CLNode {
 	switch devstackL2CLKind() {
 	case MixedL2CLKona:
-		return startMixedKonaNode(t, keys, l1Net, l2Net, l1EL, l1CL, l2EL, clKey, elKey, isSequencer, nil)
+		return startMixedKonaNode(t, keys, l1Net, l2Net, l1EL, l1CL, l2EL, clKey, elKey, isSequencer, nil, l2CLOpts...)
 	default: // op-node
 		return startL2CLNode(t, keys, l1Net, l2Net, l1EL, l1CL, l2EL, jwtSecret, l2CLNodeStartConfig{
 			Key:            clKey,
@@ -320,6 +320,10 @@ func startL2CLNode(
 	}
 
 	logger := t.Logger().New("component", "l2cl-"+startCfg.Key)
+	engineRPC := l2EL.EngineRPC()
+	if cfg.EngineRPCProxy != nil {
+		engineRPC = cfg.EngineRPCProxy(engineRPC)
+	}
 
 	// Build P2P config through the same path as sysgo op-node setup.
 	fs := flag.NewFlagSet("", flag.ContinueOnError)
@@ -376,7 +380,7 @@ func startL2CLNode(
 		},
 		L1ChainConfig: l1Net.genesis.Config,
 		L2: &config.L2EndpointConfig{
-			L2EngineAddr:      l2EL.EngineRPC(),
+			L2EngineAddr:      engineRPC,
 			L2EngineJWTSecret: jwtSecret,
 		},
 		L2FollowSource: &config.L2FollowSourceConfig{

--- a/rust/kona/crates/node/engine/src/state/core.rs
+++ b/rust/kona/crates/node/engine/src/state/core.rs
@@ -151,13 +151,6 @@ pub struct EngineState {
 
     /// Whether or not the EL has finished syncing.
     pub el_sync_finished: bool,
-
-    /// Track when the rollup node changes the forkchoice to restore previous
-    /// known unsafe chain. e.g. Unsafe Reorg caused by Invalid span batch.
-    /// This update does not retry except engine returns non-input error
-    /// because engine may forgot backupUnsafeHead or backupUnsafeHead is not part
-    /// of the chain.
-    pub need_fcu_call_backup_unsafe_reorg: bool,
 }
 
 impl EngineState {

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/build/error.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/build/error.rs
@@ -59,9 +59,14 @@ impl EngineTaskError for BuildTaskError {
             Self::EngineBuildError(EngineBuildError::FinalizedAheadOfUnsafe(_, _)) => {
                 EngineTaskErrorSeverity::Critical
             }
+            // INVALID is deterministic for the same attributes and forkchoice. Reset instead of
+            // retrying an unchanged build forever.
+            Self::EngineBuildError(
+                EngineBuildError::InvalidPayload(_) |
+                EngineBuildError::UnexpectedPayloadStatus(PayloadStatusEnum::Invalid { .. }),
+            ) => EngineTaskErrorSeverity::Reset,
             Self::EngineBuildError(
                 EngineBuildError::AttributesInsertionFailed(_) |
-                EngineBuildError::InvalidPayload(_) |
                 EngineBuildError::UnexpectedPayloadStatus(_) |
                 EngineBuildError::MissingPayloadId |
                 EngineBuildError::EngineSyncing,

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/insert/error.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/insert/error.rs
@@ -34,6 +34,11 @@ impl EngineTaskError for InsertTaskError {
             Self::FromBlockError(_) | Self::L2BlockInfoConstruction(_) => {
                 EngineTaskErrorSeverity::Critical
             }
+            // A built payload that is rejected will remain invalid on retry. Externally sourced
+            // invalid unsafe payloads are consumed before their severity is evaluated.
+            Self::UnexpectedPayloadStatus(PayloadStatusEnum::Invalid { .. }) => {
+                EngineTaskErrorSeverity::Reset
+            }
             Self::InsertFailed(_) | Self::UnexpectedPayloadStatus(_) => {
                 EngineTaskErrorSeverity::Temporary
             }

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/synchronize/error.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/synchronize/error.rs
@@ -26,10 +26,14 @@ impl EngineTaskError for SynchronizeTaskError {
     fn severity(&self) -> EngineTaskErrorSeverity {
         match self {
             Self::FinalizedAheadOfUnsafe(_, _) => EngineTaskErrorSeverity::Critical,
+            // An INVALID response cannot recover by retrying the same forkchoice update.
+            Self::InvalidForkchoiceState |
+            Self::UnexpectedPayloadStatus(PayloadStatusEnum::Invalid { .. }) => {
+                EngineTaskErrorSeverity::Reset
+            }
             Self::ForkchoiceUpdateFailed(_) | Self::UnexpectedPayloadStatus(_) => {
                 EngineTaskErrorSeverity::Temporary
             }
-            Self::InvalidForkchoiceState => EngineTaskErrorSeverity::Reset,
         }
     }
 }

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/task.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/task.rs
@@ -253,14 +253,68 @@ impl<EngineClient_: EngineClient> EngineTaskExt for EngineTask<EngineClient_> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::MockEngineClient;
+    use crate::{
+        EngineBuildError, SynchronizeTaskError,
+        test_utils::{
+            MockEngineClient, TestAttributesBuilder, TestEngineStateBuilder, test_block_info,
+        },
+    };
     use alloy_consensus::Block;
     use alloy_primitives::Bytes;
-    use alloy_rpc_types_engine::{ExecutionPayloadV1, PayloadStatus};
+    use alloy_rpc_types_engine::{ExecutionPayloadV1, ForkchoiceUpdated, PayloadStatus};
+    use alloy_rpc_types_eth::Block as RpcBlock;
     use kona_genesis::RollupConfig;
     use op_alloy_consensus::OpTxEnvelope;
+    use op_alloy_rpc_types::Transaction;
     use op_alloy_rpc_types_engine::OpExecutionPayloadEnvelope;
     use std::{sync::Arc, time::Duration};
+
+    #[test]
+    fn invalid_payload_errors_request_reset() {
+        let invalid = PayloadStatusEnum::Invalid { validation_error: "invalid payload".into() };
+
+        assert_eq!(
+            BuildTaskError::EngineBuildError(EngineBuildError::InvalidPayload(
+                "invalid payload".into()
+            ))
+            .severity(),
+            EngineTaskErrorSeverity::Reset
+        );
+        assert_eq!(
+            BuildTaskError::EngineBuildError(EngineBuildError::UnexpectedPayloadStatus(
+                invalid.clone()
+            ))
+            .severity(),
+            EngineTaskErrorSeverity::Reset
+        );
+        assert_eq!(
+            InsertTaskError::UnexpectedPayloadStatus(invalid.clone()).severity(),
+            EngineTaskErrorSeverity::Reset
+        );
+        assert_eq!(
+            SynchronizeTaskError::UnexpectedPayloadStatus(invalid).severity(),
+            EngineTaskErrorSeverity::Reset
+        );
+    }
+
+    #[test]
+    fn accepted_payload_status_errors_remain_temporary() {
+        assert_eq!(
+            BuildTaskError::EngineBuildError(EngineBuildError::UnexpectedPayloadStatus(
+                PayloadStatusEnum::Accepted
+            ))
+            .severity(),
+            EngineTaskErrorSeverity::Temporary
+        );
+        assert_eq!(
+            InsertTaskError::UnexpectedPayloadStatus(PayloadStatusEnum::Accepted).severity(),
+            EngineTaskErrorSeverity::Temporary
+        );
+        assert_eq!(
+            SynchronizeTaskError::UnexpectedPayloadStatus(PayloadStatusEnum::Accepted).severity(),
+            EngineTaskErrorSeverity::Temporary
+        );
+    }
 
     #[tokio::test]
     async fn invalid_unsafe_payload_completes_without_retry() {
@@ -286,5 +340,49 @@ mod tests {
             .await
             .expect("invalid unsafe payload task should not retry")
             .unwrap();
+    }
+
+    #[tokio::test]
+    async fn invalid_consolidation_build_requests_reset_without_retry() {
+        let mut config = RollupConfig::default();
+        config.hardforks.ecotone_time = Some(0);
+        let config = Arc::new(config);
+
+        let invalid_status = PayloadStatusEnum::Invalid {
+            validation_error: "derived payload conflicts with unsafe chain".into(),
+        };
+        let client = Arc::new(
+            MockEngineClient::builder()
+                .with_config(config.clone())
+                .with_l2_block_by_label(1_u64.into(), RpcBlock::<Transaction>::default())
+                .with_fork_choice_updated_v3_response(ForkchoiceUpdated {
+                    payload_status: PayloadStatus::from_status(invalid_status),
+                    payload_id: None,
+                })
+                .build(),
+        );
+
+        let parent = test_block_info(0);
+        let unsafe_head = test_block_info(1);
+        let attributes = TestAttributesBuilder::new()
+            .with_parent(parent)
+            .with_timestamp(unsafe_head.block_info.timestamp)
+            .build();
+        let task = EngineTask::Consolidate(Box::new(ConsolidateTask::new(
+            client,
+            config,
+            attributes.into(),
+        )));
+        let mut state = TestEngineStateBuilder::new()
+            .with_unsafe_head(unsafe_head)
+            .with_safe_head(parent)
+            .with_finalized_head(parent)
+            .build();
+
+        let err = tokio::time::timeout(Duration::from_secs(1), task.execute(&mut state))
+            .await
+            .expect("invalid consolidation task should not retry")
+            .expect_err("invalid consolidation should request an engine reset");
+        assert_eq!(err.severity(), EngineTaskErrorSeverity::Reset);
     }
 }

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/util.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/util.rs
@@ -50,10 +50,59 @@ pub(in crate::task_queue) async fn build_and_seal<EngineClient_: EngineClient>(
     .execute(state)
     .await?;
 
+    // `BuildTask` advertises the attributes parent as the forkchoice head. Keep the in-memory
+    // unsafe head in sync with that FCU before `SealTask` verifies the build parent. This matters
+    // when derivation builds a replacement block behind the current unsafe tip.
+    state.sync_state = state.sync_state.apply_update(crate::state::EngineSyncStateUpdate {
+        unsafe_head: Some(attributes.parent),
+        cross_unsafe_head: Some(attributes.parent),
+        ..Default::default()
+    });
+
     // Execute the seal task with the payload ID from the build
     SealTask::new(engine, cfg, payload_id, attributes, is_attributes_derived, None)
         .execute(state)
         .await?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::{
+        MockEngineClient, TestAttributesBuilder, TestEngineStateBuilder, test_block_info,
+    };
+    use alloy_rpc_types_engine::{ForkchoiceUpdated, PayloadId, PayloadStatus, PayloadStatusEnum};
+
+    #[tokio::test]
+    async fn reorgs_in_memory_unsafe_head_before_sealing() {
+        let cfg = Arc::new(RollupConfig::default());
+        let parent = test_block_info(1);
+        let current_unsafe = test_block_info(2);
+        let attributes = TestAttributesBuilder::new().with_parent(parent).build();
+        let client = Arc::new(
+            MockEngineClient::builder()
+                .with_config(cfg.clone())
+                .with_fork_choice_updated_v2_response(ForkchoiceUpdated {
+                    payload_status: PayloadStatus::from_status(PayloadStatusEnum::Valid),
+                    payload_id: Some(PayloadId::new([1; 8])),
+                })
+                .build(),
+        );
+        let mut state = TestEngineStateBuilder::new()
+            .with_unsafe_head(current_unsafe)
+            .with_safe_head(parent)
+            .with_finalized_head(parent)
+            .build();
+
+        let err = build_and_seal(&mut state, client, cfg, attributes, true).await.unwrap_err();
+
+        assert!(!matches!(
+            err,
+            BuildAndSealError::Seal(SealTaskError::UnsafeHeadChangedSinceBuild)
+        ));
+        assert_eq!(state.sync_state.unsafe_head(), parent);
+        assert_eq!(state.sync_state.cross_unsafe_head(), parent);
+    }
 }


### PR DESCRIPTION
## Summary

- classify `INVALID` responses while building, inserting, or synchronizing derived payloads as reset errors
- preserve temporary retry handling for `ACCEPTED` responses and drop externally sourced invalid unsafe payloads as before
- keep kona-engine's in-memory unsafe head aligned when a derived build reorgs behind the prior unsafe tip
- add a full-stack span-batch recovery test shared by op-node and kona-node, with deterministic Engine API `INVALID` fault injection
- remove the unused backup-unsafe-reorg state stub and document the reset behavior

Fixes ethereum-optimism/protocol-team#206

## Tests

- `cargo nextest run --package kona-engine` (65 passed)
- `cargo clippy --package kona-engine --all-targets --all-features -- -D warnings`
- `go test ./op-devstack/sysgo ./op-devstack/dsl ./op-acceptance-tests/tests/derivation -run '^$'`
- `RUST_JIT_BUILD=1 DEVSTACK_L2CL_KIND=op-node go test ./op-acceptance-tests/tests/derivation -run '^TestValidatorRecoversFromInvalidSpanBatch$' -count=1 -v -timeout=10m`
- `RUST_JIT_BUILD=1 DEVSTACK_L2CL_KIND=kona-node go test ./op-acceptance-tests/tests/derivation -run '^TestValidatorRecoversFromInvalidSpanBatch$' -count=1 -v -timeout=12m`
- formatting validated by the pre-push hook (`cargo +nightly-2026-02-20 fmt --all -- --check`)
