### PR TITLE
ci-base-clang: Drop redundant protobuf apt packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ parameters:
   default_docker_image:
     type: string
     default: cimg/base:2026.03
-  # Pinned ci-base-clang image (cimg/base + clang/llvm-dev/libclang-dev + protobuf-compiler) for Rust jobs.
+  # Pinned ci-base-clang image (cimg/base + clang/llvm-dev/libclang-dev) for Rust jobs.
   # Provenance is verified by .github/workflows/security.yml.
   rust_base_image:
     type: string

--- a/.circleci/continue/helpers.yml
+++ b/.circleci/continue/helpers.yml
@@ -101,13 +101,13 @@ commands:
             - run:
                 name: Ensure clang available
                 command: 'command -v clang >/dev/null 2>&1 || { echo "ERROR: clang is required but was not found in PATH" >&2; exit 1; }'
-      # protoc + libprotobuf-dev well-known types (sp1-sdk prost/tonic build
-      # dep) are preinstalled in ci-base-clang, so just assert their presence.
+      # protoc (sp1-sdk prost/tonic build dep) bundles the well-known type
+      # includes it resolves, so its presence on PATH is enough to assert.
       - run:
           name: Ensure protobuf compiler available
           command: |
-            if ! command -v protoc >/dev/null 2>&1 || [ ! -f /usr/include/google/protobuf/empty.proto ]; then
-              echo "ERROR: protoc and the protobuf well-known type includes are required but were not found in PATH (expected in the ci-base-clang image)" >&2
+            if ! command -v protoc >/dev/null 2>&1; then
+              echo "ERROR: protoc is required but was not found in PATH" >&2
               exit 1
             fi
             protoc --version

--- a/mise.toml
+++ b/mise.toml
@@ -28,9 +28,7 @@ svm-rs = "0.5.19"
 mold = { version = "2.41.0", os = ["linux"] }
 
 # Required to build the Rust workspace: prost-build (via sp1-prover-types)
-# shells out to protoc and fails the build if it is absent. CI gets it from the
-# ci-base-clang image, so this is what makes a local `cargo build` work without
-# installing protobuf-compiler by hand.
+# shells out to protoc and fails the build if it is absent.
 protoc = "35.1"
 
 # Rust tooling

--- a/ops/docker/ci-base-clang/Dockerfile
+++ b/ops/docker/ci-base-clang/Dockerfile
@@ -1,7 +1,7 @@
 FROM cimg/base:2026.03
 
 LABEL org.opencontainers.image.title="optimism ci-base clang"
-LABEL org.opencontainers.image.description="CircleCI base image with clang, llvm-dev, libclang-dev, protobuf-compiler, and sccache preinstalled for Rust bindgen and prost/tonic build jobs"
+LABEL org.opencontainers.image.description="CircleCI base image with clang, llvm-dev, libclang-dev, and sccache preinstalled for Rust bindgen and prost/tonic build jobs"
 LABEL org.opencontainers.image.source="https://github.com/ethereum-optimism/optimism"
 
 # Pinned sccache release, preinstalled so Rust CI jobs don't install it per-job.
@@ -23,8 +23,6 @@ RUN apt-get -o Acquire::Retries=8 update \
       llvm-dev \
       libclang-dev \
       mold \
-      protobuf-compiler \
-      libprotobuf-dev \
  && apt clean \
  && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Follow-up to ethereum-optimism/optimism#22423 (review comment [here](https://github.com/ethereum-optimism/optimism/pull/22423#issuecomment-5293079475)).

That PR pinned `protoc` in `mise.toml`, which now supplies protoc for both CI and local builds. The standalone protoc release also bundles the well-known type includes it resolves automatically, so the `protobuf-compiler` and `libprotobuf-dev` apt packages in the `ci-base-clang` image are redundant. This removes them and relaxes the rust-prepare check to assert only that `protoc` is on PATH (it no longer relies on the `/usr/include` well-known types).

No Rust crate links the C++ protobuf library; `libprotobuf-dev` was only present for the well-known-type includes, which mise's protoc now provides.

The image is pinned by digest and only rebuilt when `ops/docker/ci-base-clang/**` changes, so the apt removal takes effect once the image is rebuilt and the digest repinned in `.circleci/config.yml` — a required follow-up. Until then the Rust build stays green on the current image; if mise's protoc were ever insufficient it would fail loudly at repin, not merge silently.

`rust/kona/docker/apps/kona_app_generic.dockerfile` still installs the apt packages: it builds the workspace in Docker without mise, so it is out of scope.