### PR TITLE
kona-derive: Key the system config lookup by L2 block hash

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -7558,6 +7558,7 @@ dependencies = [
  "alloy-rpc-client",
  "alloy-rpc-types-beacon",
  "alloy-rpc-types-engine",
+ "alloy-rpc-types-eth 2.1.1",
  "alloy-serde 2.1.1",
  "alloy-transport",
  "alloy-transport-http",

--- a/rust/kona/crates/node/engine/src/client.rs
+++ b/rust/kona/crates/node/engine/src/client.rs
@@ -23,7 +23,7 @@ use alloy_transport_http::{
 use async_trait::async_trait;
 use http_body_util::Full;
 use kona_genesis::RollupConfig;
-use kona_protocol::{FromBlockError, L2BlockInfo};
+use kona_protocol::FromBlockError;
 use op_alloy_network::Optimism;
 use op_alloy_provider::ext::engine::OpEngineApi;
 use op_alloy_rpc_types::Transaction;
@@ -80,12 +80,6 @@ pub trait EngineClient: OpEngineApi<Optimism, Http<HyperAuthClient>> + Send + Sy
         &self,
         numtag: BlockNumberOrTag,
     ) -> Result<Option<Block<Transaction>>, EngineClientError>;
-
-    /// Fetches the [`L2BlockInfo`] by [`BlockNumberOrTag`].
-    async fn l2_block_info_by_label(
-        &self,
-        numtag: BlockNumberOrTag,
-    ) -> Result<Option<L2BlockInfo>, EngineClientError>;
 }
 
 /// Read-only subset of [`EngineClient`] used by the engine RPC actor.
@@ -232,17 +226,6 @@ where
         numtag: BlockNumberOrTag,
     ) -> Result<Option<Block<Transaction>>, EngineClientError> {
         Ok(self.engine.get_block_by_number(numtag).full().await?)
-    }
-
-    async fn l2_block_info_by_label(
-        &self,
-        numtag: BlockNumberOrTag,
-    ) -> Result<Option<L2BlockInfo>, EngineClientError> {
-        let block = self.engine.get_block_by_number(numtag).full().await?;
-        let Some(block) = block else {
-            return Ok(None);
-        };
-        Ok(Some(L2BlockInfo::from_block_and_genesis(&block.into_consensus(), &self.cfg.genesis)?))
     }
 }
 

--- a/rust/kona/crates/node/engine/src/test_utils/engine_client.rs
+++ b/rust/kona/crates/node/engine/src/test_utils/engine_client.rs
@@ -15,7 +15,6 @@ use alloy_transport::{TransportError, TransportErrorKind, TransportResult};
 use alloy_transport_http::Http;
 use async_trait::async_trait;
 use kona_genesis::RollupConfig;
-use kona_protocol::L2BlockInfo;
 use op_alloy_network::Optimism;
 use op_alloy_provider::ext::engine::OpEngineApi;
 use op_alloy_rpc_types::Transaction as OpTransaction;
