### PR TITLE
apko: publish -dev image variant, keep default tags minimal

### DIFF
--- a/.github/images.apko.json
+++ b/.github/images.apko.json
@@ -73,6 +73,10 @@
   },
   "images": {
     "op-node": {
+      "apko_configs": [
+        "apko/op-node.yaml",
+        "apko/op-node-dev.yaml"
+      ],
       "type": "go",
       "verify_version": true,
       "needs_melange": [
@@ -87,6 +91,10 @@
       "smoke_test": "op-node --version"
     },
     "op-batcher": {
+      "apko_configs": [
+        "apko/op-batcher.yaml",
+        "apko/op-batcher-dev.yaml"
+      ],
       "type": "go",
       "verify_version": true,
       "needs_melange": [
@@ -101,6 +109,10 @@
       "smoke_test": "op-batcher --version"
     },
     "op-proposer": {
+      "apko_configs": [
+        "apko/op-proposer.yaml",
+        "apko/op-proposer-dev.yaml"
+      ],
       "type": "go",
       "verify_version": true,
       "needs_melange": [
@@ -115,6 +127,10 @@
       "smoke_test": "op-proposer --version"
     },
     "op-conductor": {
+      "apko_configs": [
+        "apko/op-conductor.yaml",
+        "apko/op-conductor-dev.yaml"
+      ],
       "type": "go",
       "verify_version": true,
       "needs_melange": [
@@ -130,6 +146,10 @@
       "smoke_test": "op-conductor --version"
     },
     "op-dispute-mon": {
+      "apko_configs": [
+        "apko/op-dispute-mon.yaml",
+        "apko/op-dispute-mon-dev.yaml"
+      ],
       "type": "go",
       "verify_version": true,
       "needs_melange": [
@@ -144,6 +164,10 @@
       "smoke_test": "op-dispute-mon --version"
     },
     "op-dripper": {
+      "apko_configs": [
+        "apko/op-dripper.yaml",
+        "apko/op-dripper-dev.yaml"
+      ],
       "type": "go",
       "verify_version": true,
       "needs_melange": [
@@ -158,6 +182,10 @@
       "smoke_test": "op-dripper --version"
     },
     "op-faucet": {
+      "apko_configs": [
+        "apko/op-faucet.yaml",
+        "apko/op-faucet-dev.yaml"
+      ],
       "type": "go",
       "verify_version": true,
       "needs_melange": [
@@ -172,6 +200,10 @@
       "smoke_test": "op-faucet --version"
     },
     "op-interop-filter": {
+      "apko_configs": [
+        "apko/op-interop-filter.yaml",
+        "apko/op-interop-filter-dev.yaml"
+      ],
       "type": "go",
       "verify_version": true,
       "needs_melange": [
@@ -186,6 +218,10 @@
       "smoke_test": "op-interop-filter --version"
     },
     "op-interop-mon": {
+      "apko_configs": [
+        "apko/op-interop-mon.yaml",
+        "apko/op-interop-mon-dev.yaml"
+      ],
       "type": "go",
       "verify_version": true,
       "needs_melange": [
@@ -200,6 +236,10 @@
       "smoke_test": "op-interop-mon --version"
     },
     "op-supernode": {
+      "apko_configs": [
+        "apko/op-supernode.yaml",
+        "apko/op-supernode-dev.yaml"
+      ],
       "type": "go",
       "verify_version": true,
       "needs_melange": [
@@ -215,6 +255,10 @@
       "smoke_test": "op-supernode --version"
     },
     "op-test-sequencer": {
+      "apko_configs": [
+        "apko/op-test-sequencer.yaml",
+        "apko/op-test-sequencer-dev.yaml"
+      ],
       "type": "go",
       "verify_version": true,
       "needs_melange": [
@@ -229,6 +273,10 @@
       "smoke_test": "op-test-sequencer --version"
     },
     "da-server": {
+      "apko_configs": [
+        "apko/da-server.yaml",
+        "apko/da-server-dev.yaml"
+      ],
       "type": "go",
       "verify_version": true,
       "needs_melange": [
@@ -243,6 +291,10 @@
       "smoke_test": "da-server --version"
     },
     "op-challenger": {
+      "apko_configs": [
+        "apko/op-challenger.yaml",
+        "apko/op-challenger-dev.yaml"
+      ],
       "type": "go",
       "verify_version": true,
       "needs_melange": [
@@ -262,6 +314,10 @@
       "smoke_test": "op-challenger --version,cannon --help,cannon load-elf --type multithreaded64-5 --help,kona-host --help"
     },
     "kona-node": {
+      "apko_configs": [
+        "apko/kona-node.yaml",
+        "apko/kona-node-dev.yaml"
+      ],
       "type": "rust",
       "verify_version": true,
       "needs_melange": [
@@ -276,6 +332,10 @@
       "smoke_test": "kona-node --version"
     },
     "kona-host": {
+      "apko_configs": [
+        "apko/kona-host.yaml",
+        "apko/kona-host-dev.yaml"
+      ],
       "type": "rust",
       "needs_melange": [
         "op-stack-rust"
@@ -289,6 +349,10 @@
       "smoke_test": "kona-host --help"
     },
     "kona-client": {
+      "apko_configs": [
+        "apko/kona-client.yaml",
+        "apko/kona-client-dev.yaml"
+      ],
       "type": "rust",
       "needs_melange": [
         "op-stack-rust"
@@ -302,6 +366,10 @@
       "smoke_test": "kona-client --help"
     },
     "kona-sp1-proposer": {
+      "apko_configs": [
+        "apko/kona-sp1-proposer.yaml",
+        "apko/kona-sp1-proposer-dev.yaml"
+      ],
       "type": "rust",
       "needs_melange": [
         "op-stack-rust"
@@ -315,6 +383,10 @@
       "smoke_test": "kona-sp1-proposer --version"
     },
     "op-reth": {
+      "apko_configs": [
+        "apko/op-reth.yaml",
+        "apko/op-reth-dev.yaml"
+      ],
       "type": "rust",
       "verify_version": true,
       "needs_melange": [
@@ -329,6 +401,10 @@
       "smoke_test": "op-reth --version"
     },
     "op-rbuilder": {
+      "apko_configs": [
+        "apko/op-rbuilder.yaml",
+        "apko/op-rbuilder-dev.yaml"
+      ],
       "type": "rust",
       "needs_melange": [
         "op-stack-rust"
@@ -342,6 +418,10 @@
       "smoke_test": "/app/rbuilder --help"
     },
     "rollup-boost": {
+      "apko_configs": [
+        "apko/rollup-boost.yaml",
+        "apko/rollup-boost-dev.yaml"
+      ],
       "type": "rust",
       "needs_melange": [
         "op-stack-rust"
@@ -355,6 +435,10 @@
       "smoke_test": "rollup-boost --help"
     },
     "op-deployer": {
+      "apko_configs": [
+        "apko/op-deployer.yaml",
+        "apko/op-deployer-dev.yaml"
+      ],
       "type": "go",
       "verify_version": true,
       "needs_melange": [

--- a/.github/workflows/build-images.apko.yaml
+++ b/.github/workflows/build-images.apko.yaml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Plan melange, apko, and smoke matrices
         id: plan
-        uses: ethereum-optimism/factory/actions/apko-plan@103d850873d85202fc2f53473191d691229240d3
+        uses: ethereum-optimism/factory/actions/apko-plan@c134f3256fe2bff619e0ac24be44d1f6e47164b2
         with:
           config: .github/images.apko.json
 
@@ -80,7 +80,7 @@ jobs:
       id-token: write
       attestations: write
       artifact-metadata: write
-    uses: ethereum-optimism/factory/.github/workflows/melange-build.yaml@103d850873d85202fc2f53473191d691229240d3
+    uses: ethereum-optimism/factory/.github/workflows/melange-build.yaml@c134f3256fe2bff619e0ac24be44d1f6e47164b2
     with:
       stack: ${{ matrix.stack }}
       arch: ${{ matrix.arch }}
@@ -113,12 +113,14 @@ jobs:
       attestations: write
       artifact-metadata: write
       actions: read
-    uses: ethereum-optimism/factory/.github/workflows/apko-publish.yaml@103d850873d85202fc2f53473191d691229240d3
+    uses: ethereum-optimism/factory/.github/workflows/apko-publish.yaml@c134f3256fe2bff619e0ac24be44d1f6e47164b2
     with:
       service: ${{ matrix.service }}
       needs-melange-apks: ${{ matrix.needs_melange_apks }}
       registry: us-docker.pkg.dev/oplabs-tools-artifacts/images
       publish-tag: ${{ matrix.publish_tag }}
+      apko-config: ${{ matrix.apko_config }}
+      tag-suffix: ${{ matrix.tag_suffix }}
       archs: ${{ matrix.archs }}
 
   smoke-test:
@@ -136,7 +138,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: ethereum-optimism/factory/.github/workflows/apko-smoke-test.yaml@103d850873d85202fc2f53473191d691229240d3
+    uses: ethereum-optimism/factory/.github/workflows/apko-smoke-test.yaml@c134f3256fe2bff619e0ac24be44d1f6e47164b2
     with:
       service: ${{ matrix.service }}
       registry: us-docker.pkg.dev/oplabs-tools-artifacts/images

--- a/apko/da-server-dev.yaml
+++ b/apko/da-server-dev.yaml
@@ -1,0 +1,4 @@
+include: apko/da-server.yaml
+contents:
+  packages:
+    - apk-tools

--- a/apko/da-server.yaml
+++ b/apko/da-server.yaml
@@ -8,7 +8,6 @@ contents:
     - wolfi-baselayout
     - da-server@local
     - busybox
-    - apk-tools
 
 environment:
   PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin

--- a/apko/kona-client-dev.yaml
+++ b/apko/kona-client-dev.yaml
@@ -1,0 +1,4 @@
+include: apko/kona-client.yaml
+contents:
+  packages:
+    - apk-tools

--- a/apko/kona-client.yaml
+++ b/apko/kona-client.yaml
@@ -13,7 +13,6 @@ contents:
     - libstdc++
     - openssl
     - kona-client@local
-    - apk-tools
 
 environment:
   PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin

--- a/apko/kona-host-dev.yaml
+++ b/apko/kona-host-dev.yaml
@@ -1,0 +1,4 @@
+include: apko/kona-host.yaml
+contents:
+  packages:
+    - apk-tools

--- a/apko/kona-host.yaml
+++ b/apko/kona-host.yaml
@@ -13,7 +13,6 @@ contents:
     - libstdc++
     - openssl
     - kona-host@local
-    - apk-tools
 
 environment:
   PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin

--- a/apko/kona-node-dev.yaml
+++ b/apko/kona-node-dev.yaml
@@ -1,0 +1,4 @@
+include: apko/kona-node.yaml
+contents:
+  packages:
+    - apk-tools

--- a/apko/kona-node.yaml
+++ b/apko/kona-node.yaml
@@ -13,7 +13,6 @@ contents:
     - libstdc++
     - openssl
     - kona-node@local
-    - apk-tools
 
 environment:
   PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin

--- a/apko/kona-sp1-proposer-dev.yaml
+++ b/apko/kona-sp1-proposer-dev.yaml
@@ -1,0 +1,4 @@
+include: apko/kona-sp1-proposer.yaml
+contents:
+  packages:
+    - apk-tools

--- a/apko/kona-sp1-proposer.yaml
+++ b/apko/kona-sp1-proposer.yaml
@@ -13,7 +13,6 @@ contents:
     - libstdc++
     - openssl
     - kona-sp1-proposer@local
-    - apk-tools
 
 environment:
   PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin

--- a/apko/op-batcher-dev.yaml
+++ b/apko/op-batcher-dev.yaml
@@ -1,0 +1,4 @@
+include: apko/op-batcher.yaml
+contents:
+  packages:
+    - apk-tools

--- a/apko/op-batcher.yaml
+++ b/apko/op-batcher.yaml
@@ -8,7 +8,6 @@ contents:
     - wolfi-baselayout
     - op-batcher@local
     - busybox
-    - apk-tools
 
 environment:
   PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin

--- a/apko/op-challenger-dev.yaml
+++ b/apko/op-challenger-dev.yaml
@@ -1,0 +1,4 @@
+include: apko/op-challenger.yaml
+contents:
+  packages:
+    - apk-tools

--- a/apko/op-challenger.yaml
+++ b/apko/op-challenger.yaml
@@ -9,7 +9,6 @@ contents:
   packages:
     - ca-certificates-bundle
     - busybox
-    - apk-tools
     # ca-certificates provides update-ca-certificates binary (ca-certificates-bundle is cert data only).
     # Required: the chart's /init/entrypoint.sh calls update-ca-certificates before exec.
     - ca-certificates

--- a/apko/op-conductor-dev.yaml
+++ b/apko/op-conductor-dev.yaml
@@ -1,0 +1,4 @@
+include: apko/op-conductor.yaml
+contents:
+  packages:
+    - apk-tools

--- a/apko/op-conductor.yaml
+++ b/apko/op-conductor.yaml
@@ -8,7 +8,6 @@ contents:
     - wolfi-baselayout
     - op-conductor@local
     - busybox
-    - apk-tools
 
 environment:
   PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin

--- a/apko/op-deployer-dev.yaml
+++ b/apko/op-deployer-dev.yaml
@@ -1,0 +1,4 @@
+include: apko/op-deployer.yaml
+contents:
+  packages:
+    - apk-tools

--- a/apko/op-deployer.yaml
+++ b/apko/op-deployer.yaml
@@ -8,7 +8,6 @@ contents:
     - wolfi-baselayout
     - op-deployer@local
     - busybox
-    - apk-tools
 
 archs:
   - amd64

--- a/apko/op-dispute-mon-dev.yaml
+++ b/apko/op-dispute-mon-dev.yaml
@@ -1,0 +1,4 @@
+include: apko/op-dispute-mon.yaml
+contents:
+  packages:
+    - apk-tools

--- a/apko/op-dispute-mon.yaml
+++ b/apko/op-dispute-mon.yaml
@@ -8,7 +8,6 @@ contents:
     - wolfi-baselayout
     - op-dispute-mon@local
     - busybox
-    - apk-tools
 
 environment:
   PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin

--- a/apko/op-dripper-dev.yaml
+++ b/apko/op-dripper-dev.yaml
@@ -1,0 +1,4 @@
+include: apko/op-dripper.yaml
+contents:
+  packages:
+    - apk-tools

--- a/apko/op-dripper.yaml
+++ b/apko/op-dripper.yaml
@@ -8,7 +8,6 @@ contents:
     - wolfi-baselayout
     - op-dripper@local
     - busybox
-    - apk-tools
 
 environment:
   PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin

--- a/apko/op-faucet-dev.yaml
+++ b/apko/op-faucet-dev.yaml
@@ -1,0 +1,4 @@
+include: apko/op-faucet.yaml
+contents:
+  packages:
+    - apk-tools

--- a/apko/op-faucet.yaml
+++ b/apko/op-faucet.yaml
@@ -8,7 +8,6 @@ contents:
     - wolfi-baselayout
     - op-faucet@local
     - busybox
-    - apk-tools
 
 environment:
   PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin

--- a/apko/op-interop-filter-dev.yaml
+++ b/apko/op-interop-filter-dev.yaml
@@ -1,0 +1,4 @@
+include: apko/op-interop-filter.yaml
+contents:
+  packages:
+    - apk-tools

--- a/apko/op-interop-filter.yaml
+++ b/apko/op-interop-filter.yaml
@@ -8,7 +8,6 @@ contents:
     - wolfi-baselayout
     - op-interop-filter@local
     - busybox
-    - apk-tools
 
 environment:
   PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin

--- a/apko/op-interop-mon-dev.yaml
+++ b/apko/op-interop-mon-dev.yaml
@@ -1,0 +1,4 @@
+include: apko/op-interop-mon.yaml
+contents:
+  packages:
+    - apk-tools

--- a/apko/op-interop-mon.yaml
+++ b/apko/op-interop-mon.yaml
@@ -8,7 +8,6 @@ contents:
     - wolfi-baselayout
     - op-interop-mon@local
     - busybox
-    - apk-tools
 
 environment:
   PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin

--- a/apko/op-node-dev.yaml
+++ b/apko/op-node-dev.yaml
@@ -1,0 +1,4 @@
+include: apko/op-node.yaml
+contents:
+  packages:
+    - apk-tools

--- a/apko/op-node.yaml
+++ b/apko/op-node.yaml
@@ -8,7 +8,6 @@ contents:
     - wolfi-baselayout
     - op-node@local
     - busybox
-    - apk-tools
 
 environment:
   PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin

--- a/apko/op-proposer-dev.yaml
+++ b/apko/op-proposer-dev.yaml
@@ -1,0 +1,4 @@
+include: apko/op-proposer.yaml
+contents:
+  packages:
+    - apk-tools

--- a/apko/op-proposer.yaml
+++ b/apko/op-proposer.yaml
@@ -8,7 +8,6 @@ contents:
     - wolfi-baselayout
     - op-proposer@local
     - busybox
-    - apk-tools
 
 environment:
   PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin

--- a/apko/op-rbuilder-dev.yaml
+++ b/apko/op-rbuilder-dev.yaml
@@ -1,0 +1,4 @@
+include: apko/op-rbuilder.yaml
+contents:
+  packages:
+    - apk-tools

--- a/apko/op-rbuilder.yaml
+++ b/apko/op-rbuilder.yaml
@@ -13,7 +13,6 @@ contents:
     - libstdc++
     - openssl
     - op-rbuilder@local
-    - apk-tools
 
 environment:
   PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin

--- a/apko/op-reth-dev.yaml
+++ b/apko/op-reth-dev.yaml
@@ -1,0 +1,4 @@
+include: apko/op-reth.yaml
+contents:
+  packages:
+    - apk-tools

--- a/apko/op-reth.yaml
+++ b/apko/op-reth.yaml
@@ -13,7 +13,6 @@ contents:
     - libstdc++
     - openssl
     - op-reth@local
-    - apk-tools
 
 environment:
   PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin

--- a/apko/op-supernode-dev.yaml
+++ b/apko/op-supernode-dev.yaml
@@ -1,0 +1,4 @@
+include: apko/op-supernode.yaml
+contents:
+  packages:
+    - apk-tools

--- a/apko/op-supernode.yaml
+++ b/apko/op-supernode.yaml
@@ -8,7 +8,6 @@ contents:
     - wolfi-baselayout
     - op-supernode@local
     - busybox
-    - apk-tools
 
 environment:
   PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin

--- a/apko/op-test-sequencer-dev.yaml
+++ b/apko/op-test-sequencer-dev.yaml
@@ -1,0 +1,4 @@
+include: apko/op-test-sequencer.yaml
+contents:
+  packages:
+    - apk-tools

--- a/apko/op-test-sequencer.yaml
+++ b/apko/op-test-sequencer.yaml
@@ -8,7 +8,6 @@ contents:
     - wolfi-baselayout
     - op-test-sequencer@local
     - busybox
-    - apk-tools
 
 environment:
   PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin

--- a/apko/rollup-boost-dev.yaml
+++ b/apko/rollup-boost-dev.yaml
@@ -1,0 +1,4 @@
+include: apko/rollup-boost.yaml
+contents:
+  packages:
+    - apk-tools

--- a/apko/rollup-boost.yaml
+++ b/apko/rollup-boost.yaml
@@ -13,7 +13,6 @@ contents:
     - libstdc++
     - openssl
     - rollup-boost@local
-    - apk-tools
 
 environment:
   PATH: /usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin


### PR DESCRIPTION
## What
- Move `apk-tools` out of the default `apko/*.yaml` configs into per-image `apko/<svc>-dev.yaml` overlays — each is a pure-YAML apko `include:` of the base plus `apk-tools`, so the base stays the single source of truth.
- Declare `apko_configs: [base, -dev]` per image in `.github/images.apko.json`, publishing both the default tag (minimal) and a `-dev` tag (with `apk-tools`) to the same repo.
- Thread `apko-config` + `tag-suffix` through `build-images.apko.yaml` and pin the factory reusable workflows to the release that supports `apko_configs`.

`busybox` stays in the default images.

## Result
- `<image>:<tag>` — minimal (no `apk-tools`, no apk DB)
- `<image>:<tag>-dev` — includes `apk-tools`

No extra melange build legs: `-dev` variants reuse the same prebuilt APKs.
