### PR TITLE
docs/ai: state the cross-implementation parity rule

### DIFF
--- a/docs/ai/go-dev.md
+++ b/docs/ai/go-dev.md
@@ -61,6 +61,7 @@ cd <service> && just generate-mocks
 
 ## Conventions
 
+- **OP type encodings**: a change to an OP type's wire format, hash rule, or codec accept-set has to agree with `rust/op-alloy` (the types op-reth and kona consume), not just op-geth — see [Cross-implementation parity](opgeth-decoupling.md#cross-implementation-parity).
 - **Pointers to values**: use `ptr.New(v)` from `github.com/ethereum-optimism/optimism/op-service/ptr` to take the address of a literal or expression — common for optional `*uint64` config fields like fork-activation times (`cfg.SomeTime = ptr.New(uint64(123))`). Don't define a local `ptr`/`ptrTo` helper; the shared one avoids per-package duplicates, and a local `func ptr` collides with importing the `ptr` package in the same package.
 
 ## Linting

--- a/docs/ai/opgeth-decoupling.md
+++ b/docs/ai/opgeth-decoupling.md
@@ -88,6 +88,32 @@ All op-geth-specific code lives in `op-core/` packages (alongside the pre-existi
   (`OptimismConfig`), byte-identical encodings (`DepositTx`: `0x7E || RLP(struct)`), verified by
   the differential tests.
 
+### Cross-implementation parity
+
+Every OP wire format and hash rule has a second implementation in this repo: `rust/op-alloy`
+defines the OP transaction and receipt types that both op-reth and kona consume, opposite op-geth's
+Go definitions that `op-core/*` mirrors. Both sides serve one chain, so a value one produces and
+the other rejects is a consensus split — and agreeing with op-geth establishes only the Go half.
+
+- **op-geth parity is necessary, never sufficient.** The differential tests pin the Go side to
+  the fork; by construction they cannot see a rule where the fork itself is wrong. Any new or
+  changed encoding, hash or accept-set is checked against `rust/op-alloy` too, and a disagreement
+  is a question of which one is correct — decided from the [specs](https://specs.optimism.io), not
+  from the incumbent. Fixing op-geth (and bumping the pin) is a normal outcome.
+- **Pin the agreed value in both languages.** A shared golden vector — the same literal asserted
+  in the Go and the Rust suite — is what keeps the pair locked together;
+  `TestPostExecTxHashGoldenVector` (`op-core/types/post_exec_tx_test.go`) and
+  `rust/op-alloy/crates/consensus/src/post_exec/tests.rs` pin the post-exec (`0x7D`) tx hash this
+  way. Reference-implementation fixtures are not a substitute: they only cover values that
+  implementation can produce.
+- **The vectors outlive the differential tests.** op-geth differential tests are deleted at the
+  cutover (§ #20266). The cross-implementation vectors are not — after the flip they are the only
+  thing tying the Go types to op-reth and kona.
+
+For batcher-controlled bytes (batches, frames, channels) the second implementation is kona's own
+decoder rather than op-alloy's types, and the rule takes a different shape — accept-sets compared
+over a generated corpus rather than single values; see [derivation.md](derivation.md).
+
 ---
 
 ## 0. Remove ProtocolVersions watching from op-node — **DONE**

--- a/docs/ai/rust-dev.md
+++ b/docs/ai/rust-dev.md
@@ -176,6 +176,15 @@ Run these checks from `rust/`. Fix all issues — CI enforces zero warnings.
 
 Op-reth requires `clang` / `libclang-dev` for reth-mdbx-sys bindgen. CI installs this automatically — if you see bindgen errors locally, install clang.
 
+## Cross-implementation parity
+
+`rust/op-alloy` holds the OP transaction and receipt types that op-reth and kona consume; the Go
+services run the same formats through op-geth and `op-core/*`. A change to a wire format or hash
+rule on either side has to agree with the other, pinned by a shared golden vector asserted in both
+suites. The rule and the current
+example live in [opgeth-decoupling.md](opgeth-decoupling.md#cross-implementation-parity);
+batcher-controlled decoders are covered in [derivation.md](derivation.md).
+
 ## Hardforks
 
 The OP fork → implied L1 (Ethereum) fork mapping is defined once, in `OpHardfork::activates_l1_fork` in `rust/alloy-op-hardforks/src/lib.rs`. When a new OP hardfork rides an L1 fork (e.g. Isthmus → Prague, Karst → Osaka), add the single match arm there; the cumulative (`implied_l1_fork`) and inverse (`activating_op_fork`) views and all downstream consumers (op-revm, op-reth chainspec, kona) derive from it.


### PR DESCRIPTION
Records the review rule that the post-exec (`0x7D`) tx-hash divergence exposed: **op-geth parity is necessary, never sufficient.** The op-core differential tests pin the Go types to the fork, so by construction they cannot see a rule the fork itself gets wrong — which is exactly the case where op-geth and op-alloy disagreed.

New `### Cross-implementation parity` subsection in `docs/ai/opgeth-decoupling.md` (unnumbered — the stable §0–§19 numbering issues reference is untouched):

- Any new or changed OP encoding, hash rule, or accept-set is checked against `rust/op-alloy` too, and a disagreement is decided from the specs rather than from the incumbent. Fixing op-geth and bumping the pin is a normal outcome.
- The agreed value is pinned by a golden vector asserted in **both** suites — `TestPostExecTxHashGoldenVector` and `rust/op-alloy/crates/consensus/src/post_exec/tests.rs` are the worked example. Reference-implementation fixtures don't substitute: they only cover values that implementation can produce.
- Those vectors outlive the op-geth differential tests, which are deleted at the cutover (#20266).

Batcher-controlled formats (batches, frames, channels) are a different shape of the same rule — kona's own decoder is the counterpart, and accept-sets are compared over a corpus rather than single values — so the section points at `docs/ai/derivation.md` instead of restating it.

`go-dev.md` and `rust-dev.md` each get a pointer so the rule is reachable from either language's entry doc.

Docs only.

🤖 *Co-created with Claude Opus 5*
