### PR TITLE
kona-protocol: Add a hash-keyed L2BlockInfo lookup for the reset walk-back

### DIFF
--- a/rust/kona/crates/proof/proof/src/l2/chain_provider.rs
+++ b/rust/kona/crates/proof/proof/src/l2/chain_provider.rs
@@ -155,6 +155,15 @@ impl<T: CommsClient + Send + Sync> BatchValidationProvider for OracleL2ChainProv
             .map_err(OracleProviderError::BlockInfo)
     }
 
+    async fn l2_block_info_by_hash(&mut self, hash: B256) -> Result<L2BlockInfo, Self::Error> {
+        // A hash addresses the header directly, sparing the walk back from the safe head that a
+        // lookup by number requires.
+        let block = self.block_from_header(self.header_by_hash(hash)?, hash).await?;
+
+        L2BlockInfo::from_block_and_genesis(&block, &self.rollup_config.genesis)
+            .map_err(OracleProviderError::BlockInfo)
+    }
+
     async fn block_by_number(&mut self, number: u64) -> Result<Arc<OpBlock>, Self::Error> {
         // Fetch the header for the given block number.
         let header = self.header_by_number(number).await?;

--- a/rust/kona/crates/proof/proof/src/sync.rs
+++ b/rust/kona/crates/proof/proof/src/sync.rs
@@ -31,7 +31,7 @@ where
     OracleProviderError:
         From<<L1 as ChainProvider>::Error> + From<<L2 as BatchValidationProvider>::Error>,
 {
-    let safe_head_info = l2_chain_provider.l2_block_info_by_number(safe_header.number).await?;
+    let safe_head_info = l2_chain_provider.l2_block_info_by_hash(safe_header.hash()).await?;
     let l1_origin = chain_provider.block_info_by_number(safe_head_info.l1_origin.number).await?;
 
     // Walk back the starting L1 block by `channel_timeout` to ensure that the full channel is

--- a/rust/kona/crates/protocol/derive/src/pipeline/core.rs
+++ b/rust/kona/crates/protocol/derive/src/pipeline/core.rs
@@ -69,7 +69,7 @@ where
 
             current = self
                 .l2_chain_provider
-                .l2_block_info_by_number(current.block_info.number - 1)
+                .l2_block_info_by_hash(current.block_info.parent_hash)
                 .await
                 .map_err(|e| {
                     PipelineError::Provider(alloc::string::ToString::to_string(&e)).temp()
@@ -415,7 +415,12 @@ mod tests {
         // Walkback: block 90 has L1 origin 40. 40 + 10 = 50, NOT > 50, so walkback stops.
         for n in 89u64..=100 {
             l2_chain_provider.blocks.push(L2BlockInfo {
-                block_info: BlockInfo { hash: test_block_hash(n), number: n, ..Default::default() },
+                block_info: BlockInfo {
+                    hash: test_block_hash(n),
+                    number: n,
+                    parent_hash: test_block_hash(n - 1),
+                    ..Default::default()
+                },
                 l1_origin: BlockNumHash { number: n - 50, ..Default::default() },
                 seq_num: 0,
             });
@@ -443,7 +448,12 @@ mod tests {
         let mut pipeline = DerivationPipeline::new(attributes, rollup_config, l2_chain_provider);
 
         let l2_safe_head = L2BlockInfo {
-            block_info: BlockInfo { hash: test_block_hash(100), number: 100, ..Default::default() },
+            block_info: BlockInfo {
+                hash: test_block_hash(100),
+                number: 100,
+                parent_hash: test_block_hash(99),
+                ..Default::default()
+            },
             l1_origin: BlockNumHash { number: 50, ..Default::default() },
             seq_num: 0,
         };
@@ -471,12 +481,22 @@ mod tests {
 
         let mut l2_chain_provider = TestL2ChainProvider::default();
         l2_chain_provider.blocks.push(L2BlockInfo {
-            block_info: BlockInfo { hash: test_block_hash(5), number: 5, ..Default::default() },
+            block_info: BlockInfo {
+                hash: test_block_hash(5),
+                number: 5,
+                parent_hash: test_block_hash(4),
+                ..Default::default()
+            },
             l1_origin: BlockNumHash { number: 3, ..Default::default() },
             seq_num: 0,
         });
         l2_chain_provider.blocks.push(L2BlockInfo {
-            block_info: BlockInfo { hash: test_block_hash(6), number: 6, ..Default::default() },
+            block_info: BlockInfo {
+                hash: test_block_hash(6),
+                number: 6,
+                parent_hash: test_block_hash(5),
+                ..Default::default()
+            },
             l1_origin: BlockNumHash { number: 4, ..Default::default() },
             seq_num: 0,
         });
@@ -487,7 +507,12 @@ mod tests {
         let mut pipeline = DerivationPipeline::new(attributes, rollup_config, l2_chain_provider);
 
         let l2_safe_head = L2BlockInfo {
-            block_info: BlockInfo { hash: test_block_hash(6), number: 6, ..Default::default() },
+            block_info: BlockInfo {
+                hash: test_block_hash(6),
+                number: 6,
+                parent_hash: test_block_hash(5),
+                ..Default::default()
+            },
             l1_origin: BlockNumHash { number: 4, ..Default::default() },
             seq_num: 0,
         };

--- a/rust/kona/crates/protocol/derive/src/pipeline/core.rs
+++ b/rust/kona/crates/protocol/derive/src/pipeline/core.rs
@@ -71,9 +71,7 @@ where
                 .l2_chain_provider
                 .l2_block_info_by_hash(current.block_info.parent_hash)
                 .await
-                .map_err(|e| {
-                    PipelineError::Provider(alloc::string::ToString::to_string(&e)).temp()
-                })?;
+                .map_err(Into::<PipelineErrorKind>::into)?;
         }
 
         let system_config = self
@@ -261,7 +259,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{DerivationPipeline, test_utils::*};
+    use crate::{DerivationPipeline, ResetError, test_utils::*};
     use alloc::{string::ToString, sync::Arc};
     use alloy_rpc_types_engine::PayloadAttributes;
     use kona_genesis::{RollupConfig, SystemConfig};
@@ -465,6 +463,29 @@ mod tests {
             address!("000000000000000000000000000000000000aaaa"),
             "Expected old batcher from walked-back block 90"
         );
+    }
+
+    #[tokio::test]
+    async fn test_initial_reset_preserves_parent_lookup_error_kind() {
+        let rollup_config = Arc::new(RollupConfig { channel_timeout: 1, ..Default::default() });
+        let l2_chain_provider = TestL2ChainProvider::default();
+        let attributes = TestNextAttributes::default();
+        let mut pipeline = DerivationPipeline::new(attributes, rollup_config, l2_chain_provider);
+
+        let parent_hash = test_block_hash(1);
+        let l2_safe_head = L2BlockInfo {
+            block_info: BlockInfo {
+                hash: test_block_hash(2),
+                number: 2,
+                parent_hash,
+                ..Default::default()
+            },
+            l1_origin: BlockNumHash { number: 2, ..Default::default() },
+            seq_num: 0,
+        };
+
+        let err = pipeline.initial_reset(l2_safe_head).await.unwrap_err();
+        assert_eq!(err, ResetError::BlockNotFound(parent_hash.into()).reset());
     }
 
     #[tokio::test]

--- a/rust/kona/crates/protocol/derive/src/test_utils/chain_providers.rs
+++ b/rust/kona/crates/protocol/derive/src/test_utils/chain_providers.rs
@@ -1,7 +1,7 @@
 //! Test Utilities for chain provider traits
 
 use crate::{
-    errors::{PipelineError, PipelineErrorKind},
+    errors::{PipelineError, PipelineErrorKind, ResetError},
     traits::{ChainProvider, L2ChainProvider},
 };
 use alloc::{boxed::Box, string::ToString, sync::Arc, vec::Vec};
@@ -91,6 +91,9 @@ pub enum TestProviderError {
     /// The L2 block was not found.
     #[error("L2 Block not found")]
     L2BlockNotFound,
+    /// The L2 block was not found by hash.
+    #[error("L2 block {0} not found by hash")]
+    L2BlockHashNotFound(B256),
     /// The system config was not found.
     #[error("System config not found")]
     SystemConfigNotFound(B256),
@@ -98,7 +101,12 @@ pub enum TestProviderError {
 
 impl From<TestProviderError> for PipelineErrorKind {
     fn from(val: TestProviderError) -> Self {
-        PipelineError::Provider(val.to_string()).temp()
+        match val {
+            TestProviderError::L2BlockHashNotFound(hash) => {
+                ResetError::BlockNotFound(hash.into()).reset()
+            }
+            other => PipelineError::Provider(other.to_string()).temp(),
+        }
     }
 }
 
@@ -191,13 +199,17 @@ impl BatchValidationProvider for TestL2ChainProvider {
 
     async fn l2_block_info_by_hash(&mut self, hash: B256) -> Result<L2BlockInfo, Self::Error> {
         if self.short_circuit {
-            return self.blocks.first().copied().ok_or(TestProviderError::BlockNotFound);
+            return self
+                .blocks
+                .first()
+                .copied()
+                .ok_or(TestProviderError::L2BlockHashNotFound(hash));
         }
         self.blocks
             .iter()
             .find(|b| b.block_info.hash == hash)
             .copied()
-            .ok_or(TestProviderError::BlockNotFound)
+            .ok_or(TestProviderError::L2BlockHashNotFound(hash))
     }
 
     async fn block_by_number(&mut self, number: u64) -> Result<Arc<OpBlock>, Self::Error> {

--- a/rust/kona/crates/protocol/derive/src/test_utils/chain_providers.rs
+++ b/rust/kona/crates/protocol/derive/src/test_utils/chain_providers.rs
@@ -189,6 +189,17 @@ impl BatchValidationProvider for TestL2ChainProvider {
             .ok_or_else(|| TestProviderError::BlockNotFound)
     }
 
+    async fn l2_block_info_by_hash(&mut self, hash: B256) -> Result<L2BlockInfo, Self::Error> {
+        if self.short_circuit {
+            return self.blocks.first().copied().ok_or(TestProviderError::BlockNotFound);
+        }
+        self.blocks
+            .iter()
+            .find(|b| b.block_info.hash == hash)
+            .copied()
+            .ok_or(TestProviderError::BlockNotFound)
+    }
+
     async fn block_by_number(&mut self, number: u64) -> Result<Arc<OpBlock>, Self::Error> {
         self.op_blocks
             .iter()

--- a/rust/kona/crates/protocol/derive/src/test_utils/sys_config_fetcher.rs
+++ b/rust/kona/crates/protocol/derive/src/test_utils/sys_config_fetcher.rs
@@ -56,6 +56,10 @@ impl BatchValidationProvider for TestSystemConfigL2Fetcher {
     async fn l2_block_info_by_number(&mut self, _: u64) -> Result<L2BlockInfo, Self::Error> {
         unimplemented!()
     }
+
+    async fn l2_block_info_by_hash(&mut self, _: B256) -> Result<L2BlockInfo, Self::Error> {
+        unimplemented!()
+    }
 }
 
 #[async_trait]

--- a/rust/kona/crates/protocol/derive/src/traits/providers.rs
+++ b/rust/kona/crates/protocol/derive/src/traits/providers.rs
@@ -49,13 +49,14 @@ pub trait L2ChainProvider: BatchValidationProviderDerive {
 
 /// A super-trait for [`BatchValidationProvider`] that binds `Self::Error` to have a conversion into
 /// [`PipelineErrorKind`].
-pub trait BatchValidationProviderDerive: BatchValidationProvider {}
+pub trait BatchValidationProviderDerive:
+    BatchValidationProvider<Error: Into<PipelineErrorKind>>
+{
+}
 
 // Auto-implement the [BatchValidationProviderDerive] trait for all types that implement
 // [BatchValidationProvider] where the error can be converted into [PipelineErrorKind].
-impl<T> BatchValidationProviderDerive for T
-where
-    T: BatchValidationProvider,
-    <T as BatchValidationProvider>::Error: Into<PipelineErrorKind>,
+impl<T> BatchValidationProviderDerive for T where
+    T: BatchValidationProvider<Error: Into<PipelineErrorKind>>
 {
 }

--- a/rust/kona/crates/protocol/protocol/src/batch/traits.rs
+++ b/rust/kona/crates/protocol/protocol/src/batch/traits.rs
@@ -1,6 +1,7 @@
 //! Traits for working with protocol types.
 
 use alloc::{boxed::Box, sync::Arc};
+use alloy_primitives::B256;
 use async_trait::async_trait;
 use core::fmt::Display;
 use op_alloy_consensus::OpBlock;
@@ -15,8 +16,16 @@ pub trait BatchValidationProvider {
 
     /// Returns the [`L2BlockInfo`] given a block number.
     ///
+    /// Answers which block is canonical at that height, so it can only be served by a source that
+    /// tracks the chain. Prefer [`Self::l2_block_info_by_hash`] where the caller holds the hash.
+    ///
     /// Errors if the block does not exist.
     async fn l2_block_info_by_number(&mut self, number: u64) -> Result<L2BlockInfo, Self::Error>;
+
+    /// Returns the [`L2BlockInfo`] for the block with the given hash.
+    ///
+    /// Errors if the block does not exist.
+    async fn l2_block_info_by_hash(&mut self, hash: B256) -> Result<L2BlockInfo, Self::Error>;
 
     /// Returns the [`OpBlock`] for a given number.
     ///

--- a/rust/kona/crates/protocol/protocol/src/test_utils.rs
+++ b/rust/kona/crates/protocol/protocol/src/test_utils.rs
@@ -1,7 +1,7 @@
 //! Test utilities for the protocol crate.
 
 use alloc::{boxed::Box, format, string::String, sync::Arc, vec::Vec};
-use alloy_primitives::hex;
+use alloy_primitives::{B256, hex};
 use async_trait::async_trait;
 use op_alloy_consensus::OpBlock;
 use spin::Mutex;
@@ -74,6 +74,17 @@ impl BatchValidationProvider for TestBatchValidator {
             .find(|b| b.block_info.number == number)
             .copied()
             .ok_or_else(|| TestBatchValidatorError::BlockNotFound)
+    }
+
+    async fn l2_block_info_by_hash(&mut self, hash: B256) -> Result<L2BlockInfo, Self::Error> {
+        if self.short_circuit {
+            return self.blocks.first().copied().ok_or(TestBatchValidatorError::BlockNotFound);
+        }
+        self.blocks
+            .iter()
+            .find(|b| b.block_info.hash == hash)
+            .copied()
+            .ok_or(TestBatchValidatorError::BlockNotFound)
     }
 
     async fn block_by_number(&mut self, number: u64) -> Result<Arc<OpBlock>, Self::Error> {

--- a/rust/kona/crates/providers/providers-alloy/src/buffered_l2_chain_provider.rs
+++ b/rust/kona/crates/providers/providers-alloy/src/buffered_l2_chain_provider.rs
@@ -38,6 +38,13 @@ impl BatchValidationProvider for BufferedAlloyL2ChainProvider {
         self.rpc.l2_block_info_by_number(number).await
     }
 
+    async fn l2_block_info_by_hash(&mut self, hash: B256) -> Result<L2BlockInfo, Self::Error> {
+        match self.buffered.l2_block_info_by_hash(hash).await {
+            Ok(block_info) => Ok(block_info),
+            Err(_) => self.rpc.l2_block_info_by_hash(hash).await,
+        }
+    }
+
     async fn block_by_number(&mut self, number: u64) -> Result<Arc<OpBlock>, Self::Error> {
         self.rpc.block_by_number(number).await
     }

--- a/rust/kona/crates/providers/providers-alloy/src/l2_chain_provider.rs
+++ b/rust/kona/crates/providers/providers-alloy/src/l2_chain_provider.rs
@@ -175,6 +175,9 @@ pub enum AlloyL2ChainProviderError {
     /// Failed to construct [`L2BlockInfo`] from the block and genesis.
     #[error("Failed to construct L2BlockInfo from block {0} and genesis")]
     L2BlockInfoConstruction(u64),
+    /// Failed to construct [`L2BlockInfo`] from the block with the given hash and genesis.
+    #[error("Failed to construct L2BlockInfo from block {0} and genesis")]
+    L2BlockInfoConstructionByHash(B256),
     /// Failed to convert the block into a [`SystemConfig`].
     #[error("Failed to convert block {0} into SystemConfig")]
     SystemConfigConversion(B256),
@@ -193,7 +196,8 @@ impl From<AlloyL2ChainProviderError> for PipelineErrorKind {
             AlloyL2ChainProviderError::BlockHashNotFound(hash) => {
                 ResetError::BlockNotFound(hash.into()).reset()
             }
-            AlloyL2ChainProviderError::L2BlockInfoConstruction(_) => Self::Temporary(
+            AlloyL2ChainProviderError::L2BlockInfoConstruction(_) |
+            AlloyL2ChainProviderError::L2BlockInfoConstructionByHash(_) => Self::Temporary(
                 PipelineError::Provider("L2 block info construction failed".to_string()),
             ),
             AlloyL2ChainProviderError::SystemConfigConversion(_) => Self::Temporary(
@@ -214,6 +218,12 @@ impl BatchValidationProvider for AlloyL2ChainProvider {
             .map_err(|_| AlloyL2ChainProviderError::BlockNotFound(number))?;
         L2BlockInfo::from_block_and_genesis(&block, &self.rollup_config.genesis)
             .map_err(|_| AlloyL2ChainProviderError::L2BlockInfoConstruction(number))
+    }
+
+    async fn l2_block_info_by_hash(&mut self, hash: B256) -> Result<L2BlockInfo, Self::Error> {
+        let block = self.block_by_hash(hash).await?;
+        L2BlockInfo::from_block_and_genesis(&block, &self.rollup_config.genesis)
+            .map_err(|_| AlloyL2ChainProviderError::L2BlockInfoConstructionByHash(hash))
     }
 
     async fn block_by_number(&mut self, number: u64) -> Result<Arc<OpBlock>, Self::Error> {

--- a/rust/kona/crates/providers/providers-local/src/buffered.rs
+++ b/rust/kona/crates/providers/providers-local/src/buffered.rs
@@ -242,6 +242,22 @@ impl BatchValidationProvider for BufferedL2Provider {
 
         Ok(cached_block.l2_block_info)
     }
+
+    async fn l2_block_info_by_hash(&mut self, hash: B256) -> Result<L2BlockInfo, Self::Error> {
+        let cached_block = self.buffer.get_block_by_hash(hash);
+
+        #[cfg(feature = "metrics")]
+        {
+            use crate::Metrics;
+            if cached_block.is_some() {
+                kona_macros::inc!(gauge, Metrics::BUFFERED_PROVIDER_CACHE_HITS, "method" => "l2_block_info_by_hash");
+            } else {
+                kona_macros::inc!(gauge, Metrics::BUFFERED_PROVIDER_CACHE_MISSES, "method" => "l2_block_info_by_hash");
+            }
+        }
+
+        Ok(cached_block.ok_or(BufferedProviderError::BlockHashNotFound(hash))?.l2_block_info)
+    }
 }
 
 /// Errors that can occur in the buffered provider


### PR DESCRIPTION
> Stacked on #22466.

Same drift as #22465, in the same function. op-node's `initialReset` walks back by parent hash; kona walked back by decrementing a height while holding the parent hash it needed:

```go
// op-node pipeline.go:245
parent, err := dp.l2.L2BlockRefByHash(ctx, pipelineL2.ParentHash)
```
```rust
// kona pipeline/core.rs, before
.l2_block_info_by_number(current.block_info.number - 1)
```

Adds `BatchValidationProvider::l2_block_info_by_hash` and uses it for the walk-back and for the proof pipeline cursor, which likewise had the safe header in hand (`safe_header: Sealed<Header>`) and asked by number anyway. Asking by hash pins each step to one specific block, lets the node's block buffer answer it, and lets the oracle provider address the header directly instead of walking back from the safe head.

`l2_block_info_by_number` stays. Span batch validation asks which block is canonical at a computed height and only then checks the batch's claimed parent against it — the claim is untrusted input, so it cannot be the key. op-node keeps both methods for the same reason (`L2BlockRefByNumber` at `batches.go:273`, `L2BlockRefByHash` at `pipeline.go:245`).

The reset walk-back tests previously gave every fixture block `parent_hash: B256::ZERO`, so they only ever exercised the height arithmetic. They are now a real linked chain, which is what makes them cover the traversal.

## Second commit: preserve reset errors during the walk-back (#22475, by @joshklop)

Making the walk-back hash-keyed exposed a latent defect. `initial_reset` flattened every parent lookup failure into a temporary provider error, so the `BlockHashNotFound -> ResetError::BlockNotFound` classification that #22465 introduced was produced and then stringified away. A reorged-out parent would have left the pipeline retrying a lookup that can never succeed instead of resetting. op-node returns `NewResetError` on the same fetch (`pipeline.go:247`).

The fix preserves the provider's error kind, and expresses the existing `Into<PipelineErrorKind>` requirement as an associated-type bound on `BatchValidationProviderDerive` so generic callers can use the conversion.

One deliberate deviation worth recording: preserving the provider's classification means a *transport* failure on that lookup stays `Temporary`, where op-node returns `NewResetError` unconditionally. That looks like the better behaviour — a transient RPC blip should not force a pipeline reset, and it can only affect the retry path, not the derived chain — but it is a difference from op-node rather than an oversight.

Part of #22432.

🤖 *Co-created with Claude Opus 5*
