### PR TITLE
mise: Add protoc

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -27,6 +27,12 @@ svm-rs = "0.5.19"
 # developer Macs. Pinned here so CI's linker version is fixed and reproducible.
 mold = { version = "2.41.0", os = ["linux"] }
 
+# Required to build the Rust workspace: prost-build (via sp1-prover-types)
+# shells out to protoc and fails the build if it is absent. CI gets it from the
+# ci-base-clang image, so this is what makes a local `cargo build` work without
+# installing protobuf-compiler by hand.
+protoc = "35.1"
+
 # Rust tooling
 "github:crate-ci/cargo-release" = { version = "1.1.2" }
 


### PR DESCRIPTION
`cargo build` on the Rust workspace fails on a clean machine: prost-build shells out to `protoc` while building `sp1-prover-types`, and errors out when it is missing, telling the developer to `apt-get install protobuf-compiler` by hand.

CI does not hit this because the `ci-base-clang` image installs `protobuf-compiler`, so the gap is local-only and easy to miss.

Pinning `protoc` in `mise.toml` closes it. It also fixes the version CI builds against, since mise now supplies protoc in place of the image's apt package — worth a look if anyone would rather CI keep using the image's copy.