### PR TITLE
op-node: don't let sequencer Stop wait for a block that will never arrive

### DIFF
--- a/op-node/rollup/sequencing/sequencer.go
+++ b/op-node/rollup/sequencing/sequencer.go
@@ -555,6 +555,9 @@ func (s *Sequencer) onReset(x rollup.ResetEvent) {
 		s.emitter.Emit(s.ctx, engine.BuildCancelEvent{Info: s.building.Info})
 	}
 	s.building = BuildingState{}
+	// A block we sealed may be discarded by this reset, and the head is rewound
+	// again right after, so clear the marker rather than pointing it at the head.
+	s.lastSealed = eth.L2BlockRef{}
 	s.stalledByMaxSafeLag = false
 	// no action to perform until we get a reset-confirmation
 	s.nextActionArmed = false
@@ -977,8 +980,9 @@ func (s *Sequencer) Stop(ctx context.Context) (common.Hash, error) {
 		return common.Hash{}, ErrSequencerAlreadyStopped
 	}
 
-	// ensure unsafeHead has been updated to the latest sealed/gossiped block before stopping the sequencer
-	for s.unsafeHead.Hash != s.lastSealed.Hash {
+	// Wait for the head to catch up to a block we sealed and gossiped. A zero
+	// marker means there is no such block, so there is nothing to wait for.
+	for s.lastSealed != (eth.L2BlockRef{}) && s.unsafeHead.Hash != s.lastSealed.Hash {
 
 		// if we are not the leader, lastSealed will never be updated and we will wait forever
 		if isLeader, err := s.conductor.Leader(ctx); err != nil {

--- a/op-node/rollup/sequencing/sequencer_test.go
+++ b/op-node/rollup/sequencing/sequencer_test.go
@@ -1432,3 +1432,59 @@ func TestSequencerStartDuringResetStaysParked(t *testing.T) {
 	_, ok = s.seq.NextAction()
 	require.True(t, ok, "the confirmation arms it on the post-reset head")
 }
+
+// TestSequencerStopWithoutSealedBlock covers stopping a sequencer that has not
+// sealed anything yet. There is no published block for the head to catch up to,
+// so Stop must not wait for one: it would block until the caller's context
+// expires, which on the conductor's failover path has no deadline at all.
+func TestSequencerStopWithoutSealedBlock(t *testing.T) {
+	s := newSeqSetup(t)
+	require.Equal(t, eth.L2BlockRef{}, s.seq.lastSealed, "nothing sealed yet")
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	hash, err := s.seq.Stop(ctx)
+	require.NoError(t, err, "Stop must not wait when we never sealed a block")
+	require.Equal(t, s.seq.unsafeHead.Hash, hash)
+}
+
+// TestSequencerStopAfterResetDropsSealed covers a reset that rewinds below the
+// block we last sealed and gossiped. That block is discarded, so the head can
+// never reach it and Stop would wait forever — the same "dead block" case that
+// handleInvalid and the stale-insert path already reconcile, but on the reset
+// path, which does not.
+func TestSequencerStopAfterResetDropsSealed(t *testing.T) {
+	s := newSeqSetup(t)
+	info := s.startBuild(t)
+	envelope, ref := s.sealedPayload()
+	s.deps.eng.sealBuildFn = func(ctx context.Context, gotInfo eth.PayloadInfo, buildStarted time.Time) (*engine.SealResult, error) {
+		require.Equal(t, info, gotInfo)
+		return &engine.SealResult{Envelope: envelope, Ref: ref}, nil
+	}
+	// Sealed and gossiped, but the local insert failed temporarily, so the block
+	// is outstanding: Stop legitimately waits for the head to catch up to it.
+	s.deps.eng.processPayloadFn = func(context.Context, *eth.ExecutionPayloadEnvelope, eth.L2BlockRef, time.Time) error {
+		return errors.New("mock temporary insert failure")
+	}
+	s.seq.RunAction()
+	require.Equal(t, ref, s.seq.lastSealed, "our gossiped block is outstanding")
+
+	// An L1 reorg now resets the engine below that block, discarding it.
+	em := &testutils.MockEmitter{}
+	em.ExpectOnceType("engine.BuildCancelEvent") // the reset cancels the in-flight job
+	s.seq.AttachEmitter(em)
+	deliver(s.seq, rollup.ResetEvent{Err: errors.New("mock reset")})
+	rewound := s.head
+	rewound.Hash = common.Hash{0x33}
+	rewound.Number = s.head.Number - 1
+	deliver(s.seq, engine.ForkchoiceUpdateEvent{UnsafeL2Head: rewound})
+	deliver(s.seq, engine.EngineResetConfirmedEvent{})
+	em.AssertExpectations(t)
+	require.NotEqual(t, ref.Hash, s.seq.unsafeHead.Hash, "the sealed block is not the head")
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	hash, err := s.seq.Stop(ctx)
+	require.NoError(t, err, "Stop must not wait for a block the reset discarded")
+	require.Equal(t, s.seq.unsafeHead.Hash, hash)
+}


### PR DESCRIPTION
`Sequencer.Stop` waits for the L2 head to reach the last block the sequencer sealed, so the hash it returns is the true head for handoff. The loop had no termination guarantee: it advances only when `setLatestHead` closes its channel, and exits only when the head reaches a marker that in two reachable states it can never equal. The only escape hatches are "the conductor says we are not leader" and "the conductor call errored", and `NoOpConductor.Leader` always returns `true`, so a non-HA sequencer has neither. The caller's context deadline was the sole bound.

That matters because `Stop` is on three paths, not just an interactive RPC: `admin_stopSequencer`, node shutdown via `OpNode.Stop`, and — the one that counts — **op-conductor's leadership handoff**, which calls `StopSequencer(oc.shutdownCtx)` with no deadline. A stalled sequencer is exactly when a failover happens.

## The two non-converging states

**Never sealed since start.** `latestSealed` is the zero ref until the first successful seal. While the sequencer is active but not producing — parked awaiting a reset confirmation, in an engine backoff, stalled by `maxSafeLag`, or waiting on an unknown head — nothing will ever set it, and the loop waits for the head to equal a zero hash.

**A reset discarded the marker.** `onReset` clears the build state but leaves `latestSealed` naming the block we last sealed and gossiped. If the reset rewinds past it, that block is never canonical again, so the head can never reach it — permanently.

## The fix

Two changes, each closing one state, both following patterns already in the file:

- **Only wait while a block is genuinely outstanding.** The loop now requires a non-zero `latestSealed`. A zero marker means we published nothing, so there is nothing to wait for.
- **Reconcile `latestSealed` on reset.** `handleInvalid` and the stale-insert path already do exactly this when a sealed block is discarded — `handleInvalid`'s comment even says *"so Stop, which waits for the head to catch up to it, is not left waiting for a dead block."* `onReset` was the one discard site that didn't. It clears the marker rather than assigning `latestHead`, because the reset rewinds the head again immediately afterwards; assigning the pre-reset head would just move the hang.

`latestSealed`'s only consumer is this loop, so neither change has other effects.

## Deliberately not included

- **A bounded wait.** Both non-converging states are now closed at the source, and what remains is the case the wait exists for: a genuinely outstanding gossiped block while we are still leader. A timeout would paper over a future third case rather than surface it. If a backstop is wanted, the right place is the caller — op-conductor passing a deadline-less `shutdownCtx` into a blocking call is the more defensible thing to change, and it belongs in that repo.
- **The concurrent-`Stop` waiter overwrite** (two callers race, the earlier one's channel is dropped and it waits out its own context). Pre-existing, unrelated to these two states, and previously judged not worth the change. Not made worse here.

## Tests

`TestSequencerStopWithoutSealedBlock` and `TestSequencerStopAfterResetDropsSealed`, alongside the existing `TestSequencerStopAfterStaleProcess` / `TestSequencerStopAfterRejectedInsert` which cover the discard sites that were already reconciled. Both new tests were verified red first — each hung for its full context second — and each fix was mutation-checked in isolation: reverting the loop guard alone fails both, reverting the reset reconciliation alone fails only the reset test. So neither half is redundant.

The reset test builds the realistic outstanding state (seal and gossip succeed, the local insert fails temporarily) rather than poking fields, and asserts the reset cancels the in-flight job via the emitter.

`-race` green on `op-node/rollup/sequencing` and `op-node/rollup/driver`; `just lint-go` 0 issues. I did not run `op-e2e/actions` locally: it contains no sequencer `Stop` calls, so it does not exercise this path, and this machine currently lacks the headroom to rebuild contracts without an OOM. CI covers it.

Fixes #22318

🤖 *Co-created with Claude (Opus 5)*
