### PR TITLE
ci: switch Rust CI base image to the Wolfi runner image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,11 +11,11 @@ parameters:
   default_docker_image:
     type: string
     default: cimg/base:2026.03
-  # Pinned ci-base-clang image (cimg/base + clang/llvm-dev/libclang-dev) for Rust jobs.
+  # Pinned Wolfi Rust base image (clang/libclang, mold, sccache, Go, Rust) for Rust jobs.
   # Provenance is verified by .github/workflows/security.yml.
   rust_base_image:
     type: string
-    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-base-clang@sha256:873a6709dd48d7706b0baee139300f18ab7babf4a66f982b2383fe51ce2e5489
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi@sha256:02bbcf0c7bdc15da25149060330d28929c988a118490489f9d71cf981f40593f
   base_image:
     type: string
     default: default

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ parameters:
   # Provenance is verified by .github/workflows/security.yml.
   rust_base_image:
     type: string
-    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi@sha256:61d609ab8025d197e46c80b9193eb33229512dd970069dd43171c25915c2e337
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi@sha256:c27652bd50a5e70cedfffebcead6b5c6356e51044f456e03b9ee4eee7d2de612
   base_image:
     type: string
     default: default

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ parameters:
   # Provenance is verified by .github/workflows/security.yml.
   rust_base_image:
     type: string
-    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi@sha256:c27652bd50a5e70cedfffebcead6b5c6356e51044f456e03b9ee4eee7d2de612
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi@sha256:f79d7c422cf320f67bbd9dbe3f36ed2755bf800d7065e4fbb63a034c3ff56914
   base_image:
     type: string
     default: default

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ parameters:
   # Provenance is verified by .github/workflows/security.yml.
   rust_base_image:
     type: string
-    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi@sha256:28a2c5983c222bcb0f3c9d33e38c62ef87b01b92aeab4386e0e2140ecda32ed1
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi@sha256:61d609ab8025d197e46c80b9193eb33229512dd970069dd43171c25915c2e337
   base_image:
     type: string
     default: default

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ parameters:
   # Provenance is verified by .github/workflows/security.yml.
   rust_base_image:
     type: string
-    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi@sha256:02bbcf0c7bdc15da25149060330d28929c988a118490489f9d71cf981f40593f
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi@sha256:2727f032ee6155e1c94ab4e2ac26c8c6a735cb3166ef710ba408989ae4d0d881
   base_image:
     type: string
     default: default

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ parameters:
   # Provenance is verified by .github/workflows/security.yml.
   rust_base_image:
     type: string
-    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi@sha256:2727f032ee6155e1c94ab4e2ac26c8c6a735cb3166ef710ba408989ae4d0d881
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi@sha256:28a2c5983c222bcb0f3c9d33e38c62ef87b01b92aeab4386e0e2140ecda32ed1
   base_image:
     type: string
     default: default

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -6,7 +6,7 @@ parameters:
     default: cimg/base:2026.03
   c-rust_base_image:
     type: string
-    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi@sha256:c27652bd50a5e70cedfffebcead6b5c6356e51044f456e03b9ee4eee7d2de612
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi@sha256:f79d7c422cf320f67bbd9dbe3f36ed2755bf800d7065e4fbb63a034c3ff56914
   c-base_image:
     type: string
     default: default
@@ -28,7 +28,7 @@ parameters:
     default: cimg/base:2026.03
   rust_base_image:
     type: string
-    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi@sha256:c27652bd50a5e70cedfffebcead6b5c6356e51044f456e03b9ee4eee7d2de612
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi@sha256:f79d7c422cf320f67bbd9dbe3f36ed2755bf800d7065e4fbb63a034c3ff56914
   base_image:
     type: string
     default: default

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -6,7 +6,7 @@ parameters:
     default: cimg/base:2026.03
   c-rust_base_image:
     type: string
-    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-base-clang@sha256:873a6709dd48d7706b0baee139300f18ab7babf4a66f982b2383fe51ce2e5489
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi@sha256:02bbcf0c7bdc15da25149060330d28929c988a118490489f9d71cf981f40593f
   c-base_image:
     type: string
     default: default
@@ -28,7 +28,7 @@ parameters:
     default: cimg/base:2026.03
   rust_base_image:
     type: string
-    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-base-clang@sha256:873a6709dd48d7706b0baee139300f18ab7babf4a66f982b2383fe51ce2e5489
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi@sha256:02bbcf0c7bdc15da25149060330d28929c988a118490489f9d71cf981f40593f
   base_image:
     type: string
     default: default
