### PR TITLE
contracts-bedrock: Bind the dispute game AnchorStateRegistry to the portal

### DIFF
--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -20,8 +20,8 @@
     "sourceCodeHash": "0x0ef8461e8bc55314e61e60924465574db17bdf30bbbfe9739b52cac623bba2db"
   },
   "src/L1/OPContractsManagerStandardValidator.sol:OPContractsManagerStandardValidator": {
-    "initCodeHash": "0x0b705f03b754c5575ee220c824c3bef68fc98075b7e1e10fc06968b85c1714de",
-    "sourceCodeHash": "0x197e1c42e06597ba49fe5211765a5e4c002ac0d169134bfd3ce82f79f9efc253"
+    "initCodeHash": "0xbe11f1f682870fef423354ea210151a91f82703e5524dbe2f9a3221bedbe5ed7",
+    "sourceCodeHash": "0x983f90f2198b5116b5498081a909ce1c6a88019a0005bbad2e462c10cd83fcbb"
   },
   "src/L1/OptimismPortal2.sol:OptimismPortal2": {
     "initCodeHash": "0x67bbf6c9b344870cdbd7b041ddad6fb69057a4b48ec6dd96876af55d14fc1943",

--- a/packages/contracts-bedrock/src/L1/OPContractsManagerStandardValidator.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManagerStandardValidator.sol
@@ -46,8 +46,8 @@ import { IBigStepper } from "interfaces/dispute/IBigStepper.sol";
 /// before and after an upgrade.
 contract OPContractsManagerStandardValidator is ISemver {
     /// @notice The semantic version of the OPContractsManagerStandardValidator contract.
-    /// @custom:semver 3.2.0
-    string public constant version = "3.2.0";
+    /// @custom:semver 3.3.0
+    string public constant version = "3.3.0";
 
     /// @notice The SuperchainConfig contract.
     ISuperchainConfig public superchainConfig;

--- a/packages/contracts-bedrock/src/L1/opcm/StandardValidatorUtils.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/StandardValidatorUtils.sol
@@ -395,6 +395,14 @@ contract StandardValidatorUtils {
             IProxyAdminOwnedBase(address(_asr)).proxyAdmin() == _admin, string.concat(_errorPrefix, "-50"), _errors
         );
         _errors = internalRequire(_asr.retirementTimestamp() > 0, string.concat(_errorPrefix, "-60"), _errors);
+        // The registry a game anchors against must be the one the portal consults when finalizing
+        // withdrawals. Without this, a game could snapshot the respected game type of a second,
+        // locally valid registry that the portal never reads.
+        _errors = internalRequire(
+            IOptimismPortal2(payable(_sysCfg.optimismPortal())).anchorStateRegistry() == _asr,
+            string.concat(_errorPrefix, "-70"),
+            _errors
+        );
         return _errors;
     }
 

--- a/packages/contracts-bedrock/test/L1/OPContractsManagerStandardValidator.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManagerStandardValidator.t.sol
@@ -1345,6 +1345,17 @@ contract OPContractsManagerStandardValidator_AnchorStateRegistry_Test is
         );
         assertEq("PDDG-ANCHORP-60,CKDG-ANCHORP-60", _validate(true));
     }
+
+    /// @notice Tests that the validate function successfully returns the right error when the
+    ///         AnchorStateRegistry in the game args is not the one the OptimismPortal uses.
+    function test_validate_anchorStateRegistryNotUsedByPortal_succeeds() public {
+        vm.mockCall(
+            address(optimismPortal2),
+            abi.encodeCall(IOptimismPortal2.anchorStateRegistry, ()),
+            abi.encode(address(0xbad))
+        );
+        assertEq("PDDG-ANCHORP-70,CKDG-ANCHORP-70", _validate(true));
+    }
 }
 
 /// @title OPContractsManagerStandardValidator_DelayedWETH_Test
@@ -1866,6 +1877,23 @@ contract OPContractsManagerStandardValidator_SuperModeCoreValidation_Test is
         vm.mockCall(address(systemConfig), abi.encodeCall(ISystemConfig.l2ChainId, ()), abi.encode(l2ChainId + 1));
         assertEq("SYSCON-140", _validate(true));
     }
