### PR TITLE
kona-sp1-proposer: Implement fallover for superroot RPCs

### DIFF
--- a/op-devstack/sysgo/zk_proposer.go
+++ b/op-devstack/sysgo/zk_proposer.go
@@ -201,7 +201,7 @@ func startZKProposer(
 
 	env := []string{
 		zkProposerEnv("L1_RPC", l1EL.UserRPC()),
-		zkProposerEnv("SUPERROOT_RPC", superRootRPC),
+		zkProposerEnv("SUPERROOT_RPCS", superRootRPC),
 		zkProposerEnv("FACTORY_ADDRESS", factoryAddr.Hex()),
 		zkProposerEnv("PRESTATES_URL", "file://"+prestatesDir),
 		zkProposerEnv("PRIVATE_KEY", hexutil.Encode(crypto.FromECDSA(proposerSecret))),

--- a/rust/kona/sp1/README.md
+++ b/rust/kona/sp1/README.md
@@ -219,7 +219,7 @@ Required core configuration:
 | Variable | Purpose |
 |---|---|
 | `KONA_SP1_PROPOSER_L1_RPC` | L1 execution RPC |
-| `KONA_SP1_PROPOSER_SUPERROOT_RPC` | op-supernode or single-chain op-node RPC serving `superroot_atTimestamp` |
+| `KONA_SP1_PROPOSER_SUPERROOT_RPCS` | op-supernode or single-chain op-node RPCs serving `superroot_atTimestamp`. Multiple RPCs can be provided for failover |
 | `KONA_SP1_PROPOSER_FACTORY_ADDRESS` | `DisputeGameFactory` address |
 | `KONA_SP1_PROPOSER_PRESTATES_URL` | prestate artifact directory (`<vkey>.agg.bin.gz` + `<vkey>.range.bin.gz`) |
 | `KONA_SP1_PROPOSER_PROOF_PROVIDER` | `network` or `mock`; no default |

--- a/rust/kona/sp1/README.md
+++ b/rust/kona/sp1/README.md
@@ -219,7 +219,7 @@ Required core configuration:
 | Variable | Purpose |
 |---|---|
 | `KONA_SP1_PROPOSER_L1_RPC` | L1 execution RPC |
-| `KONA_SP1_PROPOSER_SUPERROOT_RPCS` | op-supernode or single-chain op-node RPCs serving `superroot_atTimestamp`. Multiple RPCs can be provided for failover |
+| `KONA_SP1_PROPOSER_SUPERROOT_RPCS` | op-supernode or single-chain op-node RPCs serving `superroot_atTimestamp`. Multiple comma-separated RPCs can be provided for redundancy |
 | `KONA_SP1_PROPOSER_FACTORY_ADDRESS` | `DisputeGameFactory` address |
 | `KONA_SP1_PROPOSER_PRESTATES_URL` | prestate artifact directory (`<vkey>.agg.bin.gz` + `<vkey>.range.bin.gz`) |
 | `KONA_SP1_PROPOSER_PROOF_PROVIDER` | `network` or `mock`; no default |

--- a/rust/kona/sp1/crates/proposer/src/bin/kona-sp1-proposer.rs
+++ b/rust/kona/sp1/crates/proposer/src/bin/kona-sp1-proposer.rs
@@ -37,7 +37,7 @@ async fn main() -> Result<()> {
 
     tracing::info!(
         l1_rpc = %redacted_url(&config.l1_rpc),
-        superroot_rpc = %redacted_url(&config.superroot_rpc),
+        superroot_rpcs = &config.superroot_rpcs.iter().map(redacted_url).collect::<Vec<_>>().join(","),
         factory_address = %config.factory_address,
         prestates_url = %redacted_url(&config.prestates_url),
         proposal_interval_seconds = config.proposal_interval_seconds,

--- a/rust/kona/sp1/crates/proposer/src/config.rs
+++ b/rust/kona/sp1/crates/proposer/src/config.rs
@@ -75,7 +75,7 @@ pub struct ProposerConfig {
     pub l1_rpc: Url,
 
     /// The RPC URL serving `superroot_atTimestamp`, provided by an op-supernode
-    /// or a single-chain op-node.
+    /// or a single-chain op-node. Multiple URLs are accepted for redundancy
     pub superroot_rpcs: Vec<Url>,
 
     /// The address of the `DisputeGameFactory` contract.

--- a/rust/kona/sp1/crates/proposer/src/config.rs
+++ b/rust/kona/sp1/crates/proposer/src/config.rs
@@ -76,7 +76,7 @@ pub struct ProposerConfig {
 
     /// The RPC URL serving `superroot_atTimestamp`, provided by an op-supernode
     /// or a single-chain op-node.
-    pub superroot_rpc: Url,
+    pub superroot_rpcs: Vec<Url>,
 
     /// The address of the `DisputeGameFactory` contract.
     pub factory_address: Address,
@@ -244,9 +244,12 @@ impl ProposerConfig {
         let l2_rpcs_name = env_var("L2_RPCS");
         let l2_rpcs = parse_url_list(&required_env("L2_RPCS")?)
             .with_context(|| format!("invalid {l2_rpcs_name}"))?;
+        let superroot_rpcs_name = env_var("SUPERROOT_RPCS");
+        let superroot_rpcs = parse_url_list(&required_env("SUPERROOT_RPCS")?)
+            .with_context(|| format!("invalid {superroot_rpcs_name}"))?;
         Ok(Self {
             l1_rpc: parsed_required_env("L1_RPC")?,
-            superroot_rpc: parsed_required_env("SUPERROOT_RPC")?,
+            superroot_rpcs,
             factory_address: parsed_required_env("FACTORY_ADDRESS")?,
             prestates_url: parsed_required_env("PRESTATES_URL")?,
             proposal_interval_seconds: parsed_env_or("PROPOSAL_INTERVAL_SECONDS", 3600u64)?,
@@ -732,7 +735,7 @@ mod tests {
         #[test]
         fn from_env_requires_defend_path_vars() {
             set_proposer_env("L1_RPC", "http://127.0.0.1:8545");
-            set_proposer_env("SUPERROOT_RPC", "http://127.0.0.1:9545");
+            set_proposer_env("SUPERROOT_RPCS", "http://127.0.0.1:9545,http://127.0.0.1:9546");
             set_proposer_env("FACTORY_ADDRESS", "0x000000000000000000000000000000000000dEaD");
             set_proposer_env("PRESTATES_URL", "file:///tmp/prestates");
 
@@ -752,6 +755,7 @@ mod tests {
             set_proposer_env("L1_BEACON_RPC", "http://127.0.0.1:5052");
             let config = ProposerConfig::from_env().unwrap();
             assert_eq!(config.proof_provider, ProofProviderKind::Mock);
+            assert_eq!(config.superroot_rpcs.len(), 2);
             assert_eq!(config.l2_rpcs.len(), 2);
             assert!(config.rollup_config_paths.is_none());
             assert_eq!(config.range_split_count, RangeSplitCount::one());
@@ -767,7 +771,7 @@ mod tests {
         #[test]
         fn zero_defense_cap_is_rejected() {
             set_proposer_env("L1_RPC", "http://127.0.0.1:8545");
-            set_proposer_env("SUPERROOT_RPC", "http://127.0.0.1:9545");
+            set_proposer_env("SUPERROOT_RPCS", "http://127.0.0.1:9545");
             set_proposer_env("FACTORY_ADDRESS", "0x000000000000000000000000000000000000dEaD");
             set_proposer_env("PRESTATES_URL", "file:///tmp/prestates");
             set_proposer_env("PROOF_PROVIDER", "mock");
@@ -787,7 +791,7 @@ mod tests {
         #[test]
         fn zero_spn_timeouts_are_rejected() {
             set_proposer_env("L1_RPC", "http://127.0.0.1:8545");
-            set_proposer_env("SUPERROOT_RPC", "http://127.0.0.1:9545");
+            set_proposer_env("SUPERROOT_RPCS", "http://127.0.0.1:9545");
             set_proposer_env("FACTORY_ADDRESS", "0x000000000000000000000000000000000000dEaD");
             set_proposer_env("PRESTATES_URL", "file:///tmp/prestates");
             set_proposer_env("PROOF_PROVIDER", "mock");

--- a/rust/kona/sp1/crates/proposer/src/proposer.rs
+++ b/rust/kona/sp1/crates/proposer/src/proposer.rs
@@ -47,7 +47,7 @@ use crate::{
         GameProofInputs, fetch_span_responses, is_unprovable, prove_game_inner, response_trusted,
     },
     signer::{FeeCaps, SignerLock},
-    superroot::{SuperrootClient, zk_extra_data},
+    superroot::{ResponseSelection, SuperrootClient, zk_extra_data},
 };
 
 /// Max allowed time (secs) between a game's deadline and the anchor game's deadline.
@@ -1724,7 +1724,11 @@ where
         // force. Hold the game as pending instead: it stays outside the DAG
         // (never parent-eligible) and is re-checked each sync, bounded to one
         // query per cycle.
-        let response = match self.superroot_client.superroot_at_timestamp(sequence_number).await {
+        let response = match self
+            .superroot_client
+            .superroot_at_timestamp(sequence_number, ResponseSelection::PreferData)
+            .await
+        {
             Ok(response) => response,
             Err(e) => {
                 tracing::warn!(
@@ -1869,7 +1873,10 @@ where
         let max_proposable = self.max_proposable_timestamp().await?;
 
         loop {
-            let response = self.superroot_client.superroot_at_timestamp(sequence_number).await?;
+            let response = self
+                .superroot_client
+                .superroot_at_timestamp(sequence_number, ResponseSelection::PreferData)
+                .await?;
             let Some(super_root) = SuperrootClient::super_root_at(&response, sequence_number)?
             else {
                 // Transient: the chosen timestamp is not yet safe from this
@@ -2540,7 +2547,8 @@ where
     /// configured safety level, from a fresh supernode response.
     async fn max_proposable_timestamp(&self) -> Result<u64> {
         let now = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH)?.as_secs();
-        let response = self.superroot_client.superroot_at_timestamp(now).await?;
+        let response =
+            self.superroot_client.superroot_at_timestamp(now, ResponseSelection::HighestL1).await?;
         Ok(SuperrootClient::max_proposable_timestamp(&response, self.config.proposal_safety))
     }
 

--- a/rust/kona/sp1/crates/proposer/src/proposer.rs
+++ b/rust/kona/sp1/crates/proposer/src/proposer.rs
@@ -468,7 +468,7 @@ where
         identity.log_startup_info(&config.prestates_url);
 
         let l1_provider = ProviderBuilder::default().connect_http(config.l1_rpc.clone());
-        let superroot_client = SuperrootClient::new(config.superroot_rpc.as_str())?;
+        let superroot_client = SuperrootClient::new(&config.superroot_rpcs)?;
 
         let prestates = Arc::new(PrestateCache::new(config.prestates_url.clone()));
         let host_inputs = Arc::new(HostInputs {
@@ -3551,7 +3551,7 @@ mod tests {
     fn test_config() -> ProposerConfig {
         ProposerConfig {
             l1_rpc: "http://127.0.0.1:1".parse().unwrap(),
-            superroot_rpc: "http://127.0.0.1:1".parse().unwrap(),
+            superroot_rpcs: vec!["http://127.0.0.1:1".parse().unwrap()],
             factory_address: Address::ZERO,
             prestates_url: "file:///nonexistent".parse().unwrap(),
             proposal_interval_seconds: 3600,

--- a/rust/kona/sp1/crates/proposer/src/proving.rs
+++ b/rust/kona/sp1/crates/proposer/src/proving.rs
@@ -24,7 +24,7 @@ use crate::{
     config::RangeSplitCount,
     metrics::ProposerGauge,
     prover::{MOCK_PROOF_BYTES, ProofKeys, ProofProvider},
-    superroot::SuperrootClient,
+    superroot::{ResponseSelection, SuperrootClient},
 };
 
 /// The on-chain facts a defense proof is built from, read from the game
@@ -106,7 +106,8 @@ pub async fn fetch_span_responses(
     let mut responses = Vec::with_capacity((game.claim_ts - game.starting_ts + 1) as usize);
     let mut roots = Vec::with_capacity(responses.capacity());
     for timestamp in game.starting_ts..=game.claim_ts {
-        let response = client.superroot_at_timestamp(timestamp).await?;
+        let response =
+            client.superroot_at_timestamp(timestamp, ResponseSelection::PreferData).await?;
         let Some(at) = SuperrootClient::super_root_at(&response, timestamp)? else {
             ProposerGauge::SuperRootUnavailable.increment(1.0);
             return Err(anyhow::Error::new(SuperRootDataUnavailable(timestamp)));

--- a/rust/kona/sp1/crates/proposer/src/superroot.rs
+++ b/rust/kona/sp1/crates/proposer/src/superroot.rs
@@ -5,7 +5,9 @@
 //! cross-chain safe/finalized timestamp views that gate proposal cadence.
 
 use alloy_primitives::B256;
+use alloy_transport_http::reqwest::Url;
 use anyhow::{Context, Result, anyhow};
+use futures::future::join_all;
 use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
 use kona_sp1_client_utils::super_root::{encode_super_root_proof, hash_super_root_proof};
 pub use kona_sp1_super_range_executor::{
@@ -18,7 +20,7 @@ use crate::config::ProposalSafety;
 /// Thin supernode client wrapper.
 #[derive(Clone, Debug)]
 pub struct SuperrootClient {
-    client: HttpClient,
+    clients: Vec<HttpClient>,
 }
 
 /// Canonical super-root material for one timestamp.
@@ -32,11 +34,16 @@ pub struct SuperRootAt {
 
 impl SuperrootClient {
     /// Builds a client for the supernode (or single-chain op-node) RPC.
-    pub fn new(url: &str) -> Result<Self> {
-        let client = HttpClientBuilder::default()
-            .build(url)
-            .with_context(|| format!("failed to build super-root client for {url}"))?;
-        Ok(Self { client })
+    pub fn new(urls: &[Url]) -> Result<Self> {
+        let clients = urls
+            .iter()
+            .map(|url| {
+                HttpClientBuilder::default()
+                    .build(url.as_str())
+                    .with_context(|| format!("failed to build super-root client for {url}"))
+            })
+            .collect::<Result<Vec<_>>>()?;
+        Ok(Self { clients })
     }
 
     /// Raw `superroot_atTimestamp` response.
@@ -44,7 +51,12 @@ impl SuperrootClient {
         &self,
         timestamp: u64,
     ) -> Result<SuperRootAtTimestampResponse> {
-        fetch_superroot_at_timestamp(&self.client, timestamp).await
+        let results = join_all(
+            self.clients.iter().map(|client| fetch_superroot_at_timestamp(client, timestamp)),
+        )
+        .await;
+
+        select_highest_response(results)
     }
 
     /// The highest timestamp the proposer may propose at under the
@@ -89,6 +101,36 @@ impl SuperrootClient {
         }
         Ok(Some(SuperRootAt { proof_bytes, super_root: B256::from(*super_root) }))
     }
+}
+
+fn select_highest_response(
+    results: Vec<Result<SuperRootAtTimestampResponse>>,
+) -> Result<SuperRootAtTimestampResponse> {
+    let mut errors = Vec::new();
+    let mut highest_response: Option<SuperRootAtTimestampResponse> = None;
+    for (idx, result) in results.into_iter().enumerate() {
+        match result {
+            Ok(response) => {
+                let is_higher = highest_response
+                    .as_ref()
+                    .is_none_or(|highest| response.current_l1.number > highest.current_l1.number);
+                if is_higher {
+                    highest_response = Some(response);
+                }
+            }
+            Err(err) => {
+                tracing::warn!(
+                    idx,
+                    error = %err,
+                    "Failed to retrieve super-root"
+                );
+                errors.push(format!("supernode {idx}: {err:#}"));
+            }
+        }
+    }
+
+    highest_response
+        .ok_or_else(|| anyhow!("no valid super-root response received: {}", errors.join("; ")))
 }
 
 /// Builds ZK dispute game extraData: `parentIndex (4B BE) || superRootProof`.
@@ -175,5 +217,42 @@ mod tests {
         let mut response = response_at(101);
         response.data = None;
         assert!(SuperrootClient::super_root_at(&response, 101).unwrap().is_none());
+    }
+
+    #[test]
+    fn response_selection_falls_over_to_a_healthy_source() {
+        let expected = response_at(101);
+        let response = select_highest_response(vec![
+            Err(anyhow!("first source unavailable")),
+            Ok(expected.clone()),
+        ])
+        .unwrap();
+
+        assert_eq!(response, expected);
+    }
+
+    #[test]
+    fn response_selection_uses_the_highest_l1_view() {
+        let mut lagging = response_at(101);
+        lagging.current_l1.number = 10;
+        let mut expected = response_at(101);
+        expected.current_l1.number = 12;
+
+        let response = select_highest_response(vec![Ok(lagging), Ok(expected.clone())]).unwrap();
+
+        assert_eq!(response, expected);
+    }
+
+    #[test]
+    fn response_selection_reports_all_source_failures() {
+        let err = select_highest_response(vec![
+            Err(anyhow!("first source unavailable")),
+            Err(anyhow!("second source unavailable")),
+        ])
+        .unwrap_err()
+        .to_string();
+
+        assert!(err.contains("supernode 0: first source unavailable"));
+        assert!(err.contains("supernode 1: second source unavailable"));
     }
 }

--- a/rust/kona/sp1/crates/proposer/src/superroot.rs
+++ b/rust/kona/sp1/crates/proposer/src/superroot.rs
@@ -24,6 +24,15 @@ pub struct SuperrootClient {
     clients: Vec<HttpClient>,
 }
 
+/// How responses from multiple supernodes are prioritized.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ResponseSelection {
+    /// Select the response with the highest L1 view.
+    HighestL1,
+    /// Prefer responses containing super-root data, then select by highest L1 view.
+    PreferData,
+}
+
 /// Canonical super-root material for one timestamp.
 #[derive(Debug, Clone)]
 pub struct SuperRootAt {
@@ -52,13 +61,14 @@ impl SuperrootClient {
     pub async fn superroot_at_timestamp(
         &self,
         timestamp: u64,
+        selection: ResponseSelection,
     ) -> Result<SuperRootAtTimestampResponse> {
         let results = join_all(
             self.clients.iter().map(|client| fetch_superroot_at_timestamp(client, timestamp)),
         )
         .await;
 
-        select_highest_response(results)
+        select_highest_response(results, selection)
     }
 
     /// The highest timestamp the proposer may propose at under the
@@ -107,15 +117,22 @@ impl SuperrootClient {
 
 fn select_highest_response(
     results: Vec<Result<SuperRootAtTimestampResponse>>,
+    selection: ResponseSelection,
 ) -> Result<SuperRootAtTimestampResponse> {
     let mut errors = Vec::new();
     let mut highest_response: Option<SuperRootAtTimestampResponse> = None;
     for (idx, result) in results.into_iter().enumerate() {
         match result {
             Ok(response) => {
-                let is_higher = highest_response
-                    .as_ref()
-                    .is_none_or(|highest| response.current_l1.number > highest.current_l1.number);
+                let is_higher = highest_response.as_ref().is_none_or(|highest| match selection {
+                    ResponseSelection::HighestL1 => {
+                        response.current_l1.number > highest.current_l1.number
+                    }
+                    ResponseSelection::PreferData => {
+                        (response.data.is_some(), response.current_l1.number) >
+                            (highest.data.is_some(), highest.current_l1.number)
+                    }
+                });
                 if is_higher {
                     highest_response = Some(response);
                 }
@@ -224,10 +241,10 @@ mod tests {
     #[test]
     fn response_selection_falls_over_to_a_healthy_source() {
         let expected = response_at(101);
-        let response = select_highest_response(vec![
-            Err(anyhow!("first source unavailable")),
-            Ok(expected.clone()),
-        ])
+        let response = select_highest_response(
+            vec![Err(anyhow!("first source unavailable")), Ok(expected.clone())],
+            ResponseSelection::HighestL1,
+        )
         .unwrap();
 
         assert_eq!(response, expected);
@@ -240,17 +257,58 @@ mod tests {
         let mut expected = response_at(101);
         expected.current_l1.number = 12;
 
-        let response = select_highest_response(vec![Ok(lagging), Ok(expected.clone())]).unwrap();
+        let response = select_highest_response(
+            vec![Ok(lagging), Ok(expected.clone())],
+            ResponseSelection::HighestL1,
+        )
+        .unwrap();
+
+        assert_eq!(response, expected);
+    }
+
+    #[test]
+    fn response_selection_prefers_available_data_for_exact_lookup() {
+        let mut expected = response_at(101);
+        expected.current_l1.number = 10;
+        let mut ahead_without_data = response_at(101);
+        ahead_without_data.current_l1.number = 12;
+        ahead_without_data.data = None;
+
+        let response = select_highest_response(
+            vec![Ok(expected.clone()), Ok(ahead_without_data)],
+            ResponseSelection::PreferData,
+        )
+        .unwrap();
+
+        assert_eq!(response, expected);
+    }
+
+    #[test]
+    fn response_selection_uses_highest_l1_for_sync_status_without_data() {
+        let mut behind_with_data = response_at(101);
+        behind_with_data.current_l1.number = 10;
+        let mut expected = response_at(101);
+        expected.current_l1.number = 12;
+        expected.data = None;
+
+        let response = select_highest_response(
+            vec![Ok(behind_with_data), Ok(expected.clone())],
+            ResponseSelection::HighestL1,
+        )
+        .unwrap();
 
         assert_eq!(response, expected);
     }
 
     #[test]
     fn response_selection_reports_all_source_failures() {
-        let err = select_highest_response(vec![
-            Err(anyhow!("first source unavailable")),
-            Err(anyhow!("second source unavailable")),
-        ])
+        let err = select_highest_response(
+            vec![
+                Err(anyhow!("first source unavailable")),
+                Err(anyhow!("second source unavailable")),
+            ],
+            ResponseSelection::HighestL1,
+        )
         .unwrap_err()
         .to_string();
 

--- a/rust/kona/sp1/crates/proposer/src/superroot.rs
+++ b/rust/kona/sp1/crates/proposer/src/superroot.rs
@@ -14,6 +14,7 @@ pub use kona_sp1_super_range_executor::{
     SuperRootAtTimestampResponse, SuperRootResponseData, fetch_superroot_at_timestamp,
     proof_from_super_v1,
 };
+use std::time::Duration;
 
 use crate::config::ProposalSafety;
 
@@ -39,6 +40,7 @@ impl SuperrootClient {
             .iter()
             .map(|url| {
                 HttpClientBuilder::default()
+                    .request_timeout(Duration::from_secs(30))
                     .build(url.as_str())
                     .with_context(|| format!("failed to build super-root client for {url}"))
             })


### PR DESCRIPTION
Updates the kona-sp1-proposer to accept multiple superroot RPCs to allow for failover whenever an RPC is unavailable or not yet synced.

Fixes https://github.com/ethereum-optimism/optimism/issues/22403