@@ -197,7 +197,7 @@ commands:
       for every ref and develop overrides to the writer. The write/read split is
       enforced by GCP Workload Identity on the signed CircleCI OIDC vcs-ref
       claim, so a non-develop ref impersonating the writer is denied by GCP;
-      this only selects the SA. sccache is preinstalled in the ci-base-clang
+      this only selects the SA. sccache is preinstalled in the Rust base
       image.
 
       Not fail-open: if the sccache server can't start, the job fails so a
@@ -247,7 +247,7 @@ commands:
                 name: "Start sccache"
                 command: |
                   # Skip where sccache is not installed (machine-executor jobs like
-                  # the cannon builds run on a VM, not the ci-base-clang image). This
+                  # the cannon builds run on a VM, not the Rust base image). This
                   # is NOT fail-open for a broken cache: if sccache IS present, a
                   # failed server start below still fails the job.
                   if ! command -v sccache >/dev/null 2>&1; then
@@ -695,7 +695,7 @@ commands:
               # build alone would omit crates other workspace members need).
               cargo fetch --locked
             fi
-            # Use the mold linker (pinned via mise; also present in ci-base-clang)
+            # Use the mold linker (pinned via mise; also present in the Rust base image)
             # to cut final link time. `mold -run` intercepts the linker at exec
             # time, so it needs no RUSTFLAGS change and does not perturb the sccache
             # compile-cache key. The CI env is controlled, so a missing mold must

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -6,7 +6,7 @@ parameters:
     default: cimg/base:2026.03
   c-rust_base_image:
     type: string
-    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi@sha256:02bbcf0c7bdc15da25149060330d28929c988a118490489f9d71cf981f40593f
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi@sha256:2727f032ee6155e1c94ab4e2ac26c8c6a735cb3166ef710ba408989ae4d0d881
   c-base_image:
     type: string
     default: default
@@ -28,7 +28,7 @@ parameters:
     default: cimg/base:2026.03
   rust_base_image:
     type: string
-    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi@sha256:02bbcf0c7bdc15da25149060330d28929c988a118490489f9d71cf981f40593f
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi@sha256:2727f032ee6155e1c94ab4e2ac26c8c6a735cb3166ef710ba408989ae4d0d881
   base_image:
     type: string
     default: default

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -6,7 +6,7 @@ parameters:
     default: cimg/base:2026.03
   c-rust_base_image:
     type: string
-    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi@sha256:28a2c5983c222bcb0f3c9d33e38c62ef87b01b92aeab4386e0e2140ecda32ed1
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi@sha256:61d609ab8025d197e46c80b9193eb33229512dd970069dd43171c25915c2e337
   c-base_image:
     type: string
     default: default
@@ -28,7 +28,7 @@ parameters:
     default: cimg/base:2026.03
   rust_base_image:
     type: string
-    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi@sha256:28a2c5983c222bcb0f3c9d33e38c62ef87b01b92aeab4386e0e2140ecda32ed1
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi@sha256:61d609ab8025d197e46c80b9193eb33229512dd970069dd43171c25915c2e337
   base_image:
     type: string
     default: default

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -6,7 +6,7 @@ parameters:
     default: cimg/base:2026.03
   c-rust_base_image:
     type: string
-    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi@sha256:2727f032ee6155e1c94ab4e2ac26c8c6a735cb3166ef710ba408989ae4d0d881
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi@sha256:28a2c5983c222bcb0f3c9d33e38c62ef87b01b92aeab4386e0e2140ecda32ed1
   c-base_image:
     type: string
     default: default
@@ -28,7 +28,7 @@ parameters:
     default: cimg/base:2026.03
   rust_base_image:
     type: string
-    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi@sha256:2727f032ee6155e1c94ab4e2ac26c8c6a735cb3166ef710ba408989ae4d0d881
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi@sha256:28a2c5983c222bcb0f3c9d33e38c62ef87b01b92aeab4386e0e2140ecda32ed1
   base_image:
     type: string
     default: default

--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -6,7 +6,7 @@ parameters:
     default: cimg/base:2026.03
   c-rust_base_image:
     type: string
-    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi@sha256:61d609ab8025d197e46c80b9193eb33229512dd970069dd43171c25915c2e337
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi@sha256:c27652bd50a5e70cedfffebcead6b5c6356e51044f456e03b9ee4eee7d2de612
   c-base_image:
     type: string
     default: default
@@ -28,7 +28,7 @@ parameters:
     default: cimg/base:2026.03
   rust_base_image:
     type: string