@@ -41,8 +40,6 @@ pub fn test_engine_client_builder() -> MockEngineClientBuilder {
 pub struct MockEngineStorage {
     /// Storage for block responses by tag.
     pub l2_blocks_by_label: HashMap<BlockNumberOrTag, Block<OpTransaction>>,
-    /// Storage for block info responses by tag.
-    pub block_info_by_tag: HashMap<BlockNumberOrTag, L2BlockInfo>,
 
     // Version-specific new_payload responses
     /// Storage for `new_payload_v1` responses.
@@ -136,12 +133,6 @@ impl MockEngineClientBuilder {
         block: Block<OpTransaction>,
     ) -> Self {
         self.storage.l2_blocks_by_label.insert(tag, block);
-        self
-    }
-
-    /// Sets a block info response for a specific tag.
-    pub fn with_block_info_by_tag(mut self, tag: BlockNumberOrTag, info: L2BlockInfo) -> Self {
-        self.storage.block_info_by_tag.insert(tag, info);
         self
     }
 
@@ -305,11 +296,6 @@ impl MockEngineClient {
     /// Sets a block response for a specific tag.
     pub async fn set_l2_block_by_label(&self, tag: BlockNumberOrTag, block: Block<OpTransaction>) {
         self.storage.write().await.l2_blocks_by_label.insert(tag, block);
-    }
-
-    /// Sets a block info response for a specific tag.
-    pub async fn set_block_info_by_tag(&self, tag: BlockNumberOrTag, info: L2BlockInfo) {
-        self.storage.write().await.block_info_by_tag.insert(tag, info);
     }
 
     /// Sets the `new_payload_v1` response.
@@ -485,14 +471,6 @@ impl EngineClient for MockEngineClient {
     ) -> Result<Option<Block<OpTransaction>>, EngineClientError> {
         let storage = self.storage.read().await;
         Ok(storage.l2_blocks_by_label.get(&numtag).cloned())
-    }
-
-    async fn l2_block_info_by_label(
-        &self,
-        numtag: BlockNumberOrTag,
-    ) -> Result<Option<L2BlockInfo>, EngineClientError> {
-        let storage = self.storage.read().await;
-        Ok(storage.block_info_by_tag.get(&numtag).copied())
     }
 }
 

--- a/rust/kona/crates/proof/proof/src/l1/pipeline.rs
+++ b/rust/kona/crates/proof/proof/src/l1/pipeline.rs
@@ -2,6 +2,7 @@
 
 use crate::FlushableCache;
 use alloc::{boxed::Box, sync::Arc};
+use alloy_primitives::B256;
 use async_trait::async_trait;
 use core::fmt::Debug;
 use kona_derive::{
@@ -169,10 +170,10 @@ where
     }
 
     /// Returns the [`SystemConfig`] by L2 number.
-    async fn system_config_by_number(
+    async fn system_config_by_l2_hash(
         &mut self,
-        number: u64,
+        hash: B256,
     ) -> Result<SystemConfig, PipelineErrorKind> {
-        self.pipeline.system_config_by_number(number).await
+        self.pipeline.system_config_by_l2_hash(hash).await
     }
 }

--- a/rust/kona/crates/proof/proof/src/l2/chain_provider.rs
+++ b/rust/kona/crates/proof/proof/src/l2/chain_provider.rs
@@ -117,9 +117,23 @@ impl<T: CommsClient + Send + Sync> BatchValidationProvider for OracleL2ChainProv
 
     async fn block_by_number(&mut self, number: u64) -> Result<OpBlock, Self::Error> {
         // Fetch the header for the given block number.
-        let header @ Header { transactions_root, timestamp, .. } =
-            self.header_by_number(number).await?;
+        let header = self.header_by_number(number).await?;
         let header_hash = header.hash_slow();
+        self.block_from_header(header, header_hash).await
+    }
+}
+
+impl<T: CommsClient + Send + Sync> OracleL2ChainProvider<T> {
+    /// Hydrates a [`Header`] into a full [`OpBlock`] by walking its transactions trie.
+    ///
+    /// `header_hash` must be the hash of `header`; it is taken as an argument because callers that
+    /// looked the header up by hash already have it.
+    async fn block_from_header(
+        &self,
+        header: Header,
+        header_hash: B256,
+    ) -> Result<OpBlock, OracleProviderError> {
+        let Header { transactions_root, timestamp, .. } = header;
 
         // Fetch the transactions in the block.
         HintType::L2Transactions
@@ -159,13 +173,14 @@ impl<T: CommsClient + Send + Sync> BatchValidationProvider for OracleL2ChainProv
 impl<T: CommsClient + Send + Sync> L2ChainProvider for OracleL2ChainProvider<T> {
     type Error = OracleProviderError;
 
-    async fn system_config_by_number(
+    async fn system_config_by_l2_hash(
         &mut self,
-        number: u64,
+        hash: B256,
         rollup_config: Arc<RollupConfig>,
     ) -> Result<SystemConfig, <Self as L2ChainProvider>::Error> {
-        // Get the block at the given number.
-        let block = self.block_by_number(number).await?;
+        // A hash addresses the header directly, sparing the walk back from the safe head that a
+        // lookup by number requires.
+        let block = self.block_from_header(self.header_by_hash(hash)?, hash).await?;
 
         // Construct the system config from the payload.
         to_system_config(&block, rollup_config.as_ref())

--- a/rust/kona/crates/protocol/derive/src/attributes/stateful.rs
+++ b/rust/kona/crates/protocol/derive/src/attributes/stateful.rs
@@ -93,7 +93,7 @@ where
 
         let mut sys_config = self
             .config_fetcher
-            .system_config_by_number(l2_parent.block_info.number, self.rollup_cfg.clone())
+            .system_config_by_l2_hash(l2_parent.block_info.hash, self.rollup_cfg.clone())
             .await
             .map_err(Into::into)?;
 
@@ -423,7 +423,7 @@ mod tests {
         let l1_cfg = Arc::new(L1Config::sepolia().into());
         let l2_number = 1;
         let mut fetcher = TestSystemConfigL2Fetcher::default();
-        fetcher.insert(l2_number, SystemConfig::default());
+        fetcher.insert(B256::ZERO, SystemConfig::default());
         let mut provider = TestChainProvider::default();
         let header = Header::default();
         let hash = header.hash_slow();
@@ -449,7 +449,7 @@ mod tests {
         let l1_cfg = Arc::new(L1Config::sepolia().into());
         let l2_number = 1;
         let mut fetcher = TestSystemConfigL2Fetcher::default();
-        fetcher.insert(l2_number, SystemConfig::default());
+        fetcher.insert(B256::ZERO, SystemConfig::default());
         let mut provider = TestChainProvider::default();
         let header = Header::default();
         let hash = header.hash_slow();
@@ -476,7 +476,7 @@ mod tests {
         let l1_cfg = Arc::new(L1Config::sepolia().into());
         let l2_number = 1;
         let mut fetcher = TestSystemConfigL2Fetcher::default();
-        fetcher.insert(l2_number, SystemConfig::default());
+        fetcher.insert(B256::ZERO, SystemConfig::default());
         let mut provider = TestChainProvider::default();
         let header = Header { timestamp, ..Default::default() };
         let hash = header.hash_slow();
@@ -508,7 +508,7 @@ mod tests {
         let l1_cfg = Arc::new(L1Config::sepolia().into());
         let l2_number = 1;
         let mut fetcher = TestSystemConfigL2Fetcher::default();
-        fetcher.insert(l2_number, SystemConfig::default());
+        fetcher.insert(B256::ZERO, SystemConfig::default());
         let mut provider = TestChainProvider::default();
         let header = Header { timestamp, ..Default::default() };
         let prev_randao = header.mix_hash;
@@ -562,7 +562,7 @@ mod tests {
         let l1_cfg = Arc::new(L1Config::sepolia().into());
         let l2_number = 1;
         let mut fetcher = TestSystemConfigL2Fetcher::default();
-        fetcher.insert(l2_number, SystemConfig::default());
+        fetcher.insert(B256::ZERO, SystemConfig::default());
         let mut provider = TestChainProvider::default();
         let header = Header { timestamp, ..Default::default() };
         let prev_randao = header.mix_hash;
@@ -616,7 +616,7 @@ mod tests {
         let l1_cfg = Arc::new(L1Config::sepolia().into());
         let l2_number = 1;
         let mut fetcher = TestSystemConfigL2Fetcher::default();
-        fetcher.insert(l2_number, SystemConfig::default());
+        fetcher.insert(B256::ZERO, SystemConfig::default());
         let mut provider = TestChainProvider::default();
         let header = Header { timestamp, ..Default::default() };
         let parent_beacon_block_root = Some(header.parent_beacon_block_root.unwrap_or_default());
@@ -671,7 +671,7 @@ mod tests {
         let l1_cfg = Arc::new(L1Config::sepolia().into());
         let l2_number = 1;
         let mut fetcher = TestSystemConfigL2Fetcher::default();
-        fetcher.insert(l2_number, SystemConfig::default());
+        fetcher.insert(B256::ZERO, SystemConfig::default());
         let mut provider = TestChainProvider::default();
         let header = Header { timestamp, ..Default::default() };
         let prev_randao = header.mix_hash;
@@ -758,7 +758,7 @@ mod tests {
 
         let l2_number = 1u64;
         let mut fetcher = TestSystemConfigL2Fetcher::default();
-        fetcher.insert(l2_number, SystemConfig::default());
+        fetcher.insert(B256::ZERO, SystemConfig::default());
 
         let mut builder =
             StatefulAttributesBuilder::new(cfg.clone(), l1_cfg, fetcher, provider, None);
@@ -828,7 +828,7 @@ mod tests {
         let l1_cfg = Arc::new(L1Config::sepolia().into());
         let l2_number = 1;
         let mut fetcher = TestSystemConfigL2Fetcher::default();
-        fetcher.insert(l2_number, SystemConfig::default());
+        fetcher.insert(B256::ZERO, SystemConfig::default());
         let mut provider = TestChainProvider::default();
         let header = Header { timestamp, ..Default::default() };
         let hash = header.hash_slow();
@@ -879,7 +879,7 @@ mod tests {
         let l1_cfg = Arc::new(L1Config::sepolia().into());
         let l2_number = 1;
         let mut fetcher = TestSystemConfigL2Fetcher::default();
-        fetcher.insert(l2_number, SystemConfig::default());
+        fetcher.insert(B256::ZERO, SystemConfig::default());
         let mut provider = TestChainProvider::default();
         let header = Header { timestamp, ..Default::default() };
         let hash = header.hash_slow();

--- a/rust/kona/crates/protocol/derive/src/pipeline/core.rs
+++ b/rust/kona/crates/protocol/derive/src/pipeline/core.rs
@@ -7,6 +7,7 @@ use crate::{
 };
 use alloc::{boxed::Box, collections::VecDeque, sync::Arc};
 use alloy_eips::BlockNumHash;
+use alloy_primitives::B256;
 use async_trait::async_trait;
 use core::fmt::Debug;
 use kona_genesis::{RollupConfig, SystemConfig};
@@ -77,7 +78,7 @@ where
 
         let system_config = self
             .l2_chain_provider
-            .system_config_by_number(current.block_info.number, Arc::clone(&self.rollup_config))
+            .system_config_by_l2_hash(current.block_info.hash, Arc::clone(&self.rollup_config))
             .await
             .map_err(|e| PipelineError::Provider(alloc::string::ToString::to_string(&e)).temp())?;
 
@@ -181,13 +182,13 @@ where
         &self.rollup_config
     }
 
-    /// Returns the [`SystemConfig`] by L2 number.
-    async fn system_config_by_number(
+    /// Returns the [`SystemConfig`] for the L2 block with the given hash.
+    async fn system_config_by_l2_hash(
         &mut self,
-        number: u64,
+        hash: B256,
     ) -> Result<SystemConfig, PipelineErrorKind> {
         self.l2_chain_provider
-            .system_config_by_number(number, self.rollup_config.clone())
+            .system_config_by_l2_hash(hash, self.rollup_config.clone())
             .await
             .map_err(Into::into)
     }
@@ -266,6 +267,11 @@ mod tests {
     use kona_genesis::{RollupConfig, SystemConfig};
     use kona_protocol::{L2BlockInfo, OpAttributesWithParent};
     use op_alloy_rpc_types_engine::OpPayloadAttributes;
+
+    /// A distinct hash per block number, so hash-keyed lookups address one specific block.
+    fn test_block_hash(number: u64) -> B256 {
+        B256::from(alloy_primitives::U256::from(number))
+    }
 
     fn default_test_payload_attributes() -> OpAttributesWithParent {
         OpAttributesWithParent {
@@ -355,7 +361,7 @@ mod tests {
     async fn test_derivation_pipeline_signal_activation() {
         let rollup_config = Arc::new(RollupConfig::default());
         let mut l2_chain_provider = TestL2ChainProvider::default();
-        l2_chain_provider.system_configs.insert(0, SystemConfig::default());
+        l2_chain_provider.system_configs.insert(B256::ZERO, SystemConfig::default());
         let attributes = TestNextAttributes::default();
         let mut pipeline = DerivationPipeline::new(attributes, rollup_config, l2_chain_provider);
 
@@ -389,7 +395,7 @@ mod tests {
     async fn test_derivation_pipeline_signal_reset_ok() {
         let rollup_config = Arc::new(RollupConfig::default());
         let mut l2_chain_provider = TestL2ChainProvider::default();
-        l2_chain_provider.system_configs.insert(0, SystemConfig::default());
+        l2_chain_provider.system_configs.insert(B256::ZERO, SystemConfig::default());
         let attributes = TestNextAttributes::default();
         let mut pipeline = DerivationPipeline::new(attributes, rollup_config, l2_chain_provider);
 
@@ -409,7 +415,7 @@ mod tests {
         // Walkback: block 90 has L1 origin 40. 40 + 10 = 50, NOT > 50, so walkback stops.
         for n in 89u64..=100 {
             l2_chain_provider.blocks.push(L2BlockInfo {
-                block_info: BlockInfo { number: n, ..Default::default() },
+                block_info: BlockInfo { hash: test_block_hash(n), number: n, ..Default::default() },
                 l1_origin: BlockNumHash { number: n - 50, ..Default::default() },
                 seq_num: 0,
             });
@@ -417,7 +423,7 @@ mod tests {
 
         // Old batcher at walked-back block 90.
         l2_chain_provider.system_configs.insert(
-            90,
+            test_block_hash(90),
             SystemConfig {
                 batcher_address: address!("000000000000000000000000000000000000aaaa"),
                 ..Default::default()
@@ -425,7 +431,7 @@ mod tests {
         );
         // New batcher at safe head block 100.
         l2_chain_provider.system_configs.insert(
-            100,
+            test_block_hash(100),
             SystemConfig {
                 batcher_address: address!("000000000000000000000000000000000000bbbb"),
                 ..Default::default()
@@ -437,7 +443,7 @@ mod tests {
         let mut pipeline = DerivationPipeline::new(attributes, rollup_config, l2_chain_provider);
 
         let l2_safe_head = L2BlockInfo {
-            block_info: BlockInfo { number: 100, ..Default::default() },
+            block_info: BlockInfo { hash: test_block_hash(100), number: 100, ..Default::default() },
             l1_origin: BlockNumHash { number: 50, ..Default::default() },
             seq_num: 0,
         };
@@ -465,23 +471,23 @@ mod tests {
 
         let mut l2_chain_provider = TestL2ChainProvider::default();
         l2_chain_provider.blocks.push(L2BlockInfo {
-            block_info: BlockInfo { number: 5, ..Default::default() },
+            block_info: BlockInfo { hash: test_block_hash(5), number: 5, ..Default::default() },
             l1_origin: BlockNumHash { number: 3, ..Default::default() },
             seq_num: 0,
         });
         l2_chain_provider.blocks.push(L2BlockInfo {
-            block_info: BlockInfo { number: 6, ..Default::default() },
+            block_info: BlockInfo { hash: test_block_hash(6), number: 6, ..Default::default() },
             l1_origin: BlockNumHash { number: 4, ..Default::default() },
             seq_num: 0,
         });
-        l2_chain_provider.system_configs.insert(5, SystemConfig::default());
+        l2_chain_provider.system_configs.insert(test_block_hash(5), SystemConfig::default());
 
         let rollup_config = Arc::new(rollup_config);
         let attributes = TestNextAttributes::default();
         let mut pipeline = DerivationPipeline::new(attributes, rollup_config, l2_chain_provider);
 
         let l2_safe_head = L2BlockInfo {
-            block_info: BlockInfo { number: 6, ..Default::default() },
+            block_info: BlockInfo { hash: test_block_hash(6), number: 6, ..Default::default() },
             l1_origin: BlockNumHash { number: 4, ..Default::default() },
             seq_num: 0,
         };
@@ -494,7 +500,7 @@ mod tests {
     async fn test_initial_reset_no_walkback_zero_timeout() {
         let rollup_config = Arc::new(RollupConfig::default());
         let mut l2_chain_provider = TestL2ChainProvider::default();
-        l2_chain_provider.system_configs.insert(0, SystemConfig::default());
+        l2_chain_provider.system_configs.insert(B256::ZERO, SystemConfig::default());
 
         let attributes = TestNextAttributes::default();
         let mut pipeline = DerivationPipeline::new(attributes, rollup_config, l2_chain_provider);

--- a/rust/kona/crates/protocol/derive/src/test_utils/chain_providers.rs
+++ b/rust/kona/crates/protocol/derive/src/test_utils/chain_providers.rs
@@ -93,7 +93,7 @@ pub enum TestProviderError {
     L2BlockNotFound,
     /// The system config was not found.
     #[error("System config not found")]
-    SystemConfigNotFound(u64),
+    SystemConfigNotFound(B256),
 }
 
 impl From<TestProviderError> for PipelineErrorKind {
@@ -159,8 +159,8 @@ pub struct TestL2ChainProvider {
     pub short_circuit: bool,
     /// Blocks
     pub op_blocks: Vec<OpBlock>,
-    /// System configs
-    pub system_configs: HashMap<u64, SystemConfig>,
+    /// System configs, keyed by L2 block hash
+    pub system_configs: HashMap<B256, SystemConfig>,
 }
 
 impl TestL2ChainProvider {
@@ -168,7 +168,7 @@ impl TestL2ChainProvider {
     pub const fn new(
         blocks: Vec<L2BlockInfo>,
         op_blocks: Vec<OpBlock>,
-        system_configs: HashMap<u64, SystemConfig>,
+        system_configs: HashMap<B256, SystemConfig>,
     ) -> Self {
         Self { blocks, short_circuit: false, op_blocks, system_configs }
     }
@@ -202,14 +202,11 @@ impl BatchValidationProvider for TestL2ChainProvider {
 impl L2ChainProvider for TestL2ChainProvider {
     type Error = TestProviderError;
 
-    async fn system_config_by_number(
+    async fn system_config_by_l2_hash(
         &mut self,
-        number: u64,
+        hash: B256,
         _: Arc<RollupConfig>,
     ) -> Result<SystemConfig, <Self as L2ChainProvider>::Error> {
-        self.system_configs
-            .get(&number)
-            .ok_or_else(|| TestProviderError::SystemConfigNotFound(number))
-            .cloned()
+        self.system_configs.get(&hash).ok_or(TestProviderError::SystemConfigNotFound(hash)).cloned()
     }
 }

--- a/rust/kona/crates/protocol/derive/src/test_utils/sys_config_fetcher.rs
+++ b/rust/kona/crates/protocol/derive/src/test_utils/sys_config_fetcher.rs
@@ -5,7 +5,7 @@ use crate::{
     traits::L2ChainProvider,
 };
 use alloc::{boxed::Box, string::ToString, sync::Arc};
-use alloy_primitives::map::HashMap;
+use alloy_primitives::{B256, map::HashMap};
 use async_trait::async_trait;
 use kona_genesis::{RollupConfig, SystemConfig};
 use kona_protocol::{BatchValidationProvider, L2BlockInfo};
@@ -15,14 +15,14 @@ use thiserror::Error;
 /// A mock implementation of the [`L2ChainProvider`] and [`BatchValidationProvider`] for testing.
 #[derive(Debug, Default)]
 pub struct TestSystemConfigL2Fetcher {
-    /// A map from [u64] block number to a [`SystemConfig`].
-    pub system_configs: HashMap<u64, SystemConfig>,
+    /// A map from L2 block hash to a [`SystemConfig`].
+    pub system_configs: HashMap<B256, SystemConfig>,
 }
 
 impl TestSystemConfigL2Fetcher {
-    /// Inserts a new system config into the mock fetcher with the given block number.
-    pub fn insert(&mut self, number: u64, config: SystemConfig) {
-        self.system_configs.insert(number, config);
+    /// Inserts a new system config into the mock fetcher with the given block hash.
+    pub fn insert(&mut self, hash: B256, config: SystemConfig) {
+        self.system_configs.insert(hash, config);
     }
 
     /// Clears all system configs from the mock fetcher.
@@ -36,7 +36,7 @@ impl TestSystemConfigL2Fetcher {
 pub enum TestSystemConfigL2FetcherError {
     /// The system config was not found.
     #[error("system config not found: {0}")]
-    NotFound(u64),
+    NotFound(B256),
 }
 
 impl From<TestSystemConfigL2FetcherError> for PipelineErrorKind {
@@ -62,14 +62,14 @@ impl BatchValidationProvider for TestSystemConfigL2Fetcher {
 impl L2ChainProvider for TestSystemConfigL2Fetcher {
     type Error = TestSystemConfigL2FetcherError;
 
-    async fn system_config_by_number(
+    async fn system_config_by_l2_hash(
         &mut self,
-        number: u64,
+        hash: B256,
         _: Arc<RollupConfig>,
     ) -> Result<SystemConfig, <Self as L2ChainProvider>::Error> {
         self.system_configs
-            .get(&number)
+            .get(&hash)
             .copied()
-            .ok_or_else(|| TestSystemConfigL2FetcherError::NotFound(number))
+            .ok_or(TestSystemConfigL2FetcherError::NotFound(hash))
     }
 }

--- a/rust/kona/crates/protocol/derive/src/traits/pipeline.rs
+++ b/rust/kona/crates/protocol/derive/src/traits/pipeline.rs
@@ -1,6 +1,7 @@
 //! Defines the interface for the core derivation pipeline.
 
 use alloc::boxed::Box;
+use alloy_primitives::B256;
 use async_trait::async_trait;
 use core::iter::Iterator;
 use kona_genesis::{RollupConfig, SystemConfig};
@@ -20,9 +21,9 @@ pub trait Pipeline: OriginProvider + Iterator<Item = OpAttributesWithParent> {
     /// Returns the rollup config.
     fn rollup_config(&self) -> &RollupConfig;
 
-    /// Returns the [`SystemConfig`] by L2 number.
-    async fn system_config_by_number(
+    /// Returns the [`SystemConfig`] for the L2 block with the given hash.
+    async fn system_config_by_l2_hash(
         &mut self,
-        number: u64,
+        hash: B256,
     ) -> Result<SystemConfig, PipelineErrorKind>;
 }

--- a/rust/kona/crates/protocol/derive/src/traits/providers.rs
+++ b/rust/kona/crates/protocol/derive/src/traits/providers.rs
@@ -39,10 +39,10 @@ pub trait L2ChainProvider: BatchValidationProviderDerive {
     /// The error type for the [`L2ChainProvider`].
     type Error: Display + Into<PipelineErrorKind>;
 
-    /// Returns the [`SystemConfig`] by L2 number.
-    async fn system_config_by_number(
+    /// Returns the [`SystemConfig`] for the L2 block with the given hash.
+    async fn system_config_by_l2_hash(
         &mut self,
-        number: u64,
+        hash: B256,
         rollup_config: Arc<RollupConfig>,
     ) -> Result<SystemConfig, <Self as L2ChainProvider>::Error>;
 }

--- a/rust/kona/crates/providers/providers-alloy/Cargo.toml
+++ b/rust/kona/crates/providers/providers-alloy/Cargo.toml
@@ -61,5 +61,6 @@ metrics = [ "dep:metrics", "kona-derive/metrics" ]
 
 [dev-dependencies]
 tokio.workspace = true
+alloy-rpc-types-eth.workspace = true
 httpmock.workspace = true
 serde_json.workspace = true

--- a/rust/kona/crates/providers/providers-alloy/src/l2_chain_provider.rs
+++ b/rust/kona/crates/providers/providers-alloy/src/l2_chain_provider.rs
@@ -2,7 +2,7 @@
 
 #[cfg(feature = "metrics")]
 use crate::Metrics;
-use alloy_eips::BlockId;
+use alloy_consensus::Header;
 use alloy_primitives::{B256, Bytes};
 use alloy_provider::{Provider, RootProvider};
 use alloy_rpc_client::RpcClient;
@@ -15,7 +15,7 @@ use alloy_transport_http::{
 };
 use async_trait::async_trait;
 use http_body_util::Full;
-use kona_derive::{L2ChainProvider, PipelineError, PipelineErrorKind};
+use kona_derive::{L2ChainProvider, PipelineError, PipelineErrorKind, ResetError};
 use kona_genesis::{RollupConfig, SystemConfig};
 use kona_protocol::{BatchValidationProvider, L2BlockInfo, to_system_config};
 use lru::LruCache;
@@ -34,8 +34,10 @@ pub struct AlloyL2ChainProvider {
     trust_rpc: bool,
     /// The rollup configuration.
     rollup_config: Arc<RollupConfig>,
-    /// The `block_by_number` LRU cache.
-    block_by_number_cache: LruCache<u64, OpBlock>,
+    /// The `block_by_number` LRU cache. Shares its blocks with `block_by_hash_cache`.
+    block_by_number_cache: LruCache<u64, Arc<OpBlock>>,
+    /// The `block_by_hash` LRU cache. Shares its blocks with `block_by_number_cache`.
+    block_by_hash_cache: LruCache<B256, Arc<OpBlock>>,
 }
 
 impl AlloyL2ChainProvider {
@@ -67,7 +69,40 @@ impl AlloyL2ChainProvider {
             trust_rpc,
             rollup_config,
             block_by_number_cache: LruCache::new(NonZeroUsize::new(cache_size).unwrap()),
+            block_by_hash_cache: LruCache::new(NonZeroUsize::new(cache_size).unwrap()),
         }
+    }
+
+    /// Fetches the [`OpBlock`] with the given hash, caching the result.
+    async fn block_by_hash(
+        &mut self,
+        hash: B256,
+    ) -> Result<Arc<OpBlock>, AlloyL2ChainProviderError> {
+        if let Some(block) = self.block_by_hash_cache.get(&hash) {
+            return Ok(Arc::clone(block));
+        }
+
+        kona_macros::inc!(gauge, Metrics::L2_CHAIN_PROVIDER_REQUESTS, "method" => "l2_block_by_hash");
+
+        let block = self
+            .inner
+            .get_block_by_hash(hash)
+            .full()
+            .await
+            .map_err(|e| {
+                kona_macros::inc!(gauge, Metrics::L2_CHAIN_PROVIDER_ERRORS, "method" => "l2_block_by_hash");
+                AlloyL2ChainProviderError::Transport(e)
+            })?
+            .ok_or(AlloyL2ChainProviderError::BlockHashNotFound(hash))?;
+
+        let block = block.into_consensus().map_transactions(|t| t.inner.inner.into_inner());
+        self.verify_block_hash(&block.header, hash)?;
+
+        let block = Arc::new(block);
+        // Not also cached by number: a block found by hash carries no claim to being the
+        // canonical one at its own height.
+        self.block_by_hash_cache.put(hash, Arc::clone(&block));
+        Ok(block)
     }
 
     /// Returns the chain ID.
@@ -80,81 +115,28 @@ impl AlloyL2ChainProvider {
         self.inner.get_block_number().await
     }
 
-    /// Verifies that a block's hash matches the expected hash when `trust_rpc` is false.
+    /// Verifies that a header hashes to the expected hash when `trust_rpc` is false.
+    ///
+    /// The hash an endpoint reports alongside a block is its own claim, so it is recomputed from
+    /// the header rather than taken at face value: otherwise an endpoint could echo back the hash
+    /// it was asked for while serving different header fields.
     fn verify_block_hash(
         &self,
-        block_hash: B256,
+        header: &Header,
         expected_hash: B256,
     ) -> Result<(), RpcError<TransportErrorKind>> {
         if self.trust_rpc {
             return Ok(());
         }
 
-        if block_hash != expected_hash {
+        let actual_hash = header.hash_slow();
+        if actual_hash != expected_hash {
             return Err(RpcError::local_usage_str(&format!(
-                "Block hash mismatch: expected {expected_hash:?}, got {block_hash:?}"
+                "Block hash mismatch: expected {expected_hash:?}, got {actual_hash:?}"
             )));
         }
 
         Ok(())
-    }
-
-    /// Returns the [`L2BlockInfo`] for the given [`BlockId`]. [None] is returned if the block
-    /// does not exist.
-    pub async fn block_info_by_id(
-        &mut self,
-        id: BlockId,
-    ) -> Result<Option<L2BlockInfo>, RpcError<TransportErrorKind>> {
-        #[cfg(feature = "metrics")]
-        let method_name = match id {
-            BlockId::Number(_) => "l2_block_ref_by_number",
-            BlockId::Hash(_) => "l2_block_ref_by_hash",
-        };
-
-        kona_macros::inc!(gauge, Metrics::L2_CHAIN_PROVIDER_REQUESTS, "method" => method_name);
-
-        let result = async {
-            let block = match id {
-                BlockId::Number(num) => self.inner.get_block_by_number(num).full().await?,
-                BlockId::Hash(hash) => {
-                    let block = self.inner.get_block_by_hash(hash.block_hash).full().await?;
-
-                    // Verify block hash matches if we fetched by hash
-                    if let Some(ref b) = block {
-                        self.verify_block_hash(b.header.hash, hash.block_hash)?;
-                    }
-
-                    block
-                }
-            };
-
-            match block {
-                Some(block) => {
-                    let consensus_block =
-                        block.into_consensus().map_transactions(|t| t.inner.inner);
-
-                    let l2_block = L2BlockInfo::from_block_and_genesis(
-                        &consensus_block,
-                        &self.rollup_config.genesis,
-                    )
-                    .map_err(|_| {
-                        RpcError::local_usage_str(
-                            "failed to construct L2BlockInfo from block and genesis",
-                        )
-                    })?;
-                    Ok(Some(l2_block))
-                }
-                None => Ok(None),
-            }
-        }
-        .await;
-
-        #[cfg(feature = "metrics")]
-        if result.is_err() {
-            kona_macros::inc!(gauge, Metrics::L2_CHAIN_PROVIDER_ERRORS, "method" => method_name);
-        }
-
-        result
     }
 
     /// Creates a new [`AlloyL2ChainProvider`] from the provided [`reqwest::Url`].
@@ -187,12 +169,15 @@ pub enum AlloyL2ChainProviderError {
     /// Failed to find a block.
     #[error("Failed to fetch block {0}")]
     BlockNotFound(u64),
+    /// Failed to find a block by hash.
+    #[error("Failed to fetch block {0}")]
+    BlockHashNotFound(B256),
     /// Failed to construct [`L2BlockInfo`] from the block and genesis.
     #[error("Failed to construct L2BlockInfo from block {0} and genesis")]
     L2BlockInfoConstruction(u64),
     /// Failed to convert the block into a [`SystemConfig`].
     #[error("Failed to convert block {0} into SystemConfig")]
-    SystemConfigConversion(u64),
+    SystemConfigConversion(B256),
 }
 
 impl From<AlloyL2ChainProviderError> for PipelineErrorKind {
@@ -203,6 +188,10 @@ impl From<AlloyL2ChainProviderError> for PipelineErrorKind {
             }
             AlloyL2ChainProviderError::BlockNotFound(_) => {
                 Self::Temporary(PipelineError::Provider("Block not found".to_string()))
+            }
+            // A hash that resolves to nothing was reorged out; retrying will never succeed.
+            AlloyL2ChainProviderError::BlockHashNotFound(hash) => {
+                ResetError::BlockNotFound(hash.into()).reset()
             }
             AlloyL2ChainProviderError::L2BlockInfoConstruction(_) => Self::Temporary(
                 PipelineError::Provider("L2 block info construction failed".to_string()),
@@ -229,26 +218,28 @@ impl BatchValidationProvider for AlloyL2ChainProvider {
 
     async fn block_by_number(&mut self, number: u64) -> Result<OpBlock, Self::Error> {
         if let Some(block) = self.block_by_number_cache.get(&number) {
-            return Ok(block.clone());
+            return Ok((**block).clone());
         }
 
         kona_macros::inc!(gauge, Metrics::L2_CHAIN_PROVIDER_REQUESTS, "method" => "l2_block_ref_by_number");
 
-        let block = self
-            .inner
-            .get_block_by_number(number.into())
-            .full()
-            .await
-            .map_err(|e| {
-                kona_macros::inc!(gauge, Metrics::L2_CHAIN_PROVIDER_ERRORS, "method" => "l2_block_ref_by_number");
-                AlloyL2ChainProviderError::Transport(e)
-            })?
-            .ok_or(AlloyL2ChainProviderError::BlockNotFound(number))?
-            .into_consensus()
-            .map_transactions(|t| t.inner.inner.into_inner());
+        let block = Arc::new(
+            self.inner
+                .get_block_by_number(number.into())
+                .full()
+                .await
+                .map_err(|e| {
+                    kona_macros::inc!(gauge, Metrics::L2_CHAIN_PROVIDER_ERRORS, "method" => "l2_block_ref_by_number");
+                    AlloyL2ChainProviderError::Transport(e)
+                })?
+                .ok_or(AlloyL2ChainProviderError::BlockNotFound(number))?
+                .into_consensus()
+                .map_transactions(|t| t.inner.inner.into_inner()),
+        );
 
-        self.block_by_number_cache.put(number, block.clone());
-        Ok(block)
+        self.block_by_hash_cache.put(block.header.hash_slow(), Arc::clone(&block));
+        self.block_by_number_cache.put(number, Arc::clone(&block));
+        Ok((*block).clone())
     }
 }
 
@@ -256,16 +247,78 @@ impl BatchValidationProvider for AlloyL2ChainProvider {
 impl L2ChainProvider for AlloyL2ChainProvider {
     type Error = AlloyL2ChainProviderError;
 
-    async fn system_config_by_number(
+    async fn system_config_by_l2_hash(
         &mut self,
-        number: u64,
+        hash: B256,
         rollup_config: Arc<RollupConfig>,
     ) -> Result<SystemConfig, <Self as BatchValidationProvider>::Error> {
-        let block = self
-            .block_by_number(number)
-            .await
-            .map_err(|_| AlloyL2ChainProviderError::BlockNotFound(number))?;
+        let block = self.block_by_hash(hash).await?;
         to_system_config(&block, &rollup_config)
-            .map_err(|_| AlloyL2ChainProviderError::SystemConfigConversion(number))
+            .map_err(|_| AlloyL2ChainProviderError::SystemConfigConversion(hash))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_rpc_client::RpcClient;
+    use alloy_rpc_types_eth::{Block as RpcBlock, BlockTransactions, Header as RpcHeader};
+    use httpmock::prelude::*;
+    use kona_genesis::ChainGenesis;
+
+    /// An endpoint claiming `claimed_hash` for a block whose header hashes to something else.
+    fn mismatched_block(claimed_hash: B256) -> (B256, String) {
+        let header = alloy_consensus::Header::default();
+        let true_hash = header.hash_slow();
+        let mut rpc_header = RpcHeader::new(header);
+        rpc_header.hash = claimed_hash;
+        let block: <Optimism as alloy_provider::Network>::BlockResponse =
+            RpcBlock::new(rpc_header, BlockTransactions::Full(vec![]));
+        let body = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 0,
+            "result": serde_json::to_value(block).unwrap(),
+        });
+        (true_hash, body.to_string())
+    }
+
+    #[tokio::test]
+    async fn untrusted_rpc_cannot_echo_the_requested_block_hash() {
+        // The hash an endpoint reports alongside a block is its own claim. Taken at face value, a
+        // faulty or malicious endpoint can echo back whatever hash was asked for while serving
+        // different header fields, and the block is then cached and used under a hash it does not
+        // have.
+        let requested = B256::repeat_byte(0xbb);
+        let (true_hash, response) = mismatched_block(requested);
+        assert_ne!(true_hash, requested, "the header must not actually hash to the request");
+
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(POST).body_includes("eth_getBlockByHash");
+            then.status(200).header("content-type", "application/json").body(response);
+        });
+
+        // Genesis is pinned to the header the endpoint really returned, so the lookup would
+        // otherwise succeed and the mismatch would go unnoticed.
+        let config = Arc::new(RollupConfig {
+            genesis: ChainGenesis {
+                l2: alloy_eips::BlockNumHash { hash: true_hash, number: 0 },
+                system_config: Some(SystemConfig::default()),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        let mut provider = AlloyL2ChainProvider::new_with_trust(
+            RootProvider::<Optimism>::new(RpcClient::new_http(server.base_url().parse().unwrap())),
+            config.clone(),
+            8,
+            false, // l2.trust-rpc=false
+        );
+
+        let err = provider.system_config_by_l2_hash(requested, config).await.unwrap_err();
+        assert!(
+            matches!(err, AlloyL2ChainProviderError::Transport(_)),
+            "expected the hash mismatch to be rejected, got {err:?}"
+        );
     }
 }

--- a/rust/kona/crates/providers/providers-alloy/src/pipeline.rs
+++ b/rust/kona/crates/providers/providers-alloy/src/pipeline.rs
@@ -1,6 +1,7 @@
 //! Contains an online derivation pipeline.
 
 use crate::{AlloyChainProvider, AlloyL2ChainProvider, OnlineBeaconClient, OnlineBlobProvider};
+use alloy_primitives::B256;
 use async_trait::async_trait;
 use core::fmt::Debug;
 use kona_derive::{
@@ -218,13 +219,13 @@ impl Pipeline for OnlinePipeline {
     }
 
     /// Returns the [`SystemConfig`] by L2 number.
-    async fn system_config_by_number(
+    async fn system_config_by_l2_hash(
         &mut self,
-        number: u64,
+        hash: B256,
     ) -> Result<SystemConfig, PipelineErrorKind> {
         match self {
-            Self::Polled(pipeline) => pipeline.system_config_by_number(number).await,
-            Self::Managed(pipeline) => pipeline.system_config_by_number(number).await,
+            Self::Polled(pipeline) => pipeline.system_config_by_l2_hash(hash).await,
+            Self::Managed(pipeline) => pipeline.system_config_by_l2_hash(hash).await,
         }
     }
 }

--- a/rust/kona/crates/providers/providers-local/src/buffered.rs
+++ b/rust/kona/crates/providers/providers-local/src/buffered.rs
@@ -164,18 +164,18 @@ impl Clone for BufferedL2Provider {
 impl L2ChainProvider for BufferedL2Provider {
     type Error = BufferedProviderError;
 
-    async fn system_config_by_number(
+    async fn system_config_by_l2_hash(
         &mut self,
-        number: u64,
+        hash: B256,
         rollup_config: Arc<RollupConfig>,
     ) -> Result<SystemConfig, <Self as L2ChainProvider>::Error> {
         // Check if this is the genesis block
-        if number == self.genesis.l2.number {
+        if hash == self.genesis.l2.hash {
             return self.genesis.system_config.ok_or(BufferedProviderError::SystemConfigMissing);
         }
 
         // Get the block from cache
-        let cached_block = self.buffer.get_block_by_number(number).await;
+        let cached_block = self.buffer.get_block_by_hash(hash).await;
 
         #[cfg(feature = "metrics")]
         {
@@ -187,11 +187,11 @@ impl L2ChainProvider for BufferedL2Provider {
             }
         }
 
-        let cached_block = cached_block.ok_or(BufferedProviderError::BlockNotFound(number))?;
+        let cached_block = cached_block.ok_or(BufferedProviderError::BlockHashNotFound(hash))?;
 
         // Extract system config from the block
         to_system_config(&cached_block.block, &rollup_config)
-            .map_err(|_| BufferedProviderError::SystemConfigConversion(number))
+            .map_err(|_| BufferedProviderError::SystemConfigConversion(hash))
     }
 }
 
@@ -259,9 +259,12 @@ pub enum BufferedProviderError {
     /// Failed to construct `L2BlockInfo`
     #[error("Failed to construct L2BlockInfo for block {0}")]
     L2BlockInfoConstruction(u64),
+    /// Block not found in cache, by hash
+    #[error("Block {0} not found in cache")]
+    BlockHashNotFound(B256),
     /// Failed to convert block to `SystemConfig`
     #[error("Failed to convert block {0} to SystemConfig")]
-    SystemConfigConversion(u64),
+    SystemConfigConversion(B256),
     /// System config missing from genesis
     #[error("System config missing from genesis")]
     SystemConfigMissing,
@@ -288,11 +291,12 @@ impl From<BufferedProviderError> for PipelineErrorKind {
                     "Failed to construct L2BlockInfo for block {number}"
                 )))
             }
-            BufferedProviderError::SystemConfigConversion(number) => {
-                Self::Temporary(PipelineError::Provider(format!(
-                    "Failed to convert block {number} to SystemConfig"
-                )))
+            BufferedProviderError::BlockHashNotFound(hash) => {
+                ResetError::BlockNotFound(hash.into()).reset()
             }
+            BufferedProviderError::SystemConfigConversion(hash) => Self::Temporary(
+                PipelineError::Provider(format!("Failed to convert block {hash} to SystemConfig")),
+            ),
             BufferedProviderError::SystemConfigMissing => Self::Critical(PipelineError::Provider(
                 "System config missing from genesis".to_string(),
             )),

--- a/rust/kona/crates/providers/providers-local/tests/integration.rs
+++ b/rust/kona/crates/providers/providers-local/tests/integration.rs
@@ -285,7 +285,8 @@ async fn test_system_config_retrieval(mut provider: BufferedL2Provider) {
     provider.add_block(block, l2_info).await.unwrap();
 
     // Retrieve system config for genesis
-    let genesis_config = provider.system_config_by_number(0, config.clone()).await.unwrap();
+    let genesis_config =
+        provider.system_config_by_l2_hash(config.genesis.l2.hash, config.clone()).await.unwrap();
     // Just verify we got a config back
     // The default SystemConfig might have zero values, so we just check it exists
     let _ = genesis_config;


### PR DESCRIPTION
op-node reads the system config by block **hash** at both sites kona read it by **number**:

| | op-node | kona (before) |
|---|---|---|
| attributes builder | `SystemConfigByL2Hash(ctx, l2Parent.Hash)` (`attributes.go:74`) | `system_config_by_number(l2_parent.block_info.number)` |
| pipeline reset | `SystemConfigByL2Hash(ctx, pipelineL2.Hash)` (`pipeline.go:259`) | `system_config_by_number(current.block_info.number)` |

Both kona callers already held the hash and threw it away. A height does not identify a block across a reorg, so a number-keyed lookup cannot be answered from a local cache without risking a stale answer — which blocks the follow-up that serves this lookup from blocks the node has already imported.

Renames `L2ChainProvider::system_config_by_number` and the matching `Pipeline` method to `system_config_by_l2_hash`.

Two things fall out of the change:

- The oracle-backed proof provider gains a `block_by_hash` path, letting it address the header directly instead of walking back from the safe head (`header_by_number`'s EIP-2935 leaping / linear walk is skipped entirely for this lookup).
- `AlloyL2ChainProvider` gains a hash-keyed block cache alongside its by-number one. Both hold the same blocks behind an `Arc`, and a by-number fetch seeds both, so a block fetched by number and later asked for by hash is neither fetched nor stored twice. Seeding in the other direction would not be sound: a block found by hash carries no claim to being canonical at its own height.

Also drops two unused methods found along the way — `EngineClient::l2_block_info_by_label` and `AlloyL2ChainProvider::block_info_by_id`, neither of which had callers anywhere in the workspace, and both of which fetched whole blocks to read a header and one transaction.

Part of #22432.

🤖 *Co-created with Claude Opus 5*