+
+    /// @notice Tests that the validate function returns SPDG-ANCHORP-70 and SCKDG-ANCHORP-70 when
+    ///         the portal uses a different AnchorStateRegistry than the super games do.
+    function test_validate_anchorStateRegistryNotUsedByPortal_succeeds() public {
+        address otherAsr = makeAddr("otherAnchorStateRegistry");
+        vm.mockCall(
+            address(systemConfig.optimismPortal()),
+            abi.encodeCall(IOptimismPortal2.anchorStateRegistry, ()),
+            abi.encode(otherAsr)
+        );
+        vm.mockCall(
+            otherAsr,
+            abi.encodeCall(IAnchorStateRegistry.respectedGameType, ()),
+            abi.encode(GameTypes.SUPER_CANNON_KONA)
+        );
+        assertEq("SPDG-ANCHORP-70,SCKDG-ANCHORP-70", _validate(true));
+    }
 }
 
 /// @title OPContractsManagerStandardValidator_SuperRootDisputeGames_Test
@@ -2006,7 +2034,7 @@ contract OPContractsManagerStandardValidator_SuperPermissionedDisputeGame_Test i
         vm.mockCall(badASR, abi.encodeCall(IProxyAdminOwnedBase.proxyAdmin, ()), abi.encode(proxyAdmin));
         vm.mockCall(badASR, abi.encodeCall(IAnchorStateRegistry.retirementTimestamp, ()), abi.encode(uint64(100)));
 
-        assertEq("SPDG-ANCHORP-10,SPDG-ANCHORP-20", _validate(true));
+        assertEq("SPDG-ANCHORP-10,SPDG-ANCHORP-20,SPDG-ANCHORP-70", _validate(true));
     }
 
     /// @notice Tests SPDG-120 when SUPER_PERMISSIONED's anchor root is zero.
@@ -2386,6 +2414,23 @@ contract OPContractsManagerStandardValidator_ZKValidation_Test is
         // challengerBond occupies bytes [68-99] (uint256).
         DisputeGames.mockZKGameArg(dgf, GameTypes.ZK_DISPUTE_GAME, 68, abi.encodePacked(uint256(0)));
         assertEq("ZKDG-110", _validate(true));
+    }
+
+    /// @notice Tests ZKDG-ANCHORP-70 when the portal uses a different AnchorStateRegistry than the
+    ///         one encoded in the ZK game args.
+    function test_validate_zkDisputeGameAnchorStateRegistryNotUsedByPortal_succeeds() public {
+        address otherAsr = makeAddr("otherAnchorStateRegistry");
+        vm.mockCall(
+            address(systemConfig.optimismPortal()),
+            abi.encodeCall(IOptimismPortal2.anchorStateRegistry, ()),
+            abi.encode(otherAsr)
+        );
+        vm.mockCall(
+            otherAsr,
+            abi.encodeCall(IAnchorStateRegistry.respectedGameType, ()),
+            abi.encode(GameTypes.SUPER_CANNON_KONA)
+        );
+        assertEq("SPDG-ANCHORP-70,SCKDG-ANCHORP-70,ZKDG-ANCHORP-70", _validate(true));
     }
 }
 


### PR DESCRIPTION
The standard validator selects super mode from the OptimismPortal's `AnchorStateRegistry`, but validates a registry decoded independently from each dispute game's encoded args. It never required the two to be the same, so an authorized configuration could use registry A for the portal and registry B for the games. If both pass their local checks while respecting different game types, validation reports success for a split that leaves the game and the registry the portal consults on withdrawal finalization unbound.

`StandardValidatorUtils.assertValidAnchorStateRegistry` now also requires the registry it validates to be `portal.anchorStateRegistry()`, reported as `<PREFIX>-ANCHORP-70`. The check sits in the shared helper, so it covers the permissioned, permissionless, super permissioned, super cannon kona, and ZK game args, plus the migration validator paths.

`OPContractsManagerStandardValidator` goes to 3.3.0.

## Test plan

New negative cases for super mode (`SPDG`/`SCKDG`), ZK mode (`ZKDG`), and non-super mode (`PDDG`/`CKDG`). The existing SPDG bad-ASR test now also reports `-70`, which is the new check firing correctly.

Two coverage notes:

- The non-super case cannot execute today. Its parent contract skips whenever `Config.devFeatureSuperRootGamesMigration()` is true, and that is hardcoded `return true`. Every existing PDDG/CKDG ASR test in that contract is skipped for the same reason. Executed coverage is super mode and ZK mode.
- No `MIG-*-ANCHORP-70` case. In the migration fixture the shared registry is discovered from chain 0's portal, so forcing a split means mocking the discovery source and cascades into unrelated errors. The line is identical shared code already exercised by the three cases above.

Verified locally: full `just test-dev` 2242 passed / 0 failed; validator suite with `DEV_FEATURE__ZK_DISPUTE_GAME` 31 passed; migration validator suite with `DEV_FEATURE__OPTIMISM_PORTAL_INTEROP` 58 passed; `just pr` 16/16.