### PR TITLE
op-acceptance-tests: cover ZK challenger recovery paths

### DIFF
--- a/op-acceptance-tests/tests/proofs/zk/honest_challenger_test.go
+++ b/op-acceptance-tests/tests/proofs/zk/honest_challenger_test.go
@@ -145,6 +145,60 @@ func TestZK_HonestChallenger_InvalidProposal_ChallengerWins(gt *testing.T) {
 	})
 }
 
+// TestZK_HonestChallenger_SourceRecovers_ChallengesInvalidProposal checks the live challenger's
+// recovery path when its super-root RPC is temporarily unresponsive. Two stalled requests prove the
+// first call timed out and the challenger retried; after the source resumes, the same challenger must
+// submit the on-chain challenge before the challenge window expires.
+func TestZK_HonestChallenger_SourceRecovers_ChallengesInvalidProposal(gt *testing.T) {
+	t := devtest.ParallelT(gt)
+	sys := newOpNodeSystem(t)
+	proxy := sys.ZKChallengerSuperRootRPCProxy()
+	proxy.Stall()
+
+	factory := sys.DisputeGameFactory()
+	proposer := sys.FunderL1.NewFundedEOA(eth.OneEther)
+	_, anchorSequence := sys.AnchorStateRegistry(sys.L2ChainA).AnchorRoot()
+	timestamp, outputRoots := factory.WaitForSafeSuperRootAfter(anchorSequence)
+	t.Require().NotEmpty(outputRoots)
+	outputRoots[0][0] ^= 0xff
+	game := factory.StartZKGame(proposer,
+		proofs.WithL2SequenceNumber(timestamp),
+		proofs.WithSuperRootFrom(outputRoots...),
+	)
+
+	proxy.WaitForStalledRequests(t, 2)
+	t.Require().Equal(proofs.ZKProposalUnchallenged, game.ProposalStatus())
+	proxy.Resume()
+	game.WaitForProposalStatus(proofs.ZKProposalChallenged)
+}
+
+// TestZK_HonestChallenger_InvalidChainBProposal_ChallengesProposal checks that the challenger compares
+// every chain in a multi-chain super root. Existing invalid-proposal coverage corrupts the first
+// (Chain A) output; this corrupts only the second (Chain B) output and expects the same challenge.
+func TestZK_HonestChallenger_InvalidChainBProposal_ChallengesProposal(gt *testing.T) {
+	t := devtest.ParallelT(gt)
+	multiSys := presets.NewSimpleInterop(t,
+		presets.WithZK(),
+		presets.WithoutHonestProposer(),
+	)
+	sys := &multiSys.SingleChainInterop
+	t.Require().Negative(multiSys.L2ChainA.ChainID().Cmp(multiSys.L2ChainB.ChainID()),
+		"super-root entries are sorted by chain ID, so Chain B must be the second entry")
+
+	factory := sys.DisputeGameFactory()
+	proposer := sys.FunderL1.NewFundedEOA(eth.OneEther)
+	_, anchorSequence := sys.AnchorStateRegistry(sys.L2ChainA).AnchorRoot()
+	timestamp, outputRoots := factory.WaitForSafeSuperRootAfter(anchorSequence)
+	t.Require().Len(outputRoots, 2)
+	outputRoots[1][0] ^= 0xff
+	game := factory.StartZKGame(proposer,
+		proofs.WithL2SequenceNumber(timestamp),
+		proofs.WithSuperRootFrom(outputRoots...),
+	)
+
+	game.WaitForProposalStatus(proofs.ZKProposalChallenged)
+}
+
 // TestZK_HonestChallenger_UnsafeProposal_ChallengerWins locks in the subtle rule that a proposal for
 // a timestamp the node has not yet made safe has no canonical super root (Data == nil), which the
 // honest challenger treats as invalid: it challenges and, with no proof submitted, resolves

