### PR TITLE
ci: skip merge queue test suites for docs-only changes

### DIFF
--- a/.circleci/scripts/compute-workflow-conditions.sh
+++ b/.circleci/scripts/compute-workflow-conditions.sh
@@ -80,21 +80,29 @@ case "${TRIGGER_SOURCE}" in
 
     # 2. Merge queue (pre-merge validation)
     #    Runs when GitHub merge queue picks up the PR.
-    #    Full contract tests, path-gated rust/docs.
+    #    Docs-only changes emit the required gates without running test suites.
+    #    All other changes run full contract tests and path-gated Rust tests.
     # ---------------------------------------------------------
     elif [[ "${BRANCH}" =~ ^gh-readonly-queue/ ]]; then
-      run main
-      run release
-      run contracts_feature_tests
-      if is_true rust_changes_detected; then
-        run rust_ci
-        run rust_e2e_ci
-      else
+      if is_true only_docs_changes; then
+        run ci_gate_skip
+        run contracts_feature_tests_short
         run rust_ci_gate_short
         run rust_e2e_gate_skip
-      fi
-      if is_true circleci_changed; then
-        run circleci_schedule_trigger_check
+      else
+        run main
+        run release
+        run contracts_feature_tests
+        if is_true rust_changes_detected; then
+          run rust_ci
+          run rust_e2e_ci
+        else
+          run rust_ci_gate_short
+          run rust_e2e_gate_skip
+        fi
+        if is_true circleci_changed; then
+          run circleci_schedule_trigger_check
+        fi
       fi
 
     # 3. After merge (develop push)

--- a/.circleci/scripts/test-decision-tree.sh
+++ b/.circleci/scripts/test-decision-tree.sh
@@ -144,14 +144,21 @@ run_scenario \
 run_scenario \
   "Merge queue, rust changed" \
   "webhook" "gh-readonly-queue/develop/pr-123" "" "" \
-  '{"c-rust_changes_detected": true, "c-contracts_changed": false, "c-docs_changes_detected": false}' \
+  '{"c-rust_changes_detected": true, "c-contracts_changed": false, "c-docs_changes_detected": false, "c-only_docs_changes": false}' \
   main release contracts_feature_tests rust_ci rust_e2e_ci
 
 run_scenario \
   "Merge queue, no changes" \
   "webhook" "gh-readonly-queue/develop/pr-123" "" "" \
-  '{"c-rust_changes_detected": false, "c-contracts_changed": false, "c-docs_changes_detected": false}' \
+  '{"c-rust_changes_detected": false, "c-contracts_changed": false, "c-docs_changes_detected": false, "c-only_docs_changes": false}' \
   main release contracts_feature_tests rust_ci_gate_short rust_e2e_gate_skip
+
+run_scenario \
+  "Merge queue, docs only" \
+  "webhook" "gh-readonly-queue/develop/pr-123" "" "" \
+  '{"c-rust_changes_detected": false, "c-contracts_changed": false, "c-docs_changes_detected": true, "c-only_docs_changes": true}' \
+  ci_gate_skip contracts_feature_tests_short rust_ci_gate_short rust_e2e_gate_skip \
+  --not main release contracts_feature_tests rust_ci rust_e2e_ci
 
 # Develop runs the full post-merge set unconditionally. The two scenarios below
 # seed opposite change-detection results and assert an identical routing, which


### PR DESCRIPTION
## Summary

Docs-only PRs already skip the full CI suites on feature branches, but rerun them after entering the merge queue.

Apply the existing `docs/public-docs/`-only fast path to merge-queue pipelines. The lightweight jobs still emit all four required checks:

- `ci-gate`
- `required-contracts-ci`
- `required-rust-ci`
- `required-rust-e2e`

Changes outside `docs/public-docs/` continue to use the normal merge-queue CI path.

## Testing

- Ran the CircleCI decision-tree tests: 21 passed
- Ran `shellcheck` on the changed scripts
- Ran Bash syntax checks
- Ran `git diff --check`