### PR TITLE
kona-node: isolate unsafe payload failures and retries

### DIFF
--- a/op-acceptance-tests/tests/sync/elsync/gap_elp2p/sync_test.go
+++ b/op-acceptance-tests/tests/sync/elsync/gap_elp2p/sync_test.go
@@ -402,18 +402,11 @@ func TestSafeDoesNotAdvanceWhenUnsafeIsSyncing_NoELP2P(gt *testing.T) {
 //     A new payload builds on a previously rejected block (an invalid parent),
 //     causing the EL to reject it as referencing an invalid ancestor.
 //
-// In all scenarios, both CL and EL remain at the same head height, confirming that
-// invalid payloads—whether rejected at the CL or EL—do not advance the chain.
+// In all invalid scenarios, both CL and EL remain at the same head height. The test
+// then posts a valid payload and requires both to advance, confirming that rejecting
+// an invalid payload does not wedge subsequent unsafe payload processing.
 func TestInvalidPayloadThroughCLP2P(gt *testing.T) {
 	t := devtest.ParallelT(gt)
-	// Example error with kona-node:
-	//
-	// assertions.go:387:             ERROR[03-31|10:42:03.034]
-	// assertions.go:387:             	Error Trace:	/Users/josh/repos/optimism/op-acceptance-tests/tests/sync/elsync/gap_elp2p/sync_test.go:436
-	// assertions.go:387:             	Error:      	An error is expected but got nil.
-	// assertions.go:387:             	Test:       	TestInvalidPayloadThroughCLP2P
-	// assertions.go:387:
-	sysgo.SkipOnKonaNode(t, "not supported")
 	sys := newGapELP2PSystem(t)
 	logger := t.Logger()
 	require := t.Require()
@@ -442,7 +435,7 @@ func TestInvalidPayloadThroughCLP2P(gt *testing.T) {
 	payload.ExecutionPayload.StateRoot = eth.Bytes32{}
 	logger.Info("Injected fault to payload but not updated hash")
 	// Post invalid payload with the fault that can be checked at the CL side
-	require.Error(sys.L2CLB.Escape().RollupAPI().PostUnsafePayload(ctx, payload))
+	require.ErrorContains(sys.L2CLB.Escape().RollupAPI().PostUnsafePayload(ctx, payload), "bad block hash")
 	// ex) op-node error msg: "payload has bad block hash"
 	// CL will not send the payload but drop immediately due to hash mismatch
 	// EL did not advance
@@ -480,10 +473,10 @@ func TestInvalidPayloadThroughCLP2P(gt *testing.T) {
 	require.False(ok)
 	logger.Info("Updated payload parent to invalid payload", "newHash", newHash)
 	payload2.ExecutionPayload.BlockHash = newHash
-	_, ok = payload.CheckBlockHash()
+	_, ok = payload2.CheckBlockHash()
 	require.True(ok)
 	// Post invalid payload with the fault that can be only checked at the EL side
-	sys.L2CLB.PostUnsafePayload(payload)
+	sys.L2CLB.PostUnsafePayload(payload2)
 	// ex) op-geth error msg: "ignoring bad block: links to previously rejected block"
 	sys.L2CLB.NotAdvanced(safety.LocalUnsafe, attempts)
 	sys.L2ELB.NotAdvanced(eth.Unsafe, attempts)
@@ -491,4 +484,12 @@ func TestInvalidPayloadThroughCLP2P(gt *testing.T) {
 	sys.L2ELB.UnsafeHead().NumEqualTo(startNum + 1)
 	// CL did not advance
 	sys.L2CLB.UnsafeHead().NumEqualTo(startNum + 1)
+
+	// A valid payload must still advance both the CL and EL after the invalid payloads.
+	// This ensures an EL INVALID response does not block the unsafe payload queue.
+	validTargetNum := startNum + 2
+	logger.Info("Posting valid payload after invalid payloads", "target", validTargetNum)
+	sys.L2CLB.PostUnsafePayload(sys.L2EL.PayloadByNumber(validTargetNum))
+	sys.L2CLB.Reached(safety.LocalUnsafe, validTargetNum, attempts)
+	sys.L2ELB.Reached(eth.Unsafe, validTargetNum, attempts)
 }

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -7250,6 +7250,7 @@ dependencies = [
  "alloy-chains",
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
+ "alloy-json-rpc 2.1.1",
  "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-client",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6934,6 +6934,7 @@ dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
  "alloy-hardforks",
+ "alloy-json-rpc 2.1.1",
  "alloy-network 2.1.1",
  "alloy-primitives",
  "alloy-provider",

--- a/rust/kona/crates/node/engine/Cargo.toml
+++ b/rust/kona/crates/node/engine/Cargo.toml
@@ -19,6 +19,7 @@ kona-protocol = {workspace = true, features = ["serde", "std"]}
 
 # alloy
 alloy-hardforks.workspace = true
+alloy-json-rpc.workspace = true
 alloy-eips.workspace = true
 alloy-consensus.workspace = true
 alloy-network.workspace = true

--- a/rust/kona/crates/node/engine/src/lib.rs
+++ b/rust/kona/crates/node/engine/src/lib.rs
@@ -43,7 +43,8 @@ pub use task_queue::{
     BuildTask, BuildTaskError, ConsolidateInput, ConsolidateTask, ConsolidateTaskError, Engine,
     EngineBuildError, EngineResetError, EngineTask, EngineTaskError, EngineTaskErrorSeverity,
     EngineTaskErrors, EngineTaskExt, FinalizeBlockId, FinalizeTask, FinalizeTaskError, InsertTask,
-    InsertTaskError, SealTask, SealTaskError, SynchronizeTask, SynchronizeTaskError,
+    InsertTaskError, InsertTaskErrorKind, PayloadEnvelopeOrigin, SealTask, SealTaskError,
+    SynchronizeTask, SynchronizeTaskError,
 };
 
 mod attributes;
@@ -56,7 +57,11 @@ pub use client::{
 };
 
 mod versions;
-pub use versions::{EngineForkchoiceVersion, EngineGetPayloadVersion, EngineNewPayloadVersion};
+pub use versions::{
+    EngineForkchoiceVersion, EngineGetPayloadVersion, EngineNewPayloadVersion,
+    ExecutionPayloadEnvelopeVersion, ExecutionPayloadEnvelopeVersionError,
+    validate_execution_payload_envelope_version,
+};
 
 mod state;
 pub use state::{EngineState, EngineSyncState, EngineSyncStateUpdate};

--- a/rust/kona/crates/node/engine/src/task_queue/core.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/core.rs
@@ -22,9 +22,7 @@ use tokio::sync::watch::Sender;
 ///  Because tasks are executed one at a time, they are considered to be atomic operations over the
 /// [`EngineState`], and are given exclusive access to the engine state during execution.
 ///
-/// Tasks within the queue are also considered fallible. If they fail with a temporary error,
-/// they are not popped from the queue, the error is returned, and they are retried on the
-/// next call to [`Engine::drain`].
+/// Temporary failures remain queued for retry. Permanently invalid tasks are removed.
 #[derive(Debug)]
 pub struct Engine<EngineClient_: EngineClient> {
     /// The state of the engine.
@@ -104,7 +102,7 @@ impl<EngineClient_: EngineClient> Engine<EngineClient_> {
                     warn!(target: "engine", ?err, "Forkchoice update failed during reset. Trying again...");
                     start = find_starting_forkchoice(&config, client.as_ref()).await?;
                 }
-                EngineTaskErrorSeverity::Critical => {
+                EngineTaskErrorSeverity::Drop | EngineTaskErrorSeverity::Critical => {
                     return Err(EngineResetError::Forkchoice(err));
                 }
             }
@@ -120,21 +118,19 @@ impl<EngineClient_: EngineClient> Engine<EngineClient_> {
         self.tasks.clear();
     }
 
-    /// Attempts to drain the queue by executing all [`EngineTask`]s in-order. If any task returns
-    /// an error along the way, it is not popped from the queue (in case it must be retried) and
-    /// the error is returned.
+    /// Executes queued tasks in priority order, retaining failures unless marked `Drop`.
     pub async fn drain(&mut self) -> Result<(), EngineTaskErrors> {
-        // Drain tasks in order of priority, halting on errors for a retry to be attempted.
         while let Some(task) = self.tasks.peek() {
-            // Execute the task
-            task.execute(&mut self.state).await?;
+            match task.execute(&mut self.state).await {
+                Ok(()) => {
+                    // Update the state and notify the engine actor.
+                    self.state_sender.send_replace(self.state);
+                }
+                Err(err) if err.severity() == EngineTaskErrorSeverity::Drop => {}
+                Err(err) => return Err(err),
+            }
 
-            // Update the state and notify the engine actor.
-            self.state_sender.send_replace(self.state);
-
-            // Pop the task from the queue now that it's been executed.
             self.tasks.pop();
-
             self.task_queue_length.send_replace(self.tasks.len());
         }
 
@@ -151,4 +147,65 @@ pub enum EngineResetError {
     /// An error occurred while traversing the L1 for the sync starting point.
     #[error(transparent)]
     SyncStart(#[from] SyncStartError),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        InsertTask,
+        test_utils::{TestEngineStateBuilder, test_engine_client_builder},
+    };
+    use alloy_rpc_types_engine::{ExecutionPayloadV1, PayloadStatus, PayloadStatusEnum};
+    use op_alloy_rpc_types_engine::OpExecutionPayloadEnvelope;
+    use std::time::Duration;
+    use tokio::{sync::watch, time::timeout};
+
+    #[tokio::test]
+    async fn drops_permanently_invalid_unsafe_payload() {
+        let config = Arc::new(RollupConfig::default());
+        let client = test_engine_client_builder()
+            .with_config(config.clone())
+            .with_new_payload_v1_response(PayloadStatus {
+                status: PayloadStatusEnum::Invalid {
+                    validation_error: "invalid state root".to_string(),
+                },
+                latest_valid_hash: None,
+            })
+            .build();
+        let state = TestEngineStateBuilder::new().build();
+        let (state_sender, _) = watch::channel(state);
+        let (queue_length_sender, queue_length) = watch::channel(0);
+        let mut engine = Engine::new(state, state_sender, queue_length_sender);
+
+        engine.enqueue(EngineTask::Insert(Box::new(InsertTask::new(
+            Arc::new(client),
+            config,
+            OpExecutionPayloadEnvelope::V1(ExecutionPayloadV1 {
+                parent_hash: Default::default(),
+                fee_recipient: Default::default(),
+                state_root: Default::default(),
+                receipts_root: Default::default(),
+                logs_bloom: Default::default(),
+                prev_randao: Default::default(),
+                block_number: 1,
+                gas_limit: 0,
+                gas_used: 0,
+                timestamp: 2,
+                extra_data: Default::default(),
+                base_fee_per_gas: Default::default(),
+                block_hash: Default::default(),
+                transactions: Vec::new(),
+            }),
+            false,
+        ))));
+        assert_eq!(*queue_length.borrow(), 1);
+
+        timeout(Duration::from_secs(1), engine.drain())
+            .await
+            .expect("drain timed out")
+            .expect("drain failed");
+
+        assert_eq!(*queue_length.borrow(), 0);
+    }
 }

--- a/rust/kona/crates/node/engine/src/task_queue/core.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/core.rs
@@ -8,16 +8,17 @@ use crate::{
 };
 use kona_genesis::RollupConfig;
 use kona_protocol::L2BlockInfo;
-use std::{collections::BinaryHeap, sync::Arc};
+use std::{collections::BinaryHeap, sync::Arc, time::Duration};
 use thiserror::Error;
-use tokio::sync::watch::Sender;
+use tokio::{sync::watch::Sender, time::Instant};
+
+/// Delay between attempts of temporarily failed engine tasks.
+const TEMPORARY_RETRY_DELAY: Duration = Duration::from_secs(1);
 
 /// The [`Engine`] task queue.
 ///
-/// Tasks of a shared [`EngineTask`] variant are processed in FIFO order, providing synchronization
-/// guarantees for the L2 execution layer and other actors. A priority queue, ordered by
-/// [`EngineTask`]'s [`Ord`] implementation, is used to prioritize tasks executed by the
-/// [`Engine::drain`] method.
+/// A priority queue, ordered by [`EngineTask`]'s [`Ord`] implementation, is used to prioritize
+/// tasks executed by the [`Engine::drain`] method.
 ///
 ///  Because tasks are executed one at a time, they are considered to be atomic operations over the
 /// [`EngineState`], and are given exclusive access to the engine state during execution.
@@ -31,8 +32,12 @@ pub struct Engine<EngineClient_: EngineClient> {
     state_sender: Sender<EngineState>,
     /// A sender that can be used to notify the engine actor of task queue length changes.
     task_queue_length: Sender<usize>,
-    /// The task queue.
+    /// Tasks ready to execute.
     tasks: BinaryHeap<EngineTask<EngineClient_>>,
+    /// Temporarily failed tasks waiting for the shared retry deadline.
+    retries: Vec<EngineTask<EngineClient_>>,
+    /// The time at which temporarily failed tasks become ready again.
+    retry_at: Option<Instant>,
 }
 
 impl<EngineClient_: EngineClient> Engine<EngineClient_> {
@@ -42,7 +47,14 @@ impl<EngineClient_: EngineClient> Engine<EngineClient_> {
         state_sender: Sender<EngineState>,
         task_queue_length: Sender<usize>,
     ) -> Self {
-        Self { state: initial_state, state_sender, task_queue_length, tasks: BinaryHeap::default() }
+        Self {
+            state: initial_state,
+            state_sender,
+            task_queue_length,
+            tasks: BinaryHeap::default(),
+            retries: Vec::new(),
+            retry_at: None,
+        }
     }
 
     /// Returns a reference to the inner [`EngineState`].
@@ -64,7 +76,35 @@ impl<EngineClient_: EngineClient> Engine<EngineClient_> {
     /// Updates the queue length and notifies listeners of the change.
     pub fn enqueue(&mut self, task: EngineTask<EngineClient_>) {
         self.tasks.push(task);
-        self.task_queue_length.send_replace(self.tasks.len());
+        self.update_queue_length();
+    }
+
+    /// Returns the time at which temporarily failed tasks become ready to retry.
+    pub const fn next_retry_deadline(&self) -> Option<Instant> {
+        self.retry_at
+    }
+
+    /// Updates the externally observable total queue length.
+    fn update_queue_length(&self) {
+        self.task_queue_length.send_replace(self.tasks.len() + self.retries.len());
+    }
+
+    /// Moves temporarily failed tasks back into the ready queue once their delay has elapsed.
+    fn promote_ready_retries(&mut self) {
+        if self.retry_at.is_none_or(|deadline| deadline > Instant::now()) {
+            return;
+        }
+
+        self.retry_at = None;
+        for task in self.retries.drain(..) {
+            self.tasks.push(task);
+        }
+    }
+
+    /// Defers a temporary task until the shared retry deadline.
+    fn schedule_retry(&mut self, task: EngineTask<EngineClient_>) {
+        self.retries.push(task);
+        self.retry_at.get_or_insert_with(|| Instant::now() + TEMPORARY_RETRY_DELAY);
     }
 
     /// Resets the engine by finding a plausible sync starting point via
@@ -116,22 +156,35 @@ impl<EngineClient_: EngineClient> Engine<EngineClient_> {
     /// Clears the task queue.
     pub fn clear(&mut self) {
         self.tasks.clear();
+        self.retries.clear();
+        self.retry_at = None;
+        self.update_queue_length();
     }
 
-    /// Executes queued tasks in priority order, retaining failures unless marked `Drop`.
+    /// Executes all ready tasks in priority order.
+    ///
+    /// Temporary failures are moved to the delayed retry queue so they cannot block fresh work or
+    /// spin inside a single task execution.
     pub async fn drain(&mut self) -> Result<(), EngineTaskErrors> {
-        while let Some(task) = self.tasks.peek() {
+        self.promote_ready_retries();
+
+        while let Some(task) = self.tasks.pop() {
             match task.execute(&mut self.state).await {
                 Ok(()) => {
                     // Update the state and notify the engine actor.
                     self.state_sender.send_replace(self.state);
+                    self.update_queue_length();
                 }
-                Err(err) if err.severity() == EngineTaskErrorSeverity::Drop => {}
-                Err(err) => return Err(err),
+                Err(err) => match err.severity() {
+                    EngineTaskErrorSeverity::Temporary => self.schedule_retry(task),
+                    EngineTaskErrorSeverity::Drop => self.update_queue_length(),
+                    _ => {
+                        // Preserve non-terminal tasks for the actor's reset/flush handling.
+                        self.tasks.push(task);
+                        return Err(err);
+                    }
+                },
             }
-
-            self.tasks.pop();
-            self.task_queue_length.send_replace(self.tasks.len());
         }
 
         Ok(())
@@ -153,13 +206,33 @@ pub enum EngineResetError {
 mod tests {
     use super::*;
     use crate::{
-        InsertTask,
+        InsertTask, PayloadEnvelopeOrigin,
         test_utils::{TestEngineStateBuilder, test_engine_client_builder},
     };
+    use alloy_primitives::Bytes;
     use alloy_rpc_types_engine::{ExecutionPayloadV1, PayloadStatus, PayloadStatusEnum};
     use op_alloy_rpc_types_engine::OpExecutionPayloadEnvelope;
     use std::time::Duration;
     use tokio::{sync::watch, time::timeout};
+
+    fn v1_payload(transactions: Vec<Bytes>) -> OpExecutionPayloadEnvelope {
+        OpExecutionPayloadEnvelope::V1(ExecutionPayloadV1 {
+            parent_hash: Default::default(),
+            fee_recipient: Default::default(),
+            state_root: Default::default(),
+            receipts_root: Default::default(),
+            logs_bloom: Default::default(),
+            prev_randao: Default::default(),
+            block_number: 1,
+            gas_limit: 0,
+            gas_used: 0,
+            timestamp: 2,
+            extra_data: Default::default(),
+            base_fee_per_gas: Default::default(),
+            block_hash: Default::default(),
+            transactions,
+        })
+    }
 
     #[tokio::test]
     async fn drops_permanently_invalid_unsafe_payload() {
@@ -181,23 +254,8 @@ mod tests {
         engine.enqueue(EngineTask::Insert(Box::new(InsertTask::new(
             Arc::new(client),
             config,
-            OpExecutionPayloadEnvelope::V1(ExecutionPayloadV1 {
-                parent_hash: Default::default(),
-                fee_recipient: Default::default(),
-                state_root: Default::default(),
-                receipts_root: Default::default(),
-                logs_bloom: Default::default(),
-                prev_randao: Default::default(),
-                block_number: 1,
-                gas_limit: 0,
-                gas_used: 0,
-                timestamp: 2,
-                extra_data: Default::default(),
-                base_fee_per_gas: Default::default(),
-                block_hash: Default::default(),
-                transactions: Vec::new(),
-            }),
-            false,
+            v1_payload(Vec::new()),
+            PayloadEnvelopeOrigin::RemoteSequencer,
         ))));
         assert_eq!(*queue_length.borrow(), 1);
 
@@ -207,5 +265,73 @@ mod tests {
             .expect("drain failed");
 
         assert_eq!(*queue_length.borrow(), 0);
+    }
+
+    #[tokio::test]
+    async fn schedules_temporary_task_retry_without_blocking() {
+        let config = Arc::new(RollupConfig::default());
+        let client = test_engine_client_builder()
+            .with_config(config.clone())
+            .with_new_payload_v1_response(PayloadStatus {
+                status: PayloadStatusEnum::Accepted,
+                latest_valid_hash: None,
+            })
+            .build();
+        let state = TestEngineStateBuilder::new().build();
+        let (state_sender, _) = watch::channel(state);
+        let (queue_length_sender, queue_length) = watch::channel(0);
+        let mut engine = Engine::new(state, state_sender, queue_length_sender);
+        engine.enqueue(EngineTask::Insert(Box::new(InsertTask::new(
+            Arc::new(client),
+            config.clone(),
+            v1_payload(Vec::new()),
+            PayloadEnvelopeOrigin::RemoteSequencer,
+        ))));
+
+        timeout(Duration::from_secs(1), engine.drain())
+            .await
+            .expect("drain timed out")
+            .expect("drain failed");
+
+        assert_eq!(*queue_length.borrow(), 1);
+        assert!(engine.tasks.is_empty());
+        assert_eq!(engine.retries.len(), 1);
+        assert!(engine.next_retry_deadline().is_some());
+
+        // Fresh work remains ready while the temporary task waits for its retry deadline.
+        let invalid_client = test_engine_client_builder()
+            .with_config(config.clone())
+            .with_new_payload_v1_response(PayloadStatus {
+                status: PayloadStatusEnum::Invalid {
+                    validation_error: "invalid state root".to_string(),
+                },
+                latest_valid_hash: None,
+            })
+            .build();
+        engine.enqueue(EngineTask::Insert(Box::new(InsertTask::new(
+            Arc::new(invalid_client),
+            config,
+            v1_payload(Vec::new()),
+            PayloadEnvelopeOrigin::RemoteSequencer,
+        ))));
+        engine.drain().await.expect("fresh task failed");
+
+        assert_eq!(*queue_length.borrow(), 1);
+        assert!(engine.tasks.is_empty());
+        assert_eq!(engine.retries.len(), 1);
+
+        // Once the shared deadline elapses, deferred tasks get one more attempt and are deferred
+        // again if the error remains temporary.
+        engine.retry_at = Some(Instant::now());
+        engine.drain().await.expect("retry failed");
+        assert!(engine.tasks.is_empty());
+        assert_eq!(engine.retries.len(), 1);
+        assert!(engine.next_retry_deadline().is_some_and(|deadline| deadline > Instant::now()));
+
+        engine.clear();
+        assert_eq!(*queue_length.borrow(), 0);
+        assert!(engine.tasks.is_empty());
+        assert!(engine.retries.is_empty());
+        assert!(engine.next_retry_deadline().is_none());
     }
 }

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/insert/error.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/insert/error.rs
@@ -1,43 +1,145 @@
 //! Contains the error types for the [`InsertTask`](crate::InsertTask).
 
 use crate::{
-    EngineTaskError, SynchronizeTaskError, task_queue::tasks::task::EngineTaskErrorSeverity,
+    EngineTaskError, ExecutionPayloadEnvelopeVersionError, SynchronizeTaskError,
+    task_queue::tasks::task::EngineTaskErrorSeverity,
 };
+use alloy_json_rpc::ErrorPayload;
 use alloy_rpc_types_engine::PayloadStatusEnum;
 use alloy_transport::{RpcError, TransportErrorKind};
 use kona_protocol::FromBlockError;
 use op_alloy_rpc_types_engine::OpPayloadError;
 
+/// Engine API request too large error code.
+const TOO_LARGE_REQUEST_ERROR: i64 = -38004;
+/// Engine API unsupported fork error code.
+const UNSUPPORTED_FORK_ERROR: i64 = -38005;
+
+/// The origin of an execution payload envelope passed to an [`InsertTask`](crate::InsertTask).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PayloadEnvelopeOrigin {
+    /// The payload was locally built from attributes derived from L1.
+    L1Derived,
+    /// The payload was locally built by this node's sequencer.
+    LocalSequencer,
+    /// The payload was received from a remote sequencer through gossip or the admin RPC.
+    RemoteSequencer,
+}
+
+impl PayloadEnvelopeOrigin {
+    /// Returns whether the payload advances the safe chain.
+    pub const fn is_safe(self) -> bool {
+        matches!(self, Self::L1Derived)
+    }
+
+    /// Returns whether the payload came from outside this node and its configured execution layer.
+    pub const fn is_remote(self) -> bool {
+        matches!(self, Self::RemoteSequencer)
+    }
+}
+
 /// An error that occurs when running the [`InsertTask`](crate::InsertTask).
 #[derive(Debug, thiserror::Error)]
-pub enum InsertTaskError {
+#[error("{kind}")]
+pub struct InsertTaskError {
+    /// The origin of the payload that failed insertion.
+    origin: PayloadEnvelopeOrigin,
+    /// The underlying insertion failure.
+    #[source]
+    kind: InsertTaskErrorKind,
+}
+
+impl InsertTaskError {
+    /// Creates an insertion error for a payload with the given origin.
+    pub const fn new(origin: PayloadEnvelopeOrigin, kind: InsertTaskErrorKind) -> Self {
+        Self { origin, kind }
+    }
+
+    /// Returns the underlying insertion failure.
+    pub const fn kind(&self) -> &InsertTaskErrorKind {
+        &self.kind
+    }
+
+    /// Classifies an Engine API request failure.
+    fn insert_failed_severity(
+        &self,
+        error: &RpcError<TransportErrorKind>,
+    ) -> EngineTaskErrorSeverity {
+        match error {
+            // These errors describe a malformed remote payload. The same errors for a payload
+            // produced by our configured EL indicate a local invariant or compatibility failure.
+            RpcError::ErrorResp(response)
+                if response.code == ErrorPayload::<()>::invalid_params().code ||
+                    response.code == TOO_LARGE_REQUEST_ERROR =>
+            {
+                if self.origin.is_remote() {
+                    EngineTaskErrorSeverity::Drop
+                } else {
+                    EngineTaskErrorSeverity::Critical
+                }
+            }
+            // These indicate a client or EL capability mismatch, not a bad individual payload.
+            RpcError::ErrorResp(response)
+                if response.code == ErrorPayload::<()>::invalid_request().code ||
+                    response.code == ErrorPayload::<()>::method_not_found().code ||
+                    response.code == UNSUPPORTED_FORK_ERROR =>
+            {
+                EngineTaskErrorSeverity::Critical
+            }
+            RpcError::UnsupportedFeature(_) |
+            RpcError::LocalUsageError(_) |
+            RpcError::SerError(_) => EngineTaskErrorSeverity::Critical,
+            RpcError::Transport(error) if error.is_non_retryable() => {
+                EngineTaskErrorSeverity::Critical
+            }
+            _ => EngineTaskErrorSeverity::Temporary,
+        }
+    }
+}
+
+impl EngineTaskError for InsertTaskError {
+    fn severity(&self) -> EngineTaskErrorSeverity {
+        match &self.kind {
+            InsertTaskErrorKind::FromBlockError(_) |
+            InsertTaskErrorKind::UnexpectedPayloadVersion(_) |
+            InsertTaskErrorKind::L2BlockInfoConstruction(_) => {
+                if self.origin.is_remote() {
+                    EngineTaskErrorSeverity::Drop
+                } else {
+                    EngineTaskErrorSeverity::Critical
+                }
+            }
+            InsertTaskErrorKind::InsertFailed(error) => self.insert_failed_severity(error),
+            InsertTaskErrorKind::UnexpectedPayloadStatus(status)
+                if self.origin.is_remote() && status.is_invalid() =>
+            {
+                EngineTaskErrorSeverity::Drop
+            }
+            InsertTaskErrorKind::UnexpectedPayloadStatus(_) => EngineTaskErrorSeverity::Temporary,
+            InsertTaskErrorKind::ForkchoiceUpdateFailed(inner) => inner.severity(),
+        }
+    }
+}
+
+/// The underlying cause of an [`InsertTaskError`].
+#[derive(Debug, thiserror::Error)]
+pub enum InsertTaskErrorKind {
     /// Error converting a payload into a block.
     #[error(transparent)]
     FromBlockError(#[from] OpPayloadError),
     /// Failed to insert new payload.
     #[error("Failed to insert new payload: {0}")]
     InsertFailed(RpcError<TransportErrorKind>),
-    /// Unexpected payload status
+    /// Unexpected payload status.
     #[error("Unexpected payload status: {0}")]
     UnexpectedPayloadStatus(PayloadStatusEnum),
+    /// The payload envelope version does not match the fork active at its timestamp.
+    #[error(transparent)]
+    UnexpectedPayloadVersion(#[from] ExecutionPayloadEnvelopeVersionError),
     /// Error converting the payload + chain genesis into an L2 block info.
     #[error(transparent)]
     L2BlockInfoConstruction(#[from] FromBlockError),
     /// The forkchoice update call to consolidate the block into the engine state failed.
     #[error(transparent)]
     ForkchoiceUpdateFailed(#[from] SynchronizeTaskError),
-}
-
-impl EngineTaskError for InsertTaskError {
-    fn severity(&self) -> EngineTaskErrorSeverity {
-        match self {
-            Self::FromBlockError(_) | Self::L2BlockInfoConstruction(_) => {
-                EngineTaskErrorSeverity::Critical
-            }
-            Self::InsertFailed(_) | Self::UnexpectedPayloadStatus(_) => {
-                EngineTaskErrorSeverity::Temporary
-            }
-            Self::ForkchoiceUpdateFailed(inner) => inner.severity(),
-        }
-    }
 }

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/insert/mod.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/insert/mod.rs
@@ -4,4 +4,4 @@ mod task;
 pub use task::InsertTask;
 
 mod error;
-pub use error::InsertTaskError;
+pub use error::{InsertTaskError, InsertTaskErrorKind, PayloadEnvelopeOrigin};

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/insert/task.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/insert/task.rs
@@ -73,7 +73,8 @@ impl<EngineClient_: EngineClient> EngineTaskExt for InsertTask<EngineClient_> {
             }
         };
 
-        // Check the `engine_newPayload` response.
+        // Check the `engine_newPayload` response before decoding transactions locally. The
+        // execution layer's terminal response takes precedence for externally supplied payloads.
         let response = match response {
             Ok(resp) => resp,
             Err(e) => {
@@ -84,6 +85,8 @@ impl<EngineClient_: EngineClient> EngineTaskExt for InsertTask<EngineClient_> {
         if !self.check_new_payload_status(&response.status) {
             return Err(InsertTaskError::UnexpectedPayloadStatus(response.status));
         }
+
+        let block: OpBlock = payload.try_into_block().map_err(InsertTaskError::FromBlockError)?;
         let insert_duration = insert_time_start.elapsed();
 
         let block: OpBlock = payload.try_into_block().map_err(InsertTaskError::FromBlockError)?;
@@ -118,5 +121,50 @@ impl<EngineClient_: EngineClient> EngineTaskExt for InsertTask<EngineClient_> {
         );
 
         Ok(new_unsafe_ref)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::{TestEngineStateBuilder, test_engine_client_builder};
+    use alloy_primitives::Bytes;
+    use alloy_rpc_types_engine::{ExecutionPayloadV1, PayloadStatus};
+
+    #[tokio::test]
+    async fn invalid_status_precedes_local_transaction_decoding() {
+        let config = Arc::new(RollupConfig::default());
+        let client = test_engine_client_builder()
+            .with_config(config.clone())
+            .with_new_payload_v1_response(PayloadStatus {
+                status: PayloadStatusEnum::Invalid {
+                    validation_error: "invalid transaction".to_string(),
+                },
+                latest_valid_hash: None,
+            })
+            .build();
+        let payload = OpExecutionPayloadEnvelope::V1(ExecutionPayloadV1 {
+            parent_hash: Default::default(),
+            fee_recipient: Default::default(),
+            state_root: Default::default(),
+            receipts_root: Default::default(),
+            logs_bloom: Default::default(),
+            prev_randao: Default::default(),
+            block_number: 1,
+            gas_limit: 0,
+            gas_used: 0,
+            timestamp: 2,
+            extra_data: Default::default(),
+            base_fee_per_gas: Default::default(),
+            block_hash: Default::default(),
+            transactions: vec![Bytes::from_static(&[0xff])],
+        });
+        let task = InsertTask::new(Arc::new(client), config, payload, false);
+        let mut state = TestEngineStateBuilder::new().build();
+
+        assert!(matches!(
+            task.execute(&mut state).await,
+            Err(InsertTaskError::UnexpectedPayloadStatus(PayloadStatusEnum::Invalid { .. }))
+        ));
     }
 }

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/insert/task.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/insert/task.rs
@@ -1,8 +1,9 @@
 //! A task to insert an unsafe payload into the execution engine.
 
 use crate::{
-    EngineClient, EngineState, EngineTaskExt, InsertTaskError, SynchronizeTask,
-    state::EngineSyncStateUpdate,
+    EngineClient, EngineState, EngineTaskExt, InsertTaskError, InsertTaskErrorKind,
+    PayloadEnvelopeOrigin, SynchronizeTask, state::EngineSyncStateUpdate,
+    validate_execution_payload_envelope_version,
 };
 use alloy_rpc_types_engine::{ExecutionPayloadInputV2, PayloadStatusEnum};
 use async_trait::async_trait;
@@ -21,20 +22,24 @@ pub struct InsertTask<EngineClient_: EngineClient> {
     rollup_config: Arc<RollupConfig>,
     /// The complete execution payload envelope.
     payload: OpExecutionPayloadEnvelope,
-    /// If the payload is safe this is true.
-    /// A payload is safe if it is derived from a safe block.
-    is_payload_safe: bool,
+    /// Whether the payload was derived from L1, locally sequenced, or remotely received.
+    origin: PayloadEnvelopeOrigin,
 }
 
 impl<EngineClient_: EngineClient> InsertTask<EngineClient_> {
-    /// Creates a new insert task.
+    /// Creates a task for a payload with an explicit origin.
     pub const fn new(
         client: Arc<EngineClient_>,
         rollup_config: Arc<RollupConfig>,
         payload: OpExecutionPayloadEnvelope,
-        is_attributes_derived: bool,
+        origin: PayloadEnvelopeOrigin,
     ) -> Self {
-        Self { client, rollup_config, payload, is_payload_safe: is_attributes_derived }
+        Self { client, rollup_config, payload, origin }
+    }
+
+    /// Wraps an underlying failure with this payload's origin.
+    fn error(&self, kind: impl Into<InsertTaskErrorKind>) -> InsertTaskError {
+        InsertTaskError::new(self.origin, kind.into())
     }
 
     /// Checks the response of the `engine_newPayload` call.
@@ -50,6 +55,9 @@ impl<EngineClient_: EngineClient> EngineTaskExt for InsertTask<EngineClient_> {
     type Error = InsertTaskError;
 
     async fn execute(&self, state: &mut EngineState) -> Result<L2BlockInfo, InsertTaskError> {
+        validate_execution_payload_envelope_version(&self.rollup_config, &self.payload)
+            .map_err(|error| self.error(error))?;
+
         let time_start = Instant::now();
 
         // Insert the new payload.
@@ -79,20 +87,19 @@ impl<EngineClient_: EngineClient> EngineTaskExt for InsertTask<EngineClient_> {
             Ok(resp) => resp,
             Err(e) => {
                 warn!(target: "engine", "Failed to insert new payload: {e}");
-                return Err(InsertTaskError::InsertFailed(e));
+                return Err(self.error(InsertTaskErrorKind::InsertFailed(e)));
             }
         };
         if !self.check_new_payload_status(&response.status) {
-            return Err(InsertTaskError::UnexpectedPayloadStatus(response.status));
+            return Err(self.error(InsertTaskErrorKind::UnexpectedPayloadStatus(response.status)));
         }
 
-        let block: OpBlock = payload.try_into_block().map_err(InsertTaskError::FromBlockError)?;
         let insert_duration = insert_time_start.elapsed();
 
-        let block: OpBlock = payload.try_into_block().map_err(InsertTaskError::FromBlockError)?;
+        let block: OpBlock = payload.try_into_block().map_err(|error| self.error(error))?;
         let new_unsafe_ref =
             L2BlockInfo::from_block_and_genesis(&block, &self.rollup_config.genesis)
-                .map_err(InsertTaskError::L2BlockInfoConstruction)?;
+                .map_err(|error| self.error(InsertTaskErrorKind::L2BlockInfoConstruction(error)))?;
 
         // Send a FCU to canonicalize the imported block.
         SynchronizeTask::new(
@@ -101,13 +108,14 @@ impl<EngineClient_: EngineClient> EngineTaskExt for InsertTask<EngineClient_> {
             EngineSyncStateUpdate {
                 cross_unsafe_head: Some(new_unsafe_ref),
                 unsafe_head: Some(new_unsafe_ref),
-                local_safe_head: self.is_payload_safe.then_some(new_unsafe_ref),
-                safe_head: self.is_payload_safe.then_some(new_unsafe_ref),
+                local_safe_head: self.origin.is_safe().then_some(new_unsafe_ref),
+                safe_head: self.origin.is_safe().then_some(new_unsafe_ref),
                 ..Default::default()
             },
         )
         .execute(state)
-        .await?;
+        .await
+        .map_err(|error| self.error(error))?;
 
         let total_duration = time_start.elapsed();
 
@@ -127,9 +135,53 @@ impl<EngineClient_: EngineClient> EngineTaskExt for InsertTask<EngineClient_> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::{TestEngineStateBuilder, test_engine_client_builder};
+    use crate::{
+        ExecutionPayloadEnvelopeVersion,
+        test_utils::{TestEngineStateBuilder, test_engine_client_builder},
+    };
     use alloy_primitives::Bytes;
     use alloy_rpc_types_engine::{ExecutionPayloadV1, PayloadStatus};
+    use kona_genesis::HardForkConfig;
+
+    #[test]
+    fn rejects_payload_version_mismatch_before_engine_call() {
+        let config = Arc::new(RollupConfig {
+            hardforks: HardForkConfig { canyon_time: Some(0), ..Default::default() },
+            ..Default::default()
+        });
+        let client = test_engine_client_builder().with_config(config.clone()).build();
+        let payload = OpExecutionPayloadEnvelope::V1(ExecutionPayloadV1 {
+            parent_hash: Default::default(),
+            fee_recipient: Default::default(),
+            state_root: Default::default(),
+            receipts_root: Default::default(),
+            logs_bloom: Default::default(),
+            prev_randao: Default::default(),
+            block_number: 1,
+            gas_limit: 0,
+            gas_used: 0,
+            timestamp: 2,
+            extra_data: Default::default(),
+            base_fee_per_gas: Default::default(),
+            block_hash: Default::default(),
+            transactions: Vec::new(),
+        });
+        let task = InsertTask::new(
+            Arc::new(client),
+            config.clone(),
+            payload,
+            PayloadEnvelopeOrigin::RemoteSequencer,
+        );
+
+        assert!(matches!(
+            validate_execution_payload_envelope_version(&config, &task.payload),
+            Err(crate::ExecutionPayloadEnvelopeVersionError {
+                actual: ExecutionPayloadEnvelopeVersion::V1,
+                expected: ExecutionPayloadEnvelopeVersion::V2,
+                timestamp: 2,
+            })
+        ));
+    }
 
     #[tokio::test]
     async fn invalid_status_precedes_local_transaction_decoding() {
@@ -159,12 +211,23 @@ mod tests {
             block_hash: Default::default(),
             transactions: vec![Bytes::from_static(&[0xff])],
         });
-        let task = InsertTask::new(Arc::new(client), config, payload, false);
+        let task = InsertTask::new(
+            Arc::new(client),
+            config,
+            payload,
+            PayloadEnvelopeOrigin::RemoteSequencer,
+        );
         let mut state = TestEngineStateBuilder::new().build();
 
         assert!(matches!(
             task.execute(&mut state).await,
-            Err(InsertTaskError::UnexpectedPayloadStatus(PayloadStatusEnum::Invalid { .. }))
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    InsertTaskErrorKind::UnexpectedPayloadStatus(
+                        PayloadStatusEnum::Invalid { .. }
+                    )
+                )
         ));
     }
 }

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/mod.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/mod.rs
@@ -9,7 +9,7 @@ mod synchronize;
 pub use synchronize::{SynchronizeTask, SynchronizeTaskError};
 
 mod insert;
-pub use insert::{InsertTask, InsertTaskError};
+pub use insert::{InsertTask, InsertTaskError, InsertTaskErrorKind, PayloadEnvelopeOrigin};
 
 mod build;
 pub use build::{BuildTask, BuildTaskError, EngineBuildError};

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/seal/task.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/seal/task.rs
@@ -2,8 +2,7 @@
 use super::SealTaskError;
 use crate::{
     EngineClient, EngineGetPayloadVersion, EngineState, EngineTaskExt, InsertTask,
-    InsertTaskError::{self},
-    task_queue::build_and_seal,
+    InsertTaskErrorKind, PayloadEnvelopeOrigin, task_queue::build_and_seal,
 };
 use alloy_rpc_types_engine::{ExecutionPayload, PayloadId};
 use async_trait::async_trait;
@@ -138,27 +137,34 @@ impl<EngineClient_: EngineClient> SealTask<EngineClient_> {
         payload: OpExecutionPayloadEnvelope,
     ) -> Result<L2BlockInfo, SealTaskError> {
         // Insert the new block into the engine.
+        let origin = if self.is_attributes_derived {
+            PayloadEnvelopeOrigin::L1Derived
+        } else {
+            PayloadEnvelopeOrigin::LocalSequencer
+        };
         let new_block_ref = match InsertTask::new(
             Arc::clone(&self.engine),
             self.cfg.clone(),
             payload,
-            self.is_attributes_derived,
+            origin,
         )
         .execute(state)
         .await
         {
-            Err(InsertTaskError::UnexpectedPayloadStatus(e))
-                if self.attributes.is_deposits_only() =>
+            Err(error)
+                if matches!(error.kind(), InsertTaskErrorKind::UnexpectedPayloadStatus(_)) &&
+                    self.attributes.is_deposits_only() =>
             {
-                error!(target: "engine", error = ?e, "Critical: Deposit-only payload import failed");
+                error!(target: "engine", ?error, "Critical: Deposit-only payload import failed");
                 return Err(SealTaskError::DepositOnlyPayloadFailed);
             }
-            Err(InsertTaskError::UnexpectedPayloadStatus(e))
-                if self.cfg.is_holocene_active(
-                    self.attributes.attributes().payload_attributes.timestamp,
-                ) =>
+            Err(error)
+                if matches!(error.kind(), InsertTaskErrorKind::UnexpectedPayloadStatus(_)) &&
+                    self.cfg.is_holocene_active(
+                        self.attributes.attributes().payload_attributes.timestamp,
+                    ) =>
             {
-                warn!(target: "engine", error = ?e, "Re-attempting payload import with deposits only.");
+                warn!(target: "engine", ?error, "Re-attempting payload import with deposits only.");
 
                 // HOLOCENE: Re-attempt payload import with deposits only
                 // First build the deposits-only payload, then seal it

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/task.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/task.rs
@@ -8,7 +8,6 @@ use crate::{
     InsertTaskError,
     task_queue::{SealTask, SealTaskError},
 };
-use alloy_rpc_types_engine::PayloadStatusEnum;
 use async_trait::async_trait;
 use derive_more::Display;
 use std::cmp::Ordering;
@@ -23,6 +22,9 @@ pub enum EngineTaskErrorSeverity {
     /// The error is temporary and the task is retried.
     #[display("temporary")]
     Temporary,
+    /// The task should be dropped.
+    #[display("drop")]
+    Drop,
     /// The error is critical and is propagated to the engine actor.
     #[display("critical")]
     Critical,
@@ -111,17 +113,9 @@ impl<EngineClient_: EngineClient> EngineTask<EngineClient_> {
     /// Executes the task without consuming it.
     async fn execute_inner(&self, state: &mut EngineState) -> Result<(), EngineTaskErrors> {
         match self {
-            Self::Insert(task) => match task.execute(state).await {
-                // INVALID is terminal for an externally sourced unsafe payload. Drop it so the
-                // queue can process competing or subsequent payloads instead of retrying forever.
-                Err(InsertTaskError::UnexpectedPayloadStatus(
-                    status @ PayloadStatusEnum::Invalid { .. },
-                )) => {
-                    warn!(target: "engine", %status, "Dropping invalid unsafe payload");
-                }
-                Err(err) => return Err(err.into()),
-                Ok(_) => {}
-            },
+            Self::Insert(task) => {
+                task.execute(state).await?;
+            }
             Self::Seal(task) => task.execute(state).await?,
             Self::Consolidate(task) => task.execute(state).await?,
             Self::Finalize(task) => task.execute(state).await?,
@@ -212,7 +206,6 @@ impl<EngineClient_: EngineClient> EngineTaskExt for EngineTask<EngineClient_> {
     type Error = EngineTaskErrors;
 
     async fn execute(&self, state: &mut EngineState) -> Result<(), Self::Error> {
-        // Retry the task until it succeeds or a critical error occurs.
         while let Err(e) = self.execute_inner(state).await {
             let severity = e.severity();
 
@@ -228,6 +221,10 @@ impl<EngineClient_: EngineClient> EngineTaskExt for EngineTask<EngineClient_> {
 
                     // Yield the task to allow other tasks to execute to avoid starvation.
                     yield_now().await;
+                }
+                EngineTaskErrorSeverity::Drop => {
+                    warn!(target: "engine", "Dropping permanently invalid engine task: {e}");
+                    return Err(e);
                 }
                 EngineTaskErrorSeverity::Critical => {
                     error!(target: "engine", "{e}");
@@ -253,17 +250,37 @@ impl<EngineClient_: EngineClient> EngineTaskExt for EngineTask<EngineClient_> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::MockEngineClient;
+    use crate::{
+        ExecutionPayloadEnvelopeVersion, ExecutionPayloadEnvelopeVersionError, InsertTaskErrorKind,
+        PayloadEnvelopeOrigin, test_utils::MockEngineClient,
+    };
     use alloy_consensus::Block;
+    use alloy_json_rpc::ErrorPayload;
     use alloy_primitives::Bytes;
-    use alloy_rpc_types_engine::{ExecutionPayloadV1, PayloadStatus};
+    use alloy_rpc_types_engine::{ExecutionPayloadV1, PayloadStatus, PayloadStatusEnum};
+    use alloy_transport::{RpcError, TransportErrorKind};
     use kona_genesis::RollupConfig;
     use op_alloy_consensus::OpTxEnvelope;
     use op_alloy_rpc_types_engine::OpExecutionPayloadEnvelope;
     use std::{sync::Arc, time::Duration};
 
+    fn insert_error(origin: PayloadEnvelopeOrigin, kind: InsertTaskErrorKind) -> InsertTaskError {
+        InsertTaskError::new(origin, kind)
+    }
+
+    fn rpc_error(origin: PayloadEnvelopeOrigin, code: i64) -> InsertTaskError {
+        insert_error(
+            origin,
+            InsertTaskErrorKind::InsertFailed(RpcError::ErrorResp(ErrorPayload {
+                code,
+                message: "test error".into(),
+                data: None,
+            })),
+        )
+    }
+
     #[tokio::test]
-    async fn invalid_unsafe_payload_completes_without_retry() {
+    async fn invalid_remote_payload_returns_drop_without_retry() {
         let config = Arc::new(RollupConfig::default());
         let client = Arc::new(
             MockEngineClient::builder()
@@ -279,12 +296,133 @@ mod tests {
             client,
             config,
             OpExecutionPayloadEnvelope::V1(payload),
-            false,
+            PayloadEnvelopeOrigin::RemoteSequencer,
         )));
 
-        tokio::time::timeout(Duration::from_secs(1), task.execute(&mut EngineState::default()))
-            .await
-            .expect("invalid unsafe payload task should not retry")
-            .unwrap();
+        let error =
+            tokio::time::timeout(Duration::from_secs(1), task.execute(&mut EngineState::default()))
+                .await
+                .expect("invalid remote payload task should not retry")
+                .expect_err("invalid remote payload should be dropped");
+        assert_eq!(error.severity(), EngineTaskErrorSeverity::Drop);
+    }
+
+    #[test]
+    fn payload_origin_controls_payload_specific_error_severity() {
+        let invalid_status = || {
+            InsertTaskErrorKind::UnexpectedPayloadStatus(PayloadStatusEnum::Invalid {
+                validation_error: "invalid state root".to_string(),
+            })
+        };
+        assert_eq!(
+            insert_error(PayloadEnvelopeOrigin::RemoteSequencer, invalid_status()).severity(),
+            EngineTaskErrorSeverity::Drop
+        );
+        for local_origin in
+            [PayloadEnvelopeOrigin::L1Derived, PayloadEnvelopeOrigin::LocalSequencer]
+        {
+            assert_eq!(
+                insert_error(local_origin, invalid_status()).severity(),
+                EngineTaskErrorSeverity::Temporary
+            );
+        }
+
+        let invalid_version = || {
+            InsertTaskErrorKind::UnexpectedPayloadVersion(ExecutionPayloadEnvelopeVersionError {
+                actual: ExecutionPayloadEnvelopeVersion::V3,
+                expected: ExecutionPayloadEnvelopeVersion::V4,
+                timestamp: 10,
+            })
+        };
+        assert_eq!(
+            insert_error(PayloadEnvelopeOrigin::RemoteSequencer, invalid_version()).severity(),
+            EngineTaskErrorSeverity::Drop
+        );
+        for local_origin in
+            [PayloadEnvelopeOrigin::L1Derived, PayloadEnvelopeOrigin::LocalSequencer]
+        {
+            assert_eq!(
+                insert_error(local_origin, invalid_version()).severity(),
+                EngineTaskErrorSeverity::Critical
+            );
+        }
+
+        for code in [ErrorPayload::<()>::invalid_params().code, -38004] {
+            assert_eq!(
+                rpc_error(PayloadEnvelopeOrigin::RemoteSequencer, code).severity(),
+                EngineTaskErrorSeverity::Drop,
+                "remote payload-specific RPC error {code} should be dropped"
+            );
+            for local_origin in
+                [PayloadEnvelopeOrigin::L1Derived, PayloadEnvelopeOrigin::LocalSequencer]
+            {
+                assert_eq!(
+                    rpc_error(local_origin, code).severity(),
+                    EngineTaskErrorSeverity::Critical,
+                    "local payload-specific RPC error {code} should be critical"
+                );
+            }
+        }
+
+        assert_eq!(
+            insert_error(
+                PayloadEnvelopeOrigin::RemoteSequencer,
+                InsertTaskErrorKind::UnexpectedPayloadStatus(PayloadStatusEnum::Accepted),
+            )
+            .severity(),
+            EngineTaskErrorSeverity::Temporary
+        );
+    }
+
+    #[test]
+    fn surfaces_client_and_el_capability_errors_as_critical() {
+        for code in [
+            ErrorPayload::<()>::invalid_request().code,
+            ErrorPayload::<()>::method_not_found().code,
+            -38005,
+        ] {
+            assert_eq!(
+                rpc_error(PayloadEnvelopeOrigin::RemoteSequencer, code).severity(),
+                EngineTaskErrorSeverity::Critical,
+                "client or EL capability error {code} should be critical"
+            );
+        }
+
+        let capability_errors = [
+            RpcError::UnsupportedFeature("test"),
+            RpcError::<TransportErrorKind>::local_usage_str("test"),
+            RpcError::SerError(
+                serde_json::from_str::<serde_json::Value>("{").expect_err("invalid JSON"),
+            ),
+            TransportErrorKind::non_retryable_str("test"),
+        ];
+        for error in capability_errors {
+            assert_eq!(
+                insert_error(
+                    PayloadEnvelopeOrigin::RemoteSequencer,
+                    InsertTaskErrorKind::InsertFailed(error),
+                )
+                .severity(),
+                EngineTaskErrorSeverity::Critical
+            );
+        }
+    }
+
+    #[test]
+    fn retries_transient_rpc_errors() {
+        assert_eq!(
+            rpc_error(PayloadEnvelopeOrigin::RemoteSequencer, -32603).severity(),
+            EngineTaskErrorSeverity::Temporary
+        );
+        assert_eq!(
+            insert_error(
+                PayloadEnvelopeOrigin::RemoteSequencer,
+                InsertTaskErrorKind::InsertFailed(RpcError::Transport(
+                    TransportErrorKind::BackendGone,
+                )),
+            )
+            .severity(),
+            EngineTaskErrorSeverity::Temporary
+        );
     }
 }

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/task.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/task.rs
@@ -12,7 +12,6 @@ use async_trait::async_trait;
 use derive_more::Display;
 use std::cmp::Ordering;
 use thiserror::Error;
-use tokio::task::yield_now;
 
 /// The severity of an engine task error.
 ///
@@ -206,44 +205,37 @@ impl<EngineClient_: EngineClient> EngineTaskExt for EngineTask<EngineClient_> {
     type Error = EngineTaskErrors;
 
     async fn execute(&self, state: &mut EngineState) -> Result<(), Self::Error> {
-        while let Err(e) = self.execute_inner(state).await {
-            let severity = e.severity();
-
+        let Err(error) = self.execute_inner(state).await else {
             kona_macros::inc!(
                 counter,
-                crate::Metrics::ENGINE_TASK_FAILURE,
-                self.task_metrics_label() => severity.to_string()
+                crate::Metrics::ENGINE_TASK_SUCCESS,
+                self.task_metrics_label()
             );
+            return Ok(());
+        };
+        let severity = error.severity();
 
-            match severity {
-                EngineTaskErrorSeverity::Temporary => {
-                    trace!(target: "engine", "{e}");
+        kona_macros::inc!(
+            counter,
+            crate::Metrics::ENGINE_TASK_FAILURE,
+            self.task_metrics_label() => severity.to_string()
+        );
 
-                    // Yield the task to allow other tasks to execute to avoid starvation.
-                    yield_now().await;
-                }
-                EngineTaskErrorSeverity::Drop => {
-                    warn!(target: "engine", "Dropping permanently invalid engine task: {e}");
-                    return Err(e);
-                }
-                EngineTaskErrorSeverity::Critical => {
-                    error!(target: "engine", "{e}");
-                    return Err(e);
-                }
-                EngineTaskErrorSeverity::Reset => {
-                    warn!(target: "engine", "Engine requested derivation reset");
-                    return Err(e);
-                }
-                EngineTaskErrorSeverity::Flush => {
-                    warn!(target: "engine", "Engine requested derivation flush");
-                    return Err(e);
-                }
+        match severity {
+            EngineTaskErrorSeverity::Temporary => trace!(target: "engine", "{error}"),
+            EngineTaskErrorSeverity::Drop => {
+                warn!(target: "engine", "Dropping permanently invalid engine task: {error}")
+            }
+            EngineTaskErrorSeverity::Critical => error!(target: "engine", "{error}"),
+            EngineTaskErrorSeverity::Reset => {
+                warn!(target: "engine", "Engine requested derivation reset")
+            }
+            EngineTaskErrorSeverity::Flush => {
+                warn!(target: "engine", "Engine requested derivation flush")
             }
         }
 
-        kona_macros::inc!(counter, crate::Metrics::ENGINE_TASK_SUCCESS, self.task_metrics_label());
-
-        Ok(())
+        Err(error)
     }
 }
 

--- a/rust/kona/crates/node/engine/src/test_utils/engine_client.rs
+++ b/rust/kona/crates/node/engine/src/test_utils/engine_client.rs
@@ -2,6 +2,7 @@
 
 use crate::{EngineClient, HyperAuthClient};
 use alloy_eips::{BlockId, eip1898::BlockNumberOrTag};
+use alloy_json_rpc::{ErrorPayload, RpcError};
 use alloy_network::{Ethereum, Network};
 use alloy_primitives::{Address, B256, BlockHash, StorageKey};
 use alloy_provider::{EthGetBlock, ProviderCall, RpcWithBlock};
@@ -23,7 +24,10 @@ use op_alloy_rpc_types_engine::{
     OpExecutionPayloadEnvelopeV3, OpExecutionPayloadEnvelopeV4, OpExecutionPayloadV4,
     OpPayloadAttributes,
 };
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::{HashMap, VecDeque},
+    sync::Arc,
+};
 use tokio::sync::RwLock;
 
 use crate::EngineClientError;
@@ -31,6 +35,28 @@ use crate::EngineClientError;
 /// Builder for creating test `MockEngineClient` instances with sensible defaults
 pub fn test_engine_client_builder() -> MockEngineClientBuilder {
     MockEngineClientBuilder::new().with_config(Arc::new(RollupConfig::default()))
+}
+
+/// A scripted response to an `engine_newPayload` call.
+#[derive(Debug, Clone)]
+pub enum MockNewPayloadResponse {
+    /// Return the payload status.
+    Status(PayloadStatus),
+    /// Return a JSON-RPC error response.
+    RpcError(ErrorPayload),
+    /// Return a transport error.
+    TransportError(String),
+}
+
+/// Engine API mutation observed by [`MockEngineClient`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MockEngineCall {
+    /// An `engine_newPayload` call for the given payload hash.
+    NewPayload(B256),
+    /// An `engine_forkchoiceUpdated` call for the given head hash.
+    ForkchoiceUpdated(B256),
+    /// An `engine_getPayload` call for the given payload ID.
+    GetPayload(PayloadId),
 }
 
 /// Mock storage for engine client responses.
@@ -53,6 +79,10 @@ pub struct MockEngineStorage {
     pub new_payload_v3_response: Option<PayloadStatus>,
     /// Storage for `new_payload_v4` responses.
     pub new_payload_v4_response: Option<PayloadStatus>,
+    /// Scripted responses shared by all `newPayload` versions.
+    pub new_payload_responses: VecDeque<MockNewPayloadResponse>,
+    /// Recorded Engine API mutation calls.
+    pub calls: Vec<MockEngineCall>,
 
     // Version-specific fork_choice_updated responses
     /// Storage for `fork_choice_updated_v2` responses.
@@ -166,6 +196,15 @@ impl MockEngineClientBuilder {
     /// Sets the `new_payload_v4` response.
     pub fn with_new_payload_v4_response(mut self, status: PayloadStatus) -> Self {
         self.storage.new_payload_v4_response = Some(status);
+        self
+    }
+
+    /// Sets ordered responses shared by all `newPayload` versions.
+    pub fn with_new_payload_responses(
+        mut self,
+        responses: impl IntoIterator<Item = MockNewPayloadResponse>,
+    ) -> Self {
+        self.storage.new_payload_responses = responses.into_iter().collect();
         self
     }
 
@@ -302,6 +341,19 @@ impl MockEngineClient {
         Arc::clone(&self.storage)
     }
 
+    /// Returns the recorded Engine API mutation calls.
+    pub async fn calls(&self) -> Vec<MockEngineCall> {
+        self.storage.read().await.calls.clone()
+    }
+
+    /// Sets ordered responses shared by all `newPayload` versions.
+    pub async fn set_new_payload_responses(
+        &self,
+        responses: impl IntoIterator<Item = MockNewPayloadResponse>,
+    ) {
+        self.storage.write().await.new_payload_responses = responses.into_iter().collect();
+    }
+
     /// Sets a block response for a specific tag.
     pub async fn set_l2_block_by_label(&self, tag: BlockNumberOrTag, block: Block<OpTransaction>) {
         self.storage.write().await.l2_blocks_by_label.insert(tag, block);
@@ -399,6 +451,28 @@ impl MockEngineClient {
         let key = block_id_to_key(&block_id);
         self.storage.write().await.proofs_by_address.insert((address, key), proof);
     }
+
+    async fn new_payload_response(
+        &self,
+        block_hash: B256,
+        fallback: impl FnOnce(&MockEngineStorage) -> Option<PayloadStatus>,
+        method: &'static str,
+    ) -> TransportResult<PayloadStatus> {
+        let mut storage = self.storage.write().await;
+        storage.calls.push(MockEngineCall::NewPayload(block_hash));
+        match storage.new_payload_responses.pop_front() {
+            Some(MockNewPayloadResponse::Status(status)) => Ok(status),
+            Some(MockNewPayloadResponse::RpcError(error)) => Err(RpcError::ErrorResp(error)),
+            Some(MockNewPayloadResponse::TransportError(error)) => {
+                Err(TransportErrorKind::custom_str(&error))
+            }
+            None => fallback(&storage).ok_or_else(|| {
+                TransportError::from(TransportErrorKind::custom_str(&format!(
+                    "{method} was called but no response configured"
+                )))
+            }),
+        }
+    }
 }
 
 #[async_trait]
@@ -469,14 +543,13 @@ impl EngineClient for MockEngineClient {
         })
     }
 
-    async fn new_payload_v1(&self, _payload: ExecutionPayloadV1) -> TransportResult<PayloadStatus> {
-        let storage = self.storage.read().await;
-        storage.new_payload_v1_response.clone().ok_or_else(|| {
-            TransportError::from(TransportErrorKind::custom_str(
-                "new_payload_v1 was called but no v1 response configured. \
-                 Use with_new_payload_v1_response() or set_new_payload_v1_response() to set a response."
-            ))
-        })
+    async fn new_payload_v1(&self, payload: ExecutionPayloadV1) -> TransportResult<PayloadStatus> {
+        self.new_payload_response(
+            payload.block_hash,
+            |storage| storage.new_payload_v1_response.clone(),
+            "new_payload_v1",
+        )
+        .await
     }
 
     async fn l2_block_by_label(
@@ -500,51 +573,49 @@ impl EngineClient for MockEngineClient {
 impl OpEngineApi<Optimism, Http<HyperAuthClient>> for MockEngineClient {
     async fn new_payload_v2(
         &self,
-        _payload: ExecutionPayloadInputV2,
+        payload: ExecutionPayloadInputV2,
     ) -> TransportResult<PayloadStatus> {
-        let storage = self.storage.read().await;
-        storage.new_payload_v2_response.clone().ok_or_else(|| {
-            TransportError::from(TransportErrorKind::custom_str(
-                "new_payload_v2 was called but no v2 response configured. \
-                 Use with_new_payload_v2_response() or set_new_payload_v2_response() to set a response."
-            ))
-        })
+        self.new_payload_response(
+            payload.execution_payload.block_hash,
+            |storage| storage.new_payload_v2_response.clone(),
+            "new_payload_v2",
+        )
+        .await
     }
 
     async fn new_payload_v3(
         &self,
-        _payload: ExecutionPayloadV3,
+        payload: ExecutionPayloadV3,
         _parent_beacon_block_root: B256,
     ) -> TransportResult<PayloadStatus> {
-        let storage = self.storage.read().await;
-        storage.new_payload_v3_response.clone().ok_or_else(|| {
-            TransportError::from(TransportErrorKind::custom_str(
-                "new_payload_v3 was called but no v3 response configured. \
-                 Use with_new_payload_v3_response() or set_new_payload_v3_response() to set a response."
-            ))
-        })
+        self.new_payload_response(
+            payload.payload_inner.payload_inner.block_hash,
+            |storage| storage.new_payload_v3_response.clone(),
+            "new_payload_v3",
+        )
+        .await
     }
 
     async fn new_payload_v4(
         &self,
-        _payload: OpExecutionPayloadV4,
+        payload: OpExecutionPayloadV4,
         _parent_beacon_block_root: B256,
     ) -> TransportResult<PayloadStatus> {
-        let storage = self.storage.read().await;
-        storage.new_payload_v4_response.clone().ok_or_else(|| {
-            TransportError::from(TransportErrorKind::custom_str(
-                "new_payload_v4 was called but no v4 response configured. \
-                 Use with_new_payload_v4_response() or set_new_payload_v4_response() to set a response."
-            ))
-        })
+        self.new_payload_response(
+            payload.payload_inner.payload_inner.payload_inner.block_hash,
+            |storage| storage.new_payload_v4_response.clone(),
+            "new_payload_v4",
+        )
+        .await
     }
 
     async fn fork_choice_updated_v2(
         &self,
-        _fork_choice_state: ForkchoiceState,
+        fork_choice_state: ForkchoiceState,
         _payload_attributes: Option<OpPayloadAttributes>,
     ) -> TransportResult<ForkchoiceUpdated> {
-        let storage = self.storage.read().await;
+        let mut storage = self.storage.write().await;
+        storage.calls.push(MockEngineCall::ForkchoiceUpdated(fork_choice_state.head_block_hash));
         storage.fork_choice_updated_v2_response.clone().ok_or_else(|| {
             TransportError::from(TransportErrorKind::custom_str(
                 "fork_choice_updated_v2 was called but no v2 response configured. \
@@ -555,10 +626,11 @@ impl OpEngineApi<Optimism, Http<HyperAuthClient>> for MockEngineClient {
 
     async fn fork_choice_updated_v3(
         &self,
-        _fork_choice_state: ForkchoiceState,
+        fork_choice_state: ForkchoiceState,
         _payload_attributes: Option<OpPayloadAttributes>,
     ) -> TransportResult<ForkchoiceUpdated> {
-        let storage = self.storage.read().await;
+        let mut storage = self.storage.write().await;
+        storage.calls.push(MockEngineCall::ForkchoiceUpdated(fork_choice_state.head_block_hash));
         storage.fork_choice_updated_v3_response.clone().ok_or_else(|| {
             TransportError::from(TransportErrorKind::custom_str(
                 "fork_choice_updated_v3 was called but no v3 response configured. \
@@ -569,9 +641,10 @@ impl OpEngineApi<Optimism, Http<HyperAuthClient>> for MockEngineClient {
 
     async fn get_payload_v2(
         &self,
-        _payload_id: PayloadId,
+        payload_id: PayloadId,
     ) -> TransportResult<ExecutionPayloadEnvelopeV2> {
-        let storage = self.storage.read().await;
+        let mut storage = self.storage.write().await;
+        storage.calls.push(MockEngineCall::GetPayload(payload_id));
         storage.execution_payload_v2.clone().ok_or_else(|| {
             TransportError::from(TransportErrorKind::custom_str(
                 "No execution payload v2 set in mock",
@@ -581,9 +654,10 @@ impl OpEngineApi<Optimism, Http<HyperAuthClient>> for MockEngineClient {
 
     async fn get_payload_v3(
         &self,
-        _payload_id: PayloadId,
+        payload_id: PayloadId,
     ) -> TransportResult<OpExecutionPayloadEnvelopeV3> {
-        let storage = self.storage.read().await;
+        let mut storage = self.storage.write().await;
+        storage.calls.push(MockEngineCall::GetPayload(payload_id));
         storage.execution_payload_v3.clone().ok_or_else(|| {
             TransportError::from(TransportErrorKind::custom_str(
                 "No execution payload v3 set in mock",
@@ -593,9 +667,10 @@ impl OpEngineApi<Optimism, Http<HyperAuthClient>> for MockEngineClient {
 
     async fn get_payload_v4(
         &self,
-        _payload_id: PayloadId,
+        payload_id: PayloadId,
     ) -> TransportResult<OpExecutionPayloadEnvelopeV4> {
-        let storage = self.storage.read().await;
+        let mut storage = self.storage.write().await;
+        storage.calls.push(MockEngineCall::GetPayload(payload_id));
         storage.execution_payload_v4.clone().ok_or_else(|| {
             TransportError::from(TransportErrorKind::custom_str(
                 "No execution payload v4 set in mock",
@@ -605,10 +680,11 @@ impl OpEngineApi<Optimism, Http<HyperAuthClient>> for MockEngineClient {
 
     async fn get_payload_v5(
         &self,
-        _payload_id: PayloadId,
+        payload_id: PayloadId,
     ) -> TransportResult<OpExecutionPayloadEnvelopeV4> {
         // Osaka reuses the V4-shaped envelope; serve the stored V4 payload.
-        let storage = self.storage.read().await;
+        let mut storage = self.storage.write().await;
+        storage.calls.push(MockEngineCall::GetPayload(payload_id));
         storage.execution_payload_v4.clone().ok_or_else(|| {
             TransportError::from(TransportErrorKind::custom_str(
                 "No execution payload v4 set in mock",

--- a/rust/kona/crates/node/engine/src/test_utils/mod.rs
+++ b/rust/kona/crates/node/engine/src/test_utils/mod.rs
@@ -3,7 +3,8 @@ pub use attributes::TestAttributesBuilder;
 
 mod engine_client;
 pub use engine_client::{
-    MockEngineClient, MockEngineClientBuilder, MockEngineStorage, test_engine_client_builder,
+    MockEngineCall, MockEngineClient, MockEngineClientBuilder, MockEngineStorage,
+    MockNewPayloadResponse, test_engine_client_builder,
 };
 
 mod engine_state;

--- a/rust/kona/crates/node/engine/src/versions.rs
+++ b/rust/kona/crates/node/engine/src/versions.rs
@@ -17,7 +17,76 @@
 //! Adapted from the [OP Node version providers](https://github.com/ethereum-optimism/optimism/blob/develop/op-node/rollup/types.go#L546).
 
 use alloy_hardforks::EthereumHardforks;
+use derive_more::Display;
 use kona_genesis::RollupConfig;
+use op_alloy_rpc_types_engine::OpExecutionPayloadEnvelope;
+use thiserror::Error;
+
+/// The structural version of an OP execution payload envelope.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Display)]
+pub enum ExecutionPayloadEnvelopeVersion {
+    /// Pre-Canyon payload envelope.
+    V1,
+    /// Canyon payload envelope.
+    V2,
+    /// Ecotone payload envelope.
+    V3,
+    /// Isthmus payload envelope.
+    V4,
+}
+
+impl ExecutionPayloadEnvelopeVersion {
+    /// Returns the envelope version required by the fork active at `timestamp`.
+    pub fn from_cfg(cfg: &RollupConfig, timestamp: u64) -> Self {
+        if cfg.is_isthmus_active(timestamp) {
+            Self::V4
+        } else if cfg.is_ecotone_active(timestamp) {
+            Self::V3
+        } else if cfg.is_canyon_active(timestamp) {
+            Self::V2
+        } else {
+            Self::V1
+        }
+    }
+
+    /// Returns the structural version of `payload`.
+    pub const fn from_payload(payload: &OpExecutionPayloadEnvelope) -> Self {
+        match payload {
+            OpExecutionPayloadEnvelope::V1(_) => Self::V1,
+            OpExecutionPayloadEnvelope::V2(_) => Self::V2,
+            OpExecutionPayloadEnvelope::V3 { .. } => Self::V3,
+            OpExecutionPayloadEnvelope::V4 { .. } => Self::V4,
+        }
+    }
+}
+
+/// A payload envelope does not match the fork active at its timestamp.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+#[error(
+    "payload version {actual} is invalid at timestamp {timestamp}; expected version {expected}"
+)]
+pub struct ExecutionPayloadEnvelopeVersionError {
+    /// The envelope version supplied by the caller.
+    pub actual: ExecutionPayloadEnvelopeVersion,
+    /// The envelope version required at the payload timestamp.
+    pub expected: ExecutionPayloadEnvelopeVersion,
+    /// The payload timestamp used to select the version.
+    pub timestamp: u64,
+}
+
+/// Validates that a payload envelope matches the fork active at its timestamp.
+pub fn validate_execution_payload_envelope_version(
+    cfg: &RollupConfig,
+    payload: &OpExecutionPayloadEnvelope,
+) -> Result<(), ExecutionPayloadEnvelopeVersionError> {
+    let timestamp = payload.timestamp();
+    let actual = ExecutionPayloadEnvelopeVersion::from_payload(payload);
+    let expected = ExecutionPayloadEnvelopeVersion::from_cfg(cfg, timestamp);
+    if actual != expected {
+        return Err(ExecutionPayloadEnvelopeVersionError { actual, expected, timestamp });
+    }
+    Ok(())
+}
 
 /// Engine API version for `engine_forkchoiceUpdated` method calls.
 ///
@@ -120,6 +189,7 @@ mod tests {
     fn cfg() -> RollupConfig {
         RollupConfig {
             hardforks: HardForkConfig {
+                canyon_time: Some(7),
                 ecotone_time: Some(10),
                 isthmus_time: Some(20),
                 karst_time: Some(30),
@@ -127,6 +197,27 @@ mod tests {
             },
             ..Default::default()
         }
+    }
+
+    #[test]
+    fn envelope_version_selects_by_active_hardfork() {
+        let cfg = cfg();
+        assert_eq!(
+            ExecutionPayloadEnvelopeVersion::from_cfg(&cfg, 5),
+            ExecutionPayloadEnvelopeVersion::V1
+        );
+        assert_eq!(
+            ExecutionPayloadEnvelopeVersion::from_cfg(&cfg, 8),
+            ExecutionPayloadEnvelopeVersion::V2
+        );
+        assert_eq!(
+            ExecutionPayloadEnvelopeVersion::from_cfg(&cfg, 15),
+            ExecutionPayloadEnvelopeVersion::V3
+        );
+        assert_eq!(
+            ExecutionPayloadEnvelopeVersion::from_cfg(&cfg, 25),
+            ExecutionPayloadEnvelopeVersion::V4
+        );
     }
 
     #[test]

--- a/rust/kona/crates/node/rpc/src/admin.rs
+++ b/rust/kona/crates/node/rpc/src/admin.rs
@@ -2,13 +2,14 @@
 
 use crate::{AdminApiServer, SequencerAdminAPIClient};
 use alloy_primitives::B256;
+use alloy_rpc_types_engine::PayloadError;
 use async_trait::async_trait;
 use core::fmt::Debug;
 use jsonrpsee::{
     core::RpcResult,
     types::{ErrorCode, ErrorObject},
 };
-use op_alloy_rpc_types_engine::OpExecutionPayloadEnvelope;
+use op_alloy_rpc_types_engine::{OpExecutionPayloadEnvelope, OpPayloadError};
 
 /// The query types to the network actor for the admin api.
 #[derive(Debug)]
@@ -64,6 +65,24 @@ where
         payload: OpExecutionPayloadEnvelope,
     ) -> RpcResult<()> {
         kona_macros::inc!(gauge, kona_gossip::Metrics::RPC_CALLS, "method" => "admin_postUnsafePayload");
+
+        payload.check_block_hash().map_err(|err| {
+            tracing::warn!(
+                target: "rpc",
+                %err,
+                "admin_postUnsafePayload: rejecting payload"
+            );
+            let message = match &err {
+                OpPayloadError::Eth(PayloadError::BlockHash { execution, consensus }) => {
+                    format!(
+                        "payload has bad block hash: {consensus}, actual block hash is: {execution}"
+                    )
+                }
+                _ => format!("invalid payload: {err}"),
+            };
+            ErrorObject::owned(ErrorCode::InvalidParams.code(), message, None::<()>)
+        })?;
+
         self.network_sender
             .send(NetworkAdminQuery::PostUnsafePayload { payload })
             .await

--- a/rust/kona/crates/node/rpc/src/admin.rs
+++ b/rust/kona/crates/node/rpc/src/admin.rs
@@ -9,7 +9,10 @@ use jsonrpsee::{
     core::RpcResult,
     types::{ErrorCode, ErrorObject},
 };
+use kona_engine::validate_execution_payload_envelope_version;
+use kona_genesis::RollupConfig;
 use op_alloy_rpc_types_engine::{OpExecutionPayloadEnvelope, OpPayloadError};
+use std::sync::Arc;
 
 /// The query types to the network actor for the admin api.
 #[derive(Debug)]
@@ -30,6 +33,8 @@ pub struct AdminRpc<SequencerAdminAPIClient> {
     pub sequencer_admin_client: Option<SequencerAdminAPIClient>,
     /// The sender to the network actor.
     pub network_sender: NetworkAdminQuerySender,
+    /// Rollup configuration used to validate payload versions.
+    pub rollup_config: Arc<RollupConfig>,
 }
 
 impl<SequencerAdminAPIClient_> AdminRpc<SequencerAdminAPIClient_>
@@ -43,6 +48,7 @@ where
     /// - `sequencer_sender`: The [`SequencerAdminAPIClient`] used to fulfill sequencer admin
     ///   queries.
     /// - `network_sender`: The sender to the network actor.
+    /// - `rollup_config`: The rollup configuration used to validate payload versions.
     ///
     /// # Returns
     ///
@@ -50,8 +56,9 @@ where
     pub const fn new(
         sequencer_admin_client: Option<SequencerAdminAPIClient_>,
         network_sender: NetworkAdminQuerySender,
+        rollup_config: Arc<RollupConfig>,
     ) -> Self {
-        Self { sequencer_admin_client, network_sender }
+        Self { sequencer_admin_client, network_sender, rollup_config }
     }
 }
 
@@ -65,6 +72,13 @@ where
         payload: OpExecutionPayloadEnvelope,
     ) -> RpcResult<()> {
         kona_macros::inc!(gauge, kona_gossip::Metrics::RPC_CALLS, "method" => "admin_postUnsafePayload");
+
+        validate_execution_payload_envelope_version(&self.rollup_config, &payload).map_err(
+            |err| {
+                tracing::warn!(target: "rpc", %err, "admin_postUnsafePayload: rejecting payload");
+                ErrorObject::owned(ErrorCode::InvalidParams.code(), err.to_string(), None::<()>)
+            },
+        )?;
 
         payload.check_block_hash().map_err(|err| {
             tracing::warn!(

--- a/rust/kona/crates/node/rpc/tests/admin_unsafe_payload.rs
+++ b/rust/kona/crates/node/rpc/tests/admin_unsafe_payload.rs
@@ -1,0 +1,130 @@
+//! Integration tests for `admin_postUnsafePayload` validation and routing.
+
+use alloy_primitives::{Address, B256, Bytes, U256};
+use alloy_rpc_types_engine::ExecutionPayloadV1;
+use jsonrpsee::{
+    RpcModule,
+    types::{Response, ResponsePayload},
+};
+use kona_genesis::RollupConfig;
+use kona_rpc::{AdminApiServer, AdminRpc, NetworkAdminQuery, SequencerAdminAPIClient};
+use op_alloy_rpc_types_engine::OpExecutionPayloadEnvelope;
+use std::sync::Arc;
+use tokio::sync::mpsc;
+
+#[derive(Debug)]
+struct UnusedSequencerClient;
+
+#[async_trait::async_trait]
+impl SequencerAdminAPIClient for UnusedSequencerClient {
+    async fn is_sequencer_active(&self) -> Result<bool, kona_rpc::SequencerAdminAPIError> {
+        unreachable!()
+    }
+
+    async fn is_conductor_enabled(&self) -> Result<bool, kona_rpc::SequencerAdminAPIError> {
+        unreachable!()
+    }
+
+    async fn is_recovery_mode(&self) -> Result<bool, kona_rpc::SequencerAdminAPIError> {
+        unreachable!()
+    }
+
+    async fn start_sequencer(&self) -> Result<(), kona_rpc::SequencerAdminAPIError> {
+        unreachable!()
+    }
+
+    async fn stop_sequencer(&self) -> Result<B256, kona_rpc::SequencerAdminAPIError> {
+        unreachable!()
+    }
+
+    async fn set_recovery_mode(&self, _mode: bool) -> Result<(), kona_rpc::SequencerAdminAPIError> {
+        unreachable!()
+    }
+
+    async fn override_leader(&self) -> Result<(), kona_rpc::SequencerAdminAPIError> {
+        unreachable!()
+    }
+
+    async fn reset_derivation_pipeline(&self) -> Result<(), kona_rpc::SequencerAdminAPIError> {
+        unreachable!()
+    }
+}
+
+fn payload_with_bad_hash() -> OpExecutionPayloadEnvelope {
+    OpExecutionPayloadEnvelope::V1(ExecutionPayloadV1 {
+        parent_hash: B256::ZERO,
+        fee_recipient: Address::ZERO,
+        state_root: B256::ZERO,
+        receipts_root: B256::ZERO,
+        logs_bloom: Default::default(),
+        prev_randao: B256::ZERO,
+        block_number: 1,
+        gas_limit: 30_000_000,
+        gas_used: 0,
+        timestamp: 2,
+        extra_data: Bytes::new(),
+        base_fee_per_gas: U256::from(1),
+        block_hash: B256::repeat_byte(0x42),
+        transactions: Vec::new(),
+    })
+}
+
+#[tokio::test]
+async fn admin_rejects_bad_block_hash_without_forwarding_payload() {
+    let (network_sender, mut network_rx) = mpsc::channel(1);
+    let rpc = AdminRpc::<UnusedSequencerClient>::new(
+        None,
+        network_sender,
+        Arc::new(RollupConfig::default()),
+    );
+    let module: RpcModule<_> = rpc.into_rpc();
+    let request = serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": "admin_postUnsafePayload",
+        "params": [payload_with_bad_hash()],
+        "id": 1,
+    })
+    .to_string();
+
+    let (response, _) = module.raw_json_request(&request, 1).await.expect("valid JSON-RPC request");
+    let response: Response<'_, ()> = serde_json::from_str(response.get()).expect("valid response");
+    let ResponsePayload::Error(error) = response.payload else {
+        panic!("payload should be rejected")
+    };
+
+    assert_eq!(error.code(), -32602);
+    assert!(error.message().contains("bad block hash"));
+    assert!(network_rx.try_recv().is_err());
+}
+
+#[tokio::test]
+async fn admin_forwards_payload_with_valid_block_hash() {
+    let (network_sender, mut network_rx) = mpsc::channel(1);
+    let rpc = AdminRpc::<UnusedSequencerClient>::new(
+        None,
+        network_sender,
+        Arc::new(RollupConfig::default()),
+    );
+    let module: RpcModule<_> = rpc.into_rpc();
+    let payload = OpExecutionPayloadEnvelope::from_block_slow(
+        &payload_with_bad_hash()
+            .try_into_block::<op_alloy_consensus::OpTxEnvelope>()
+            .expect("decodable test payload"),
+    )
+    .expect("valid test payload");
+    let request = serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": "admin_postUnsafePayload",
+        "params": [payload.clone()],
+        "id": 1,
+    })
+    .to_string();
+
+    let (response, _) = module.raw_json_request(&request, 1).await.expect("valid JSON-RPC request");
+    let response: Response<'_, ()> = serde_json::from_str(response.get()).expect("valid response");
+    assert!(matches!(response.payload, ResponsePayload::Success(_)));
+
+    let NetworkAdminQuery::PostUnsafePayload { payload: forwarded } =
+        network_rx.recv().await.expect("payload forwarded to network actor");
+    assert_eq!(forwarded, payload);
+}

--- a/rust/kona/crates/node/service/Cargo.toml
+++ b/rust/kona/crates/node/service/Cargo.toml
@@ -77,8 +77,11 @@ mockall.workspace = true
 alloy-primitives = { workspace = true, features = ["k256"] }
 alloy-rpc-types-engine = { workspace = true, features = ["arbitrary"] }
 alloy-consensus = { workspace = true, features = ["arbitrary"] }
+alloy-json-rpc.workspace = true
 op-alloy-consensus = { workspace = true, features = ["arbitrary", "k256"] }
-kona-derive = {workspace = true, features = ["test-utils"]}
+kona-derive = { workspace = true, features = ["test-utils"] }
+kona-engine = { workspace = true, features = ["test-utils"] }
+kona-protocol = { workspace = true, features = ["test-utils"] }
 
 [features]
 default = []

--- a/rust/kona/crates/node/service/src/actors/engine/actor.rs
+++ b/rust/kona/crates/node/service/src/actors/engine/actor.rs
@@ -6,7 +6,8 @@ use async_trait::async_trait;
 use kona_derive::{ResetSignal, Signal};
 use kona_engine::{
     BuildTask, ConsolidateInput, ConsolidateTask, Engine, EngineClient, EngineTask,
-    EngineTaskError, EngineTaskErrorSeverity, FinalizeBlockId, FinalizeTask, InsertTask, SealTask,
+    EngineTaskError, EngineTaskErrorSeverity, FinalizeBlockId, FinalizeTask, InsertTask,
+    PayloadEnvelopeOrigin, SealTask,
 };
 use kona_genesis::RollupConfig;
 use kona_protocol::L2BlockInfo;
@@ -116,6 +117,11 @@ where
             }
             Err(err) => {
                 match err.severity() {
+                    EngineTaskErrorSeverity::Drop => {
+                        // Unreachable: Engine::drain consumes drop errors.
+                        error!(target: "engine", ?err, "Drop error escaped engine task queue");
+                        return Err(err.into());
+                    }
                     EngineTaskErrorSeverity::Critical => {
                         error!(target: "engine", ?err, "Critical error draining engine tasks");
                         return Err(err.into());
@@ -262,8 +268,7 @@ where
                     self.client.clone(),
                     self.rollup.clone(),
                     *envelope,
-                    false, /* The payload is not derived in this case. This is an unsafe
-                            * block. */
+                    PayloadEnvelopeOrigin::RemoteSequencer,
                 )));
                 self.engine.enqueue(task);
             }

--- a/rust/kona/crates/node/service/src/actors/engine/actor.rs
+++ b/rust/kona/crates/node/service/src/actors/engine/actor.rs
@@ -229,8 +229,17 @@ where
             });
         }
 
-        // Wait for the next processing request.
-        let request = self.inbound_request_rx.recv().await.ok_or_else(|| {
+        // Wait for either fresh work or the next delayed task retry. This keeps temporary engine
+        // failures from blocking the request channel or spinning in a tight loop.
+        let request = if let Some(deadline) = self.engine.next_retry_deadline() {
+            tokio::select! {
+                request = self.inbound_request_rx.recv() => request,
+                _ = tokio::time::sleep_until(deadline) => return Ok(()),
+            }
+        } else {
+            self.inbound_request_rx.recv().await
+        }
+        .ok_or_else(|| {
             error!(target: "engine", "Engine processing request receiver closed unexpectedly");
             EngineError::ChannelClosed
         })?;

--- a/rust/kona/crates/node/service/src/actors/sequencer/actor.rs
+++ b/rust/kona/crates/node/service/src/actors/sequencer/actor.rs
@@ -20,7 +20,7 @@ use crate::{
 use alloy_rpc_types_engine::PayloadId;
 use async_trait::async_trait;
 use kona_derive::{AttributesBuilder, PipelineErrorKind};
-use kona_engine::{InsertTaskError, SealTaskError, SynchronizeTaskError};
+use kona_engine::{InsertTaskErrorKind, SealTaskError, SynchronizeTaskError};
 use kona_genesis::RollupConfig;
 use kona_protocol::{BlockInfo, L2BlockInfo, OpAttributesWithParent};
 use op_alloy_rpc_types_engine::OpPayloadAttributes;
@@ -516,17 +516,20 @@ where
 // added, this approach guarantees compilation will fail until it is handled here.
 fn is_seal_task_err_fatal(err: &SealTaskError) -> bool {
     match err {
-        SealTaskError::PayloadInsertionFailed(insert_err) => match &**insert_err {
-            InsertTaskError::ForkchoiceUpdateFailed(synchronize_error) => match synchronize_error {
-                SynchronizeTaskError::FinalizedAheadOfUnsafe(_, _) => true,
-                SynchronizeTaskError::ForkchoiceUpdateFailed(_) |
-                SynchronizeTaskError::InvalidForkchoiceState |
-                SynchronizeTaskError::UnexpectedPayloadStatus(_) => false,
-            },
-            InsertTaskError::FromBlockError(_) | InsertTaskError::L2BlockInfoConstruction(_) => {
-                true
+        SealTaskError::PayloadInsertionFailed(insert_err) => match insert_err.kind() {
+            InsertTaskErrorKind::ForkchoiceUpdateFailed(synchronize_error) => {
+                match synchronize_error {
+                    SynchronizeTaskError::FinalizedAheadOfUnsafe(_, _) => true,
+                    SynchronizeTaskError::ForkchoiceUpdateFailed(_) |
+                    SynchronizeTaskError::InvalidForkchoiceState |
+                    SynchronizeTaskError::UnexpectedPayloadStatus(_) => false,
+                }
             }
-            InsertTaskError::InsertFailed(_) | InsertTaskError::UnexpectedPayloadStatus(_) => false,
+            InsertTaskErrorKind::FromBlockError(_) |
+            InsertTaskErrorKind::UnexpectedPayloadVersion(_) |
+            InsertTaskErrorKind::L2BlockInfoConstruction(_) => true,
+            InsertTaskErrorKind::InsertFailed(_) |
+            InsertTaskErrorKind::UnexpectedPayloadStatus(_) => false,
         },
         SealTaskError::GetPayloadFailed(_) |
         SealTaskError::HoloceneInvalidFlush |

--- a/rust/kona/crates/node/service/src/actors/sequencer/actor.rs
+++ b/rust/kona/crates/node/service/src/actors/sequencer/actor.rs
@@ -20,7 +20,7 @@ use crate::{
 use alloy_rpc_types_engine::PayloadId;
 use async_trait::async_trait;
 use kona_derive::{AttributesBuilder, PipelineErrorKind};
-use kona_engine::{InsertTaskErrorKind, SealTaskError, SynchronizeTaskError};
+use kona_engine::{EngineTaskError, InsertTaskErrorKind, SealTaskError, SynchronizeTaskError};
 use kona_genesis::RollupConfig;
 use kona_protocol::{BlockInfo, L2BlockInfo, OpAttributesWithParent};
 use op_alloy_rpc_types_engine::OpPayloadAttributes;
@@ -528,7 +528,9 @@ fn is_seal_task_err_fatal(err: &SealTaskError) -> bool {
             InsertTaskErrorKind::FromBlockError(_) |
             InsertTaskErrorKind::UnexpectedPayloadVersion(_) |
             InsertTaskErrorKind::L2BlockInfoConstruction(_) => true,
-            InsertTaskErrorKind::InsertFailed(_) |
+            InsertTaskErrorKind::InsertFailed(_) => {
+                insert_err.severity() == kona_engine::EngineTaskErrorSeverity::Critical
+            }
             InsertTaskErrorKind::UnexpectedPayloadStatus(_) => false,
         },
         SealTaskError::GetPayloadFailed(_) |

--- a/rust/kona/crates/node/service/src/service/node.rs
+++ b/rust/kona/crates/node/service/src/service/node.rs
@@ -396,6 +396,7 @@ impl RollupNode {
             config.enable_admin(),
             sequencer_admin_client,
             network_admin_tx,
+            self.config.clone(),
         )?;
         modules
             .merge(RollupRpc::new(engine_rpc_client.clone(), l1_watcher_queries_tx).into_rpc())
@@ -554,10 +555,13 @@ fn merge_admin_module(
     enable_admin: bool,
     sequencer_admin_client: Option<QueuedSequencerAdminAPIClient>,
     network_admin_tx: mpsc::Sender<NetworkAdminQuery>,
+    rollup_config: Arc<RollupConfig>,
 ) -> Result<(), String> {
     if enable_admin {
         modules
-            .merge(AdminRpc::new(sequencer_admin_client, network_admin_tx).into_rpc())
+            .merge(
+                AdminRpc::new(sequencer_admin_client, network_admin_tx, rollup_config).into_rpc(),
+            )
             .map_err(|e| format!("Failed to register admin module: {e:?}"))?;
     }
     Ok(())
@@ -570,8 +574,14 @@ mod tests {
     fn admin_method_names(enable_admin: bool) -> Vec<String> {
         let mut modules = RpcModule::new(());
         let (network_admin_tx, _rx) = mpsc::channel(1);
-        merge_admin_module(&mut modules, enable_admin, None, network_admin_tx)
-            .expect("admin module registration");
+        merge_admin_module(
+            &mut modules,
+            enable_admin,
+            None,
+            network_admin_tx,
+            Arc::new(RollupConfig::default()),
+        )
+        .expect("admin module registration");
         modules.method_names().map(ToString::to_string).collect()
     }
 

--- a/rust/kona/crates/node/service/tests/actors/engine/harness.rs
+++ b/rust/kona/crates/node/service/tests/actors/engine/harness.rs
@@ -1,0 +1,177 @@
+use alloy_consensus::{BlockBody, EMPTY_ROOT_HASH, Header, Sealed};
+use alloy_eips::Encodable2718;
+use alloy_primitives::{Address, B256, Bytes, TxKind, U256, bytes::BufMut};
+use alloy_rpc_types_engine::{
+    ExecutionPayloadEnvelopeV2, ExecutionPayloadFieldV2, ForkchoiceUpdated, PayloadStatusEnum,
+};
+use async_trait::async_trait;
+use kona_derive::Signal;
+use kona_engine::{
+    Engine, EngineState,
+    test_utils::{MockEngineClient, MockNewPayloadResponse},
+};
+use kona_genesis::RollupConfig;
+use kona_node_service::{
+    DerivationClientResult, EngineActor, EngineActorRequest, EngineDerivationClient,
+};
+use kona_protocol::{L2BlockInfo, test_utils::RAW_BEDROCK_INFO_TX};
+use op_alloy_consensus::{OpBlock, OpTxEnvelope, TxDeposit};
+use op_alloy_rpc_types_engine::OpExecutionPayloadEnvelope;
+use std::sync::Arc;
+use tokio::sync::{Mutex, mpsc, watch};
+
+#[derive(Debug, Clone, Default)]
+pub(super) struct RecordingDerivationClient {
+    signals: Arc<Mutex<Vec<Signal>>>,
+}
+
+impl RecordingDerivationClient {
+    pub(super) async fn signals(&self) -> Vec<Signal> {
+        self.signals.lock().await.clone()
+    }
+}
+
+#[async_trait]
+impl EngineDerivationClient for RecordingDerivationClient {
+    async fn notify_sync_completed(&self, _safe_head: L2BlockInfo) -> DerivationClientResult<()> {
+        Ok(())
+    }
+
+    async fn send_new_engine_safe_head(
+        &self,
+        _safe_head: L2BlockInfo,
+    ) -> DerivationClientResult<()> {
+        Ok(())
+    }
+
+    async fn send_signal(&self, signal: Signal) -> DerivationClientResult<()> {
+        self.signals.lock().await.push(signal);
+        Ok(())
+    }
+}
+
+pub(super) struct EngineHarness {
+    pub(super) client: MockEngineClient,
+    pub(super) derivation: RecordingDerivationClient,
+    pub(super) requests: mpsc::Sender<EngineActorRequest>,
+    pub(super) unsafe_head: watch::Receiver<L2BlockInfo>,
+    pub(super) queue_length: watch::Receiver<usize>,
+    pub(super) actor: EngineActor<MockEngineClient, RecordingDerivationClient>,
+}
+
+impl EngineHarness {
+    pub(super) fn new(
+        config: Arc<RollupConfig>,
+        responses: impl IntoIterator<Item = MockNewPayloadResponse>,
+        initial_head: L2BlockInfo,
+    ) -> Self {
+        let client = MockEngineClient::builder()
+            .with_config(config.clone())
+            .with_new_payload_responses(responses)
+            .with_fork_choice_updated_v3_response(ForkchoiceUpdated::from_status(
+                PayloadStatusEnum::Valid,
+            ))
+            .build();
+        let derivation = RecordingDerivationClient::default();
+        let sync_state =
+            EngineState::default().sync_state.apply_update(kona_engine::EngineSyncStateUpdate {
+                unsafe_head: Some(initial_head),
+                cross_unsafe_head: Some(initial_head),
+                local_safe_head: Some(initial_head),
+                safe_head: Some(initial_head),
+                finalized_head: Some(initial_head),
+            });
+        let state = EngineState {
+            sync_state,
+            el_sync_finished: false,
+            need_fcu_call_backup_unsafe_reorg: false,
+        };
+        let (state_tx, _) = watch::channel(state);
+        let (queue_length_tx, queue_length) = watch::channel(0);
+        let engine = Engine::new(state, state_tx, queue_length_tx);
+        let (unsafe_head_tx, unsafe_head) = watch::channel(initial_head);
+        let (requests, request_rx) = mpsc::channel(16);
+        let actor = EngineActor::new(
+            Arc::new(client.clone()),
+            config,
+            derivation.clone(),
+            engine,
+            Some(unsafe_head_tx),
+            request_rx,
+        );
+        Self { client, derivation, requests, unsafe_head, queue_length, actor }
+    }
+
+    pub(super) async fn set_payload_to_get(&self, payload: OpExecutionPayloadEnvelope) {
+        let execution_payload = match payload {
+            OpExecutionPayloadEnvelope::V1(payload) => ExecutionPayloadFieldV2::V1(payload),
+            OpExecutionPayloadEnvelope::V2(payload) => ExecutionPayloadFieldV2::V2(payload),
+            _ => panic!("test harness only supports V1/V2 getPayload responses"),
+        };
+        self.client
+            .set_execution_payload_v2(ExecutionPayloadEnvelopeV2 {
+                execution_payload,
+                block_value: U256::ZERO,
+            })
+            .await;
+    }
+}
+
+pub(super) fn genesis_head() -> L2BlockInfo {
+    L2BlockInfo::default()
+}
+
+pub(super) fn valid_payload(parent: L2BlockInfo, number: u64) -> OpExecutionPayloadEnvelope {
+    let deposit = OpTxEnvelope::Deposit(Sealed::new(TxDeposit {
+        to: TxKind::Call(Address::ZERO),
+        gas_limit: 1_000_000,
+        input: Bytes::from_static(&RAW_BEDROCK_INFO_TX),
+        ..Default::default()
+    }));
+    let encoded = Bytes::from(deposit.encoded_2718());
+    let transactions_root =
+        alloy_consensus::proofs::ordered_trie_root_with_encoder(&[encoded], |item, buf| {
+            buf.put_slice(item)
+        });
+    let header = Header {
+        parent_hash: parent.block_info.hash,
+        transactions_root,
+        receipts_root: EMPTY_ROOT_HASH,
+        number,
+        gas_limit: 30_000_000,
+        timestamp: number.saturating_mul(2),
+        base_fee_per_gas: Some(1),
+        ..Default::default()
+    };
+    let block = OpBlock {
+        header,
+        body: BlockBody { transactions: vec![deposit], ommers: Vec::new(), withdrawals: None },
+    };
+    OpExecutionPayloadEnvelope::from_block_slow(&block).expect("valid test payload")
+}
+
+pub(super) fn payload_info(payload: &OpExecutionPayloadEnvelope) -> L2BlockInfo {
+    let block: OpBlock = payload.clone().try_into_block().expect("decodable payload");
+    L2BlockInfo::from_block_and_genesis(&block, &Default::default()).expect("L2 block info")
+}
+
+pub(super) fn malformed_payload(number: u64) -> OpExecutionPayloadEnvelope {
+    use alloy_rpc_types_engine::ExecutionPayloadV1;
+
+    OpExecutionPayloadEnvelope::V1(ExecutionPayloadV1 {
+        parent_hash: B256::ZERO,
+        fee_recipient: Address::ZERO,
+        state_root: B256::ZERO,
+        receipts_root: B256::ZERO,
+        logs_bloom: Default::default(),
+        prev_randao: B256::ZERO,
+        block_number: number,
+        gas_limit: 30_000_000,
+        gas_used: 0,
+        timestamp: number.saturating_mul(2),
+        extra_data: Bytes::new(),
+        base_fee_per_gas: U256::from(1),
+        block_hash: B256::ZERO,
+        transactions: vec![Bytes::from_static(&[0xff])],
+    })
+}

--- a/rust/kona/crates/node/service/tests/actors/engine/mod.rs
+++ b/rust/kona/crates/node/service/tests/actors/engine/mod.rs
@@ -1,0 +1,2 @@
+mod harness;
+mod unsafe_payloads;

--- a/rust/kona/crates/node/service/tests/actors/engine/unsafe_payloads.rs
+++ b/rust/kona/crates/node/service/tests/actors/engine/unsafe_payloads.rs
@@ -1,0 +1,187 @@
+use super::harness::{EngineHarness, genesis_head, malformed_payload, payload_info, valid_payload};
+use alloy_json_rpc::ErrorPayload;
+use alloy_rpc_types_engine::{PayloadId, PayloadStatus, PayloadStatusEnum};
+use kona_engine::test_utils::{MockEngineCall, MockNewPayloadResponse, TestAttributesBuilder};
+use kona_genesis::{HardForkConfig, RollupConfig};
+use kona_node_service::{EngineActorRequest, EngineError, NodeActor, SealRequest};
+use std::{sync::Arc, time::Duration};
+use tokio::time::timeout;
+
+async fn send_unsafe(
+    harness: &EngineHarness,
+    payload: op_alloy_rpc_types_engine::OpExecutionPayloadEnvelope,
+) {
+    harness
+        .requests
+        .send(EngineActorRequest::ProcessUnsafeL2Block(Box::new(payload)))
+        .await
+        .expect("engine actor request channel closed");
+}
+
+async fn drain_until_waiting(harness: &mut EngineHarness) {
+    for _ in 0..4 {
+        if timeout(Duration::from_millis(1), harness.actor.step()).await.is_err() {
+            return;
+        }
+    }
+    panic!("engine actor unexpectedly stopped waiting for work");
+}
+
+#[tokio::test]
+async fn remote_invalid_payload_does_not_block_later_valid_payload() {
+    let config = Arc::new(RollupConfig::default());
+    let head = genesis_head();
+    let invalid = malformed_payload(1);
+    let valid = valid_payload(head, 1);
+    let valid_info = payload_info(&valid);
+    let mut harness = EngineHarness::new(
+        config,
+        [
+            MockNewPayloadResponse::Status(PayloadStatus::from_status(
+                PayloadStatusEnum::Invalid { validation_error: "invalid transaction".to_string() },
+            )),
+            MockNewPayloadResponse::Status(PayloadStatus::from_status(PayloadStatusEnum::Valid)),
+        ],
+        head,
+    );
+
+    send_unsafe(&harness, invalid).await;
+    harness.actor.step().await.expect("failed to receive invalid payload");
+    drain_until_waiting(&mut harness).await;
+
+    send_unsafe(&harness, valid).await;
+    harness.actor.step().await.expect("failed to receive valid payload");
+    drain_until_waiting(&mut harness).await;
+
+    assert_eq!(*harness.unsafe_head.borrow(), valid_info);
+    assert_eq!(*harness.queue_length.borrow(), 0);
+    assert_eq!(
+        harness
+            .client
+            .calls()
+            .await
+            .into_iter()
+            .filter(|call| matches!(call, MockEngineCall::NewPayload(_)))
+            .count(),
+        2
+    );
+}
+
+#[tokio::test]
+async fn malformed_payload_rpc_error_does_not_block_later_valid_payload() {
+    let config = Arc::new(RollupConfig::default());
+    let head = genesis_head();
+    let invalid = malformed_payload(1);
+    let valid = valid_payload(head, 1);
+    let valid_info = payload_info(&valid);
+    let mut harness = EngineHarness::new(
+        config,
+        [
+            MockNewPayloadResponse::RpcError(ErrorPayload::invalid_params()),
+            MockNewPayloadResponse::Status(PayloadStatus::from_status(PayloadStatusEnum::Valid)),
+        ],
+        head,
+    );
+
+    send_unsafe(&harness, invalid).await;
+    harness.actor.step().await.expect("failed to receive malformed payload");
+    drain_until_waiting(&mut harness).await;
+
+    send_unsafe(&harness, valid).await;
+    harness.actor.step().await.expect("failed to receive valid payload");
+    drain_until_waiting(&mut harness).await;
+
+    assert_eq!(*harness.unsafe_head.borrow(), valid_info);
+    assert_eq!(*harness.queue_length.borrow(), 0);
+}
+
+#[tokio::test]
+async fn engine_capability_error_terminates_actor() {
+    let config = Arc::new(RollupConfig::default());
+    let head = genesis_head();
+    let payload = malformed_payload(1);
+    let mut harness = EngineHarness::new(
+        config,
+        [MockNewPayloadResponse::RpcError(ErrorPayload::method_not_found())],
+        head,
+    );
+
+    send_unsafe(&harness, payload).await;
+    harness.actor.step().await.expect("failed to receive payload");
+    let error = harness.actor.step().await.expect_err("capability error must terminate actor");
+
+    assert!(matches!(error, EngineError::EngineTask(_)));
+    assert_eq!(
+        harness
+            .client
+            .calls()
+            .await
+            .into_iter()
+            .filter(|call| matches!(call, MockEngineCall::NewPayload(_)))
+            .count(),
+        1
+    );
+}
+
+#[tokio::test]
+async fn remote_payload_version_mismatch_is_dropped_before_engine_call() {
+    let config = Arc::new(RollupConfig {
+        hardforks: HardForkConfig { canyon_time: Some(0), ..Default::default() },
+        ..Default::default()
+    });
+    let head = genesis_head();
+    let mismatch = malformed_payload(1);
+    let mut harness = EngineHarness::new(config, [], head);
+
+    send_unsafe(&harness, mismatch).await;
+    harness.actor.step().await.expect("failed to receive mismatched payload");
+    drain_until_waiting(&mut harness).await;
+
+    assert!(harness.client.calls().await.is_empty());
+    assert_eq!(*harness.queue_length.borrow(), 0);
+    assert!(harness.derivation.signals().await.is_empty());
+}
+
+#[tokio::test]
+async fn local_payload_capability_error_is_returned_to_sequencer() {
+    let config = Arc::new(RollupConfig::default());
+    let head = genesis_head();
+    let payload = valid_payload(head, 1);
+    let mut harness = EngineHarness::new(
+        config,
+        [MockNewPayloadResponse::RpcError(ErrorPayload::method_not_found())],
+        head,
+    );
+    harness.set_payload_to_get(payload).await;
+    let attributes = TestAttributesBuilder::new().with_parent(head).with_timestamp(2).build();
+    let (result_tx, mut result_rx) = tokio::sync::mpsc::channel(1);
+
+    harness
+        .requests
+        .send(EngineActorRequest::Seal(Box::new(SealRequest {
+            payload_id: PayloadId::new([1; 8]),
+            attributes,
+            result_tx,
+        })))
+        .await
+        .expect("engine actor request channel closed");
+    harness.actor.step().await.expect("failed to receive seal request");
+    drain_until_waiting(&mut harness).await;
+
+    let error = result_rx
+        .recv()
+        .await
+        .expect("missing seal result")
+        .expect_err("local capability error should fail sealing");
+    assert!(error.to_string().contains("Method not found"));
+    assert_eq!(
+        harness
+            .client
+            .calls()
+            .await
+            .into_iter()
+            .filter(|call| matches!(call, MockEngineCall::NewPayload(_)))
+            .count(),
+        1
+    );
+}

--- a/rust/kona/crates/node/service/tests/actors/engine/unsafe_payloads.rs
+++ b/rust/kona/crates/node/service/tests/actors/engine/unsafe_payloads.rs
@@ -68,6 +68,34 @@ async fn remote_invalid_payload_does_not_block_later_valid_payload() {
 }
 
 #[tokio::test]
+async fn accepted_payload_retry_does_not_block_fresh_payload() {
+    let config = Arc::new(RollupConfig::default());
+    let head = genesis_head();
+    let accepted = malformed_payload(1);
+    let valid = valid_payload(head, 1);
+    let valid_info = payload_info(&valid);
+    let mut harness = EngineHarness::new(
+        config,
+        [
+            MockNewPayloadResponse::Status(PayloadStatus::from_status(PayloadStatusEnum::Accepted)),
+            MockNewPayloadResponse::Status(PayloadStatus::from_status(PayloadStatusEnum::Valid)),
+            MockNewPayloadResponse::Status(PayloadStatus::from_status(PayloadStatusEnum::Accepted)),
+        ],
+        head,
+    );
+
+    send_unsafe(&harness, accepted).await;
+    harness.actor.step().await.expect("failed to receive accepted payload");
+    drain_until_waiting(&mut harness).await;
+    assert_eq!(*harness.queue_length.borrow(), 1);
+
+    send_unsafe(&harness, valid).await;
+    harness.actor.step().await.expect("failed to receive fresh payload");
+    drain_until_waiting(&mut harness).await;
+    assert_eq!(*harness.unsafe_head.borrow(), valid_info);
+}
+
+#[tokio::test]
 async fn malformed_payload_rpc_error_does_not_block_later_valid_payload() {
     let config = Arc::new(RollupConfig::default());
     let head = genesis_head();
@@ -121,6 +149,33 @@ async fn engine_capability_error_terminates_actor() {
             .count(),
         1
     );
+}
+
+#[tokio::test]
+async fn transient_transport_error_does_not_block_fresh_payload() {
+    let config = Arc::new(RollupConfig::default());
+    let head = genesis_head();
+    let transient = malformed_payload(1);
+    let valid = valid_payload(head, 1);
+    let valid_info = payload_info(&valid);
+    let mut harness = EngineHarness::new(
+        config,
+        [
+            MockNewPayloadResponse::TransportError("execution client unavailable".to_string()),
+            MockNewPayloadResponse::Status(PayloadStatus::from_status(PayloadStatusEnum::Valid)),
+            MockNewPayloadResponse::TransportError("execution client unavailable".to_string()),
+        ],
+        head,
+    );
+
+    send_unsafe(&harness, transient).await;
+    harness.actor.step().await.expect("failed to receive transient payload");
+    drain_until_waiting(&mut harness).await;
+
+    send_unsafe(&harness, valid).await;
+    harness.actor.step().await.expect("failed to receive fresh payload");
+    drain_until_waiting(&mut harness).await;
+    assert_eq!(*harness.unsafe_head.borrow(), valid_info);
 }
 
 #[tokio::test]

--- a/rust/kona/crates/node/service/tests/actors/mod.rs
+++ b/rust/kona/crates/node/service/tests/actors/mod.rs
@@ -1,4 +1,5 @@
 //! Integration tests for the node actors.
 
+mod engine;
 pub(crate) mod generator;
 mod network;


### PR DESCRIPTION
## Summary

- Preserve terminal `engine_newPayload` statuses before local transaction decoding.
- Track whether payloads are L1-derived, locally sequenced, or remotely received.
- Drop malformed remote payload failures while surfacing local execution-client capability failures.
- Validate payload envelope versions before Engine API submission.
- Delay temporary retries so `ACCEPTED` responses and transport failures do not block fresh engine actor work.
- Extend `MockEngineClient` and add actor-boundary integration coverage for these cases.

## Dependency

Draft follow-up to #22307. This PR contains the broader engine failure-classification and scheduling work that is intentionally excluded from the original admin payload hash validation fix.

## Testing

- `cargo test -p kona-engine`
- `cargo test -p kona-node-service --test integration actors::engine`
- `cargo test -p kona-rpc --test admin_unsafe_payload`
- `cargo clippy -p kona-engine -p kona-rpc -p kona-node-service --all-targets --all-features -- -D warnings`