--- a/op-devstack/presets/interop.go
+++ b/op-devstack/presets/interop.go
@@ -40,9 +40,10 @@ type SingleChainInterop struct {
 	FunderA  *dsl.FunderEOA
 
 	// May be nil if not using sysgo
-	challengerConfig *challengerConfig.Config
-	startZKProposer  func()
-	zkMetricsAddr    func() string
+	challengerConfig              *challengerConfig.Config
+	zkChallengerSuperRootRPCProxy *sysgo.StallableProxy
+	startZKProposer               func()
+	zkMetricsAddr                 func() string
 }
 
 func (s *SingleChainInterop) L2Networks() []*dsl.L2Network {
@@ -79,6 +80,14 @@ func (s *SingleChainInterop) ZKProposerMetricsURL() string {
 	addr := s.zkMetricsAddr()
 	s.T.Require().NotEmpty(addr, "no ZK proposer metrics endpoint; pass sysgo.WithZKMetrics()")
 	return "http://" + addr + "/metrics"
+}
+
+// ZKChallengerSuperRootRPCProxy returns the proxy in front of the live ZK
+// challenger's super-root RPC.
+func (s *SingleChainInterop) ZKChallengerSuperRootRPCProxy() *sysgo.StallableProxy {
+	s.T.Require().NotNil(s.zkChallengerSuperRootRPCProxy,
+		"ZK challenger super-root RPC proxy is not configured")
+	return s.zkChallengerSuperRootRPCProxy
 }
 
 func (s *SingleChainInterop) proofValidationContext() (devtest.T, *dsl.L1ELNode, []*dsl.L2Network) {

--- a/op-devstack/presets/singlechain_interop_no_supernode_from_runtime.go
+++ b/op-devstack/presets/singlechain_interop_no_supernode_from_runtime.go
@@ -51,19 +51,20 @@ func singleChainInteropNoSupernodeFromRuntime(t devtest.T, runtime *sysgo.Single
 	l2CLDSL := dsl.NewL2CLNode(l2CL)
 
 	out := &SingleChainInterop{
-		Log:              t.Logger(),
-		T:                t,
-		timeTravel:       runtime.TimeTravel,
-		SuperRoots:       dsl.NewOpNodeSuperRoots(l2CLDSL),
-		L1Network:        dsl.NewL1Network(l1Network, l1ELDSL, l1CLDSL),
-		L1EL:             l1ELDSL,
-		L1CL:             l1CLDSL,
-		L2ChainA:         dsl.NewL2Network(l2Chain, l2ELDSL, l2CLDSL, l1ELDSL, nil, nil),
-		L2BatcherA:       dsl.NewL2Batcher(l2Batcher),
-		L2ELA:            l2ELDSL,
-		L2CLA:            l2CLDSL,
-		Wallet:           dsl.NewRandomHDWallet(t, 30),
-		challengerConfig: challengerCfg,
+		Log:                           t.Logger(),
+		T:                             t,
+		timeTravel:                    runtime.TimeTravel,
+		SuperRoots:                    dsl.NewOpNodeSuperRoots(l2CLDSL),
+		L1Network:                     dsl.NewL1Network(l1Network, l1ELDSL, l1CLDSL),
+		L1EL:                          l1ELDSL,
+		L1CL:                          l1CLDSL,
+		L2ChainA:                      dsl.NewL2Network(l2Chain, l2ELDSL, l2CLDSL, l1ELDSL, nil, nil),
+		L2BatcherA:                    dsl.NewL2Batcher(l2Batcher),
+		L2ELA:                         l2ELDSL,
+		L2CLA:                         l2CLDSL,
+		Wallet:                        dsl.NewRandomHDWallet(t, 30),
+		challengerConfig:              challengerCfg,
+		zkChallengerSuperRootRPCProxy: runtime.ZKChallengerSuperRootRPCProxy,
 	}
 	out.FunderL1 = newFunderEOA(t, runtime.Keys, out.L1EL, out.Wallet)
 	out.FunderA = newFunderEOA(t, runtime.Keys, out.L2ELA, out.Wallet)

--- a/op-devstack/sysgo/runtime_state.go
+++ b/op-devstack/sysgo/runtime_state.go
@@ -84,6 +84,8 @@ type SingleChainRuntime struct {
 	L2Batcher    *L2Batcher
 	L2Proposer   *L2Proposer
 	L2Challenger *L2Challenger
+	// ZKChallengerSuperRootRPCProxy is set when the runtime starts a ZK challenger.
+	ZKChallengerSuperRootRPCProxy *StallableProxy
 
 	TimeTravel    *clock.AdvancingClock
 	TestSequencer *TestSequencerRuntime

--- a/op-devstack/sysgo/singlechain_runtime.go
+++ b/op-devstack/sysgo/singlechain_runtime.go
@@ -153,26 +153,28 @@ func newSingleChainRuntimeWithConfig(t devtest.T, cfg PresetConfig, spec singleC
 	}
 
 	var l2Challenger *L2Challenger
+	var zkChallengerSuperRootRPCProxy *StallableProxy
 	if spec.StartChallenger {
-		l2Challenger = startMinimalChallenger(t, keys, world.L1Network, world.L2Network, l1EL, l1CL, primary.EL, primary.CL, cfg.AddedGameTypes)
+		l2Challenger, zkChallengerSuperRootRPCProxy = startMinimalChallenger(t, keys, world.L1Network, world.L2Network, l1EL, l1CL, primary.EL, primary.CL, cfg.AddedGameTypes)
 	}
 
 	testSequencer := startTestSequencerForRPCs(t, keys, "test-sequencer", jwtPath, jwtSecret, world.L1Network, l1EL, l1CL, world.L2Network.ChainID(), primary.EL.UserRPC(), primary.CL.UserRPC())
 	testSequencerRuntime := newTestSequencerRuntime(testSequencer, spec.TestSequencer)
 
 	return &SingleChainRuntime{
-		Keys:          keys,
-		L1Network:     world.L1Network,
-		L2Network:     world.L2Network,
-		L1EL:          l1EL,
-		L1CL:          l1CL,
-		L2EL:          primary.EL,
-		L2CL:          primary.CL,
-		L2Batcher:     l2Batcher,
-		L2Proposer:    l2Proposer,
-		L2Challenger:  l2Challenger,
-		TimeTravel:    timeTravelClock,
-		TestSequencer: testSequencerRuntime,
+		Keys:                          keys,
+		L1Network:                     world.L1Network,
+		L2Network:                     world.L2Network,
+		L1EL:                          l1EL,
+		L1CL:                          l1CL,
+		L2EL:                          primary.EL,
+		L2CL:                          primary.CL,
+		L2Batcher:                     l2Batcher,
+		L2Proposer:                    l2Proposer,
+		L2Challenger:                  l2Challenger,
+		ZKChallengerSuperRootRPCProxy: zkChallengerSuperRootRPCProxy,
+		TimeTravel:                    timeTravelClock,
+		TestSequencer:                 testSequencerRuntime,
 		Nodes: map[string]*SingleChainNodeRuntime{
 			primaryNode.Name: primaryNode,
 		},
@@ -381,7 +383,7 @@ func startMinimalChallenger(
 	l2EL L2ELNode,
 	l2CL L2CLNode,
 	addedGameTypes []gameTypes.GameType,
-) *L2Challenger {
+) (*L2Challenger, *StallableProxy) {
 	require := t.Require()
 	challengerSecret, err := keys.Secret(devkeys.ChallengerRole.Key(l2Net.ChainID().ToBig()))
 	require.NoError(err)
@@ -411,13 +413,15 @@ func startMinimalChallenger(
 	}
 	require.False(cannonKonaEnabled && superCannonKonaEnabled, "minimal challenger cannot use legacy and interop Cannon Kona prestates simultaneously")
 	require.False(zkEnabled && (cannonKonaEnabled || superCannonKonaEnabled), "minimal challenger cannot use the ZK game alongside cannon-kona game types")
+	var zkChallengerSuperRootRPCProxy *StallableProxy
 	switch {
 	case zkEnabled:
 		// The ZK game validates super roots from the op-node's superroot_atTimestamp endpoint;
 		// it needs no VM config or dependency set.
+		zkChallengerSuperRootRPCProxy = StartStallableProxy(t, "zk-challenger-super-root", l2CL.UserRPC())
 		options = append(options,
 			sharedchallenger.WithZKDisputeGameType(),
-			sharedchallenger.WithSuperRootRPC(l2CL.UserRPC()),
+			sharedchallenger.WithSuperRootRPC(zkChallengerSuperRootRPCProxy.URL()),
 		)
 	case superCannonKonaEnabled:
 		options = append(options,
@@ -468,7 +472,7 @@ func startMinimalChallenger(
 		chainIDs: []eth.ChainID{l2Net.ChainID()},
 		service:  svc,
 		config:   cfg,
-	}
+	}, zkChallengerSuperRootRPCProxy
 }
 
 func applyMinimalGameTypeOptions(

--- a/op-devstack/sysgo/stallable_proxy.go
+++ b/op-devstack/sysgo/stallable_proxy.go
@@ -133,7 +133,7 @@ func (p *StallableProxy) WaitForStalledRequests(t devtest.T, count int64) {
 	t.Require().Positive(count)
 	t.Require().Eventuallyf(func() bool {
 		return p.StalledRequests() >= count
-	}, 30*time.Second, 100*time.Millisecond,
+	}, 2*time.Minute, 100*time.Millisecond,
 		"proxy did not stall %d requests", count)
 }
 

--- a/op-devstack/sysgo/stallable_proxy.go
+++ b/op-devstack/sysgo/stallable_proxy.go
@@ -126,6 +126,17 @@ func (p *StallableProxy) StalledRequests() int64 {
 	return p.stalledRequests.Load()
 }
 
+// WaitForStalledRequests waits until at least count requests have been held by
+// the proxy. Requiring multiple requests lets recovery tests prove that a
+// client retried after an earlier stalled request timed out.
+func (p *StallableProxy) WaitForStalledRequests(t devtest.T, count int64) {
+	t.Require().Positive(count)
+	t.Require().Eventuallyf(func() bool {
+		return p.StalledRequests() >= count
+	}, 30*time.Second, 100*time.Millisecond,
+		"proxy did not stall %d requests", count)
+}
+
 // MaxConcurrentStalledRequests returns the highest number of requests that were
 // held open by the stall at the same moment. Tests use it to pin down
 // single-flight client behavior: a client that fires a new request on every


### PR DESCRIPTION
Adds acceptance coverage for two previously uncovered ZK challenger paths:

- The challenger’s super-root RPC times out, retries, then challenges an invalid proposal after the source recovers.
- A multichain proposal corrupted only on Chain B is challenged, confirming that all super-root entries are validated.

The recovery case reuses the existing stallable proxy in pass-through mode, keeping normal preset behavior unchanged without introducing a new preset option.

Fixes: #18326