### PR TITLE
kona-sp1-proposer: prefix environment variables

### DIFF
--- a/op-devstack/sysgo/zk_proposer.go
+++ b/op-devstack/sysgo/zk_proposer.go
@@ -30,9 +30,14 @@ import (
 // emits once config validation and provider construction have completed; the
 // launcher matches it to detect startup.
 const (
-	zkProposerReadyMessage = "kona-sp1-proposer started"
-	konaSP1ELFDirEnv       = "KONA_SP1_ELF_DIR"
+	zkProposerReadyMessage   = "kona-sp1-proposer started"
+	konaSP1ELFDirEnv         = "KONA_SP1_ELF_DIR"
+	konaSP1ProposerEnvPrefix = "KONA_SP1_PROPOSER"
 )
+
+func zkProposerEnv(suffix, value string) string {
+	return konaSP1ProposerEnvPrefix + "_" + suffix + "=" + value
+}
 
 func loadZKProgramVKey(elfDir string) (common.Hash, error) {
 	if elfDir == "" {
@@ -80,7 +85,7 @@ func WithZKProposalInterval(interval time.Duration) ZKProposerOption {
 }
 
 // WithZKFastFinality makes the proposer prove every game it owns while it
-// is still unchallenged (FAST_FINALITY_MODE=true).
+// is still unchallenged.
 func WithZKFastFinality() ZKProposerOption {
 	return func(cfg *zkProposerConfig) {
 		cfg.FastFinality = true
@@ -153,7 +158,7 @@ func startZKProposer(
 	require.NotEmpty(execPath, "kona-sp1-proposer binary path resolved")
 
 	// The proposer checks and loads program artifacts at
-	// PRESTATES_URL/<vkey>.agg.bin.gz and .range.bin.gz, mirroring
+	// KONA_SP1_PROPOSER_PRESTATES_URL/<vkey>.agg.bin.gz and .range.bin.gz, mirroring
 	// op-challenger's --prestates-url convention. The aggregation vkey embeds
 	// the range program's vkey, so it keys both ELFs. Devstack publishes the
 	// real ELFs, gzipped, when KONA_SP1_ELF_DIR is set; otherwise stub bytes
@@ -195,40 +200,39 @@ func startZKProposer(
 	require.NoError(os.WriteFile(depSetPath, depSetData, 0o640), "must write interop dependency set")
 
 	env := []string{
-		"L1_RPC=" + l1EL.UserRPC(),
-		"SUPERROOT_RPC=" + superRootRPC,
-		"FACTORY_ADDRESS=" + factoryAddr.Hex(),
-		"PRESTATES_URL=file://" + prestatesDir,
-		"PRIVATE_KEY=" + hexutil.Encode(crypto.FromECDSA(proposerSecret)),
+		zkProposerEnv("L1_RPC", l1EL.UserRPC()),
+		zkProposerEnv("SUPERROOT_RPC", superRootRPC),
+		zkProposerEnv("FACTORY_ADDRESS", factoryAddr.Hex()),
+		zkProposerEnv("PRESTATES_URL", "file://"+prestatesDir),
+		zkProposerEnv("PRIVATE_KEY", hexutil.Encode(crypto.FromECDSA(proposerSecret))),
 		// The mock provider skips SP1 proving but still runs the full witness
 		// pipeline against these endpoints and configs.
-		"PROOF_PROVIDER=mock",
-		"L1_BEACON_RPC=" + l1CL.beaconHTTPAddr,
+		zkProposerEnv("PROOF_PROVIDER", "mock"),
+		zkProposerEnv("L1_BEACON_RPC", l1CL.beaconHTTPAddr),
 		// Order-irrelevant: kona-host keys L2 providers by queried eth_chainId.
-		"L2_RPCS=" + strings.Join(l2RPCs, ","),
-		"ROLLUP_CONFIG_PATHS=" + strings.Join(rollupPaths, ","),
-		"L1_CONFIG_PATH=" + l1CfgPath,
-		"DEPENDENCY_SET_PATH=" + depSetPath,
-		"PROPOSAL_SAFETY=safe",
-		"FETCH_INTERVAL=2",
-		"LOG_FORMAT=json",
+		zkProposerEnv("L2_RPCS", strings.Join(l2RPCs, ",")),
+		zkProposerEnv("ROLLUP_CONFIG_PATHS", strings.Join(rollupPaths, ",")),
+		zkProposerEnv("L1_CONFIG_PATH", l1CfgPath),
+		zkProposerEnv("DEPENDENCY_SET_PATH", depSetPath),
+		zkProposerEnv("PROPOSAL_SAFETY", "safe"),
+		zkProposerEnv("FETCH_INTERVAL", "2"),
+		zkProposerEnv("LOG_FORMAT", "json"),
 	}
 	if cfg.ProposalInterval != nil {
-		env = append(env, "PROPOSAL_INTERVAL_SECONDS="+strconv.FormatUint(uint64(*cfg.ProposalInterval/time.Second), 10))
+		env = append(env, zkProposerEnv("PROPOSAL_INTERVAL_SECONDS", strconv.FormatUint(uint64(*cfg.ProposalInterval/time.Second), 10)))
 	}
 	if cfg.FastFinality {
-		env = append(env, "FAST_FINALITY_MODE=true")
+		env = append(env, zkProposerEnv("FAST_FINALITY_MODE", "true"))
 	}
-	// Always pin METRICS_PORT: the child inherits the host environment, and
-	// an inherited value (op-succinct deployments export this exact name)
-	// would otherwise reach every devstack proposer and collide across
-	// parallel systems. 0 keeps metrics disabled; "auto" has the proposer
+	// Always pin the metrics port so inherited host configuration cannot
+	// reach every devstack proposer and collide across parallel systems.
+	// 0 keeps metrics disabled; "auto" has the proposer
 	// bind a free port and report it on its startup line.
 	metricsPort := "0"
 	if cfg.Metrics {
 		metricsPort = "auto"
 	}
-	env = append(env, "METRICS_PORT="+metricsPort)
+	env = append(env, zkProposerEnv("METRICS_PORT", metricsPort))
 
 	logOut := logpipe.ToLoggerWithMinLevel(t.Logger().New("component", "kona-sp1-proposer", "src", "stdout"), log.LevelWarn)
 	logErr := logpipe.ToLoggerWithMinLevel(t.Logger().New("component", "kona-sp1-proposer", "src", "stderr"), log.LevelWarn)

--- a/rust/kona/sp1/README.md
+++ b/rust/kona/sp1/README.md
@@ -172,18 +172,18 @@ rotation, old-signer games stay eligible for defense, resolution, and claims,
 but the restart scan does not fast-finalize them.
 
 **Operational requirement**: rotated-out prestate artifacts must remain published
-under `PRESTATES_URL` for as long as games created under them can be live, or the
+under `KONA_SP1_PROPOSER_PRESTATES_URL` for as long as games created under them can be live, or the
 proposer loses the ability to defend, resolve, and claim those games.
 
 ### Proof providers
 
-- `PROOF_PROVIDER=network`: real SP1 proving via the Succinct Prover Network.
+- `KONA_SP1_PROPOSER_PROOF_PROVIDER=network`: real SP1 proving via the Succinct Prover Network.
   Proving keys are set up per prestate on first use, and the aggregation
   verifying key must hash to the on-chain prestate (mismatches poison the
   prestate and remove its games from the owned set). The registered prestate's
   keys are verified BEFORE any game is created on it, so the proposer never
   bonds a game it has not proven it can defend.
-- `PROOF_PROVIDER=mock`: dev-only. Runs the full pipeline natively (witness
+- `KONA_SP1_PROPOSER_PROOF_PROVIDER=mock`: dev-only. Runs the full pipeline natively (witness
   collection computes the real range/consolidation outputs and the aggregation
   inputs are validated), then submits placeholder proof bytes. Only a deployment
   with a mock game verifier (devstack) accepts them. No ELFs, no SPN credentials.
@@ -212,41 +212,84 @@ slot (blocking a later defense of that game): watch
 
 ### Environment
 
-Required:
+All proposer-owned variables use the `KONA_SP1_PROPOSER_` prefix.
+
+Required core configuration:
 
 | Variable | Purpose |
 |---|---|
-| `L1_RPC` | L1 execution RPC |
-| `SUPERROOT_RPC` | op-supernode or single-chain op-node RPC serving `superroot_atTimestamp` |
-| `FACTORY_ADDRESS` | `DisputeGameFactory` address |
-| `PRESTATES_URL` | prestate artifact directory (`<vkey>.agg.bin.gz` + `<vkey>.range.bin.gz`) |
-| `PROOF_PROVIDER` | `network` or `mock`; no default |
-| `L1_BEACON_RPC` | L1 beacon API (blob sidecars for derivation witnesses) |
-| `L2_RPCS` | comma-separated L2 EL RPCs, one per chain (order-irrelevant) |
-| `PRIVATE_KEY` or `SIGNER_URL`+`SIGNER_ADDRESS` | L1 transaction signer |
+| `KONA_SP1_PROPOSER_L1_RPC` | L1 execution RPC |
+| `KONA_SP1_PROPOSER_SUPERROOT_RPC` | op-supernode or single-chain op-node RPC serving `superroot_atTimestamp` |
+| `KONA_SP1_PROPOSER_FACTORY_ADDRESS` | `DisputeGameFactory` address |
+| `KONA_SP1_PROPOSER_PRESTATES_URL` | prestate artifact directory (`<vkey>.agg.bin.gz` + `<vkey>.range.bin.gz`) |
+| `KONA_SP1_PROPOSER_PROOF_PROVIDER` | `network` or `mock`; no default |
+| `KONA_SP1_PROPOSER_L1_BEACON_RPC` | L1 beacon API (blob sidecars for derivation witnesses) |
+| `KONA_SP1_PROPOSER_L2_RPCS` | comma-separated L2 EL RPCs, one per chain (order-irrelevant) |
 
-Optional (defaults in parentheses):
+Optional core and operational configuration:
 
 | Variable | Purpose |
 |---|---|
-| `ROLLUP_CONFIG_PATHS`, `L1_CONFIG_PATH`, `DEPENDENCY_SET_PATH` | chain config files; absent = superchain-registry fallback, matching the executor CLI |
-| `PROPOSAL_INTERVAL_SECONDS` (3600), `PROPOSAL_SAFETY` (finalized), `FETCH_INTERVAL` (30) | proposal cadence |
-| `METRICS_PORT` (0 = disabled, `auto` = a free port reported on the startup line), `SYNC_L1_CONFIRMATIONS` (0), `TX_CONFIRMATION_TIMEOUT` (60) | operations |
-| `MAX_FEE_PER_GAS`, `MAX_PRIORITY_FEE_PER_GAS` | L1 fee caps in wei (unset = uncapped) |
-| `RANGE_SPLIT_COUNT` (1, max 16) | chunks a defended span is split into |
-| `MAX_CONCURRENT_RANGE_PROOFS` (1) | child-proof concurrency within one game |
-| `MAX_CONCURRENT_DEFENSE_TASKS` (8) | games defended concurrently (must be >= 1) |
-| `FAST_FINALITY_MODE` (false) | prove signer-created owned games while unchallenged |
-| `FAST_FINALITY_PROVING_LIMIT` (1) | total in-flight proving tasks (defense included) before creation pauses |
-| `NETWORK_PRIVATE_KEY` (network mode; `USE_KMS_REQUESTER` for AWS KMS) | SPN requester key |
-| `RANGE_PROOF_STRATEGY`, `AGG_PROOF_STRATEGY` (reserved) | SPN fulfillment strategies |
-| `SP1_TIMEOUT_SECONDS` (14400), `NETWORK_CALLS_TIMEOUT` (15), `AUCTION_TIMEOUT` (60) | SPN timeouts |
-| `RANGE_CYCLE_LIMIT`, `RANGE_GAS_LIMIT`, `AGG_CYCLE_LIMIT`, `AGG_GAS_LIMIT` (1e12) | SPN request limits |
-| `MAX_PRICE_PER_PGU` (3e8), `MIN_AUCTION_PERIOD` (1) | SPN pricing |
+| `KONA_SP1_PROPOSER_ROLLUP_CONFIG_PATHS` | comma-separated rollup config files; absent = registry fallback |
+| `KONA_SP1_PROPOSER_L1_CONFIG_PATH` | L1 chain config file; absent = registry fallback |
+| `KONA_SP1_PROPOSER_DEPENDENCY_SET_PATH` | dependency-set config file; absent = registry fallback |
+| `KONA_SP1_PROPOSER_PROPOSAL_INTERVAL_SECONDS` | proposal interval (default `3600`) |
+| `KONA_SP1_PROPOSER_PROPOSAL_SAFETY` | `safe` or `finalized` (default `finalized`) |
+| `KONA_SP1_PROPOSER_FETCH_INTERVAL` | loop interval in seconds (default `30`) |
+| `KONA_SP1_PROPOSER_METRICS_PORT` | `0` disables metrics; `auto` selects a free port (default `0`) |
+| `KONA_SP1_PROPOSER_SYNC_L1_CONFIRMATIONS` | L1 confirmation lag for pinned reads (default `0`) |
+| `KONA_SP1_PROPOSER_TX_CONFIRMATION_TIMEOUT` | transaction confirmation timeout in seconds (default `60`) |
+| `KONA_SP1_PROPOSER_MAX_FEE_PER_GAS` | L1 max-fee cap in wei (default uncapped) |
+| `KONA_SP1_PROPOSER_MAX_PRIORITY_FEE_PER_GAS` | L1 priority-fee cap in wei (default uncapped) |
+| `KONA_SP1_PROPOSER_RANGE_SPLIT_COUNT` | chunks per defended span (default `1`, maximum `16`) |
+| `KONA_SP1_PROPOSER_MAX_CONCURRENT_RANGE_PROOFS` | child-proof concurrency per game (default `1`) |
+| `KONA_SP1_PROPOSER_MAX_CONCURRENT_DEFENSE_TASKS` | concurrent defended games (default `8`, minimum `1`) |
+| `KONA_SP1_PROPOSER_FAST_FINALITY_MODE` | prove signer-created owned games while unchallenged (default `false`) |
+| `KONA_SP1_PROPOSER_FAST_FINALITY_PROVING_LIMIT` | total in-flight proving tasks before creation pauses (default `1`) |
+
+SP1 network configuration applies when `KONA_SP1_PROPOSER_PROOF_PROVIDER=network`:
+
+| Variable | Purpose |
+|---|---|
+| `KONA_SP1_PROPOSER_NETWORK_PRIVATE_KEY` | SPN requester private key, or AWS KMS key ARN when KMS is enabled |
+| `KONA_SP1_PROPOSER_NETWORK_RPC_URL` | SPN RPC override; absent or empty uses the SP1 SDK default for the selected network mode |
+| `KONA_SP1_PROPOSER_USE_KMS_REQUESTER` | use AWS KMS for request signing (default `false`) |
+| `KONA_SP1_PROPOSER_RANGE_PROOF_STRATEGY` | range fulfillment strategy (default `reserved`) |
+| `KONA_SP1_PROPOSER_AGG_PROOF_STRATEGY` | aggregation fulfillment strategy (default `reserved`) |
+| `KONA_SP1_PROPOSER_SP1_TIMEOUT_SECONDS` | overall proof timeout (default `14400`) |
+| `KONA_SP1_PROPOSER_NETWORK_CALLS_TIMEOUT` | individual network-call timeout (default `15`) |
+| `KONA_SP1_PROPOSER_AUCTION_TIMEOUT` | unassigned mainnet request timeout (default `60`) |
+| `KONA_SP1_PROPOSER_RANGE_CYCLE_LIMIT` | range request cycle limit (default `1e12`) |
+| `KONA_SP1_PROPOSER_RANGE_GAS_LIMIT` | range request gas limit (default `1e12`) |
+| `KONA_SP1_PROPOSER_AGG_CYCLE_LIMIT` | aggregation request cycle limit (default `1e12`) |
+| `KONA_SP1_PROPOSER_AGG_GAS_LIMIT` | aggregation request gas limit (default `1e12`) |
+| `KONA_SP1_PROPOSER_MAX_PRICE_PER_PGU` | maximum price per proving gas unit (default `3e8`) |
+| `KONA_SP1_PROPOSER_MIN_AUCTION_PERIOD` | minimum auction period in seconds (default `1`) |
+
+Transaction signing requires one of these configurations:
+
+| Variable | Purpose |
+|---|---|
+| `KONA_SP1_PROPOSER_PRIVATE_KEY` | local L1 transaction-signing key |
+| `KONA_SP1_PROPOSER_SIGNER_URL` | Web3Signer URL; requires `KONA_SP1_PROPOSER_SIGNER_ADDRESS` |
+| `KONA_SP1_PROPOSER_SIGNER_ADDRESS` | Web3Signer address; requires `KONA_SP1_PROPOSER_SIGNER_URL` |
+
+Logging and telemetry:
+
+| Variable | Purpose |
+|---|---|
+| `KONA_SP1_PROPOSER_LOGGER_NAME` | OpenTelemetry service name (default `kona-sp1`) |
+| `KONA_SP1_PROPOSER_OTLP_ENDPOINT` | OpenTelemetry endpoint (default `http://localhost:4317`) |
+| `KONA_SP1_PROPOSER_OTLP_ENABLED` | enable OpenTelemetry export (default `false`) |
+| `KONA_SP1_PROPOSER_LOG_FORMAT` | `pretty` or `json` (default `pretty`) |
+
+The proposer and its dependencies also observe the standard `RUST_LOG`, `NO_COLOR`,
+`SSL_CERT_DIR`, `SSL_CERT_FILE`, `OTEL_*`, proxy, AWS credential, and SP1 worker/debug
+variables. `KONA_SP1_ELF_DIR` configures shared build/test infrastructure.
 
 ### Fast finality
 
-With `FAST_FINALITY_MODE=true` the proposer proves every signer-created owned
+With `KONA_SP1_PROPOSER_FAST_FINALITY_MODE=true` the proposer proves every signer-created owned
 game while it is still unchallenged, spawned by the per-tick scan one fetch
 interval after creation. A proven game is over immediately, so it resolves as
 soon as its parent does instead of waiting out `maxChallengeDuration`: proof
@@ -256,7 +299,7 @@ Off by default.
 Spend framing: in network mode this proves every game created by this signer
 whose prestate artifacts are available. At a one-hour proposal interval that is
 a baseline of 24 aggregation proofs per day; the default
-`FAST_FINALITY_PROVING_LIMIT=1` serializes them. An unchallenged game created by
+`KONA_SP1_PROPOSER_FAST_FINALITY_PROVING_LIMIT=1` serializes them. An unchallenged game created by
 another proposer is not proven, even when it uses a known prestate. Enabling the
 mode on a chain with an existing unchallenged backlog proves the signer-created
 owned backlog.
@@ -267,7 +310,7 @@ Concurrency interaction:
 |---|---|
 | active proving tasks (defense + fast finality) >= limit | no new fast-finality proving; game creation paused this tick |
 | defense tasks alone >= limit | same: defense load pauses creation (upstream parity) |
-| fast-finality tasks in flight | never count against `MAX_CONCURRENT_DEFENSE_TASKS` |
+| fast-finality tasks in flight | never count against `KONA_SP1_PROPOSER_MAX_CONCURRENT_DEFENSE_TASKS` |
 | game challenged while a fast-finality proof is in flight | the proof stays valid; per-game dedup prevents a second task |
 | a fast-finality proof keeps failing at the limit | creation stays paused until it succeeds or is classified unprovable; watch `kona_sp1_proposer_game_proving_error` |
 ## Building

--- a/rust/kona/sp1/crates/host/src/lib.rs
+++ b/rust/kona/sp1/crates/host/src/lib.rs
@@ -12,3 +12,8 @@ pub mod metrics;
 pub mod network;
 pub mod witness_generation;
 pub use logger::setup_logger;
+
+/// Builds an environment-variable name from a service prefix and suffix.
+pub fn prefixed_env_var(prefix: &str, suffix: &str) -> String {
+    format!("{prefix}_{suffix}")
+}

--- a/rust/kona/sp1/crates/host/src/logger.rs
+++ b/rust/kona/sp1/crates/host/src/logger.rs
@@ -12,7 +12,36 @@ use tracing_subscriber::{
     util::SubscriberInitExt,
 };
 
+use crate::prefixed_env_var;
+
 static INIT: OnceLock<Result<()>> = OnceLock::new();
+
+struct LoggerConfig {
+    service_name: String,
+    otlp_endpoint: String,
+    otlp_enabled: bool,
+    log_format: String,
+}
+
+impl LoggerConfig {
+    fn from_env(prefix: &str) -> Self {
+        let logger_name = prefixed_env_var(prefix, "LOGGER_NAME");
+        let otlp_endpoint = prefixed_env_var(prefix, "OTLP_ENDPOINT");
+        let otlp_enabled = prefixed_env_var(prefix, "OTLP_ENABLED");
+        let log_format = prefixed_env_var(prefix, "LOG_FORMAT");
+
+        Self {
+            service_name: env::var(logger_name).unwrap_or_else(|_| "kona-sp1".to_string()),
+            otlp_endpoint: env::var(otlp_endpoint)
+                .unwrap_or_else(|_| "http://localhost:4317".to_string()),
+            otlp_enabled: env::var(otlp_enabled)
+                .unwrap_or_else(|_| "false".to_string())
+                .parse::<bool>()
+                .unwrap_or(false),
+            log_format: env::var(log_format).unwrap_or_else(|_| "pretty".to_string()),
+        }
+    }
+}
 
 fn build_env_filter() -> EnvFilter {
     let mut filter = EnvFilter::new("info")
@@ -47,36 +76,26 @@ fn build_env_filter() -> EnvFilter {
 
 /// Set up the logger with optional `OpenTelemetry` export.
 ///
-/// # Environment Variables
-/// - `LOGGER_NAME`: Service name for opentelemetry logs (defaults to `kona-sp1`)
-/// - `OTLP_ENDPOINT`: `OpenTelemetry` endpoint (defaults to <http://localhost:4317>)
-/// - `OTLP_ENABLED`: Whether to enable `OpenTelemetry` export (defaults to false)
-/// - `RUST_LOG`: Standard Rust log level configuration
-/// - `LOG_FORMAT`: Output format (pretty or json, defaults to pretty)
-pub fn setup_logger() {
-    INIT.get_or_init(|| {
-        let logger_name = std::env::var("LOGGER_NAME").ok();
-        let otlp_endpoint =
-            std::env::var("OTLP_ENDPOINT").unwrap_or_else(|_| "http://localhost:4317".to_string());
-
-        let otlp_enabled = std::env::var("OTLP_ENABLED")
-            .unwrap_or_else(|_| "false".to_string())
-            .parse::<bool>()
-            .unwrap_or(false);
-
-        let service_name = logger_name.unwrap_or_else(|| "kona-sp1".to_string());
-
+/// # Environment variables
+/// - `<PREFIX>_LOGGER_NAME`: service name (default `kona-sp1`)
+/// - `<PREFIX>_OTLP_ENDPOINT`: export endpoint (default <http://localhost:4317>)
+/// - `<PREFIX>_OTLP_ENABLED`: enable export (default `false`)
+/// - `<PREFIX>_LOG_FORMAT`: `pretty` or `json` (default `pretty`)
+/// - `RUST_LOG`: standard Rust log filtering
+/// - `NO_COLOR`: disable ANSI output
+pub fn setup_logger(prefix: &str) {
+    let config = LoggerConfig::from_env(prefix);
+    INIT.get_or_init(move || {
         let params = vec![
-            KeyValue::new("service.name", service_name),
+            KeyValue::new("service.name", config.service_name),
             KeyValue::new("service.version", env!("CARGO_PKG_VERSION").to_string()),
         ];
 
         let resource = Resource::builder_empty().with_attributes(params).build();
         global::set_text_map_propagator(TraceContextPropagator::new());
 
-        let log_format = std::env::var("LOG_FORMAT").unwrap_or_else(|_| "pretty".to_string());
         let fmt_layer: Option<Box<dyn Layer<_> + Send + Sync>> =
-            match log_format.to_lowercase().as_str() {
+            match config.log_format.to_lowercase().as_str() {
                 "json" => {
                     // Initialize with JSON formatting
                     Some(Box::new(
@@ -105,11 +124,11 @@ pub fn setup_logger() {
                 }
             };
 
-        let log_export_layer: Option<Box<dyn Layer<_> + Send + Sync>> = if otlp_enabled {
+        let log_export_layer: Option<Box<dyn Layer<_> + Send + Sync>> = if config.otlp_enabled {
             let export_layer = LogExporter::builder()
                 .with_tonic()
                 .with_export_config(ExportConfig {
-                    endpoint: Some(otlp_endpoint.clone()),
+                    endpoint: Some(config.otlp_endpoint.clone()),
                     protocol: Protocol::Grpc,
                     ..Default::default()
                 })
@@ -127,8 +146,8 @@ pub fn setup_logger() {
         };
 
         Registry::default().with(log_export_layer).with(fmt_layer).init();
-        if otlp_enabled {
-            tracing::info!("OTLP endpoint configured: {}", otlp_endpoint);
+        if config.otlp_enabled {
+            tracing::info!("OTLP endpoint configured: {}", config.otlp_endpoint);
         }
         Ok(())
     });

--- a/rust/kona/sp1/crates/host/src/logger.rs
+++ b/rust/kona/sp1/crates/host/src/logger.rs
@@ -16,33 +16,6 @@ use crate::prefixed_env_var;
 
 static INIT: OnceLock<Result<()>> = OnceLock::new();
 
-struct LoggerConfig {
-    service_name: String,
-    otlp_endpoint: String,
-    otlp_enabled: bool,
-    log_format: String,
-}
-
-impl LoggerConfig {
-    fn from_env(prefix: &str) -> Self {
-        let logger_name = prefixed_env_var(prefix, "LOGGER_NAME");
-        let otlp_endpoint = prefixed_env_var(prefix, "OTLP_ENDPOINT");
-        let otlp_enabled = prefixed_env_var(prefix, "OTLP_ENABLED");
-        let log_format = prefixed_env_var(prefix, "LOG_FORMAT");
-
-        Self {
-            service_name: env::var(logger_name).unwrap_or_else(|_| "kona-sp1".to_string()),
-            otlp_endpoint: env::var(otlp_endpoint)
-                .unwrap_or_else(|_| "http://localhost:4317".to_string()),
-            otlp_enabled: env::var(otlp_enabled)
-                .unwrap_or_else(|_| "false".to_string())
-                .parse::<bool>()
-                .unwrap_or(false),
-            log_format: env::var(log_format).unwrap_or_else(|_| "pretty".to_string()),
-        }
-    }
-}
-
 fn build_env_filter() -> EnvFilter {
     let mut filter = EnvFilter::new("info")
         .add_directive("single_hint_handler=error".parse().unwrap())
@@ -84,10 +57,20 @@ fn build_env_filter() -> EnvFilter {
 /// - `RUST_LOG`: standard Rust log filtering
 /// - `NO_COLOR`: disable ANSI output
 pub fn setup_logger(prefix: &str) {
-    let config = LoggerConfig::from_env(prefix);
-    INIT.get_or_init(move || {
+    INIT.get_or_init(|| {
+        let service_name = env::var(prefixed_env_var(prefix, "LOGGER_NAME"))
+            .unwrap_or_else(|_| "kona-sp1".to_string());
+        let otlp_endpoint = env::var(prefixed_env_var(prefix, "OTLP_ENDPOINT"))
+            .unwrap_or_else(|_| "http://localhost:4317".to_string());
+        let otlp_enabled = env::var(prefixed_env_var(prefix, "OTLP_ENABLED"))
+            .unwrap_or_else(|_| "false".to_string())
+            .parse::<bool>()
+            .unwrap_or(false);
+        let log_format = env::var(prefixed_env_var(prefix, "LOG_FORMAT"))
+            .unwrap_or_else(|_| "pretty".to_string());
+
         let params = vec![
-            KeyValue::new("service.name", config.service_name),
+            KeyValue::new("service.name", service_name),
             KeyValue::new("service.version", env!("CARGO_PKG_VERSION").to_string()),
         ];
 
@@ -95,7 +78,7 @@ pub fn setup_logger(prefix: &str) {
         global::set_text_map_propagator(TraceContextPropagator::new());
 
         let fmt_layer: Option<Box<dyn Layer<_> + Send + Sync>> =
-            match config.log_format.to_lowercase().as_str() {
+            match log_format.to_lowercase().as_str() {
                 "json" => {
                     // Initialize with JSON formatting
                     Some(Box::new(
@@ -124,11 +107,11 @@ pub fn setup_logger(prefix: &str) {
                 }
             };
 
-        let log_export_layer: Option<Box<dyn Layer<_> + Send + Sync>> = if config.otlp_enabled {
+        let log_export_layer: Option<Box<dyn Layer<_> + Send + Sync>> = if otlp_enabled {
             let export_layer = LogExporter::builder()
                 .with_tonic()
                 .with_export_config(ExportConfig {
-                    endpoint: Some(config.otlp_endpoint.clone()),
+                    endpoint: Some(otlp_endpoint.clone()),
                     protocol: Protocol::Grpc,
                     ..Default::default()
                 })
@@ -146,8 +129,8 @@ pub fn setup_logger(prefix: &str) {
         };
 
         Registry::default().with(log_export_layer).with(fmt_layer).init();
-        if config.otlp_enabled {
-            tracing::info!("OTLP endpoint configured: {}", config.otlp_endpoint);
+        if otlp_enabled {
+            tracing::info!("OTLP endpoint configured: {}", otlp_endpoint);
         }
         Ok(())
     });

--- a/rust/kona/sp1/crates/host/src/network.rs
+++ b/rust/kona/sp1/crates/host/src/network.rs
@@ -5,8 +5,12 @@ use std::env;
 use anyhow::{Context, Result, anyhow, bail};
 use sp1_sdk::{
     NetworkProver, ProverClient,
-    network::{FulfillmentStrategy, NetworkMode, signer::NetworkSigner},
+    network::{
+        FulfillmentStrategy, NetworkMode, get_default_rpc_url_for_mode, signer::NetworkSigner,
+    },
 };
+
+use crate::prefixed_env_var;
 
 /// Parse a fulfillment strategy from a string.
 pub fn parse_fulfillment_strategy(value: String) -> Result<FulfillmentStrategy> {
@@ -43,42 +47,73 @@ pub fn determine_network_mode(
     }
 }
 
-/// Compute the network signer using the `NETWORK_PRIVATE_KEY` env var.
-/// If the `use_kms_requester` parameter is set to `true`, the `NETWORK_PRIVATE_KEY` env var
-/// must be set with a key ARN.
-pub async fn get_network_signer(use_kms_requester: bool) -> Result<NetworkSigner> {
-    let network_signer = if use_kms_requester {
-        // If using KMS, NETWORK_PRIVATE_KEY should be a KMS key ARN.
-        let kms_key_arn = env::var("NETWORK_PRIVATE_KEY")
-            .context("NETWORK_PRIVATE_KEY must be set when USE_KMS_REQUESTER is true")?;
-        let signer = NetworkSigner::aws_kms(&kms_key_arn).await?;
-        tracing::info!("Using KMS requester with address: {:?}", signer.address());
+enum NetworkSignerConfig {
+    AwsKms(String),
+    Local(String),
+}
 
-        signer
+fn network_signer_config(prefix: &str, use_kms_requester: bool) -> Result<NetworkSignerConfig> {
+    let private_key_name = prefixed_env_var(prefix, "NETWORK_PRIVATE_KEY");
+    let use_kms_name = prefixed_env_var(prefix, "USE_KMS_REQUESTER");
+    if use_kms_requester {
+        let key_arn = env::var(&private_key_name).with_context(|| {
+            format!("{private_key_name} must be set when {use_kms_name} is true")
+        })?;
+        Ok(NetworkSignerConfig::AwsKms(key_arn))
     } else {
-        // Network proving spends real money. Require the key at startup instead
-        // of failing on the first proof request.
-        let private_key =
-            env::var("NETWORK_PRIVATE_KEY").ok().filter(|key| !key.trim().is_empty()).context(
-                "NETWORK_PRIVATE_KEY must be set for network proving \
-                 (or set USE_KMS_REQUESTER=true to sign requests with AWS KMS)",
-            )?;
-        let signer = NetworkSigner::local(&private_key)?;
-        tracing::info!("Using local requester with address: {:?}", signer.address());
+        let private_key = env::var(&private_key_name)
+            .ok()
+            .filter(|key| !key.trim().is_empty())
+            .with_context(|| {
+                format!(
+                    "{private_key_name} must be set for network proving (or set {use_kms_name}=true \
+                     to sign requests with AWS KMS)"
+                )
+            })?;
+        Ok(NetworkSignerConfig::Local(private_key))
+    }
+}
 
-        signer
+/// Computes the network signer from `<PREFIX>_NETWORK_PRIVATE_KEY`.
+///
+/// When `use_kms_requester` is `true`, the value must be an AWS KMS key ARN. Otherwise,
+/// it must be a local private key. The proposer supplies `KONA_SP1_PROPOSER` as the prefix.
+pub async fn get_network_signer(prefix: &str, use_kms_requester: bool) -> Result<NetworkSigner> {
+    let private_key_name = prefixed_env_var(prefix, "NETWORK_PRIVATE_KEY");
+    let network_signer = match network_signer_config(prefix, use_kms_requester)? {
+        NetworkSignerConfig::AwsKms(key_arn) => {
+            let signer = NetworkSigner::aws_kms(&key_arn)
+                .await
+                .with_context(|| format!("failed to create requester from {private_key_name}"))?;
+            tracing::info!("Using KMS requester with address: {:?}", signer.address());
+            signer
+        }
+        NetworkSignerConfig::Local(private_key) => {
+            let signer = NetworkSigner::local(&private_key)
+                .with_context(|| format!("failed to create requester from {private_key_name}"))?;
+            tracing::info!("Using local requester with address: {:?}", signer.address());
+            signer
+        }
     };
 
     Ok(network_signer)
 }
 
-/// Build a network prover from `USE_KMS_REQUESTER`, using the provided fulfillment strategy.
-pub async fn build_network_prover_from_env(strategy: FulfillmentStrategy) -> Result<NetworkProver> {
-    let use_kms_requester = env::var("USE_KMS_REQUESTER")
+struct NetworkProverConfig {
+    use_kms_requester: bool,
+    network_mode: NetworkMode,
+    rpc_url: String,
+}
+
+fn network_prover_config(
+    prefix: &str,
+    strategy: FulfillmentStrategy,
+) -> Result<NetworkProverConfig> {
+    let use_kms_name = prefixed_env_var(prefix, "USE_KMS_REQUESTER");
+    let use_kms_requester = env::var(&use_kms_name)
         .unwrap_or_else(|_| "false".to_string())
         .parse::<bool>()
-        .context("USE_KMS_REQUESTER must be true or false")?;
-    let network_signer = get_network_signer(use_kms_requester).await?;
+        .with_context(|| format!("{use_kms_name} must be true or false"))?;
 
     let network_mode = match strategy {
         FulfillmentStrategy::Auction => NetworkMode::Mainnet,
@@ -86,8 +121,97 @@ pub async fn build_network_prover_from_env(strategy: FulfillmentStrategy) -> Res
         _ => bail!("Fulfillment strategy must be 'reserved', 'hosted', or 'auction'"),
     };
 
-    let prover =
-        ProverClient::builder().network_for(network_mode).signer(network_signer).build().await;
+    let rpc_url_name = prefixed_env_var(prefix, "NETWORK_RPC_URL");
+    let rpc_url = env::var(rpc_url_name)
+        .ok()
+        .filter(|url| !url.trim().is_empty())
+        .unwrap_or_else(|| get_default_rpc_url_for_mode(network_mode));
+
+    Ok(NetworkProverConfig { use_kms_requester, network_mode, rpc_url })
+}
+
+/// Builds a network prover using the provided fulfillment strategy and
+/// `<PREFIX>_USE_KMS_REQUESTER`.
+///
+/// `<PREFIX>_NETWORK_RPC_URL` overrides the SP1 endpoint. If it is absent or empty, the
+/// SDK default for the fulfillment strategy's network mode is used.
+pub async fn build_network_prover_from_env(
+    prefix: &str,
+    strategy: FulfillmentStrategy,
+) -> Result<NetworkProver> {
+    let config = network_prover_config(prefix, strategy)?;
+    let network_signer = get_network_signer(prefix, config.use_kms_requester).await?;
+
+    let prover = ProverClient::builder()
+        .network_for(config.network_mode)
+        .signer(network_signer)
+        .rpc_url(&config.rpc_url)
+        .build()
+        .await;
 
     Ok(prover)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const PREFIX: &str = "KONA_SP1_PROPOSER";
+
+    fn set_env(suffix: &str, value: &str) {
+        unsafe { env::set_var(prefixed_env_var(PREFIX, suffix), value) };
+    }
+
+    fn remove_env(suffix: &str) {
+        unsafe { env::remove_var(prefixed_env_var(PREFIX, suffix)) };
+    }
+
+    #[test]
+    fn requester_selection_uses_configured_network_private_key() {
+        set_env("NETWORK_PRIVATE_KEY", "key");
+        unsafe { env::set_var("NETWORK_PRIVATE_KEY", "other-key") };
+
+        match network_signer_config(PREFIX, false).unwrap() {
+            NetworkSignerConfig::Local(key) => assert_eq!(key, "key"),
+            NetworkSignerConfig::AwsKms(_) => panic!("expected local requester"),
+        }
+        match network_signer_config(PREFIX, true).unwrap() {
+            NetworkSignerConfig::AwsKms(key) => assert_eq!(key, "key"),
+            NetworkSignerConfig::Local(_) => panic!("expected KMS requester"),
+        }
+
+        remove_env("NETWORK_PRIVATE_KEY");
+        let err = network_signer_config(PREFIX, false)
+            .err()
+            .expect("expected missing requester key")
+            .to_string();
+        assert!(err.contains("KONA_SP1_PROPOSER_NETWORK_PRIVATE_KEY"), "unexpected: {err}");
+    }
+
+    #[test]
+    fn network_rpc_override_and_mode_defaults() {
+        set_env("USE_KMS_REQUESTER", "true");
+        set_env("NETWORK_RPC_URL", "https://rpc.example");
+        unsafe { env::set_var("NETWORK_RPC_URL", "https://other.example") };
+        let config = network_prover_config(PREFIX, FulfillmentStrategy::Auction).unwrap();
+        assert!(config.use_kms_requester);
+        assert_eq!(config.network_mode, NetworkMode::Mainnet);
+        assert_eq!(config.rpc_url, "https://rpc.example");
+
+        remove_env("USE_KMS_REQUESTER");
+        remove_env("NETWORK_RPC_URL");
+        let config = network_prover_config(PREFIX, FulfillmentStrategy::Auction).unwrap();
+        assert!(!config.use_kms_requester);
+        assert_eq!(config.network_mode, NetworkMode::Mainnet);
+        assert_eq!(config.rpc_url, get_default_rpc_url_for_mode(NetworkMode::Mainnet));
+
+        let config = network_prover_config(PREFIX, FulfillmentStrategy::Hosted).unwrap();
+        assert_eq!(config.network_mode, NetworkMode::Reserved);
+        assert_eq!(config.rpc_url, get_default_rpc_url_for_mode(NetworkMode::Reserved));
+
+        set_env("NETWORK_RPC_URL", "   ");
+        let config = network_prover_config(PREFIX, FulfillmentStrategy::Reserved).unwrap();
+        assert_eq!(config.network_mode, NetworkMode::Reserved);
+        assert_eq!(config.rpc_url, get_default_rpc_url_for_mode(NetworkMode::Reserved));
+    }
 }

--- a/rust/kona/sp1/crates/host/src/network.rs
+++ b/rust/kona/sp1/crates/host/src/network.rs
@@ -47,19 +47,22 @@ pub fn determine_network_mode(
     }
 }
 
-enum NetworkSignerConfig {
-    AwsKms(String),
-    Local(String),
-}
-
-fn network_signer_config(prefix: &str, use_kms_requester: bool) -> Result<NetworkSignerConfig> {
+/// Computes the network signer from `<PREFIX>_NETWORK_PRIVATE_KEY`.
+///
+/// When `use_kms_requester` is `true`, the value must be an AWS KMS key ARN. Otherwise,
+/// it must be a local private key. The proposer supplies `KONA_SP1_PROPOSER` as the prefix.
+pub async fn get_network_signer(prefix: &str, use_kms_requester: bool) -> Result<NetworkSigner> {
     let private_key_name = prefixed_env_var(prefix, "NETWORK_PRIVATE_KEY");
     let use_kms_name = prefixed_env_var(prefix, "USE_KMS_REQUESTER");
-    if use_kms_requester {
+    let network_signer = if use_kms_requester {
         let key_arn = env::var(&private_key_name).with_context(|| {
             format!("{private_key_name} must be set when {use_kms_name} is true")
         })?;
-        Ok(NetworkSignerConfig::AwsKms(key_arn))
+        let signer = NetworkSigner::aws_kms(&key_arn)
+            .await
+            .with_context(|| format!("failed to create requester from {private_key_name}"))?;
+        tracing::info!("Using KMS requester with address: {:?}", signer.address());
+        signer
     } else {
         let private_key = env::var(&private_key_name)
             .ok()
@@ -70,45 +73,24 @@ fn network_signer_config(prefix: &str, use_kms_requester: bool) -> Result<Networ
                      to sign requests with AWS KMS)"
                 )
             })?;
-        Ok(NetworkSignerConfig::Local(private_key))
-    }
-}
-
-/// Computes the network signer from `<PREFIX>_NETWORK_PRIVATE_KEY`.
-///
-/// When `use_kms_requester` is `true`, the value must be an AWS KMS key ARN. Otherwise,
-/// it must be a local private key. The proposer supplies `KONA_SP1_PROPOSER` as the prefix.
-pub async fn get_network_signer(prefix: &str, use_kms_requester: bool) -> Result<NetworkSigner> {
-    let private_key_name = prefixed_env_var(prefix, "NETWORK_PRIVATE_KEY");
-    let network_signer = match network_signer_config(prefix, use_kms_requester)? {
-        NetworkSignerConfig::AwsKms(key_arn) => {
-            let signer = NetworkSigner::aws_kms(&key_arn)
-                .await
-                .with_context(|| format!("failed to create requester from {private_key_name}"))?;
-            tracing::info!("Using KMS requester with address: {:?}", signer.address());
-            signer
-        }
-        NetworkSignerConfig::Local(private_key) => {
-            let signer = NetworkSigner::local(&private_key)
-                .with_context(|| format!("failed to create requester from {private_key_name}"))?;
-            tracing::info!("Using local requester with address: {:?}", signer.address());
-            signer
-        }
+        let signer = NetworkSigner::local(&private_key)
+            .with_context(|| format!("failed to create requester from {private_key_name}"))?;
+        tracing::info!("Using local requester with address: {:?}", signer.address());
+        signer
     };
 
     Ok(network_signer)
 }
 
-struct NetworkProverConfig {
-    use_kms_requester: bool,
-    network_mode: NetworkMode,
-    rpc_url: String,
-}
-
-fn network_prover_config(
+/// Builds a network prover using the provided fulfillment strategy and
+/// `<PREFIX>_USE_KMS_REQUESTER`.
+///
+/// `<PREFIX>_NETWORK_RPC_URL` overrides the SP1 endpoint. If it is absent or empty, the
+/// SDK default for the fulfillment strategy's network mode is used.
+pub async fn build_network_prover_from_env(
     prefix: &str,
     strategy: FulfillmentStrategy,
-) -> Result<NetworkProverConfig> {
+) -> Result<NetworkProver> {
     let use_kms_name = prefixed_env_var(prefix, "USE_KMS_REQUESTER");
     let use_kms_requester = env::var(&use_kms_name)
         .unwrap_or_else(|_| "false".to_string())
@@ -121,97 +103,18 @@ fn network_prover_config(
         _ => bail!("Fulfillment strategy must be 'reserved', 'hosted', or 'auction'"),
     };
 
-    let rpc_url_name = prefixed_env_var(prefix, "NETWORK_RPC_URL");
-    let rpc_url = env::var(rpc_url_name)
+    let rpc_url = env::var(prefixed_env_var(prefix, "NETWORK_RPC_URL"))
         .ok()
         .filter(|url| !url.trim().is_empty())
         .unwrap_or_else(|| get_default_rpc_url_for_mode(network_mode));
-
-    Ok(NetworkProverConfig { use_kms_requester, network_mode, rpc_url })
-}
-
-/// Builds a network prover using the provided fulfillment strategy and
-/// `<PREFIX>_USE_KMS_REQUESTER`.
-///
-/// `<PREFIX>_NETWORK_RPC_URL` overrides the SP1 endpoint. If it is absent or empty, the
-/// SDK default for the fulfillment strategy's network mode is used.
-pub async fn build_network_prover_from_env(
-    prefix: &str,
-    strategy: FulfillmentStrategy,
-) -> Result<NetworkProver> {
-    let config = network_prover_config(prefix, strategy)?;
-    let network_signer = get_network_signer(prefix, config.use_kms_requester).await?;
+    let network_signer = get_network_signer(prefix, use_kms_requester).await?;
 
     let prover = ProverClient::builder()
-        .network_for(config.network_mode)
+        .network_for(network_mode)
         .signer(network_signer)
-        .rpc_url(&config.rpc_url)
+        .rpc_url(&rpc_url)
         .build()
         .await;
 
     Ok(prover)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    const PREFIX: &str = "KONA_SP1_PROPOSER";
-
-    fn set_env(suffix: &str, value: &str) {
-        unsafe { env::set_var(prefixed_env_var(PREFIX, suffix), value) };
-    }
-
-    fn remove_env(suffix: &str) {
-        unsafe { env::remove_var(prefixed_env_var(PREFIX, suffix)) };
-    }
-
-    #[test]
-    fn requester_selection_uses_configured_network_private_key() {
-        set_env("NETWORK_PRIVATE_KEY", "key");
-        unsafe { env::set_var("NETWORK_PRIVATE_KEY", "other-key") };
-
-        match network_signer_config(PREFIX, false).unwrap() {
-            NetworkSignerConfig::Local(key) => assert_eq!(key, "key"),
-            NetworkSignerConfig::AwsKms(_) => panic!("expected local requester"),
-        }
-        match network_signer_config(PREFIX, true).unwrap() {
-            NetworkSignerConfig::AwsKms(key) => assert_eq!(key, "key"),
-            NetworkSignerConfig::Local(_) => panic!("expected KMS requester"),
-        }
-
-        remove_env("NETWORK_PRIVATE_KEY");
-        let err = network_signer_config(PREFIX, false)
-            .err()
-            .expect("expected missing requester key")
-            .to_string();
-        assert!(err.contains("KONA_SP1_PROPOSER_NETWORK_PRIVATE_KEY"), "unexpected: {err}");
-    }
-
-    #[test]
-    fn network_rpc_override_and_mode_defaults() {
-        set_env("USE_KMS_REQUESTER", "true");
-        set_env("NETWORK_RPC_URL", "https://rpc.example");
-        unsafe { env::set_var("NETWORK_RPC_URL", "https://other.example") };
-        let config = network_prover_config(PREFIX, FulfillmentStrategy::Auction).unwrap();
-        assert!(config.use_kms_requester);
-        assert_eq!(config.network_mode, NetworkMode::Mainnet);
-        assert_eq!(config.rpc_url, "https://rpc.example");
-
-        remove_env("USE_KMS_REQUESTER");
-        remove_env("NETWORK_RPC_URL");
-        let config = network_prover_config(PREFIX, FulfillmentStrategy::Auction).unwrap();
-        assert!(!config.use_kms_requester);
-        assert_eq!(config.network_mode, NetworkMode::Mainnet);
-        assert_eq!(config.rpc_url, get_default_rpc_url_for_mode(NetworkMode::Mainnet));
-
-        let config = network_prover_config(PREFIX, FulfillmentStrategy::Hosted).unwrap();
-        assert_eq!(config.network_mode, NetworkMode::Reserved);
-        assert_eq!(config.rpc_url, get_default_rpc_url_for_mode(NetworkMode::Reserved));
-
-        set_env("NETWORK_RPC_URL", "   ");
-        let config = network_prover_config(PREFIX, FulfillmentStrategy::Reserved).unwrap();
-        assert_eq!(config.network_mode, NetworkMode::Reserved);
-        assert_eq!(config.rpc_url, get_default_rpc_url_for_mode(NetworkMode::Reserved));
-    }
 }

--- a/rust/kona/sp1/crates/proposer/src/bin/kona-sp1-proposer.rs
+++ b/rust/kona/sp1/crates/proposer/src/bin/kona-sp1-proposer.rs
@@ -14,6 +14,7 @@ use kona_sp1_host_utils::{
     network::{build_network_prover_from_env, determine_network_mode},
 };
 use kona_sp1_proposer::{
+    ENV_VAR_PREFIX,
     config::{ProofProviderKind, ProposerConfig, redacted_url},
     contract::DisputeGameFactory,
     metrics::ProposerGauge,
@@ -30,7 +31,7 @@ struct Cli {}
 #[tokio::main]
 async fn main() -> Result<()> {
     Cli::parse();
-    setup_logger();
+    setup_logger(ENV_VAR_PREFIX);
 
     let config = ProposerConfig::from_env()?;
 
@@ -66,8 +67,7 @@ async fn main() -> Result<()> {
         "Resolved proposer configuration"
     );
 
-    // Read NETWORK_PRIVATE_KEY only in network mode; mock deployments
-    // need no SPN credentials.
+    // Mock deployments need no SPN credentials.
     let proof_provider = match config.proof_provider {
         ProofProviderKind::Network => {
             let provider_config = config.proof_provider_config.clone();
@@ -76,7 +76,8 @@ async fn main() -> Result<()> {
                 provider_config.agg_proof_strategy,
             )?;
             let prover =
-                build_network_prover_from_env(provider_config.range_proof_strategy).await?;
+                build_network_prover_from_env(ENV_VAR_PREFIX, provider_config.range_proof_strategy)
+                    .await?;
             ProofProvider::Network(NetworkProofProvider::new(
                 Arc::new(prover),
                 provider_config,

--- a/rust/kona/sp1/crates/proposer/src/config.rs
+++ b/rust/kona/sp1/crates/proposer/src/config.rs
@@ -19,6 +19,8 @@ use anyhow::{Context, Result, anyhow, bail};
 use kona_sp1_host_utils::{metrics::MetricsListen, network::parse_fulfillment_strategy};
 use sp1_sdk::network::FulfillmentStrategy;
 
+use crate::env_var;
+
 /// Safety level gating how far proposals may advance.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ProposalSafety {
@@ -35,7 +37,7 @@ impl FromStr for ProposalSafety {
         match value.to_ascii_lowercase().as_str() {
             "safe" => Ok(Self::Safe),
             "finalized" => Ok(Self::Finalized),
-            other => bail!("invalid PROPOSAL_SAFETY: {other} (expected safe|finalized)"),
+            other => bail!("{other} (expected safe|finalized)"),
         }
     }
 }
@@ -61,7 +63,7 @@ impl FromStr for ProofProviderKind {
         match value.to_ascii_lowercase().as_str() {
             "network" => Ok(Self::Network),
             "mock" => Ok(Self::Mock),
-            other => bail!("invalid PROOF_PROVIDER: {other} (expected network|mock)"),
+            other => bail!("{other} (expected network|mock)"),
         }
     }
 }
@@ -150,7 +152,7 @@ pub struct ProposerConfig {
     pub l1_config_path: Option<PathBuf>,
 
     /// Optional dependency-set config file. Absent = superchain-registry
-    /// fallback. The env name matches the executor's `DEPENDENCY_SET_PATH`.
+    /// fallback. The suffix matches the executor's `DEPENDENCY_SET_PATH`.
     pub dependency_set_path: Option<PathBuf>,
 
     /// Number of proof chunks per defended timestamp span.
@@ -177,25 +179,44 @@ pub struct ProposerConfig {
     pub proof_provider_config: ProofProviderConfig,
 }
 
-fn optional_env(name: &str) -> Option<String> {
+fn required_env(suffix: &str) -> Result<String> {
+    let name = env_var(suffix);
+    env::var(&name).with_context(|| format!("{name} not set"))
+}
+
+fn optional_env(suffix: &str) -> Option<String> {
+    let name = env_var(suffix);
     match env::var(name) {
         Ok(value) if !value.is_empty() => Some(value),
         _ => None,
     }
 }
 
-fn parsed_env_or<T: FromStr>(name: &str, default: T) -> Result<T>
-where
-    T::Err: std::fmt::Display,
-{
-    parsed_optional_env(name).map(|value| value.unwrap_or(default))
+fn env_or(suffix: &str, default: &str) -> String {
+    env::var(env_var(suffix)).unwrap_or_else(|_| default.to_string())
 }
 
-fn parsed_optional_env<T: FromStr>(name: &str) -> Result<Option<T>>
+fn parsed_required_env<T: FromStr>(suffix: &str) -> Result<T>
 where
     T::Err: std::fmt::Display,
 {
-    optional_env(name)
+    let name = env_var(suffix);
+    required_env(suffix)?.parse::<T>().map_err(|err| anyhow!("invalid {name}: {err}"))
+}
+
+fn parsed_env_or<T: FromStr>(suffix: &str, default: T) -> Result<T>
+where
+    T::Err: std::fmt::Display,
+{
+    parsed_optional_env(suffix).map(|value| value.unwrap_or(default))
+}
+
+fn parsed_optional_env<T: FromStr>(suffix: &str) -> Result<Option<T>>
+where
+    T::Err: std::fmt::Display,
+{
+    let name = env_var(suffix);
+    optional_env(suffix)
         .map(|value| value.parse::<T>().map_err(|err| anyhow!("invalid {name}: {err}")))
         .transpose()
 }
@@ -207,31 +228,27 @@ impl ProposerConfig {
         let tx_confirmation_timeout = parsed_env_or("TX_CONFIRMATION_TIMEOUT", 60u64)?;
         anyhow::ensure!(
             tx_confirmation_timeout > 0,
-            "TX_CONFIRMATION_TIMEOUT must be positive (0 would time out every transaction immediately)"
+            "{} must be positive (0 would time out every transaction immediately)",
+            env_var("TX_CONFIRMATION_TIMEOUT")
         );
 
-        let proof_provider = env::var("PROOF_PROVIDER")
-            .context("PROOF_PROVIDER not set (expected network|mock; there is no default)")?
-            .parse::<ProofProviderKind>()?;
-        let l2_rpcs = parse_url_list(&env::var("L2_RPCS").context("L2_RPCS not set")?)
-            .context("invalid L2_RPCS")?;
+        let proof_provider_name = env_var("PROOF_PROVIDER");
+        let proof_provider = env::var(&proof_provider_name)
+            .with_context(|| {
+                format!(
+                    "{proof_provider_name} not set (expected network|mock; there is no default)"
+                )
+            })?
+            .parse::<ProofProviderKind>()
+            .map_err(|err| anyhow!("invalid {proof_provider_name}: {err}"))?;
+        let l2_rpcs_name = env_var("L2_RPCS");
+        let l2_rpcs = parse_url_list(&required_env("L2_RPCS")?)
+            .with_context(|| format!("invalid {l2_rpcs_name}"))?;
         Ok(Self {
-            l1_rpc: env::var("L1_RPC")
-                .context("L1_RPC not set")?
-                .parse()
-                .map_err(|err| anyhow!("invalid L1_RPC: {err}"))?,
-            superroot_rpc: env::var("SUPERROOT_RPC")
-                .context("SUPERROOT_RPC not set")?
-                .parse()
-                .map_err(|err| anyhow!("invalid SUPERROOT_RPC: {err}"))?,
-            factory_address: env::var("FACTORY_ADDRESS")
-                .context("FACTORY_ADDRESS not set")?
-                .parse()
-                .map_err(|err| anyhow!("invalid FACTORY_ADDRESS: {err}"))?,
-            prestates_url: env::var("PRESTATES_URL")
-                .context("PRESTATES_URL not set")?
-                .parse()
-                .map_err(|err| anyhow!("invalid PRESTATES_URL: {err}"))?,
+            l1_rpc: parsed_required_env("L1_RPC")?,
+            superroot_rpc: parsed_required_env("SUPERROOT_RPC")?,
+            factory_address: parsed_required_env("FACTORY_ADDRESS")?,
+            prestates_url: parsed_required_env("PRESTATES_URL")?,
             proposal_interval_seconds: parsed_env_or("PROPOSAL_INTERVAL_SECONDS", 3600u64)?,
             proposal_safety: parsed_env_or("PROPOSAL_SAFETY", ProposalSafety::Finalized)?,
             fetch_interval: parsed_env_or("FETCH_INTERVAL", 30u64)?,
@@ -241,10 +258,7 @@ impl ProposerConfig {
             max_fee_per_gas: parsed_optional_env("MAX_FEE_PER_GAS")?,
             max_priority_fee_per_gas: parsed_optional_env("MAX_PRIORITY_FEE_PER_GAS")?,
             proof_provider,
-            l1_beacon_rpc: env::var("L1_BEACON_RPC")
-                .context("L1_BEACON_RPC not set")?
-                .parse()
-                .map_err(|err| anyhow!("invalid L1_BEACON_RPC: {err}"))?,
+            l1_beacon_rpc: parsed_required_env("L1_BEACON_RPC")?,
             l2_rpcs,
             rollup_config_paths: optional_env("ROLLUP_CONFIG_PATHS")
                 .map(|list| list.split(',').map(|path| PathBuf::from(path.trim())).collect()),
@@ -293,7 +307,7 @@ const DEFAULT_PROOF_LIMIT: u64 = 1_000_000_000_000;
 /// SP1 proof-provider settings (timeouts, strategies, limits, prices).
 ///
 /// Parsed in mock mode too, but all values have defaults and require no credentials.
-/// `NETWORK_PRIVATE_KEY` is read only when the network provider is built.
+/// `KONA_SP1_PROPOSER_NETWORK_PRIVATE_KEY` is read only when the network provider is built.
 #[derive(Debug, Clone)]
 pub struct ProofProviderConfig {
     /// Overall per-proof timeout in seconds: the server-side deadline for
@@ -329,31 +343,36 @@ impl ProofProviderConfig {
         let timeout = parsed_env_or("SP1_TIMEOUT_SECONDS", 14_400u64)?;
         anyhow::ensure!(
             timeout > 0,
-            "SP1_TIMEOUT_SECONDS must be positive: 0 would abandon every proof request at its \
-             first poll, right after paying to submit it"
+            "{} must be positive: 0 would abandon every proof request at its first poll, right \
+             after paying to submit it",
+            env_var("SP1_TIMEOUT_SECONDS")
         );
         let network_calls_timeout = parsed_env_or("NETWORK_CALLS_TIMEOUT", 15u64)?;
         anyhow::ensure!(
             network_calls_timeout > 0,
-            "NETWORK_CALLS_TIMEOUT must be positive: 0 would time out every SPN call before any \
-             I/O completes"
+            "{} must be positive: 0 would time out every SPN call before any I/O completes",
+            env_var("NETWORK_CALLS_TIMEOUT")
         );
         let auction_timeout = parsed_env_or("AUCTION_TIMEOUT", 60u64)?;
         anyhow::ensure!(
             auction_timeout > 0,
-            "AUCTION_TIMEOUT must be positive: 0 would cancel every mainnet request by its second \
-             poll"
+            "{} must be positive: 0 would cancel every mainnet request by its second poll",
+            env_var("AUCTION_TIMEOUT")
         );
         Ok(Self {
             timeout,
             network_calls_timeout,
             auction_timeout,
-            range_proof_strategy: parse_fulfillment_strategy(
-                env::var("RANGE_PROOF_STRATEGY").unwrap_or_else(|_| "reserved".to_string()),
-            )?,
-            agg_proof_strategy: parse_fulfillment_strategy(
-                env::var("AGG_PROOF_STRATEGY").unwrap_or_else(|_| "reserved".to_string()),
-            )?,
+            range_proof_strategy: parse_fulfillment_strategy(env_or(
+                "RANGE_PROOF_STRATEGY",
+                "reserved",
+            ))
+            .with_context(|| format!("invalid {}", env_var("RANGE_PROOF_STRATEGY")))?,
+            agg_proof_strategy: parse_fulfillment_strategy(env_or(
+                "AGG_PROOF_STRATEGY",
+                "reserved",
+            ))
+            .with_context(|| format!("invalid {}", env_var("AGG_PROOF_STRATEGY")))?,
             range_cycle_limit: parsed_env_or("RANGE_CYCLE_LIMIT", DEFAULT_PROOF_LIMIT)?,
             range_gas_limit: parsed_env_or("RANGE_GAS_LIMIT", DEFAULT_PROOF_LIMIT)?,
             agg_cycle_limit: parsed_env_or("AGG_CYCLE_LIMIT", DEFAULT_PROOF_LIMIT)?,
@@ -457,7 +476,9 @@ pub const RANGE_ARTIFACT_SUFFIX: &str = ".range.bin.gz";
 pub fn prestate_artifact_url(base: &Url, prestate: B256, suffix: &str) -> Result<Url> {
     let mut url = base.clone();
     url.path_segments_mut()
-        .map_err(|()| anyhow!("PRESTATES_URL cannot be a base: {}", redacted_url(base)))?
+        .map_err(|()| {
+            anyhow!("{} cannot be a base: {}", env_var("PRESTATES_URL"), redacted_url(base))
+        })?
         .pop_if_empty()
         .push(&format!("{prestate}{suffix}"));
     Ok(url)
@@ -502,9 +523,9 @@ const ARTIFACT_FETCH_TIMEOUT: std::time::Duration = std::time::Duration::from_se
 async fn fetch_artifact(url: &Url) -> Result<Vec<u8>> {
     let compressed = match url.scheme() {
         "file" => {
-            let path = url
-                .to_file_path()
-                .map_err(|()| anyhow!("invalid file path in PRESTATES_URL: {url}"))?;
+            let path = url.to_file_path().map_err(|()| {
+                anyhow!("invalid file path in {}: {url}", env_var("PRESTATES_URL"))
+            })?;
             tokio::fs::read(&path)
                 .await
                 .with_context(|| format!("failed to read prestate artifact {path:?}"))?
@@ -525,7 +546,10 @@ async fn fetch_artifact(url: &Url) -> Result<Vec<u8>> {
                 format!("failed to read prestate artifact body from {}", redacted_url(url))
             })?
             .to_vec(),
-        other => bail!("unsupported PRESTATES_URL scheme {other} (expected file, http, or https)"),
+        other => bail!(
+            "unsupported {} scheme {other} (expected file, http, or https)",
+            env_var("PRESTATES_URL")
+        ),
     };
 
     let mut elf = Vec::new();
@@ -553,7 +577,7 @@ mod tests {
         assert_eq!(redacted_url(&plain), "http://127.0.0.1:8545/");
         // file:// URLs cannot carry userinfo: set_username/set_password return
         // Err, which redacted_url ignores. This pins that choice (panicking on
-        // Err would break file:// PRESTATES_URL) and that the URL renders
+        // Err would break file:// prestate URLs) and that the URL renders
         // unchanged.
         let file: Url = "file:///data/prestates".parse().unwrap();
         assert_eq!(redacted_url(&file), "file:///data/prestates");
@@ -646,6 +670,93 @@ mod tests {
     mod proving_config {
         use super::*;
 
+        const REQUIRED_ENV: [(&str, &str); 7] = [
+            ("L1_RPC", "http://127.0.0.1:8545"),
+            ("SUPERROOT_RPC", "http://127.0.0.1:9545"),
+            ("FACTORY_ADDRESS", "0x000000000000000000000000000000000000dEaD"),
+            ("PRESTATES_URL", "file:///tmp/prestates"),
+            ("PROOF_PROVIDER", "mock"),
+            ("L2_RPCS", "http://127.0.0.1:8646"),
+            ("L1_BEACON_RPC", "http://127.0.0.1:5052"),
+        ];
+
+        fn set_required_env(prefixed: bool) {
+            for (name, value) in REQUIRED_ENV {
+                let name = if prefixed { env_var(name) } else { name.to_string() };
+                unsafe { env::set_var(name, value) };
+            }
+        }
+
+        fn clear_required_env(prefixed: bool) {
+            for (name, _) in REQUIRED_ENV {
+                let name = if prefixed { env_var(name) } else { name.to_string() };
+                unsafe { env::remove_var(name) };
+            }
+        }
+
+        fn set_proposer_env(suffix: &str, value: &str) {
+            unsafe { env::set_var(env_var(suffix), value) };
+        }
+
+        #[test]
+        fn from_env_reads_prefixed_vars() {
+            clear_required_env(false);
+            set_required_env(true);
+
+            let config = ProposerConfig::from_env().unwrap();
+            assert_eq!(config.proof_provider, ProofProviderKind::Mock);
+            assert_eq!(config.l2_rpcs.len(), 1);
+        }
+
+        #[test]
+        fn from_env_ignores_unprefixed_vars() {
+            clear_required_env(true);
+            set_required_env(false);
+
+            let err = ProposerConfig::from_env().unwrap_err().to_string();
+            assert!(err.contains("KONA_SP1_PROPOSER_PROOF_PROVIDER"), "unexpected error: {err}");
+        }
+
+        #[test]
+        fn prefixed_optional_values_override_bare_values_and_defaults() {
+            set_required_env(true);
+            unsafe {
+                env::set_var("FETCH_INTERVAL", "99");
+                env::set_var("PROPOSAL_SAFETY", "finalized");
+                env::set_var("ROLLUP_CONFIG_PATHS", "/bare/config.json");
+            }
+            set_proposer_env("FETCH_INTERVAL", "7");
+            set_proposer_env("PROPOSAL_SAFETY", "safe");
+
+            let config = ProposerConfig::from_env().unwrap();
+            assert_eq!(config.fetch_interval, 7);
+            assert_eq!(config.proposal_safety, ProposalSafety::Safe);
+            assert!(config.rollup_config_paths.is_none());
+            assert_eq!(config.proposal_interval_seconds, 3600);
+        }
+
+        #[test]
+        fn invalid_prefixed_value_names_the_prefixed_variable() {
+            set_required_env(true);
+            unsafe { env::set_var("FETCH_INTERVAL", "9") };
+            set_proposer_env("FETCH_INTERVAL", "not-a-number");
+
+            let err = ProposerConfig::from_env().unwrap_err().to_string();
+            assert!(err.contains("invalid KONA_SP1_PROPOSER_FETCH_INTERVAL"), "unexpected: {err}");
+        }
+
+        #[test]
+        fn empty_fulfillment_strategy_remains_invalid() {
+            set_required_env(true);
+            set_proposer_env("RANGE_PROOF_STRATEGY", "");
+
+            let err = ProposerConfig::from_env().unwrap_err().to_string();
+            assert!(
+                err.contains("invalid KONA_SP1_PROPOSER_RANGE_PROOF_STRATEGY"),
+                "unexpected: {err}"
+            );
+        }
+
         #[test]
         fn proof_provider_kind_parse_rejects_unknown() {
             assert_eq!(ProofProviderKind::from_str("network").unwrap(), ProofProviderKind::Network);
@@ -703,28 +814,25 @@ mod tests {
         /// is `unsafe` on edition 2024.
         #[test]
         fn from_env_requires_defend_path_vars() {
-            unsafe {
-                env::set_var("L1_RPC", "http://127.0.0.1:8545");
-                env::set_var("SUPERROOT_RPC", "http://127.0.0.1:9545");
-                env::set_var("FACTORY_ADDRESS", "0x000000000000000000000000000000000000dEaD");
-                env::set_var("PRESTATES_URL", "file:///tmp/prestates");
-            }
+            set_proposer_env("L1_RPC", "http://127.0.0.1:8545");
+            set_proposer_env("SUPERROOT_RPC", "http://127.0.0.1:9545");
+            set_proposer_env("FACTORY_ADDRESS", "0x000000000000000000000000000000000000dEaD");
+            set_proposer_env("PRESTATES_URL", "file:///tmp/prestates");
 
-            // PROOF_PROVIDER has no default.
+            // The proof provider has no default.
             let err = ProposerConfig::from_env().unwrap_err().to_string();
-            assert!(err.contains("PROOF_PROVIDER"), "unexpected error: {err}");
+            assert!(err.contains("KONA_SP1_PROPOSER_PROOF_PROVIDER"), "unexpected error: {err}");
 
-            unsafe { env::set_var("PROOF_PROVIDER", "mock") };
+            set_proposer_env("PROOF_PROVIDER", "mock");
             let err = ProposerConfig::from_env().unwrap_err().to_string();
-            assert!(err.contains("L2_RPCS"), "unexpected error: {err}");
+            assert!(err.contains("KONA_SP1_PROPOSER_L2_RPCS"), "unexpected error: {err}");
 
-            unsafe { env::set_var("L2_RPCS", "http://127.0.0.1:8646,http://127.0.0.1:8647") };
+            set_proposer_env("L2_RPCS", "http://127.0.0.1:8646,http://127.0.0.1:8647");
             let err = ProposerConfig::from_env().unwrap_err().to_string();
-            assert!(err.contains("L1_BEACON_RPC"), "unexpected error: {err}");
+            assert!(err.contains("KONA_SP1_PROPOSER_L1_BEACON_RPC"), "unexpected error: {err}");
 
-            // Mock mode requires no NETWORK_* variables: with the witness
-            // endpoints present, parsing succeeds without SPN credentials.
-            unsafe { env::set_var("L1_BEACON_RPC", "http://127.0.0.1:5052") };
+            // Mock mode requires no SPN credentials.
+            set_proposer_env("L1_BEACON_RPC", "http://127.0.0.1:5052");
             let config = ProposerConfig::from_env().unwrap();
             assert_eq!(config.proof_provider, ProofProviderKind::Mock);
             assert_eq!(config.l2_rpcs.len(), 2);
@@ -741,18 +849,13 @@ mod tests {
         /// process-per-test model; env mutation is `unsafe` on edition 2024.
         #[test]
         fn zero_defense_cap_is_rejected() {
-            unsafe {
-                env::set_var("L1_RPC", "http://127.0.0.1:8545");
-                env::set_var("SUPERROOT_RPC", "http://127.0.0.1:9545");
-                env::set_var("FACTORY_ADDRESS", "0x000000000000000000000000000000000000dEaD");
-                env::set_var("PRESTATES_URL", "file:///tmp/prestates");
-                env::set_var("PROOF_PROVIDER", "mock");
-                env::set_var("L2_RPCS", "http://127.0.0.1:8646");
-                env::set_var("L1_BEACON_RPC", "http://127.0.0.1:5052");
-                env::set_var("MAX_CONCURRENT_DEFENSE_TASKS", "0");
-            }
+            set_required_env(true);
+            set_proposer_env("MAX_CONCURRENT_DEFENSE_TASKS", "0");
             let err = ProposerConfig::from_env().unwrap_err().to_string();
-            assert!(err.contains("MAX_CONCURRENT_DEFENSE_TASKS"), "unexpected error: {err}");
+            assert!(
+                err.contains("KONA_SP1_PROPOSER_MAX_CONCURRENT_DEFENSE_TASKS"),
+                "unexpected error: {err}"
+            );
         }
 
         /// Zero SPN timeouts are configuration errors, not degraded modes:
@@ -760,20 +863,13 @@ mod tests {
         /// under nextest's process-per-test model.
         #[test]
         fn zero_spn_timeouts_are_rejected() {
-            unsafe {
-                env::set_var("L1_RPC", "http://127.0.0.1:8545");
-                env::set_var("SUPERROOT_RPC", "http://127.0.0.1:9545");
-                env::set_var("FACTORY_ADDRESS", "0x000000000000000000000000000000000000dEaD");
-                env::set_var("PRESTATES_URL", "file:///tmp/prestates");
-                env::set_var("PROOF_PROVIDER", "mock");
-                env::set_var("L2_RPCS", "http://127.0.0.1:8646");
-                env::set_var("L1_BEACON_RPC", "http://127.0.0.1:5052");
-            }
+            set_required_env(true);
             for var in ["SP1_TIMEOUT_SECONDS", "NETWORK_CALLS_TIMEOUT", "AUCTION_TIMEOUT"] {
-                unsafe { env::set_var(var, "0") };
+                set_proposer_env(var, "0");
                 let err = ProposerConfig::from_env().unwrap_err().to_string();
-                assert!(err.contains(var), "expected {var} rejection, got: {err}");
-                unsafe { env::remove_var(var) };
+                let name = env_var(var);
+                assert!(err.contains(&name), "expected {name} rejection, got: {err}");
+                unsafe { env::remove_var(name) };
             }
         }
     }

--- a/rust/kona/sp1/crates/proposer/src/config.rs
+++ b/rust/kona/sp1/crates/proposer/src/config.rs
@@ -670,91 +670,8 @@ mod tests {
     mod proving_config {
         use super::*;
 
-        const REQUIRED_ENV: [(&str, &str); 7] = [
-            ("L1_RPC", "http://127.0.0.1:8545"),
-            ("SUPERROOT_RPC", "http://127.0.0.1:9545"),
-            ("FACTORY_ADDRESS", "0x000000000000000000000000000000000000dEaD"),
-            ("PRESTATES_URL", "file:///tmp/prestates"),
-            ("PROOF_PROVIDER", "mock"),
-            ("L2_RPCS", "http://127.0.0.1:8646"),
-            ("L1_BEACON_RPC", "http://127.0.0.1:5052"),
-        ];
-
-        fn set_required_env(prefixed: bool) {
-            for (name, value) in REQUIRED_ENV {
-                let name = if prefixed { env_var(name) } else { name.to_string() };
-                unsafe { env::set_var(name, value) };
-            }
-        }
-
-        fn clear_required_env(prefixed: bool) {
-            for (name, _) in REQUIRED_ENV {
-                let name = if prefixed { env_var(name) } else { name.to_string() };
-                unsafe { env::remove_var(name) };
-            }
-        }
-
         fn set_proposer_env(suffix: &str, value: &str) {
             unsafe { env::set_var(env_var(suffix), value) };
-        }
-
-        #[test]
-        fn from_env_reads_prefixed_vars() {
-            clear_required_env(false);
-            set_required_env(true);
-
-            let config = ProposerConfig::from_env().unwrap();
-            assert_eq!(config.proof_provider, ProofProviderKind::Mock);
-            assert_eq!(config.l2_rpcs.len(), 1);
-        }
-
-        #[test]
-        fn from_env_ignores_unprefixed_vars() {
-            clear_required_env(true);
-            set_required_env(false);
-
-            let err = ProposerConfig::from_env().unwrap_err().to_string();
-            assert!(err.contains("KONA_SP1_PROPOSER_PROOF_PROVIDER"), "unexpected error: {err}");
-        }
-
-        #[test]
-        fn prefixed_optional_values_override_bare_values_and_defaults() {
-            set_required_env(true);
-            unsafe {
-                env::set_var("FETCH_INTERVAL", "99");
-                env::set_var("PROPOSAL_SAFETY", "finalized");
-                env::set_var("ROLLUP_CONFIG_PATHS", "/bare/config.json");
-            }
-            set_proposer_env("FETCH_INTERVAL", "7");
-            set_proposer_env("PROPOSAL_SAFETY", "safe");
-
-            let config = ProposerConfig::from_env().unwrap();
-            assert_eq!(config.fetch_interval, 7);
-            assert_eq!(config.proposal_safety, ProposalSafety::Safe);
-            assert!(config.rollup_config_paths.is_none());
-            assert_eq!(config.proposal_interval_seconds, 3600);
-        }
-
-        #[test]
-        fn invalid_prefixed_value_names_the_prefixed_variable() {
-            set_required_env(true);
-            unsafe { env::set_var("FETCH_INTERVAL", "9") };
-            set_proposer_env("FETCH_INTERVAL", "not-a-number");
-
-            let err = ProposerConfig::from_env().unwrap_err().to_string();
-            assert!(err.contains("invalid KONA_SP1_PROPOSER_FETCH_INTERVAL"), "unexpected: {err}");
-        }
-
-        #[test]
-        fn empty_fulfillment_strategy_remains_invalid() {
-            set_required_env(true);
-            set_proposer_env("RANGE_PROOF_STRATEGY", "");
-
-            let err = ProposerConfig::from_env().unwrap_err().to_string();
-            assert!(
-                err.contains("invalid KONA_SP1_PROPOSER_RANGE_PROOF_STRATEGY"),
-                "unexpected: {err}"
-            );
         }
 
         #[test]
@@ -849,7 +766,13 @@ mod tests {
         /// process-per-test model; env mutation is `unsafe` on edition 2024.
         #[test]
         fn zero_defense_cap_is_rejected() {
-            set_required_env(true);
+            set_proposer_env("L1_RPC", "http://127.0.0.1:8545");
+            set_proposer_env("SUPERROOT_RPC", "http://127.0.0.1:9545");
+            set_proposer_env("FACTORY_ADDRESS", "0x000000000000000000000000000000000000dEaD");
+            set_proposer_env("PRESTATES_URL", "file:///tmp/prestates");
+            set_proposer_env("PROOF_PROVIDER", "mock");
+            set_proposer_env("L2_RPCS", "http://127.0.0.1:8646");
+            set_proposer_env("L1_BEACON_RPC", "http://127.0.0.1:5052");
             set_proposer_env("MAX_CONCURRENT_DEFENSE_TASKS", "0");
             let err = ProposerConfig::from_env().unwrap_err().to_string();
             assert!(
@@ -863,7 +786,13 @@ mod tests {
         /// under nextest's process-per-test model.
         #[test]
         fn zero_spn_timeouts_are_rejected() {
-            set_required_env(true);
+            set_proposer_env("L1_RPC", "http://127.0.0.1:8545");
+            set_proposer_env("SUPERROOT_RPC", "http://127.0.0.1:9545");
+            set_proposer_env("FACTORY_ADDRESS", "0x000000000000000000000000000000000000dEaD");
+            set_proposer_env("PRESTATES_URL", "file:///tmp/prestates");
+            set_proposer_env("PROOF_PROVIDER", "mock");
+            set_proposer_env("L2_RPCS", "http://127.0.0.1:8646");
+            set_proposer_env("L1_BEACON_RPC", "http://127.0.0.1:5052");
             for var in ["SP1_TIMEOUT_SECONDS", "NETWORK_CALLS_TIMEOUT", "AUCTION_TIMEOUT"] {
                 set_proposer_env(var, "0");
                 let err = ProposerConfig::from_env().unwrap_err().to_string();

--- a/rust/kona/sp1/crates/proposer/src/lib.rs
+++ b/rust/kona/sp1/crates/proposer/src/lib.rs
@@ -5,6 +5,14 @@
 //! of challenged games in the owned set. Witness collection and native output computation
 //! live in [`proving`]; SP1 proof providers live in [`prover`].
 
+/// Prefix for all proposer-owned environment variables.
+pub const ENV_VAR_PREFIX: &str = "KONA_SP1_PROPOSER";
+
+/// Builds a proposer-owned environment-variable name.
+pub fn env_var(suffix: &str) -> String {
+    kona_sp1_host_utils::prefixed_env_var(ENV_VAR_PREFIX, suffix)
+}
+
 pub mod config;
 pub mod contract;
 pub mod metrics;

--- a/rust/kona/sp1/crates/proposer/src/metrics.rs
+++ b/rust/kona/sp1/crates/proposer/src/metrics.rs
@@ -133,7 +133,7 @@ pub enum ProposerGauge {
     )]
     GamesDefenseSpawned,
     /// Total number of fast finality proving tasks spawned (games proven
-    /// while still unchallenged; see `FAST_FINALITY_MODE`).
+    /// while still unchallenged; see `KONA_SP1_PROPOSER_FAST_FINALITY_MODE`).
     #[strum(
         serialize = "kona_sp1_proposer_games_fast_finality_spawned",
         message = "Total number of fast finality proving tasks spawned"

--- a/rust/kona/sp1/crates/proposer/src/proposer.rs
+++ b/rust/kona/sp1/crates/proposer/src/proposer.rs
@@ -74,8 +74,8 @@ pub type TaskMap = HashMap<TaskId, (TaskHandle, TaskInfo)>;
 /// most one task per variant runs at a time (see
 /// `has_active_task_of_type`). `GameProving` is exempt from that rule and
 /// deduplicated PER GAME instead: several games can be proven
-/// concurrently (defense bounded by `MAX_CONCURRENT_DEFENSE_TASKS`, fast
-/// finality by `FAST_FINALITY_PROVING_LIMIT`).
+/// concurrently (defense bounded by `KONA_SP1_PROPOSER_MAX_CONCURRENT_DEFENSE_TASKS`, fast
+/// finality by `KONA_SP1_PROPOSER_FAST_FINALITY_PROVING_LIMIT`).
 #[derive(Clone, Debug)]
 pub enum TaskInfo {
     /// Task creating a new game at the given super-root timestamp.
@@ -171,7 +171,7 @@ pub struct Game {
 impl Game {
     /// Returns true when the proposer owns this game's defense, resolution, and
     /// claim lifecycle: its `absolutePrestate()` is in the known-prestates set
-    /// (artifacts loadable from `PRESTATES_URL`, proving keys not poisoned).
+    /// (artifacts loadable from `KONA_SP1_PROPOSER_PRESTATES_URL`, proving keys not poisoned).
     ///
     /// Lifecycle ownership is prestate-based, not creator-based. Claims stay
     /// credit-driven, so iterating foreign games costs nothing where the proposer
@@ -393,7 +393,7 @@ where
     /// `DisputeGameFactory` contract instance used to create and enumerate games.
     pub factory: Arc<DisputeGameFactoryInstance<P>>,
     /// Prestate program cache: loaded ELFs keyed by `absolutePrestate()`
-    /// hash, fetched from `PRESTATES_URL` on demand (see [`PrestateCache`]).
+    /// hash, fetched from `KONA_SP1_PROPOSER_PRESTATES_URL` on demand (see [`PrestateCache`]).
     pub prestates: Arc<PrestateCache>,
     tasks: Arc<tokio::sync::Mutex<TaskMap>>,
     next_task_id: Arc<AtomicU64>,
@@ -577,7 +577,7 @@ where
         let game_args = self.registered_game_args(BlockId::latest()).await?;
         if !self.prestates.ensure_loaded(game_args.absolute_prestate).await {
             // Not fatal: creation stays paused until the artifacts appear
-            // under PRESTATES_URL (PrestateCache::ensure_loaded logged why).
+            // under KONA_SP1_PROPOSER_PRESTATES_URL (PrestateCache::ensure_loaded logged why).
             tracing::warn!(
                 registered = %game_args.absolute_prestate,
                 "registered prestate programs unavailable; creation will pause"
@@ -2381,7 +2381,7 @@ where
     /// Check if we should create a game.
     ///
     /// In fast finality mode this FIRST spawns proving for owned
-    /// unchallenged games without one (up to `FAST_FINALITY_PROVING_LIMIT`,
+    /// unchallenged games without one (up to `KONA_SP1_PROPOSER_FAST_FINALITY_PROVING_LIMIT`,
     /// counting ALL in-flight proving tasks), then skips creation while at
     /// that capacity: never create games faster than they can be proven.
     ///
@@ -2584,7 +2584,7 @@ where
     /// Count ALL active proving tasks, defense and fast finality alike.
     ///
     /// This is the fast-finality capacity number: defense load counts
-    /// against `FAST_FINALITY_PROVING_LIMIT` (upstream parity), so heavy
+    /// against `KONA_SP1_PROPOSER_FAST_FINALITY_PROVING_LIMIT` (upstream parity), so heavy
     /// defense pauses fast-finality proving AND game creation.
     async fn count_active_proving_tasks(&self) -> u64 {
         let tasks = self.tasks.lock().await;
@@ -3236,7 +3236,7 @@ pub enum UnknownPrestatePolicy {
 pub const UNKNOWN_PRESTATE_POLICY: UnknownPrestatePolicy = UnknownPrestatePolicy::Pause;
 
 /// How long a failed prestate artifact load is cached before the next fetch
-/// attempt. Bounds `PRESTATES_URL` traffic and log noise for genuinely
+/// attempt. Bounds `KONA_SP1_PROPOSER_PRESTATES_URL` traffic and log noise for genuinely
 /// unknown prestates while keeping them retryable: an operator can publish
 /// artifacts later and the proposer self-heals without a restart.
 pub const UNKNOWN_PRESTATE_RETRY: Duration = Duration::from_secs(60);
@@ -3288,7 +3288,7 @@ impl std::fmt::Display for PrestateKeyError {
 impl std::error::Error for PrestateKeyError {}
 
 /// Prestate program cache: loaded ELFs keyed by `absolutePrestate()` hash,
-/// fetched from the base `PRESTATES_URL` on demand, plus per-prestate SP1
+/// fetched from the base `KONA_SP1_PROPOSER_PRESTATES_URL` on demand, plus per-prestate SP1
 /// proving keys for the defend path.
 ///
 /// The artifact directory is consulted live on every cache miss (subject to
@@ -3352,10 +3352,11 @@ impl PrestateCache {
                     if *poisoned == programs {
                         // Identical artifacts would poison again; keep the
                         // stored verdict and re-check on the next window.
+                        let prestates_url = crate::env_var("PRESTATES_URL");
                         tracing::warn!(
                             prestate = %prestate,
                             "Prestate stays poisoned: published artifacts are unchanged \
-                             (publish corrected artifacts under PRESTATES_URL to heal)"
+                             (publish corrected artifacts under {prestates_url} to heal)"
                         );
                         self.misses.write().await.insert(prestate, Instant::now());
                         return unknown;
@@ -3383,12 +3384,13 @@ impl PrestateCache {
                 true
             }
             Err(e) => {
+                let prestates_url = crate::env_var("PRESTATES_URL");
                 tracing::warn!(
                     prestate = %prestate,
                     error = %e,
                     retry_seconds = self.unknown_retry.as_secs(),
                     "Failed to load prestate programs \
-                     (publish the artifacts under PRESTATES_URL if this is a hardfork)"
+                     (publish the artifacts under {prestates_url} if this is a hardfork)"
                 );
                 ProposerGauge::UnknownRegisteredPrestate.increment(1.0);
                 self.misses.write().await.insert(prestate, Instant::now());

--- a/rust/kona/sp1/crates/proposer/src/prover.rs
+++ b/rust/kona/sp1/crates/proposer/src/prover.rs
@@ -256,9 +256,10 @@ impl NetworkProofProvider {
                     "proving timeout exceeded"
                 );
                 ProposerGauge::ProvingTimeoutError.increment(1.0);
+                let range_split_count = crate::env_var("RANGE_SPLIT_COUNT");
                 bail!(
                     "Proving timeout: proof_id={}, elapsed={}s, timeout={}s \
-                    (consider increasing RANGE_SPLIT_COUNT to shrink per-proof workloads)",
+                    (consider increasing {range_split_count} to shrink per-proof workloads)",
                     proof_id,
                     elapsed_secs,
                     self.config.timeout

--- a/rust/kona/sp1/crates/proposer/src/signer.rs
+++ b/rust/kona/sp1/crates/proposer/src/signer.rs
@@ -269,18 +269,8 @@ impl SignerLock {
 
 #[cfg(test)]
 mod tests {
-    use super::{FeeCaps, Signer, clamp_fee_caps};
+    use super::{FeeCaps, clamp_fee_caps};
     use alloy_rpc_types_eth::TransactionRequest;
-
-    use crate::env_var;
-
-    fn set_signer_env(suffix: &str, value: &str) {
-        unsafe { std::env::set_var(env_var(suffix), value) };
-    }
-
-    fn remove_signer_env(suffix: &str) {
-        unsafe { std::env::remove_var(env_var(suffix)) };
-    }
 
     fn filled_request(max_fee: u128, max_priority: u128) -> TransactionRequest {
         TransactionRequest {
@@ -342,44 +332,5 @@ mod tests {
         );
         assert_eq!(request.max_fee_per_gas, None);
         assert_eq!(request.max_priority_fee_per_gas, None);
-    }
-
-    #[tokio::test]
-    async fn signer_configuration_selection() {
-        unsafe {
-            std::env::set_var("SIGNER_URL", "http://127.0.0.1:8000");
-            std::env::set_var("SIGNER_ADDRESS", "0x0000000000000000000000000000000000000001");
-            std::env::set_var(
-                "PRIVATE_KEY",
-                "0x0000000000000000000000000000000000000000000000000000000000000002",
-            );
-        }
-        set_signer_env("SIGNER_URL", "http://127.0.0.1:9000");
-        set_signer_env("SIGNER_ADDRESS", "0x000000000000000000000000000000000000dEaD");
-        let signer = Signer::from_env().await.unwrap();
-        assert!(matches!(signer, Signer::Web3Signer(_, _)));
-
-        remove_signer_env("SIGNER_URL");
-        remove_signer_env("SIGNER_ADDRESS");
-        set_signer_env(
-            "PRIVATE_KEY",
-            "0x0000000000000000000000000000000000000000000000000000000000000001",
-        );
-        let signer = Signer::from_env().await.unwrap();
-        assert!(matches!(signer, Signer::LocalSigner(_)));
-
-        remove_signer_env("PRIVATE_KEY");
-        set_signer_env("SIGNER_URL", "http://127.0.0.1:9000");
-        let err = Signer::from_env().await.unwrap_err().to_string();
-        assert!(err.contains("KONA_SP1_PROPOSER_SIGNER_ADDRESS"), "unexpected error: {err}");
-
-        remove_signer_env("SIGNER_URL");
-        set_signer_env("SIGNER_ADDRESS", "0x000000000000000000000000000000000000dEaD");
-        let err = Signer::from_env().await.unwrap_err().to_string();
-        assert!(err.contains("KONA_SP1_PROPOSER_SIGNER_URL"), "unexpected error: {err}");
-
-        remove_signer_env("SIGNER_ADDRESS");
-        let err = Signer::from_env().await.unwrap_err().to_string();
-        assert!(err.contains("KONA_SP1_PROPOSER_PRIVATE_KEY"), "unexpected error: {err}");
     }
 }

--- a/rust/kona/sp1/crates/proposer/src/signer.rs
+++ b/rust/kona/sp1/crates/proposer/src/signer.rs
@@ -18,6 +18,8 @@ use alloy_transport_http::reqwest::Url;
 use anyhow::{Context, Result};
 use tokio::{sync::Mutex, time::Duration};
 
+use crate::env_var;
+
 /// Number of L1 confirmations required before a transaction is considered included.
 pub const NUM_CONFIRMATIONS: u64 = 3;
 
@@ -83,47 +85,54 @@ impl Signer {
         Ok(Self::LocalSigner(private_key))
     }
 
-    /// Builds a signer from the environment: `SIGNER_URL` + `SIGNER_ADDRESS` selects
-    /// [`Signer::Web3Signer`], otherwise `PRIVATE_KEY` selects [`Signer::LocalSigner`].
-    /// Setting only one of `SIGNER_URL` / `SIGNER_ADDRESS` is an error rather than a
-    /// silent fallback to the local key.
+    /// Builds a signer from the environment. `KONA_SP1_PROPOSER_SIGNER_URL` and
+    /// `KONA_SP1_PROPOSER_SIGNER_ADDRESS` select [`Signer::Web3Signer`]; otherwise,
+    /// `KONA_SP1_PROPOSER_PRIVATE_KEY` selects [`Signer::LocalSigner`]. Setting only one
+    /// `Web3Signer` variable is an error instead of falling back to the local key.
     pub async fn from_env() -> Result<Self> {
-        let signer_url = std::env::var("SIGNER_URL").ok();
-        let signer_address = std::env::var("SIGNER_ADDRESS").ok();
+        let signer_url_name = env_var("SIGNER_URL");
+        let signer_address_name = env_var("SIGNER_ADDRESS");
+        let private_key_name = env_var("PRIVATE_KEY");
+        let signer_url = std::env::var(&signer_url_name).ok();
+        let signer_address = std::env::var(&signer_address_name).ok();
         match (signer_url, signer_address) {
             (Some(url), Some(address)) => {
-                let signer_url = Url::parse(&url).context("Failed to parse SIGNER_URL")?;
-                let signer_address =
-                    Address::from_str(&address).context("Failed to parse SIGNER_ADDRESS")?;
+                let signer_url = Url::parse(&url)
+                    .with_context(|| format!("Failed to parse {signer_url_name}"))?;
+                let signer_address = Address::from_str(&address)
+                    .with_context(|| format!("Failed to parse {signer_address_name}"))?;
                 tracing::info!(
                     url = %crate::config::redacted_url(&signer_url),
                     address = %signer_address,
-                    "Using Web3Signer (SIGNER_URL + SIGNER_ADDRESS)"
+                    "Using Web3Signer ({signer_url_name} + {signer_address_name})"
                 );
                 Ok(Self::new_web3_signer(signer_url, signer_address))
             }
             (Some(_), None) => {
                 anyhow::bail!(
-                    "SIGNER_URL is set but SIGNER_ADDRESS is not; set both to use the Web3Signer"
+                    "{signer_url_name} is set but {signer_address_name} is not; set both to use \
+                     the Web3Signer"
                 )
             }
             (None, Some(_)) => {
                 anyhow::bail!(
-                    "SIGNER_ADDRESS is set but SIGNER_URL is not; set both to use the Web3Signer"
+                    "{signer_address_name} is set but {signer_url_name} is not; set both to use \
+                     the Web3Signer"
                 )
             }
             (None, None) => {
-                let private_key_str = std::env::var("PRIVATE_KEY").map_err(|_| {
+                let private_key_str = std::env::var(&private_key_name).map_err(|_| {
                     anyhow::anyhow!(
                         "None of the required signer configurations are set in environment:\n\
-                        - For Web3Signer: SIGNER_URL and SIGNER_ADDRESS\n\
-                        - For Local: PRIVATE_KEY"
+                        - For Web3Signer: {signer_url_name} and {signer_address_name}\n\
+                        - For Local: {private_key_name}"
                     )
                 })?;
-                let signer = Self::new_local_signer(&private_key_str)?;
+                let signer = Self::new_local_signer(&private_key_str)
+                    .with_context(|| format!("Failed to parse {private_key_name}"))?;
                 tracing::info!(
                     address = %signer.address(),
-                    "Using local private-key signer (PRIVATE_KEY)"
+                    "Using local private-key signer ({private_key_name})"
                 );
                 Ok(signer)
             }
@@ -232,11 +241,6 @@ impl SignerLock {
         Self { inner: Arc::new(Mutex::new(signer)), cached_address }
     }
 
-    /// Creates a `SignerLock` from environment variables.
-    pub async fn from_env() -> Result<Self> {
-        Ok(Self::new(Signer::from_env().await?))
-    }
-
     /// Returns the address of the signer without acquiring a lock.
     pub const fn address(&self) -> Address {
         self.cached_address
@@ -265,8 +269,18 @@ impl SignerLock {
 
 #[cfg(test)]
 mod tests {
-    use super::{FeeCaps, clamp_fee_caps};
+    use super::{FeeCaps, Signer, clamp_fee_caps};
     use alloy_rpc_types_eth::TransactionRequest;
+
+    use crate::env_var;
+
+    fn set_signer_env(suffix: &str, value: &str) {
+        unsafe { std::env::set_var(env_var(suffix), value) };
+    }
+
+    fn remove_signer_env(suffix: &str) {
+        unsafe { std::env::remove_var(env_var(suffix)) };
+    }
 
     fn filled_request(max_fee: u128, max_priority: u128) -> TransactionRequest {
         TransactionRequest {
@@ -328,5 +342,44 @@ mod tests {
         );
         assert_eq!(request.max_fee_per_gas, None);
         assert_eq!(request.max_priority_fee_per_gas, None);
+    }
+
+    #[tokio::test]
+    async fn signer_configuration_selection() {
+        unsafe {
+            std::env::set_var("SIGNER_URL", "http://127.0.0.1:8000");
+            std::env::set_var("SIGNER_ADDRESS", "0x0000000000000000000000000000000000000001");
+            std::env::set_var(
+                "PRIVATE_KEY",
+                "0x0000000000000000000000000000000000000000000000000000000000000002",
+            );
+        }
+        set_signer_env("SIGNER_URL", "http://127.0.0.1:9000");
+        set_signer_env("SIGNER_ADDRESS", "0x000000000000000000000000000000000000dEaD");
+        let signer = Signer::from_env().await.unwrap();
+        assert!(matches!(signer, Signer::Web3Signer(_, _)));
+
+        remove_signer_env("SIGNER_URL");
+        remove_signer_env("SIGNER_ADDRESS");
+        set_signer_env(
+            "PRIVATE_KEY",
+            "0x0000000000000000000000000000000000000000000000000000000000000001",
+        );
+        let signer = Signer::from_env().await.unwrap();
+        assert!(matches!(signer, Signer::LocalSigner(_)));
+
+        remove_signer_env("PRIVATE_KEY");
+        set_signer_env("SIGNER_URL", "http://127.0.0.1:9000");
+        let err = Signer::from_env().await.unwrap_err().to_string();
+        assert!(err.contains("KONA_SP1_PROPOSER_SIGNER_ADDRESS"), "unexpected error: {err}");
+
+        remove_signer_env("SIGNER_URL");
+        set_signer_env("SIGNER_ADDRESS", "0x000000000000000000000000000000000000dEaD");
+        let err = Signer::from_env().await.unwrap_err().to_string();
+        assert!(err.contains("KONA_SP1_PROPOSER_SIGNER_URL"), "unexpected error: {err}");
+
+        remove_signer_env("SIGNER_ADDRESS");
+        let err = Signer::from_env().await.unwrap_err().to_string();
+        assert!(err.contains("KONA_SP1_PROPOSER_PRIVATE_KEY"), "unexpected error: {err}");
     }
 }


### PR DESCRIPTION
## Summary

- Standardizes `kona-sp1-proposer` environment variables with the prefixed configuration style used by other tooling.
- Centralizes proposer environment-name construction and threads the service prefix through configuration, signing, SP1 network setup, logging, diagnostics, and the devstack launcher.
- Explicitly supplies the configured SP1 network RPC URL, or the SDK's mode-specific default, so network behavior is controlled by the proposer configuration.
- Documents the complete runtime environment contract and preserves the existing defaults and validation behavior.

## Environment contract

All proposer-owned runtime variables use the `KONA_SP1_PROPOSER_` prefix.

### Core configuration

- `KONA_SP1_PROPOSER_L1_RPC`
- `KONA_SP1_PROPOSER_SUPERROOT_RPC`
- `KONA_SP1_PROPOSER_FACTORY_ADDRESS`
- `KONA_SP1_PROPOSER_PRESTATES_URL`
- `KONA_SP1_PROPOSER_PROOF_PROVIDER`
- `KONA_SP1_PROPOSER_L1_BEACON_RPC`
- `KONA_SP1_PROPOSER_L2_RPCS`
- `KONA_SP1_PROPOSER_ROLLUP_CONFIG_PATHS`
- `KONA_SP1_PROPOSER_L1_CONFIG_PATH`
- `KONA_SP1_PROPOSER_DEPENDENCY_SET_PATH`

### Scheduling and operations

- `KONA_SP1_PROPOSER_PROPOSAL_INTERVAL_SECONDS`
- `KONA_SP1_PROPOSER_PROPOSAL_SAFETY`
- `KONA_SP1_PROPOSER_FETCH_INTERVAL`
- `KONA_SP1_PROPOSER_METRICS_PORT`
- `KONA_SP1_PROPOSER_SYNC_L1_CONFIRMATIONS`
- `KONA_SP1_PROPOSER_TX_CONFIRMATION_TIMEOUT`
- `KONA_SP1_PROPOSER_MAX_FEE_PER_GAS`
- `KONA_SP1_PROPOSER_MAX_PRIORITY_FEE_PER_GAS`
- `KONA_SP1_PROPOSER_RANGE_SPLIT_COUNT`
- `KONA_SP1_PROPOSER_MAX_CONCURRENT_RANGE_PROOFS`
- `KONA_SP1_PROPOSER_MAX_CONCURRENT_DEFENSE_TASKS`
- `KONA_SP1_PROPOSER_FAST_FINALITY_MODE`
- `KONA_SP1_PROPOSER_FAST_FINALITY_PROVING_LIMIT`

### SP1 network

- `KONA_SP1_PROPOSER_NETWORK_PRIVATE_KEY`
- `KONA_SP1_PROPOSER_NETWORK_RPC_URL`
- `KONA_SP1_PROPOSER_USE_KMS_REQUESTER`
- `KONA_SP1_PROPOSER_RANGE_PROOF_STRATEGY`
- `KONA_SP1_PROPOSER_AGG_PROOF_STRATEGY`
- `KONA_SP1_PROPOSER_SP1_TIMEOUT_SECONDS`
- `KONA_SP1_PROPOSER_NETWORK_CALLS_TIMEOUT`
- `KONA_SP1_PROPOSER_AUCTION_TIMEOUT`
- `KONA_SP1_PROPOSER_RANGE_CYCLE_LIMIT`
- `KONA_SP1_PROPOSER_RANGE_GAS_LIMIT`
- `KONA_SP1_PROPOSER_AGG_CYCLE_LIMIT`
- `KONA_SP1_PROPOSER_AGG_GAS_LIMIT`
- `KONA_SP1_PROPOSER_MAX_PRICE_PER_PGU`
- `KONA_SP1_PROPOSER_MIN_AUCTION_PERIOD`

### Transaction signer

- `KONA_SP1_PROPOSER_PRIVATE_KEY`
- `KONA_SP1_PROPOSER_SIGNER_URL`
- `KONA_SP1_PROPOSER_SIGNER_ADDRESS`

### Logging and telemetry

- `KONA_SP1_PROPOSER_LOGGER_NAME`
- `KONA_SP1_PROPOSER_OTLP_ENDPOINT`
- `KONA_SP1_PROPOSER_OTLP_ENABLED`
- `KONA_SP1_PROPOSER_LOG_FORMAT`

### Reserved mTLS variables

These names are reserved for proposer-side signer mTLS support and are not read yet:

- `KONA_SP1_PROPOSER_SIGNER_TLS_CERT`
- `KONA_SP1_PROPOSER_SIGNER_TLS_KEY`
- `KONA_SP1_PROPOSER_SIGNER_TLS_CA`

### Standard and dependency-owned variables

`RUST_LOG`, `NO_COLOR`, `SSL_CERT_DIR`, `SSL_CERT_FILE`, `OTEL_*`, proxy variables, AWS credential variables, and SP1 worker/debug variables remain ecosystem- or dependency-owned. `KONA_SP1_ELF_DIR` remains the shared artifact/build-test configuration variable.

## Test plan

- `mise exec -- just l` from `rust/`
- `mise exec -- cargo nextest run --package kona-sp1-host-utils --package kona-sp1-proposer` from `rust/`
- `mise exec -- just build-superchain-go`
- `mise exec -- go test ./op-devstack/sysgo -run 'TestZKProposer' -count=1`

