### PR TITLE
circleci: Run rust CI and prestate publishing on develop

### DIFF
--- a/.circleci/scripts/compute-workflow-conditions.sh
+++ b/.circleci/scripts/compute-workflow-conditions.sh
@@ -100,6 +100,12 @@ case "${TRIGGER_SOURCE}" in
     # 3. After merge (develop push)
     #    Runs after the merge queue completes and pushes to develop.
     #    Adds expensive post-merge jobs: fault proofs, kontrol, prestate publishing.
+    #
+    #    Nothing here is path-gated. Change detection diffs against
+    #    origin/${BASE_REVISION}, and BASE_REVISION is develop, so on a develop
+    #    push HEAD is the base and the changed-file list is always empty. Every
+    #    is_true check would therefore be false, making the gated branch dead
+    #    code rather than a conditional.
     # ---------------------------------------------------------
     elif [[ "${BRANCH}" == "develop" ]]; then
       run main
@@ -108,14 +114,10 @@ case "${TRIGGER_SOURCE}" in
       run develop_fault_proofs
       run develop_kontrol_tests
       run contracts_feature_tests
-      if is_true rust_changes_detected; then
-        run rust_ci
-        run rust_e2e_ci
-        run kona_publish_prestates
-      else
-        run rust_ci_gate_short
-        run rust_e2e_gate_skip
-      fi
+      run rust_ci
+      run rust_e2e_ci
+      run kona_publish_prestates
+      run circleci_schedule_trigger_check
     fi
     ;;
 

--- a/.circleci/scripts/test-decision-tree.sh
+++ b/.circleci/scripts/test-decision-tree.sh
@@ -153,17 +153,24 @@ run_scenario \
   '{"c-rust_changes_detected": false, "c-contracts_changed": false, "c-docs_changes_detected": false}' \
   main release contracts_feature_tests rust_ci_gate_short rust_e2e_gate_skip
 
+# Develop runs the full post-merge set unconditionally. The two scenarios below
+# seed opposite change-detection results and assert an identical routing, which
+# is what pins that behaviour: on a develop push the changed-file list is always
+# empty (BASE_REVISION is develop, so HEAD is the base), so any path gating here
+# would be dead code that never fires in production.
 run_scenario \
-  "After merge (develop), rust changed" \
+  "After merge (develop), empty change set (production reality)" \
   "webhook" "develop" "" "" \
-  '{"c-rust_changes_detected": true, "c-contracts_changed": false, "c-docs_changes_detected": true}' \
-  main release publish_contract_artifacts develop_fault_proofs develop_kontrol_tests contracts_feature_tests rust_ci rust_e2e_ci kona_publish_prestates
+  '{"c-rust_changes_detected": false, "c-contracts_changed": false, "c-circleci_changed": false, "c-docs_changes_detected": false, "c-only_docs_changes": false}' \
+  main release publish_contract_artifacts develop_fault_proofs develop_kontrol_tests contracts_feature_tests rust_ci rust_e2e_ci kona_publish_prestates circleci_schedule_trigger_check \
+  --not rust_ci_gate_short rust_e2e_gate_skip ci_gate_skip contracts_feature_tests_short
 
 run_scenario \
-  "After merge (develop), no rust changes" \
+  "After merge (develop), change detection must not alter routing" \
   "webhook" "develop" "" "" \
-  '{"c-rust_changes_detected": false, "c-contracts_changed": false, "c-docs_changes_detected": false}' \
-  main release publish_contract_artifacts develop_fault_proofs develop_kontrol_tests contracts_feature_tests rust_ci_gate_short rust_e2e_gate_skip
+  '{"c-rust_changes_detected": true, "c-contracts_changed": true, "c-circleci_changed": true, "c-docs_changes_detected": true, "c-only_docs_changes": true}' \
+  main release publish_contract_artifacts develop_fault_proofs develop_kontrol_tests contracts_feature_tests rust_ci rust_e2e_ci kona_publish_prestates circleci_schedule_trigger_check \
+  --not rust_ci_gate_short rust_e2e_gate_skip ci_gate_skip contracts_feature_tests_short
 
 run_scenario \
   "Scheduled: build_four_hours" \


### PR DESCRIPTION
Four workflows never ran on a develop push.

`rust-ci`, `rust-e2e-ci` and `kona-publish-prestates` sat behind `if is_true rust_changes_detected`. Change detection diffs against `origin/$BASE_REVISION`, and `BASE_REVISION` is `develop`, so on a develop push HEAD is the base and the changed-file list is always empty. Every detector is false there, so that branch was dead code. Over the last 30 days all 360 develop pipelines took the else path, and `kona-publish-prestates` — reachable only from this branch — ran zero times across all 1736 pipelines in the window.

`circleci-schedule-trigger-check` was a separate omission: the routing script only calls it for PR and merge-queue pushes.

Develop now runs all four unconditionally. It also drops the `rust-ci-gate-short` and `rust-e2e-gate-skip` placeholders, because the real workflows emit the same `required-rust-ci` and `required-rust-e2e` check names.

This does mean we run some extra builds which theoretically are redundant with the merge queue but it means that develop is just running everything rather than trying to make file path based decisions of what to run which provides an important safety net for any bugs in the change detection code (which we've seen plenty of).