### PR TITLE
circleci: Add slack context to rust-nightly-bump

### DIFF
--- a/.circleci/continue/rust-nightly-bump.yml
+++ b/.circleci/continue/rust-nightly-bump.yml
@@ -106,3 +106,4 @@ workflows:
       - rust-nightly-bump:
           context:
             - circleci-repo-optimism
+            - slack


### PR DESCRIPTION
The scheduled `rust-nightly-bump` job sends pass and fail Slack notifications, but its workflow entry only had the `circleci-repo-optimism` context. `SLACK_ACCESS_TOKEN` was unset, so both notify steps failed and the job went red even when the bump itself succeeded.

Add the `slack` context, which the other notifying jobs already use.

Example failure: https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/132702/workflows/1ecb944a-2cd2-4ff1-bafb-446f9bd02d2f