### PR TITLE
ci: bump apko factory pin to restore version stamping

### DIFF
--- a/.github/workflows/build-images.apko.yaml
+++ b/.github/workflows/build-images.apko.yaml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Plan melange, apko, and smoke matrices
         id: plan
-        uses: ethereum-optimism/factory/actions/apko-plan@12411827f96e70e564f1b459a1c50bd6e3bd6199
+        uses: ethereum-optimism/factory/actions/apko-plan@103d850873d85202fc2f53473191d691229240d3
         with:
           config: .github/images.apko.json
 
@@ -77,7 +77,7 @@ jobs:
       id-token: write
       attestations: write
       artifact-metadata: write
-    uses: ethereum-optimism/factory/.github/workflows/melange-build.yaml@12411827f96e70e564f1b459a1c50bd6e3bd6199
+    uses: ethereum-optimism/factory/.github/workflows/melange-build.yaml@103d850873d85202fc2f53473191d691229240d3
     with:
       stack: ${{ matrix.stack }}
       arch: ${{ matrix.arch }}
@@ -110,7 +110,7 @@ jobs:
       attestations: write
       artifact-metadata: write
       actions: read
-    uses: ethereum-optimism/factory/.github/workflows/apko-publish.yaml@12411827f96e70e564f1b459a1c50bd6e3bd6199
+    uses: ethereum-optimism/factory/.github/workflows/apko-publish.yaml@103d850873d85202fc2f53473191d691229240d3
     with:
       service: ${{ matrix.service }}
       needs-melange-apks: ${{ matrix.needs_melange_apks }}
@@ -133,7 +133,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: ethereum-optimism/factory/.github/workflows/apko-smoke-test.yaml@12411827f96e70e564f1b459a1c50bd6e3bd6199
+    uses: ethereum-optimism/factory/.github/workflows/apko-smoke-test.yaml@103d850873d85202fc2f53473191d691229240d3
     with:
       service: ${{ matrix.service }}
       registry: us-docker.pkg.dev/oplabs-tools-artifacts/images


### PR DESCRIPTION
Points the apko workflows at factory `103d850` (ethereum-optimism/factory#57), which restores the `--env-file` metadata pass so `GIT_VERSION`/`GIT_COMMIT`/`GIT_DATE` reach the melange sandbox. Fixes apko release images stamped `v0.0.0-unknown-0`.

Validated end-to-end on this branch via throwaway tags: `op-batcher/v0.0.0-envfix.1` smoke green with `op-batcher version v0.0.0-envfix.1-…`.