### PR TITLE
op-stack-rust: strip package-metadata note from release binaries

### DIFF
--- a/melange/op-stack-rust.yaml
+++ b/melange/op-stack-rust.yaml
@@ -67,6 +67,8 @@ subpackages:
             "${CARGO_TARGET_DIR}/rust/${profile}/op-reth" \
             "${{targets.contextdir}}/usr/local/bin/op-reth"
       - uses: strip
+        with:
+          opts: -g --remove-section=.note.package
 
   - name: kona-node
     description: kona-node — OP Stack Kona rollup node
@@ -77,6 +79,8 @@ subpackages:
             "${CARGO_TARGET_DIR}/rust/${profile}/kona-node" \
             "${{targets.contextdir}}/usr/local/bin/kona-node"
       - uses: strip
+        with:
+          opts: -g --remove-section=.note.package
 
   - name: kona-host
     description: kona-host — OP Stack Kona fault proof host
@@ -87,6 +91,8 @@ subpackages:
             "${CARGO_TARGET_DIR}/rust/${profile}/kona-host" \
             "${{targets.contextdir}}/usr/local/bin/kona-host"
       - uses: strip
+        with:
+          opts: -g --remove-section=.note.package
 
   - name: kona-client
     description: kona-client — OP Stack Kona fault proof client
@@ -97,6 +103,8 @@ subpackages:
             "${CARGO_TARGET_DIR}/rust/${profile}/kona-client" \
             "${{targets.contextdir}}/usr/local/bin/kona-client"
       - uses: strip
+        with:
+          opts: -g --remove-section=.note.package
 
   - name: kona-sp1-proposer
     description: kona-sp1-proposer — OP Stack SP1 fault proof proposer
@@ -107,6 +115,8 @@ subpackages:
             "${CARGO_TARGET_DIR}/rust/${profile}/kona-sp1-proposer" \
             "${{targets.contextdir}}/usr/local/bin/kona-sp1-proposer"
       - uses: strip
+        with:
+          opts: -g --remove-section=.note.package
 
   # The monorepo vendors op-rbuilder and rollup-boost as NESTED workspaces
   # (own Cargo.toml + Cargo.lock, not members of the main rust/ workspace), and
@@ -128,6 +138,8 @@ subpackages:
           mv "${{targets.contextdir}}/usr/local/bin/op-rbuilder" \
              "${{targets.contextdir}}/app/rbuilder"
       - uses: strip
+        with:
+          opts: -g --remove-section=.note.package
 
   - name: rollup-boost
     description: rollup-boost — OP Stack block builder multiplexer (monorepo vendored copy)
@@ -140,3 +152,5 @@ subpackages:
           output: rollup-boost
           opts: --release --locked --package rollup-boost
       - uses: strip
+        with:
+          opts: -g --remove-section=.note.package


### PR DESCRIPTION
## What
Pass `--remove-section=.note.package` to the existing `strip` step for each Rust binary in `op-stack-rust.yaml`.

## Why
melange links in an FDO `--package-metadata` ELF note (`.note.package`, `type: apk`). SBOM scanners read that note and classify the binary itself as an apk OS package. When the binary is `COPY`d into a downstream image built on a non-apk (e.g. Debian) base, the aggregated SBOM then reports mixed apk+deb OS packages, which some scanners refuse to process. Stripping the note during the existing strip pass removes the misclassification with no other effect.

## Validation
CI builds the Rust images natively; once published I'll confirm the op-reth binary no longer carries `.note.package` and that a downstream multi-stage SBOM is single-OS.
