### PR TITLE
ci: Switch Rust base image to Wolfi runner image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,11 +11,11 @@ parameters:
   default_docker_image:
     type: string
     default: cimg/base:2026.03
-  # Pinned ci-base-clang image (cimg/base + clang/llvm-dev/libclang-dev) for Rust jobs.
+  # Pinned Wolfi Rust base image (clang/libclang, mold, sccache, Go, Rust) for Rust jobs.
   # Provenance is verified by .github/workflows/security.yml.
   rust_base_image:
     type: string
-    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-base-clang@sha256:873a6709dd48d7706b0baee139300f18ab7babf4a66f982b2383fe51ce2e5489
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi@sha256:02bbcf0c7bdc15da25149060330d28929c988a118490489f9d71cf981f40593f
   base_image:
     type: string
     default: default

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -6,7 +6,7 @@ parameters:
     default: cimg/base:2026.03
   c-rust_base_image:
     type: string
-    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-base-clang@sha256:873a6709dd48d7706b0baee139300f18ab7babf4a66f982b2383fe51ce2e5489
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi@sha256:02bbcf0c7bdc15da25149060330d28929c988a118490489f9d71cf981f40593f
   c-base_image:
     type: string
     default: default
@@ -28,7 +28,7 @@ parameters:
     default: cimg/base:2026.03
   rust_base_image:
     type: string
-    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-base-clang@sha256:873a6709dd48d7706b0baee139300f18ab7babf4a66f982b2383fe51ce2e5489
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi@sha256:02bbcf0c7bdc15da25149060330d28929c988a118490489f9d71cf981f40593f
   base_image:
     type: string
     default: default
@@ -197,7 +197,7 @@ commands:
       for every ref and develop overrides to the writer. The write/read split is
       enforced by GCP Workload Identity on the signed CircleCI OIDC vcs-ref
       claim, so a non-develop ref impersonating the writer is denied by GCP;
-      this only selects the SA. sccache is preinstalled in the ci-base-clang
+      this only selects the SA. sccache is preinstalled in the Rust base
       image.
 
       Not fail-open: if the sccache server can't start, the job fails so a
@@ -247,7 +247,7 @@ commands:
                 name: "Start sccache"
                 command: |
                   # Skip where sccache is not installed (machine-executor jobs like
-                  # the cannon builds run on a VM, not the ci-base-clang image). This
+                  # the cannon builds run on a VM, not the Rust base image). This
                   # is NOT fail-open for a broken cache: if sccache IS present, a
                   # failed server start below still fails the job.
                   if ! command -v sccache >/dev/null 2>&1; then
@@ -695,7 +695,7 @@ commands:
               # build alone would omit crates other workspace members need).
               cargo fetch --locked
             fi
-            # Use the mold linker (pinned via mise; also present in ci-base-clang)
+            # Use the mold linker (pinned via mise; also present in the Rust base image)
             # to cut final link time. `mold -run` intercepts the linker at exec
             # time, so it needs no RUSTFLAGS change and does not perturb the sccache
             # compile-cache key. The CI env is controlled, so a missing mold must

--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -13,7 +13,7 @@ parameters:
     default: cimg/base:2026.03
   c-rust_base_image:
     type: string
-    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-base-clang@sha256:873a6709dd48d7706b0baee139300f18ab7babf4a66f982b2383fe51ce2e5489
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi@sha256:02bbcf0c7bdc15da25149060330d28929c988a118490489f9d71cf981f40593f
   c-base_image:
     type: string
     default: default

--- a/.circleci/continue/rust-e2e.yml
+++ b/.circleci/continue/rust-e2e.yml
@@ -13,7 +13,7 @@ parameters:
     default: cimg/base:2026.03
   c-rust_base_image:
     type: string
-    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-base-clang@sha256:873a6709dd48d7706b0baee139300f18ab7babf4a66f982b2383fe51ce2e5489
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi@sha256:02bbcf0c7bdc15da25149060330d28929c988a118490489f9d71cf981f40593f
   c-go-cache-version:
     type: string
     default: "v0.1"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   verify:
-    name: verify provenance ci-base-clang
+    name: verify provenance circleci-runner-wolfi
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -33,10 +33,10 @@ jobs:
         run: |
           set -euo pipefail
           IMAGE_REF=$(grep -A2 '^  rust_base_image:' .circleci/config.yml \
-            | grep -oE 'us-docker\.pkg\.dev/oplabs-tools-artifacts/images/ci-base-clang@sha256:[0-9a-f]{64}' \
+            | grep -oE 'us-docker\.pkg\.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi@sha256:[0-9a-f]{64}' \
             | head -n1)
           if [[ -z "${IMAGE_REF}" ]]; then
-            echo "Could not extract ci-base-clang image reference from .circleci/config.yml" >&2
+            echo "Could not extract circleci-runner-wolfi image reference from .circleci/config.yml" >&2
             exit 1
           fi
           echo "image=${IMAGE_REF}" >> "$GITHUB_OUTPUT"
@@ -51,4 +51,4 @@ jobs:
             --bundle-from-oci \
             --owner ethereum-optimism \
             --signer-repo ethereum-optimism/factory \
-            --source-ref refs/heads/develop
+            --source-ref refs/heads/main


### PR DESCRIPTION
Point the Rust CI base image (`rust_base_image`) at the Wolfi/apko `circleci-runner-wolfi` image built by `ethereum-optimism/infra`, replacing the retired `ci-base-clang` docker image.

Docker image builds in this repo were disabled in favour of apko, so `ci-base-clang` is no longer rebuilt. The Wolfi image ships the same toolchain the Rust jobs need — clang/libclang (bindgen), mold, sccache, Go and Rust — and is pinned by digest.

- Update all five `rust_base_image` / `c-rust_base_image` pins.
- Update `security.yml` provenance verification to the new image and its build ref (`ethereum-optimism/infra` `main`). Provenance verifies against `ethereum-optimism/factory` and passes.
- `default_docker_image` stays on `cimg/base`; only the Rust jobs move.

Validated: `merge-configs.sh`, `circleci config validate` on the merged config, and `test-decision-tree.sh` (20/20) all pass. CI on this PR exercises the image for real.

Follow-ups: drop the now-redundant `protoc` from the infra image, and remove the unused `ci-base-clang` docker image from this repo (separate PRs).