### PR TITLE
contracts-bedrock: Validate dispute game configs in OPCM migrate

### DIFF
--- a/op-chain-ops/interopgen/deploy.go
+++ b/op-chain-ops/interopgen/deploy.go
@@ -295,15 +295,11 @@ func MigrateInterop(
 		chainSystemConfigs[i] = l2Deployments[l2ChainID].SystemConfigProxy
 	}
 
-	// ABI-encode the cannon prestates as game args (from the first chain config).
+	// ABI-encode the cannon kona prestate as game args (from the first chain config).
 	l2ChainID := l2ChainIDs[0]
-	cannonGameArgs := common.LeftPadBytes(l2Cfgs[l2ChainID].DisputeAbsolutePrestate.Bytes(), 32)
 	cannonKonaGameArgs := common.LeftPadBytes(l2Cfgs[l2ChainID].DisputeKonaAbsolutePrestate.Bytes(), 32)
 
-	const (
-		GameTypeCannon          = uint32(0)
-		GameTypeSuperCannonKona = uint32(9)
-	)
+	const GameTypeSuperCannonKona = uint32(9)
 
 	imi := manage.InteropMigrationInput{
 		Prank: superCfg.ProxyAdminOwner,
@@ -311,12 +307,6 @@ func MigrateInterop(
 		MigrateInputV2: &manage.MigrateInputV2{
 			ChainSystemConfigs: chainSystemConfigs,
 			DisputeGameConfigs: []manage.DisputeGameConfig{
-				{
-					Enabled:  true,
-					InitBond: new(big.Int).Set(defaultInitBond),
-					GameType: GameTypeCannon,
-					GameArgs: cannonGameArgs,
-				},
 				{
 					Enabled:  true,
 					InitBond: new(big.Int).Set(defaultInitBond),

--- a/op-deployer/pkg/deployer/manage/migrate_test.go
+++ b/op-deployer/pkg/deployer/manage/migrate_test.go
@@ -109,15 +109,8 @@ func TestInteropMigration(t *testing.T) {
 	require.NoError(t, err)
 
 	// Define game type constants matching Solidity GameTypes library.
-	const (
-		GameTypeCannon          = uint32(0)
-		GameTypeSuperCannonKona = uint32(9)
-	)
+	const GameTypeSuperCannonKona = uint32(9)
 
-	// The registered game type and the starting respected game type are intentionally
-	// different: the migrator does not validate disputeGameConfigs[i].gameType (see
-	// OPContractsManagerMigrator.migrate), so this exercises the permissive-registration
-	// invariant alongside the strict respected-type check.
 	input := InteropMigrationInput{
 		Prank: l1ProxyAdminOwner,
 		Opcm:  opcmAddr,
@@ -129,7 +122,7 @@ func TestInteropMigration(t *testing.T) {
 				{
 					Enabled:  true,
 					InitBond: big.NewInt(1000000000000000000), // 1 ETH
-					GameType: GameTypeCannon,
+					GameType: GameTypeSuperCannonKona,
 					GameArgs: gameArgs,
 				},
 			},

--- a/packages/contracts-bedrock/interfaces/L1/opcm/IOPContractsManagerMigrator.sol
+++ b/packages/contracts-bedrock/interfaces/L1/opcm/IOPContractsManagerMigrator.sol
@@ -49,6 +49,17 @@ interface IOPContractsManagerMigrator {
     /// @notice Thrown when chainSystemConfigs are not provided in ascending order by l2ChainId.
     error OPContractsManagerMigrator_ChainIdsNotAscending();
 
+    /// @notice Thrown when the ZK_DISPUTE_GAME dev feature is not enabled.
+    error OPContractsManagerMigrator_ZKDisputeGameNotEnabled();
+
+    /// @notice Thrown when a dispute game config has an init bond that its game type does not
+    ///         allow: non-zero for SUPER_PERMISSIONED, which does not use bonds, or zero for any
+    ///         other game type.
+    error OPContractsManagerMigrator_InvalidInitBond();
+
+    /// @notice Thrown when a permissionless fault game config has a zero absolute prestate.
+    error OPContractsManagerMigrator_InvalidAbsolutePrestate();
+
     /// @notice Returns the container of blueprint and implementation contract addresses.
     function contractsContainer() external view returns (IOPContractsManagerContainer);
 

--- a/packages/contracts-bedrock/interfaces/L1/opcm/IOPContractsManagerMigrator.sol
+++ b/packages/contracts-bedrock/interfaces/L1/opcm/IOPContractsManagerMigrator.sol
@@ -60,6 +60,13 @@ interface IOPContractsManagerMigrator {
     /// @notice Thrown when a permissionless fault game config has a zero absolute prestate.
     error OPContractsManagerMigrator_InvalidAbsolutePrestate();
 
+    /// @notice Thrown when a dispute game config is for a game type that does not use super roots.
+    error OPContractsManagerMigrator_InvalidGameType();
+
+    /// @notice Thrown when a dispute game config is not enabled. Migration registers every config
+    ///         it is given, so a disabled config would be registered anyway.
+    error OPContractsManagerMigrator_DisputeGameNotEnabled();
+
     /// @notice Returns the container of blueprint and implementation contract addresses.
     function contractsContainer() external view returns (IOPContractsManagerContainer);
 

--- a/packages/contracts-bedrock/snapshots/abi/OPContractsManagerMigrator.json
+++ b/packages/contracts-bedrock/snapshots/abi/OPContractsManagerMigrator.json
@@ -127,6 +127,16 @@
   },
   {
     "inputs": [],
+    "name": "OPContractsManagerMigrator_InvalidAbsolutePrestate",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "OPContractsManagerMigrator_InvalidInitBond",
+    "type": "error"
+  },
+  {
+    "inputs": [],
     "name": "OPContractsManagerMigrator_InvalidStartingRespectedGameType",
     "type": "error"
   },
@@ -148,6 +158,11 @@
   {
     "inputs": [],
     "name": "OPContractsManagerMigrator_SystemPaused",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "OPContractsManagerMigrator_ZKDisputeGameNotEnabled",
     "type": "error"
   },
   {

--- a/packages/contracts-bedrock/snapshots/abi/OPContractsManagerMigrator.json
+++ b/packages/contracts-bedrock/snapshots/abi/OPContractsManagerMigrator.json
@@ -117,6 +117,11 @@
   },
   {
     "inputs": [],
+    "name": "OPContractsManagerMigrator_DisputeGameNotEnabled",
+    "type": "error"
+  },
+  {
+    "inputs": [],
     "name": "OPContractsManagerMigrator_DuplicateL2ChainId",
     "type": "error"
   },
@@ -128,6 +133,11 @@
   {
     "inputs": [],
     "name": "OPContractsManagerMigrator_InvalidAbsolutePrestate",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "OPContractsManagerMigrator_InvalidGameType",
     "type": "error"
   },
   {

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -36,8 +36,8 @@
     "sourceCodeHash": "0xceeedf69dcb6c05b88fd1569c53606dec02195b4d393a6491876b6d2f0c2ff1f"
   },
   "src/L1/opcm/OPContractsManagerV2.sol:OPContractsManagerV2": {
-    "initCodeHash": "0x9fc4e59fc030710f9efc653b648c1d021515abdddc294d19cee5cd8891f96987",
-    "sourceCodeHash": "0xb0d348a418fbb31cd9e3b0c9e9621f345fb70987a77ecee8658317d00a878326"
+    "initCodeHash": "0x81553faee6dfead8f15319088db35dde88ddb8196a99c4df9f7eb7569b72b86f",
+    "sourceCodeHash": "0x55e34a11ced7e8b135e01d3a661276ab94173a6d92255c092c2ba44d25afc31d"
   },
   "src/L2/BaseFeeVault.sol:BaseFeeVault": {
     "initCodeHash": "0x18650c65fa6f23fefc6f0c5fff605f12be99fce0bfbcbc0644403138e4c8bb12",

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerMigrator.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerMigrator.sol
@@ -66,6 +66,17 @@ contract OPContractsManagerMigrator is OPContractsManagerUtilsCaller {
     /// @notice Thrown when chainSystemConfigs are not provided in ascending order by l2ChainId.
     error OPContractsManagerMigrator_ChainIdsNotAscending();
 
+    /// @notice Thrown when the ZK_DISPUTE_GAME dev feature is not enabled.
+    error OPContractsManagerMigrator_ZKDisputeGameNotEnabled();
+
+    /// @notice Thrown when a dispute game config has an init bond that its game type does not
+    ///         allow: non-zero for SUPER_PERMISSIONED, which does not use bonds, or zero for any
+    ///         other game type.
+    error OPContractsManagerMigrator_InvalidInitBond();
+
+    /// @notice Thrown when a permissionless fault game config has a zero absolute prestate.
+    error OPContractsManagerMigrator_InvalidAbsolutePrestate();
+
     /// @param _utils The utility functions for the OPContractsManager.
     constructor(IOPContractsManagerUtils _utils) OPContractsManagerUtilsCaller(_utils) { }
 
@@ -228,8 +239,8 @@ contract OPContractsManagerMigrator is OPContractsManagerUtilsCaller {
         }
 
         // Set up the dispute games in the new DisputeGameFactory.
-        // NOTE: Unlike deploy/upgrade, migration does not perform full game config
-        // validation. This is intentional:
+        // NOTE: Migration applies the per-config checks from the deploy/upgrade path (see
+        // _assertValidDisputeGameConfig) but not its structural checks. This is intentional:
         // 1. Migration is a privileged, one-off admin action by the ProxyAdmin owner
         // 2. getGameImpl() rejects unrecognized game types
         // 3. Only super game types are meaningful here — non-super types would have
@@ -237,6 +248,7 @@ contract OPContractsManagerMigrator is OPContractsManagerUtilsCaller {
         // 4. All supplied configs are registered regardless of the enabled flag —
         //    callers must only include configs they want active
         for (uint256 i = 0; i < _input.disputeGameConfigs.length; i++) {
+            _assertValidDisputeGameConfig(_input.disputeGameConfigs[i]);
             disputeGameFactory.setImplementation(
                 _input.disputeGameConfigs[i].gameType,
                 _getGameImpl(_input.disputeGameConfigs[i].gameType),
@@ -278,6 +290,45 @@ contract OPContractsManagerMigrator is OPContractsManagerUtilsCaller {
                 revert OPContractsManagerMigrator_ChainIdsNotAscending();
             }
             prevL2ChainId = l2ChainId;
+        }
+    }
+
+    /// @notice Validates a single dispute game config supplied to migrate(). Applies the per-config
+    ///         checks that OPContractsManagerV2 applies on the deploy/upgrade path. The structural
+    ///         checks from that path do not carry over: migrate() takes a variable-length list of
+    ///         super game types rather than one config per valid game type, and it registers every
+    ///         supplied config regardless of the enabled flag.
+    /// @param _gameConfig The dispute game config to validate.
+    function _assertValidDisputeGameConfig(IOPContractsManagerUtils.DisputeGameConfig calldata _gameConfig)
+        internal
+        view
+    {
+        uint32 rawGameType = _gameConfig.gameType.raw();
+
+        // SUPER_PERMISSIONED does not use bonds. Every other game type does.
+        if (rawGameType == GameTypes.SUPER_PERMISSIONED.raw()) {
+            if (_gameConfig.initBond != 0) {
+                revert OPContractsManagerMigrator_InvalidInitBond();
+            }
+        } else if (_gameConfig.initBond == 0) {
+            revert OPContractsManagerMigrator_InvalidInitBond();
+        }
+
+        // A permissionless fault game is unplayable without an absolute prestate.
+        if (rawGameType == GameTypes.SUPER_CANNON_KONA.raw()) {
+            IOPContractsManagerUtils.FaultDisputeGameConfig memory faultGameConfig =
+                abi.decode(_gameConfig.gameArgs, (IOPContractsManagerUtils.FaultDisputeGameConfig));
+            if (faultGameConfig.absolutePrestate.raw() == bytes32(0)) {
+                revert OPContractsManagerMigrator_InvalidAbsolutePrestate();
+            }
+        }
+
+        // ZK_DISPUTE_GAME can only be registered when the dev feature is on.
+        if (
+            rawGameType == GameTypes.ZK_DISPUTE_GAME.raw()
+                && !contractsContainer().isDevFeatureEnabled(DevFeatures.ZK_DISPUTE_GAME)
+        ) {
+            revert OPContractsManagerMigrator_ZKDisputeGameNotEnabled();
         }
     }
 

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerMigrator.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerMigrator.sol
@@ -77,6 +77,13 @@ contract OPContractsManagerMigrator is OPContractsManagerUtilsCaller {
     /// @notice Thrown when a permissionless fault game config has a zero absolute prestate.
     error OPContractsManagerMigrator_InvalidAbsolutePrestate();
 
+    /// @notice Thrown when a dispute game config is for a game type that does not use super roots.
+    error OPContractsManagerMigrator_InvalidGameType();
+
+    /// @notice Thrown when a dispute game config is not enabled. Migration registers every config
+    ///         it is given, so a disabled config would be registered anyway.
+    error OPContractsManagerMigrator_DisputeGameNotEnabled();
+
     /// @param _utils The utility functions for the OPContractsManager.
     constructor(IOPContractsManagerUtils _utils) OPContractsManagerUtilsCaller(_utils) { }
 
@@ -131,6 +138,10 @@ contract OPContractsManagerMigrator is OPContractsManagerUtilsCaller {
         // zero l2ChainId, that no two chains share the same l2ChainId, and that l2ChainIds are
         // provided in ascending order.
         _validateChainSystemConfigs(_input.chainSystemConfigs);
+
+        // Check that every supplied dispute game config is valid and that the starting respected
+        // game type is one of them.
+        _validateDisputeGameConfigs(_input.disputeGameConfigs, _input.startingRespectedGameType);
 
         // NOTE: Interop doesn't have a real chain ID, and the chain ID provided here is ONLY used
         // as a salt mixer, so we just use the block.timestamp instead. It really doesn't matter
@@ -238,17 +249,9 @@ contract OPContractsManagerMigrator is OPContractsManagerUtilsCaller {
             }
         }
 
-        // Set up the dispute games in the new DisputeGameFactory.
-        // NOTE: Migration applies the per-config checks from the deploy/upgrade path (see
-        // _assertValidDisputeGameConfig) but not its structural checks. This is intentional:
-        // 1. Migration is a privileged, one-off admin action by the ProxyAdmin owner
-        // 2. getGameImpl() rejects unrecognized game types
-        // 3. Only super game types are meaningful here — non-super types would have
-        //    l2ChainId=0, causing FaultDisputeGame to revert on chain ID mismatch
-        // 4. All supplied configs are registered regardless of the enabled flag —
-        //    callers must only include configs they want active
+        // Set up the dispute games in the new DisputeGameFactory. Configs are validated by
+        // _validateDisputeGameConfigs above.
         for (uint256 i = 0; i < _input.disputeGameConfigs.length; i++) {
-            _assertValidDisputeGameConfig(_input.disputeGameConfigs[i]);
             disputeGameFactory.setImplementation(
                 _input.disputeGameConfigs[i].gameType,
                 _getGameImpl(_input.disputeGameConfigs[i].gameType),
@@ -293,17 +296,55 @@ contract OPContractsManagerMigrator is OPContractsManagerUtilsCaller {
         }
     }
 
-    /// @notice Validates a single dispute game config supplied to migrate(). Applies the per-config
-    ///         checks that OPContractsManagerV2 applies on the deploy/upgrade path. The structural
-    ///         checks from that path do not carry over: migrate() takes a variable-length list of
-    ///         super game types rather than one config per valid game type, and it registers every
-    ///         supplied config regardless of the enabled flag.
+    /// @notice Validates the dispute game configs supplied to migrate(). Migration is a
+    ///         privileged, one-off admin action, so it does not repeat the structural checks that
+    ///         OPContractsManagerV2 applies on the deploy/upgrade path: it takes a variable-length
+    ///         list of super game types rather than one config per valid game type. It does apply
+    ///         the per-config checks from that path, and rejects configs that migration cannot
+    ///         act on: every config is registered as supplied, so a disabled config or a game type
+    ///         that does not use super roots is a caller mistake rather than a no-op.
+    /// @param _gameConfigs The dispute game configs to validate.
+    /// @param _startingRespectedGameType The game type the AnchorStateRegistry will respect.
+    function _validateDisputeGameConfigs(
+        IOPContractsManagerUtils.DisputeGameConfig[] calldata _gameConfigs,
+        GameType _startingRespectedGameType
+    )
+        internal
+        view
+    {
+        bool startingGameTypeFound;
+        for (uint256 i = 0; i < _gameConfigs.length; i++) {
+            _assertValidDisputeGameConfig(_gameConfigs[i]);
+            if (_gameConfigs[i].gameType.raw() == _startingRespectedGameType.raw()) {
+                startingGameTypeFound = true;
+            }
+        }
+
+        // The respected game type must have an implementation registered by this migration.
+        if (!startingGameTypeFound) {
+            revert OPContractsManagerMigrator_InvalidStartingRespectedGameType();
+        }
+    }
+
+    /// @notice Validates a single dispute game config supplied to migrate(). See
+    ///         _validateDisputeGameConfigs for which checks apply and why.
     /// @param _gameConfig The dispute game config to validate.
     function _assertValidDisputeGameConfig(IOPContractsManagerUtils.DisputeGameConfig calldata _gameConfig)
         internal
         view
     {
         uint32 rawGameType = _gameConfig.gameType.raw();
+
+        // Non-super game types would have l2ChainId=0, causing the game to revert on chain ID
+        // mismatch, and legacy fault game types are not validated by this path at all.
+        if (!GameTypes.isSuperGame(_gameConfig.gameType)) {
+            revert OPContractsManagerMigrator_InvalidGameType();
+        }
+
+        // Every supplied config is registered, so a disabled config is a caller mistake.
+        if (!_gameConfig.enabled) {
+            revert OPContractsManagerMigrator_DisputeGameNotEnabled();
+        }
 
         // SUPER_PERMISSIONED does not use bonds. Every other game type does.
         if (rawGameType == GameTypes.SUPER_PERMISSIONED.raw()) {
@@ -314,21 +355,27 @@ contract OPContractsManagerMigrator is OPContractsManagerUtilsCaller {
             revert OPContractsManagerMigrator_InvalidInitBond();
         }
 
-        // A permissionless fault game is unplayable without an absolute prestate.
-        if (rawGameType == GameTypes.SUPER_CANNON_KONA.raw()) {
-            IOPContractsManagerUtils.FaultDisputeGameConfig memory faultGameConfig =
-                abi.decode(_gameConfig.gameArgs, (IOPContractsManagerUtils.FaultDisputeGameConfig));
-            if (faultGameConfig.absolutePrestate.raw() == bytes32(0)) {
-                revert OPContractsManagerMigrator_InvalidAbsolutePrestate();
-            }
-        }
-
         // ZK_DISPUTE_GAME can only be registered when the dev feature is on.
         if (
             rawGameType == GameTypes.ZK_DISPUTE_GAME.raw()
                 && !contractsContainer().isDevFeatureEnabled(DevFeatures.ZK_DISPUTE_GAME)
         ) {
             revert OPContractsManagerMigrator_ZKDisputeGameNotEnabled();
+        }
+
+        // A permissionless game is unplayable without an absolute prestate.
+        if (rawGameType == GameTypes.SUPER_CANNON_KONA.raw()) {
+            IOPContractsManagerUtils.FaultDisputeGameConfig memory faultGameConfig =
+                abi.decode(_gameConfig.gameArgs, (IOPContractsManagerUtils.FaultDisputeGameConfig));
+            if (faultGameConfig.absolutePrestate.raw() == bytes32(0)) {
+                revert OPContractsManagerMigrator_InvalidAbsolutePrestate();
+            }
+        } else if (rawGameType == GameTypes.ZK_DISPUTE_GAME.raw()) {
+            IOPContractsManagerUtils.ZKDisputeGameConfig memory zkGameConfig =
+                abi.decode(_gameConfig.gameArgs, (IOPContractsManagerUtils.ZKDisputeGameConfig));
+            if (zkGameConfig.absolutePrestate.raw() == bytes32(0)) {
+                revert OPContractsManagerMigrator_InvalidAbsolutePrestate();
+            }
         }
     }
 

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
@@ -158,9 +158,9 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
     ///         - Major bump: New required sequential upgrade
     ///         - Minor bump: Replacement OPCM for same upgrade
     ///         - Patch bump: Development changes (expected for normal dev work)
-    /// @custom:semver 8.0.2
+    /// @custom:semver 8.0.3
     function version() public pure returns (string memory) {
-        return "8.0.2";
+        return "8.0.3";
     }
 
     /// @param _standardValidator The standard validator for this OPCM release.
@@ -776,6 +776,16 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
                 IOPContractsManagerUtils.FaultDisputeGameConfig memory faultGameConfig =
                     abi.decode(_cfg.disputeGameConfigs[i].gameArgs, (IOPContractsManagerUtils.FaultDisputeGameConfig));
                 if (faultGameConfig.absolutePrestate.raw() == bytes32(0)) {
+                    revert OPContractsManagerV2_InvalidGameConfigs();
+                }
+            }
+
+            // The ZK game is permissionless too, and its absolute prestate is the verification key
+            // the proof is checked against, so an empty prestate makes the game unplayable.
+            if (_cfg.disputeGameConfigs[i].enabled && isZkDisputeGame) {
+                IOPContractsManagerUtils.ZKDisputeGameConfig memory zkGameConfig =
+                    abi.decode(_cfg.disputeGameConfigs[i].gameArgs, (IOPContractsManagerUtils.ZKDisputeGameConfig));
+                if (zkGameConfig.absolutePrestate.raw() == bytes32(0)) {
                     revert OPContractsManagerV2_InvalidGameConfigs();
                 }
             }

--- a/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
@@ -1099,6 +1099,28 @@ contract OPContractsManagerV2_Upgrade_Test is OPContractsManagerV2_Upgrade_TestI
         );
     }
 
+    /// @notice Tests that enabling the ZK dispute game with a zero absolute prestate reverts. The
+    ///         prestate is the verification key, so an empty one makes the game unplayable.
+    function test_upgrade_enableZKGameZeroPrestate_reverts() public {
+        skipIfDevFeatureDisabled(DevFeatures.ZK_DISPUTE_GAME);
+
+        v2UpgradeInput.disputeGameConfigs[5].enabled = true;
+        v2UpgradeInput.disputeGameConfigs[5].initBond = 1 ether;
+        v2UpgradeInput.disputeGameConfigs[5].gameArgs = abi.encode(
+            IOPContractsManagerUtils.ZKDisputeGameConfig({
+                absolutePrestate: Claim.wrap(bytes32(0)),
+                maxChallengeDuration: Duration.wrap(uint64(7 days)),
+                maxProveDuration: Duration.wrap(uint64(3 days)),
+                challengerBond: 1 ether
+            })
+        );
+
+        // nosemgrep: sol-style-use-abi-encodecall
+        runCurrentUpgradeV2(
+            chainPAO, abi.encodeWithSelector(IOPContractsManagerV2.OPContractsManagerV2_InvalidGameConfigs.selector)
+        );
+    }
+
     /// @notice Tests that setting ZK config to enabled without the dev feature reverts.
     function test_upgrade_enableZKGameWithoutDevFeature_reverts() public {
         // Mock the container to report ZK_DISPUTE_GAME dev feature as disabled, regardless of
@@ -2560,6 +2582,34 @@ contract OPContractsManagerV2_Migrate_Test is OPContractsManagerV2_TestInit {
         });
     }
 
+    /// @notice Helper function to build a ZK_DISPUTE_GAME dispute game config. ZK_DISPUTE_GAME is
+    ///         a permissionless super-root game, so its absolute prestate is the verification key.
+    /// @param _initBond The init bond for the game.
+    /// @param _absolutePrestate The absolute prestate for the game.
+    /// @return config_ The dispute game config.
+    function _zkDisputeGameConfig(
+        uint256 _initBond,
+        Claim _absolutePrestate
+    )
+        internal
+        pure
+        returns (IOPContractsManagerUtils.DisputeGameConfig memory config_)
+    {
+        config_ = IOPContractsManagerUtils.DisputeGameConfig({
+            enabled: true,
+            initBond: _initBond,
+            gameType: GameTypes.ZK_DISPUTE_GAME,
+            gameArgs: abi.encode(
+                IOPContractsManagerUtils.ZKDisputeGameConfig({
+                    absolutePrestate: _absolutePrestate,
+                    maxChallengeDuration: Duration.wrap(uint64(7 days)),
+                    maxProveDuration: Duration.wrap(uint64(3 days)),
+                    challengerBond: 1 ether
+                })
+            )
+        });
+    }
+
     /// @notice Helper function to execute a migration.
     /// @param _input The input to the migration function.
     function _doMigration(IOPContractsManagerMigrator.MigrateInput memory _input) internal {
@@ -3121,6 +3171,84 @@ contract OPContractsManagerV2_Migrate_Test is OPContractsManagerV2_TestInit {
         );
 
         _doMigration(input, IOPContractsManagerMigrator.OPContractsManagerMigrator_ZKDisputeGameNotEnabled.selector);
+    }
+
+    /// @notice Tests that the migration function reverts when a supplied game config is for a game
+    ///         type that does not use super roots.
+    function test_migrate_nonSuperGameType_reverts() public {
+        IOPContractsManagerMigrator.MigrateInput memory input = _getDefaultMigrateInput();
+        _appendDisputeGameConfig(
+            input,
+            IOPContractsManagerUtils.DisputeGameConfig({
+                enabled: true,
+                initBond: 0.08 ether,
+                gameType: GameTypes.CANNON_KONA,
+                gameArgs: abi.encode(IOPContractsManagerUtils.FaultDisputeGameConfig({ absolutePrestate: superPrestate }))
+            })
+        );
+
+        _doMigration(input, IOPContractsManagerMigrator.OPContractsManagerMigrator_InvalidGameType.selector);
+    }
+
+    /// @notice Tests that the migration function reverts when a supplied game config is disabled.
+    function test_migrate_disabledGameConfig_reverts() public {
+        IOPContractsManagerMigrator.MigrateInput memory input = _getDefaultMigrateInput();
+        input.disputeGameConfigs[0].enabled = false;
+
+        _doMigration(input, IOPContractsManagerMigrator.OPContractsManagerMigrator_DisputeGameNotEnabled.selector);
+    }
+
+    /// @notice Tests that the migration function reverts when the starting respected game type is
+    ///         not one of the supplied game configs.
+    function test_migrate_startingRespectedGameTypeNotConfigured_reverts() public {
+        IOPContractsManagerMigrator.MigrateInput memory input = _getDefaultMigrateInput();
+        input.startingRespectedGameType = GameTypes.SUPER_CANNON_KONA;
+
+        _doMigration(
+            input, IOPContractsManagerMigrator.OPContractsManagerMigrator_InvalidStartingRespectedGameType.selector
+        );
+    }
+
+    /// @notice Tests that the migration function reverts when a ZK_DISPUTE_GAME config has a zero
+    ///         absolute prestate.
+    function test_migrate_zkZeroAbsolutePrestate_reverts() public {
+        skipIfDevFeatureDisabled(DevFeatures.ZK_DISPUTE_GAME);
+
+        IOPContractsManagerMigrator.MigrateInput memory input = _getDefaultMigrateInput();
+        _appendDisputeGameConfig(input, _zkDisputeGameConfig(1 ether, Claim.wrap(bytes32(0))));
+
+        _doMigration(input, IOPContractsManagerMigrator.OPContractsManagerMigrator_InvalidAbsolutePrestate.selector);
+    }
+
+    /// @notice Tests that the migration function registers a ZK_DISPUTE_GAME config when the dev
+    ///         feature is enabled.
+    function test_migrate_zkDisputeGame_succeeds() public {
+        skipIfDevFeatureDisabled(DevFeatures.ZK_DISPUTE_GAME);
+
+        Claim zkPrestate = Claim.wrap(bytes32(keccak256("zk prestate")));
+        IOPContractsManagerMigrator.MigrateInput memory input = _getDefaultMigrateInput();
+        _appendDisputeGameConfig(input, _zkDisputeGameConfig(1 ether, zkPrestate));
+
+        _doMigration(input);
+
+        IOptimismPortal2 portal = IOptimismPortal2(payable(chainContracts1.systemConfig.optimismPortal()));
+        IDisputeGameFactory sharedDGF = IDisputeGameFactory(payable(address(portal.disputeGameFactory())));
+
+        assertEq(
+            address(sharedDGF.gameImpls(GameTypes.ZK_DISPUTE_GAME)),
+            opcmV2.implementations().zkDisputeGameImpl,
+            "ZK game impl not registered in shared DGF"
+        );
+        assertEq(sharedDGF.initBonds(GameTypes.ZK_DISPUTE_GAME), 1 ether, "ZK init bond not set");
+
+        LibGameArgs.ZKGameArgs memory args = LibGameArgs.decodeZK(sharedDGF.gameArgs(GameTypes.ZK_DISPUTE_GAME));
+        assertEq(args.absolutePrestate, zkPrestate.raw(), "ZK absolute prestate mismatch");
+        assertEq(args.verifier, opcmV2.implementations().sp1PlonkAdapterImpl, "ZK verifier must be the release adapter");
+        assertEq(args.maxChallengeDuration, uint64(7 days), "ZK max challenge duration mismatch");
+        assertEq(args.maxProveDuration, uint64(3 days), "ZK max prove duration mismatch");
+        assertEq(args.challengerBond, 1 ether, "ZK challenger bond mismatch");
+        assertEq(args.anchorStateRegistry, address(portal.anchorStateRegistry()), "ZK anchor state registry mismatch");
+        assertEq(args.weth, chainContracts1.systemConfig.delayedWETH(), "ZK delayed WETH mismatch");
     }
 
     /// @notice Tests that the migration function succeeds with SUPER_CANNON_KONA as the starting

--- a/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
@@ -2518,6 +2518,48 @@ contract OPContractsManagerV2_Migrate_Test is OPContractsManagerV2_TestInit {
         });
     }
 
+    /// @notice Helper function to append a dispute game config to a migrate input.
+    /// @param _input The migrate input to append to.
+    /// @param _gameConfig The dispute game config to append.
+    function _appendDisputeGameConfig(
+        IOPContractsManagerMigrator.MigrateInput memory _input,
+        IOPContractsManagerUtils.DisputeGameConfig memory _gameConfig
+    )
+        internal
+        pure
+    {
+        IOPContractsManagerUtils.DisputeGameConfig[] memory existing = _input.disputeGameConfigs;
+        IOPContractsManagerUtils.DisputeGameConfig[] memory updated =
+            new IOPContractsManagerUtils.DisputeGameConfig[](existing.length + 1);
+        for (uint256 i = 0; i < existing.length; i++) {
+            updated[i] = existing[i];
+        }
+        updated[existing.length] = _gameConfig;
+        _input.disputeGameConfigs = updated;
+    }
+
+    /// @notice Helper function to build a SUPER_CANNON_KONA dispute game config. SUPER_CANNON_KONA
+    ///         is a permissionless super-root FDG, so its game args are the single absolute
+    ///         prestate.
+    /// @param _initBond The init bond for the game.
+    /// @param _absolutePrestate The absolute prestate for the game.
+    /// @return config_ The dispute game config.
+    function _superCannonKonaConfig(
+        uint256 _initBond,
+        Claim _absolutePrestate
+    )
+        internal
+        pure
+        returns (IOPContractsManagerUtils.DisputeGameConfig memory config_)
+    {
+        config_ = IOPContractsManagerUtils.DisputeGameConfig({
+            enabled: true,
+            initBond: _initBond,
+            gameType: GameTypes.SUPER_CANNON_KONA,
+            gameArgs: abi.encode(IOPContractsManagerUtils.FaultDisputeGameConfig({ absolutePrestate: _absolutePrestate }))
+        });
+    }
+
     /// @notice Helper function to execute a migration.
     /// @param _input The input to the migration function.
     function _doMigration(IOPContractsManagerMigrator.MigrateInput memory _input) internal {
@@ -3026,27 +3068,69 @@ contract OPContractsManagerV2_Migrate_Test is OPContractsManagerV2_TestInit {
         );
     }
 
+    /// @notice Tests that the migration function reverts when the SUPER_PERMISSIONED game config
+    ///         has a non-zero init bond. SUPER_PERMISSIONED does not use bonds.
+    /// @param _initBond The non-zero init bond to test.
+    function testFuzz_migrate_superPermissionedNonZeroInitBond_reverts(uint256 _initBond) public {
+        vm.assume(_initBond != 0);
+
+        IOPContractsManagerMigrator.MigrateInput memory input = _getDefaultMigrateInput();
+        input.disputeGameConfigs[0].initBond = _initBond;
+
+        _doMigration(input, IOPContractsManagerMigrator.OPContractsManagerMigrator_InvalidInitBond.selector);
+    }
+
+    /// @notice Tests that the migration function reverts when a game type that uses bonds is given
+    ///         a zero init bond.
+    function test_migrate_bondedGameZeroInitBond_reverts() public {
+        IOPContractsManagerMigrator.MigrateInput memory input = _getDefaultMigrateInput();
+        _appendDisputeGameConfig(input, _superCannonKonaConfig(0, superPrestate));
+
+        _doMigration(input, IOPContractsManagerMigrator.OPContractsManagerMigrator_InvalidInitBond.selector);
+    }
+
+    /// @notice Tests that the migration function reverts when a permissionless fault game config
+    ///         has a zero absolute prestate.
+    function test_migrate_zeroAbsolutePrestate_reverts() public {
+        IOPContractsManagerMigrator.MigrateInput memory input = _getDefaultMigrateInput();
+        _appendDisputeGameConfig(input, _superCannonKonaConfig(0.08 ether, Claim.wrap(bytes32(0))));
+
+        _doMigration(input, IOPContractsManagerMigrator.OPContractsManagerMigrator_InvalidAbsolutePrestate.selector);
+    }
+
+    /// @notice Tests that the migration function reverts when a ZK_DISPUTE_GAME config is supplied
+    ///         while the ZK_DISPUTE_GAME dev feature is disabled.
+    function test_migrate_zkDisputeGameNotEnabled_reverts() public {
+        IOPContractsManagerMigrator.MigrateInput memory input = _getDefaultMigrateInput();
+
+        // Game args are irrelevant: validation rejects the config before they are decoded.
+        _appendDisputeGameConfig(
+            input,
+            IOPContractsManagerUtils.DisputeGameConfig({
+                enabled: true,
+                initBond: 0.08 ether,
+                gameType: GameTypes.ZK_DISPUTE_GAME,
+                gameArgs: hex""
+            })
+        );
+
+        vm.mockCall(
+            address(opcmV2.contractsContainer()),
+            abi.encodeCall(IOPContractsManagerContainer.isDevFeatureEnabled, (DevFeatures.ZK_DISPUTE_GAME)),
+            abi.encode(false)
+        );
+
+        _doMigration(input, IOPContractsManagerMigrator.OPContractsManagerMigrator_ZKDisputeGameNotEnabled.selector);
+    }
+
     /// @notice Tests that the migration function succeeds with SUPER_CANNON_KONA as the starting
     ///         respected game type. The default input registers SUPER_PERMISSIONED;
     ///         this test appends a SUPER_CANNON_KONA config so the respected type has a matching impl.
     function test_migrate_superCannonKonaStartingRespectedGameType_succeeds() public {
         IOPContractsManagerMigrator.MigrateInput memory input = _getDefaultMigrateInput();
 
-        // SUPER_CANNON_KONA is a permissionless super-root FDG, so its game args are the
-        // single absolute prestate. `superPrestate` is already a Claim; do not wrap it again.
-        IOPContractsManagerUtils.DisputeGameConfig[] memory existing = input.disputeGameConfigs;
-        IOPContractsManagerUtils.DisputeGameConfig[] memory updated =
-            new IOPContractsManagerUtils.DisputeGameConfig[](existing.length + 1);
-        for (uint256 i = 0; i < existing.length; i++) {
-            updated[i] = existing[i];
-        }
-        updated[existing.length] = IOPContractsManagerUtils.DisputeGameConfig({
-            enabled: true,
-            initBond: 0.08 ether,
-            gameType: GameTypes.SUPER_CANNON_KONA,
-            gameArgs: abi.encode(IOPContractsManagerUtils.FaultDisputeGameConfig({ absolutePrestate: superPrestate }))
-        });
-        input.disputeGameConfigs = updated;
+        // `superPrestate` is already a Claim; do not wrap it again.
+        _appendDisputeGameConfig(input, _superCannonKonaConfig(0.08 ether, superPrestate));
         input.startingRespectedGameType = GameTypes.SUPER_CANNON_KONA;
 
         _doMigration(input);

--- a/packages/contracts-bedrock/test/dispute/zk/ZKDisputeGameSuperMigration.t.sol
+++ b/packages/contracts-bedrock/test/dispute/zk/ZKDisputeGameSuperMigration.t.sol
@@ -50,6 +50,10 @@ contract ZKDisputeGameSuperMigration_Test is DisputeGameFactory_TestInit {
     Duration internal zkMaxChallengeDuration = Duration.wrap(uint64(12 hours));
     Duration internal zkMaxProveDuration = Duration.wrap(uint64(3 days));
 
+    /// @notice ZK circuit vkey injected via the OPCM upgrade. The verifier is mocked, so the value
+    ///         only has to be non-zero.
+    Claim internal zkAbsolutePrestate = Claim.wrap(keccak256("zkFlipPrestate"));
+
     /// @notice Storage-resident upgrade input (nested dynamic arrays must live in storage to push).
     IOPContractsManagerV2.UpgradeInput internal _zkUpgradeInput;
 
@@ -202,7 +206,7 @@ contract ZKDisputeGameSuperMigration_Test is DisputeGameFactory_TestInit {
                 gameType: GameTypes.ZK_DISPUTE_GAME,
                 gameArgs: abi.encode(
                     IOPContractsManagerUtils.ZKDisputeGameConfig({
-                        absolutePrestate: Claim.wrap(bytes32(0)),
+                        absolutePrestate: zkAbsolutePrestate,
                         maxChallengeDuration: zkMaxChallengeDuration,
                         maxProveDuration: zkMaxProveDuration,
                         challengerBond: flipBond


### PR DESCRIPTION
`OPContractsManagerMigrator.migrate()` registered whatever dispute game configs it was given, without applying any of the per-config checks that `OPContractsManagerV2` applies on the deploy/upgrade path. A `SUPER_PERMISSIONED` game could be registered with an init bond even though it does not use bonds, a permissionless fault game with a zero absolute prestate, a legacy non-super game type, and a ZK game while the dev feature was off.

Add `_validateDisputeGameConfigs`, called once from `migrate()`. Each config must:

- be a game type that uses super roots
- be enabled, since every supplied config is registered as given
- have a zero init bond for `SUPER_PERMISSIONED` and a non-zero one for every other game type
- have a non-zero `absolutePrestate` if it is a permissionless game
- have the dev feature enabled if it is `ZK_DISPUTE_GAME`

`startingRespectedGameType` must also be one of the supplied configs, so the respected game type always has an implementation.

The ZK game absolute prestate is the verification key the proof is checked against, so a zero value makes the game unplayable. The deploy/upgrade path only required a non-zero prestate for the cannon family, so that check is added there too and `OPContractsManagerV2` is bumped to 8.0.3.

The structural checks from the deploy/upgrade path do not carry over: `migrate()` takes a variable-length list of super game types rather than one config per valid game type.

The interop dev recipe in op-chain-ops registered legacy `CANNON` through `migrate()`. That game gets an l2ChainId of zero, so it could never be created; it is removed rather than kept working around the new check.