-    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi@sha256:61d609ab8025d197e46c80b9193eb33229512dd970069dd43171c25915c2e337
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi@sha256:c27652bd50a5e70cedfffebcead6b5c6356e51044f456e03b9ee4eee7d2de612
   base_image:
     type: string
     default: default

--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -13,7 +13,7 @@ parameters:
     default: cimg/base:2026.03
   c-rust_base_image:
     type: string
-    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi@sha256:02bbcf0c7bdc15da25149060330d28929c988a118490489f9d71cf981f40593f
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi@sha256:2727f032ee6155e1c94ab4e2ac26c8c6a735cb3166ef710ba408989ae4d0d881
   c-base_image:
     type: string
     default: default

--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -13,7 +13,7 @@ parameters:
     default: cimg/base:2026.03
   c-rust_base_image:
     type: string
-    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi@sha256:c27652bd50a5e70cedfffebcead6b5c6356e51044f456e03b9ee4eee7d2de612
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi@sha256:f79d7c422cf320f67bbd9dbe3f36ed2755bf800d7065e4fbb63a034c3ff56914
   c-base_image:
     type: string
     default: default

--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -13,7 +13,7 @@ parameters:
     default: cimg/base:2026.03
   c-rust_base_image:
     type: string
-    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi@sha256:2727f032ee6155e1c94ab4e2ac26c8c6a735cb3166ef710ba408989ae4d0d881
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi@sha256:28a2c5983c222bcb0f3c9d33e38c62ef87b01b92aeab4386e0e2140ecda32ed1
   c-base_image:
     type: string
     default: default

--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -13,7 +13,7 @@ parameters:
     default: cimg/base:2026.03
   c-rust_base_image:
     type: string
-    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi@sha256:28a2c5983c222bcb0f3c9d33e38c62ef87b01b92aeab4386e0e2140ecda32ed1
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi@sha256:61d609ab8025d197e46c80b9193eb33229512dd970069dd43171c25915c2e337
   c-base_image:
     type: string
     default: default

--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -13,7 +13,7 @@ parameters:
     default: cimg/base:2026.03
   c-rust_base_image:
     type: string
-    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-base-clang@sha256:873a6709dd48d7706b0baee139300f18ab7babf4a66f982b2383fe51ce2e5489
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi@sha256:02bbcf0c7bdc15da25149060330d28929c988a118490489f9d71cf981f40593f
   c-base_image:
     type: string
     default: default

--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -13,7 +13,7 @@ parameters:
     default: cimg/base:2026.03
   c-rust_base_image:
     type: string
-    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi@sha256:61d609ab8025d197e46c80b9193eb33229512dd970069dd43171c25915c2e337
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi@sha256:c27652bd50a5e70cedfffebcead6b5c6356e51044f456e03b9ee4eee7d2de612
   c-base_image:
     type: string
     default: default

--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -1008,8 +1008,8 @@ workflows:
       - rust-vendored-checks:
           name: op-rbuilder-checks
           directory: rust/op-rbuilder
-          # libsqlite3 (db), libtss2 (tdx-quote-provider); upstream installs both.
-          apt_packages: "libsqlite3-dev libtss2-dev"
+          # libsqlite3 (db) + libtss2 (tdx-quote-provider) are preinstalled in the
+          # Wolfi base image (sqlite-dev, tpm2-tss-dev); no apt-install needed.
           # Match upstream's pre-compile of the tester helper + main binary.
           pre_command: |
             make tester

--- a/.circleci/continue/rust-e2e.yml
+++ b/.circleci/continue/rust-e2e.yml
@@ -13,7 +13,7 @@ parameters:
     default: cimg/base:2026.03
   c-rust_base_image:
     type: string
-    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi@sha256:02bbcf0c7bdc15da25149060330d28929c988a118490489f9d71cf981f40593f
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi@sha256:2727f032ee6155e1c94ab4e2ac26c8c6a735cb3166ef710ba408989ae4d0d881
   c-go-cache-version:
     type: string
     default: "v0.1"

--- a/.circleci/continue/rust-e2e.yml
+++ b/.circleci/continue/rust-e2e.yml
@@ -13,7 +13,7 @@ parameters:
     default: cimg/base:2026.03
   c-rust_base_image:
     type: string
-    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-base-clang@sha256:873a6709dd48d7706b0baee139300f18ab7babf4a66f982b2383fe51ce2e5489
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi@sha256:02bbcf0c7bdc15da25149060330d28929c988a118490489f9d71cf981f40593f
   c-go-cache-version:
     type: string
     default: "v0.1"

