### PR TITLE
contracts-bedrock: correct readMem @return NatSpec

### DIFF
--- a/packages/contracts-bedrock/src/cannon/libraries/MIPS64Memory.sol
+++ b/packages/contracts-bedrock/src/cannon/libraries/MIPS64Memory.sol
@@ -13,7 +13,7 @@ library MIPS64Memory {
     /// @param _memRoot The current memory root
     /// @param _addr The address to read from.
     /// @param _proofOffset The offset of the memory proof in calldata.
-    /// @return out_ The hashed MIPS state.
+    /// @return out_ The 64-bit word read from memory.
     function readMem(bytes32 _memRoot, uint64 _addr, uint256 _proofOffset) internal pure returns (uint64 out_) {
         bool valid;
         (out_, valid) = readMemUnchecked(_memRoot, _addr, _proofOffset);
@@ -26,7 +26,7 @@ library MIPS64Memory {
     /// @param _memRoot The current memory root
     /// @param _addr The address to read from.
     /// @param _proofOffset The offset of the memory proof in calldata.
-    /// @return out_ The hashed MIPS state.
+    /// @return out_ The 64-bit word read from memory.
     ///         valid_ Whether the proof is valid.
     function readMemUnchecked(
         bytes32 _memRoot,


### PR DESCRIPTION
## Description

Fixes #13436.

The `@return out_` NatSpec on `MIPS64Memory.readMem` and `readMemUnchecked` incorrectly said `The hashed MIPS state.` — a copy-paste from an unrelated function. Both functions are documented as reading a 64-bit word and return `uint64 out_`, so the return description is now `The 64-bit word read from memory.`

This is the Spearbit audit finding referenced in the issue. Documentation-only change; the `valid_` return line on `readMemUnchecked` is unchanged.

## Testing

- [x] `FOUNDRY_PROFILE=lite FOUNDRY_TEST=test/cannon forge test --match-path test/cannon/MIPS64Memory.t.sol`
  - 18 passed, 0 failed (existing `MIPS64Memory` unit tests, including `readMem` returning the stored word)

## Metadata

- Fixes #13436