--- a/.circleci/continue/rust-e2e.yml
+++ b/.circleci/continue/rust-e2e.yml
@@ -13,7 +13,7 @@ parameters:
     default: cimg/base:2026.03
   c-rust_base_image:
     type: string
-    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi@sha256:c27652bd50a5e70cedfffebcead6b5c6356e51044f456e03b9ee4eee7d2de612
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi@sha256:f79d7c422cf320f67bbd9dbe3f36ed2755bf800d7065e4fbb63a034c3ff56914
   c-go-cache-version:
     type: string
     default: "v0.1"

--- a/.circleci/continue/rust-e2e.yml
+++ b/.circleci/continue/rust-e2e.yml
@@ -13,7 +13,7 @@ parameters:
     default: cimg/base:2026.03
   c-rust_base_image:
     type: string
-    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi@sha256:28a2c5983c222bcb0f3c9d33e38c62ef87b01b92aeab4386e0e2140ecda32ed1
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi@sha256:61d609ab8025d197e46c80b9193eb33229512dd970069dd43171c25915c2e337
   c-go-cache-version:
     type: string
     default: "v0.1"

--- a/.circleci/continue/rust-e2e.yml
+++ b/.circleci/continue/rust-e2e.yml
@@ -13,7 +13,7 @@ parameters:
     default: cimg/base:2026.03
   c-rust_base_image:
     type: string
-    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi@sha256:2727f032ee6155e1c94ab4e2ac26c8c6a735cb3166ef710ba408989ae4d0d881
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi@sha256:28a2c5983c222bcb0f3c9d33e38c62ef87b01b92aeab4386e0e2140ecda32ed1
   c-go-cache-version:
     type: string
     default: "v0.1"

--- a/.circleci/continue/rust-e2e.yml
+++ b/.circleci/continue/rust-e2e.yml
@@ -13,7 +13,7 @@ parameters:
     default: cimg/base:2026.03
   c-rust_base_image:
     type: string
-    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi@sha256:61d609ab8025d197e46c80b9193eb33229512dd970069dd43171c25915c2e337
+    default: us-docker.pkg.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi@sha256:c27652bd50a5e70cedfffebcead6b5c6356e51044f456e03b9ee4eee7d2de612
   c-go-cache-version:
     type: string
     default: "v0.1"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   verify:
-    name: verify provenance ci-base-clang
+    name: verify provenance circleci-runner-wolfi
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -33,10 +33,10 @@ jobs:
         run: |
           set -euo pipefail
           IMAGE_REF=$(grep -A2 '^  rust_base_image:' .circleci/config.yml \
-            | grep -oE 'us-docker\.pkg\.dev/oplabs-tools-artifacts/images/ci-base-clang@sha256:[0-9a-f]{64}' \
+            | grep -oE 'us-docker\.pkg\.dev/oplabs-tools-artifacts/images/nexus/circleci-runner-wolfi@sha256:[0-9a-f]{64}' \
             | head -n1)
           if [[ -z "${IMAGE_REF}" ]]; then
-            echo "Could not extract ci-base-clang image reference from .circleci/config.yml" >&2
+            echo "Could not extract circleci-runner-wolfi image reference from .circleci/config.yml" >&2
             exit 1
           fi
           echo "image=${IMAGE_REF}" >> "$GITHUB_OUTPUT"
@@ -51,4 +51,4 @@ jobs:
             --bundle-from-oci \
             --owner ethereum-optimism \
             --signer-repo ethereum-optimism/factory \
-            --source-ref refs/heads/develop
+            --source-ref refs/heads/main


### PR DESCRIPTION
## Summary
Switches the Rust CI base image from `ci-base-clang` (Debian/cimg) to the apko/Wolfi `circleci-runner-wolfi` image built in ethereum-optimism/infra, aligning CI with our apko images and shrinking the package/CVE surface of CI jobs.

## Changes
- Pin `rust_base_image` to the `circleci-runner-wolfi` digest published from ethereum-optimism/infra `main`, across `.circleci/config.yml` and the three `continue/*.yml` fragments.
- Update `security.yml` to verify the image's provenance from `ethereum-optimism/infra` `main`.
- Drop the redundant `apt install libsqlite3-dev libtss2-dev` from `op-rbuilder-checks`: those libs (`sqlite-dev`, `tpm2-tss-dev`) are preinstalled in the Wolfi image, which has no `apt-get`.

## Notes
- The Wolfi image gained `sudo`, `openssl`, `jq`, `m4`, `zip`/`unzip` (ethereum-optimism/infra#720) to match the cimg/base environment CI relies on.
- Supersedes #22444.