### PR TITLE
contracts-bedrock: Add missing StandardValidator assertions

### DIFF
--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -20,8 +20,8 @@
     "sourceCodeHash": "0x0ef8461e8bc55314e61e60924465574db17bdf30bbbfe9739b52cac623bba2db"
   },
   "src/L1/OPContractsManagerStandardValidator.sol:OPContractsManagerStandardValidator": {
-    "initCodeHash": "0x0efca7e5a55d7958ed35f5a66e1e50c1b24f02acc817a43980bfc76b528140d9",
-    "sourceCodeHash": "0xa2cee81c7b1be17227c883f78cbe18b473a901fcb4da4466b53cc94d42a2611f"
+    "initCodeHash": "0xb73f5009c294d528b93afade71848333359f97887b2ae2b6d62a825af0bf872b",
+    "sourceCodeHash": "0x5fcdf107f058376ea44ecf6fd5aa23ef4a9a12ffa8b19f2e15bd5c9fe52e7a00"
   },
   "src/L1/OptimismPortal2.sol:OptimismPortal2": {
     "initCodeHash": "0x67bbf6c9b344870cdbd7b041ddad6fb69057a4b48ec6dd96876af55d14fc1943",
@@ -36,8 +36,8 @@
     "sourceCodeHash": "0xceeedf69dcb6c05b88fd1569c53606dec02195b4d393a6491876b6d2f0c2ff1f"
   },
   "src/L1/opcm/OPContractsManagerV2.sol:OPContractsManagerV2": {
-    "initCodeHash": "0x9fc4e59fc030710f9efc653b648c1d021515abdddc294d19cee5cd8891f96987",
-    "sourceCodeHash": "0xb0d348a418fbb31cd9e3b0c9e9621f345fb70987a77ecee8658317d00a878326"
+    "initCodeHash": "0x81553faee6dfead8f15319088db35dde88ddb8196a99c4df9f7eb7569b72b86f",
+    "sourceCodeHash": "0x55e34a11ced7e8b135e01d3a661276ab94173a6d92255c092c2ba44d25afc31d"
   },
   "src/L2/BaseFeeVault.sol:BaseFeeVault": {
     "initCodeHash": "0x18650c65fa6f23fefc6f0c5fff605f12be99fce0bfbcbc0644403138e4c8bb12",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -20,8 +20,8 @@
     "sourceCodeHash": "0x0ef8461e8bc55314e61e60924465574db17bdf30bbbfe9739b52cac623bba2db"
   },
   "src/L1/OPContractsManagerStandardValidator.sol:OPContractsManagerStandardValidator": {
-    "initCodeHash": "0xb73f5009c294d528b93afade71848333359f97887b2ae2b6d62a825af0bf872b",
-    "sourceCodeHash": "0x5fcdf107f058376ea44ecf6fd5aa23ef4a9a12ffa8b19f2e15bd5c9fe52e7a00"
+    "initCodeHash": "0x8678105da10b320addd21fdc48b820a75b20629c46c2397d936018d09e7cde97",
+    "sourceCodeHash": "0xf2e567392187bf2c8cd1b39525f7be2ee393f5cd2b6a57b98ed1ac36c0f37505"
   },
   "src/L1/OptimismPortal2.sol:OptimismPortal2": {
     "initCodeHash": "0x67bbf6c9b344870cdbd7b041ddad6fb69057a4b48ec6dd96876af55d14fc1943",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -20,8 +20,8 @@
     "sourceCodeHash": "0x0ef8461e8bc55314e61e60924465574db17bdf30bbbfe9739b52cac623bba2db"
   },
   "src/L1/OPContractsManagerStandardValidator.sol:OPContractsManagerStandardValidator": {
-    "initCodeHash": "0x5a98e583c7346965800a2f9502e9e8b08289ab6a08125a83bf638896f867bf75",
-    "sourceCodeHash": "0x62d04258c345b1ab8340e37ddc077cf8fa1b28c5ca2127c9ffa0d93f39675112"
+    "initCodeHash": "0x0efca7e5a55d7958ed35f5a66e1e50c1b24f02acc817a43980bfc76b528140d9",
+    "sourceCodeHash": "0xa2cee81c7b1be17227c883f78cbe18b473a901fcb4da4466b53cc94d42a2611f"
   },
   "src/L1/OptimismPortal2.sol:OptimismPortal2": {
     "initCodeHash": "0x67bbf6c9b344870cdbd7b041ddad6fb69057a4b48ec6dd96876af55d14fc1943",
@@ -36,8 +36,8 @@
     "sourceCodeHash": "0xceeedf69dcb6c05b88fd1569c53606dec02195b4d393a6491876b6d2f0c2ff1f"
   },
   "src/L1/opcm/OPContractsManagerV2.sol:OPContractsManagerV2": {
-    "initCodeHash": "0x81553faee6dfead8f15319088db35dde88ddb8196a99c4df9f7eb7569b72b86f",
-    "sourceCodeHash": "0x55e34a11ced7e8b135e01d3a661276ab94173a6d92255c092c2ba44d25afc31d"
+    "initCodeHash": "0x9fc4e59fc030710f9efc653b648c1d021515abdddc294d19cee5cd8891f96987",
+    "sourceCodeHash": "0xb0d348a418fbb31cd9e3b0c9e9621f345fb70987a77ecee8658317d00a878326"
   },
   "src/L2/BaseFeeVault.sol:BaseFeeVault": {
     "initCodeHash": "0x18650c65fa6f23fefc6f0c5fff605f12be99fce0bfbcbc0644403138e4c8bb12",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -20,8 +20,8 @@
     "sourceCodeHash": "0x0ef8461e8bc55314e61e60924465574db17bdf30bbbfe9739b52cac623bba2db"
   },
   "src/L1/OPContractsManagerStandardValidator.sol:OPContractsManagerStandardValidator": {
-    "initCodeHash": "0x8678105da10b320addd21fdc48b820a75b20629c46c2397d936018d09e7cde97",
-    "sourceCodeHash": "0xf2e567392187bf2c8cd1b39525f7be2ee393f5cd2b6a57b98ed1ac36c0f37505"
+    "initCodeHash": "0x13cc3e8d9c1907fa6108667848d07bf8a4cc79790392abc9e5dfce7a3768b4d0",
+    "sourceCodeHash": "0xac01c00c951bfab0bcb1fe917803a8b6393902d54bc131387f24f8cb7e59923d"
   },
   "src/L1/OptimismPortal2.sol:OptimismPortal2": {
     "initCodeHash": "0x67bbf6c9b344870cdbd7b041ddad6fb69057a4b48ec6dd96876af55d14fc1943",

--- a/packages/contracts-bedrock/src/L1/OPContractsManagerStandardValidator.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManagerStandardValidator.sol
@@ -46,8 +46,8 @@ import { IBigStepper } from "interfaces/dispute/IBigStepper.sol";
 /// before and after an upgrade.
 contract OPContractsManagerStandardValidator is ISemver {
     /// @notice The semantic version of the OPContractsManagerStandardValidator contract.
-    /// @custom:semver 3.4.0
-    string public constant version = "3.4.0";
+    /// @custom:semver 3.5.0
+    string public constant version = "3.5.0";
 
     /// @notice The SuperchainConfig contract.
     ISuperchainConfig public superchainConfig;
@@ -859,6 +859,33 @@ contract OPContractsManagerStandardValidator is ISemver {
         });
     }
 
+    /// @notice Returns whether the respected game type is one the selected validation branch
+    ///         requires to be registered. The ZK game is a super game type, but it is a per-chain
+    ///         opt-in, so it only counts as validated when its dev feature is enabled and the
+    ///         factory registers an implementation for it.
+    function isRespectedGameTypeValidated(
+        GameType _gameType,
+        bool _isSuperMode,
+        ISystemConfig _sysCfg
+    )
+        internal
+        view
+        returns (bool)
+    {
+        uint32 raw = _gameType.raw();
+        if (!_isSuperMode) {
+            return raw == GameTypes.PERMISSIONED_CANNON.raw() || raw == GameTypes.CANNON_KONA.raw();
+        }
+        if (raw == GameTypes.SUPER_PERMISSIONED.raw() || raw == GameTypes.SUPER_CANNON_KONA.raw()) {
+            return true;
+        }
+        if (raw != GameTypes.ZK_DISPUTE_GAME.raw()) {
+            return false;
+        }
+        return DevFeatures.isDevFeatureEnabled(devFeatureBitmap, DevFeatures.ZK_DISPUTE_GAME)
+            && address(IDisputeGameFactory(_sysCfg.disputeGameFactory()).gameImpls(GameTypes.ZK_DISPUTE_GAME)) != address(0);
+    }
+
     /// @notice Validates the configuration of the L1 contracts.
     function validate(ValidationInput memory _input, bool _allowFailure) external view returns (string memory) {
         ValidationInputDev memory devInput = _toValidationInputDev(_input);
@@ -912,25 +939,12 @@ contract OPContractsManagerStandardValidator is ISemver {
         _errors = assertValidOptimismPortal(_errors, _input.sysCfg, _proxyAdmin);
         _errors = assertValidDisputeGameFactory(_errors, _input.sysCfg, _proxyAdmin, _overrides);
 
-        IAnchorStateRegistry asr = IOptimismPortal2(payable(_input.sysCfg.optimismPortal())).anchorStateRegistry();
-        // Left as CANNON, which no branch accepts, when the registry is not a contract: reporting
-        // ASR-RGT keeps the remaining errors readable instead of reverting the whole run.
-        GameType rgt;
-        if (address(asr).code.length > 0) {
-            rgt = asr.respectedGameType();
-        }
-        bool isSuperMode = false;
-        if (DevFeatures.isDevFeatureEnabled(devFeatureBitmap, DevFeatures.SUPER_ROOT_GAMES_MIGRATION)) {
-            isSuperMode = GameTypes.isSuperGame(rgt);
-        }
+        GameType rgt =
+            IOptimismPortal2(payable(_input.sysCfg.optimismPortal())).anchorStateRegistry().respectedGameType();
+        bool isSuperMode = DevFeatures.isDevFeatureEnabled(devFeatureBitmap, DevFeatures.SUPER_ROOT_GAMES_MIGRATION)
+            && GameTypes.isSuperGame(rgt);
 
-        _errors = internalRequire(
-            isSuperMode
-                ? (rgt.raw() == GameTypes.SUPER_PERMISSIONED.raw() || rgt.raw() == GameTypes.SUPER_CANNON_KONA.raw())
-                : (rgt.raw() == GameTypes.PERMISSIONED_CANNON.raw() || rgt.raw() == GameTypes.CANNON_KONA.raw()),
-            "ASR-RGT",
-            _errors
-        );
+        _errors = internalRequire(isRespectedGameTypeValidated(rgt, isSuperMode, _input.sysCfg), "ASR-RGT", _errors);
 
         if (isSuperMode) {
             _errors = assertValidSuperRootDisputeGames(_errors, _input.sysCfg);

--- a/packages/contracts-bedrock/src/L1/OPContractsManagerStandardValidator.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManagerStandardValidator.sol
@@ -882,8 +882,11 @@ contract OPContractsManagerStandardValidator is ISemver {
         if (raw != GameTypes.ZK_DISPUTE_GAME.raw()) {
             return false;
         }
-        return DevFeatures.isDevFeatureEnabled(devFeatureBitmap, DevFeatures.ZK_DISPUTE_GAME)
-            && address(IDisputeGameFactory(_sysCfg.disputeGameFactory()).gameImpls(GameTypes.ZK_DISPUTE_GAME)) != address(0);
+        if (!DevFeatures.isDevFeatureEnabled(devFeatureBitmap, DevFeatures.ZK_DISPUTE_GAME)) {
+            return false;
+        }
+        IDisputeGameFactory factory = IDisputeGameFactory(_sysCfg.disputeGameFactory());
+        return address(factory.gameImpls(GameTypes.ZK_DISPUTE_GAME)) != address(0);
     }
 
     /// @notice Validates the configuration of the L1 contracts.
@@ -1107,6 +1110,8 @@ contract OPContractsManagerStandardValidator is ISemver {
             _errors
         );
         _errors = internalRequire(args.challengerBond > 0, string.concat(_errorPrefix, "-110"), _errors);
+        (Hash anchorRoot,) = IAnchorStateRegistry(args.anchorStateRegistry).getAnchorRoot();
+        _errors = internalRequire(Hash.unwrap(anchorRoot) != bytes32(0), string.concat(_errorPrefix, "-120"), _errors);
         _errors = standardValidatorUtils.assertValidDelayedWETH(
             _errors,
             _sysCfg,
@@ -1126,8 +1131,6 @@ contract OPContractsManagerStandardValidator is ISemver {
             anchorStateRegistryImpl,
             _errorPrefix
         );
-        (Hash anchorRoot,) = IAnchorStateRegistry(args.anchorStateRegistry).getAnchorRoot();
-        _errors = internalRequire(Hash.unwrap(anchorRoot) != bytes32(0), string.concat(_errorPrefix, "-120"), _errors);
         return _errors;
     }
 

--- a/packages/contracts-bedrock/src/L1/OPContractsManagerStandardValidator.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManagerStandardValidator.sol
@@ -1170,7 +1170,11 @@ contract OPContractsManagerStandardValidator is ISemver {
         );
         _errors =
             internalRequire(gameImpl.gameAddress == zkDisputeGameImpl, string.concat(errorPrefix, "-150"), _errors);
-        return _assertValidZKGameArgs(_errors, _sysCfg, _admin, _overrides, errorPrefix);
+        _errors = _assertValidZKGameArgs(_errors, _sysCfg, _admin, _overrides, errorPrefix);
+        // ZK game creation is permissionless, so a zero init bond leaves root claims free to spam.
+        return internalRequire(
+            _factory.initBonds(GameTypes.ZK_DISPUTE_GAME) > 0, string.concat(errorPrefix, "-160"), _errors
+        );
     }
 
     /// @notice Internal function to read all information from a dispute game.

--- a/packages/contracts-bedrock/src/L1/OPContractsManagerStandardValidator.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManagerStandardValidator.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.15;
 
 // Libraries
 import { LibString } from "@solady/utils/LibString.sol";
-import { GameType, Claim, GameTypes } from "src/dispute/lib/Types.sol";
+import { GameType, Claim, GameTypes, Hash } from "src/dispute/lib/Types.sol";
 import { Predeploys } from "src/libraries/Predeploys.sol";
 import { Features } from "src/libraries/Features.sol";
 import { DevFeatures } from "src/libraries/DevFeatures.sol";
@@ -630,6 +630,12 @@ contract OPContractsManagerStandardValidator is ISemver {
             _buildDisputeGameConfig(_overrides)
         );
 
+        _errors = internalRequire(
+            IDisputeGameFactory(_sysCfg.disputeGameFactory()).initBonds(_gameType) > 0,
+            string.concat(_errorPrefix, "-160"),
+            _errors
+        );
+
         return _errors;
     }
 
@@ -906,14 +912,25 @@ contract OPContractsManagerStandardValidator is ISemver {
         _errors = assertValidOptimismPortal(_errors, _input.sysCfg, _proxyAdmin);
         _errors = assertValidDisputeGameFactory(_errors, _input.sysCfg, _proxyAdmin, _overrides);
 
-        // Determine if the chain is in super game mode by checking the ASR's respectedGameType.
+        IAnchorStateRegistry asr = IOptimismPortal2(payable(_input.sysCfg.optimismPortal())).anchorStateRegistry();
+        // Left as CANNON, which no branch accepts, when the registry is not a contract: reporting
+        // ASR-RGT keeps the remaining errors readable instead of reverting the whole run.
+        GameType rgt;
+        if (address(asr).code.length > 0) {
+            rgt = asr.respectedGameType();
+        }
         bool isSuperMode = false;
         if (DevFeatures.isDevFeatureEnabled(devFeatureBitmap, DevFeatures.SUPER_ROOT_GAMES_MIGRATION)) {
-            IOptimismPortal2 portal = IOptimismPortal2(payable(_input.sysCfg.optimismPortal()));
-            IAnchorStateRegistry asr = portal.anchorStateRegistry();
-            GameType rgt = asr.respectedGameType();
             isSuperMode = GameTypes.isSuperGame(rgt);
         }
+
+        _errors = internalRequire(
+            isSuperMode
+                ? (rgt.raw() == GameTypes.SUPER_PERMISSIONED.raw() || rgt.raw() == GameTypes.SUPER_CANNON_KONA.raw())
+                : (rgt.raw() == GameTypes.PERMISSIONED_CANNON.raw() || rgt.raw() == GameTypes.CANNON_KONA.raw()),
+            "ASR-RGT",
+            _errors
+        );
 
         if (isSuperMode) {
             _errors = assertValidSuperRootDisputeGames(_errors, _input.sysCfg);
@@ -1095,6 +1112,8 @@ contract OPContractsManagerStandardValidator is ISemver {
             anchorStateRegistryImpl,
             _errorPrefix
         );
+        (Hash anchorRoot,) = IAnchorStateRegistry(args.anchorStateRegistry).getAnchorRoot();
+        _errors = internalRequire(Hash.unwrap(anchorRoot) != bytes32(0), string.concat(_errorPrefix, "-120"), _errors);
         return _errors;
     }
 

--- a/packages/contracts-bedrock/src/L1/opcm/StandardValidatorUtils.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/StandardValidatorUtils.sol
@@ -293,8 +293,6 @@ contract StandardValidatorUtils {
         );
         _errors = internalRequire(_admin.getProxyImplementation(address(_portal)) == _impl, "PORTAL-20", _errors);
 
-        IDisputeGameFactory _dgf = IDisputeGameFactory(_sysCfg.disputeGameFactory());
-        _errors = internalRequire(address(_portal.disputeGameFactory()) == address(_dgf), "PORTAL-30", _errors);
         _errors = internalRequire(address(_portal.systemConfig()) == address(_sysCfg), "PORTAL-40", _errors);
         _errors = internalRequire(_portal.l2Sender() == Constants.DEFAULT_L2_SENDER, "PORTAL-80", _errors);
         _errors = internalRequire(IProxyAdminOwnedBase(address(_portal)).proxyAdmin() == _admin, "PORTAL-90", _errors);
@@ -359,6 +357,7 @@ contract StandardValidatorUtils {
         _errors = internalRequire(
             IProxyAdminOwnedBase(address(_weth)).proxyAdmin() == _admin, string.concat(_errorPrefix, "-60"), _errors
         );
+        _errors = internalRequire(address(_weth) == _sysCfg.delayedWETH(), string.concat(_errorPrefix, "-70"), _errors);
         return _errors;
     }
 

--- a/packages/contracts-bedrock/test/L1/OPContractsManagerStandardValidator.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManagerStandardValidator.t.sol
@@ -1338,12 +1338,18 @@ contract OPContractsManagerStandardValidator_AnchorStateRegistry_Test is
     /// @notice Tests that the validate function successfully returns the right error when the
     ///         AnchorStateRegistry in the game args is not the one the OptimismPortal uses.
     function test_validate_anchorStateRegistryNotUsedByPortal_succeeds() public {
+        address otherAsr = makeAddr("otherAnchorStateRegistry");
         vm.mockCall(
-            address(optimismPortal2),
-            abi.encodeCall(IOptimismPortal2.anchorStateRegistry, ()),
-            abi.encode(address(0xbad))
+            address(optimismPortal2), abi.encodeCall(IOptimismPortal2.anchorStateRegistry, ()), abi.encode(otherAsr)
         );
-        assertEq("ASR-RGT,PDDG-ANCHORP-70,CKDG-ANCHORP-70", _validate(true));
+        // The validator reads the respected game type from whatever registry the portal reports, so
+        // the stand-in must answer with the type this chain actually runs.
+        vm.mockCall(
+            otherAsr,
+            abi.encodeCall(IAnchorStateRegistry.respectedGameType, ()),
+            abi.encode(anchorStateRegistry.respectedGameType())
+        );
+        assertEq("PDDG-ANCHORP-70,CKDG-ANCHORP-70", _validate(true));
     }
 
     /// @notice Tests that the validate function successfully returns the right error when the
@@ -2511,6 +2517,34 @@ contract OPContractsManagerStandardValidator_ZKValidation_Test is
             abi.encode(Hash.wrap(bytes32(0)), uint256(0))
         );
         assertEq("SPDG-120,SCKDG-120,ZKDG-120", _validate(true));
+    }
+
+    /// @notice Tests that respecting ZK_DISPUTE_GAME is valid. It is a super game type that the ZK
+    ///         path registers, so ASR-RGT must not fire on a ZK-respecting chain.
+    function test_validate_zkRespectedGameType_succeeds() public {
+        IOptimismPortal2 portal = IOptimismPortal2(payable(systemConfig.optimismPortal()));
+        vm.mockCall(
+            address(portal.anchorStateRegistry()),
+            abi.encodeCall(IAnchorStateRegistry.respectedGameType, ()),
+            abi.encode(GameTypes.ZK_DISPUTE_GAME)
+        );
+        assertEq("", _validate(false));
+    }
+
+    /// @notice Tests ASR-RGT when the chain respects ZK_DISPUTE_GAME but opts out of the ZK game.
+    ///         Nothing else reports it: ZK validation returns early when no implementation is
+    ///         registered, so withdrawals would sit behind a game type that cannot resolve.
+    function test_validate_zkRespectedGameTypeWithoutImplementation_succeeds() public {
+        IOptimismPortal2 portal = IOptimismPortal2(payable(systemConfig.optimismPortal()));
+        vm.mockCall(
+            address(portal.anchorStateRegistry()),
+            abi.encodeCall(IAnchorStateRegistry.respectedGameType, ()),
+            abi.encode(GameTypes.ZK_DISPUTE_GAME)
+        );
+        vm.mockCall(
+            address(dgf), abi.encodeCall(IDisputeGameFactory.gameImpls, (GameTypes.ZK_DISPUTE_GAME)), abi.encode(0)
+        );
+        assertEq("ASR-RGT", _validate(true));
     }
 }
 

--- a/packages/contracts-bedrock/test/L1/OPContractsManagerStandardValidator.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManagerStandardValidator.t.sol
@@ -840,17 +840,6 @@ contract OPContractsManagerStandardValidator_OptimismPortal_Test is OPContractsM
     }
 
     /// @notice Tests that the validate function successfully returns the right error when the
-    ///         OptimismPortal disputeGameFactory is invalid.
-    function test_validate_optimismPortalInvalidDisputeGameFactory_succeeds() public {
-        vm.mockFunction(
-            address(optimismPortal2),
-            address(badDisputeGameFactoryReturner),
-            abi.encodeCall(IOptimismPortal2.disputeGameFactory, ())
-        );
-        assertEq("PORTAL-30", _validate(true));
-    }
-
-    /// @notice Tests that the validate function successfully returns the right error when the
     ///         OptimismPortal systemConfig is invalid.
     function test_validate_optimismPortalInvalidSystemConfig_succeeds() public {
         vm.mockCall(
@@ -1172,7 +1161,7 @@ contract OPContractsManagerStandardValidator_PermissionedDisputeGame_Test is
         vm.mockCall(badWeth, abi.encodeCall(IDelayedWETH.systemConfig, ()), abi.encode(sysCfg));
         vm.mockCall(badWeth, abi.encodeCall(IProxyAdminOwnedBase.proxyAdmin, ()), abi.encode(proxyAdmin));
 
-        assertEq("PDDG-DWETH-10,PDDG-DWETH-20", _validate(true));
+        assertEq("PDDG-DWETH-10,PDDG-DWETH-20,PDDG-DWETH-70", _validate(true));
     }
 
     /// @notice Tests that the validate function successfully returns the right error when the
@@ -1354,7 +1343,18 @@ contract OPContractsManagerStandardValidator_AnchorStateRegistry_Test is
             abi.encodeCall(IOptimismPortal2.anchorStateRegistry, ()),
             abi.encode(address(0xbad))
         );
-        assertEq("PDDG-ANCHORP-70,CKDG-ANCHORP-70", _validate(true));
+        assertEq("ASR-RGT,PDDG-ANCHORP-70,CKDG-ANCHORP-70", _validate(true));
+    }
+
+    /// @notice Tests that the validate function successfully returns the right error when the
+    ///         AnchorStateRegistry respects a game type outside the validated set.
+    function test_validate_anchorStateRegistryInvalidRespectedGameType_succeeds() public {
+        vm.mockCall(
+            address(anchorStateRegistry),
+            abi.encodeCall(IAnchorStateRegistry.respectedGameType, ()),
+            abi.encode(GameTypes.ASTERISC)
+        );
+        assertEq("ASR-RGT", _validate(true));
     }
 }
 
@@ -1409,6 +1409,13 @@ contract OPContractsManagerStandardValidator_DelayedWETH_Test is OPContractsMana
             address(delayedWeth), abi.encodeCall(IProxyAdminOwnedBase.proxyAdmin, ()), abi.encode(address(0xbad))
         );
         assertEq("PDDG-DWETH-60,CKDG-DWETH-60", _validate(true));
+    }
+
+    /// @notice Tests that the validate function successfully returns the right error when the
+    ///         DelayedWETH the games use is not the one recorded on the SystemConfig.
+    function test_validate_delayedWETHNotSystemConfigDelayedWETH_succeeds() public {
+        vm.mockCall(address(systemConfig), abi.encodeCall(ISystemConfig.delayedWETH, ()), abi.encode(address(0xbad)));
+        assertEq("PDDG-DWETH-70,CKDG-DWETH-70", _validate(true));
     }
 }
 
@@ -1524,7 +1531,7 @@ contract OPContractsManagerStandardValidator_FaultDisputeGame_Test is OPContract
     ///         FaultDisputeGame (permissionless) CannonKona Weth address is invalid.
     function test_validate_faultDisputeGameInvalidCannonKonaWeth_succeeds() public {
         _mockInvalidWeth(GameTypes.CANNON_KONA);
-        assertEq("CKDG-DWETH-10,CKDG-DWETH-20", _validate(true));
+        assertEq("CKDG-DWETH-10,CKDG-DWETH-20,CKDG-DWETH-70", _validate(true));
     }
 
     function _mockInvalidWeth(GameType _gameType) internal {
@@ -1601,6 +1608,13 @@ contract OPContractsManagerStandardValidator_FaultDisputeGame_Test is OPContract
             address(fdgImpl), abi.encodeCall(IFaultDisputeGame.maxClockDuration, ()), abi.encode(Duration.wrap(1000))
         );
         assertEq("CKDG-110", _validate(true));
+    }
+
+    /// @notice Tests that the validate function successfully returns the right error when the
+    ///         FaultDisputeGame (permissionless) init bond is zero.
+    function test_validate_faultDisputeGameZeroInitBond_succeeds() public {
+        vm.mockCall(address(dgf), abi.encodeCall(IDisputeGameFactory.initBonds, (GameTypes.CANNON_KONA)), abi.encode(0));
+        assertEq("CKDG-160", _validate(true));
     }
 }
 
@@ -2116,6 +2130,36 @@ contract OPContractsManagerStandardValidator_SuperPermissionlessDisputeGame_Test
         vm.mockCall(gameArgs.weth, abi.encodeCall(IProxyAdminOwnedBase.proxyAdminOwner, ()), abi.encode(address(0xbad)));
         assertEq("SCKDG-DWETH-30", _validate(true));
     }
+
+    /// @notice Tests SCKDG-DWETH-70 when the DelayedWETH the game uses is not the one recorded on
+    ///         the SystemConfig.
+    function test_validate_superPermissionlessDisputeGameWethNotSystemConfigWeth_succeeds() public {
+        vm.mockCall(address(systemConfig), abi.encodeCall(ISystemConfig.delayedWETH, ()), abi.encode(address(0xbad)));
+        assertEq("SCKDG-DWETH-70", _validate(true));
+    }
+
+    /// @notice Tests SCKDG-160 when the SUPER_CANNON_KONA init bond is zero.
+    function test_validate_superPermissionlessDisputeGameZeroInitBond_succeeds() public {
+        vm.mockCall(
+            address(disputeGameFactory),
+            abi.encodeCall(IDisputeGameFactory.initBonds, (GameTypes.SUPER_CANNON_KONA)),
+            abi.encode(0)
+        );
+        assertEq("SCKDG-160", _validate(true));
+    }
+
+    /// @notice Tests ASR-RGT when the respected game type is a super game type outside the
+    ///         validated set. A super type keeps the validator on the super-mode branch, so only
+    ///         the respected-game-type assertion fires.
+    function test_validate_unexpectedRespectedGameType_succeeds() public {
+        IOptimismPortal2 portal = IOptimismPortal2(payable(systemConfig.optimismPortal()));
+        vm.mockCall(
+            address(portal.anchorStateRegistry()),
+            abi.encodeCall(IAnchorStateRegistry.respectedGameType, ()),
+            abi.encode(GameTypes.SUPER_CANNON)
+        );
+        assertEq("ASR-RGT", _validate(true));
+    }
 }
 
 /// @title OPContractsManagerStandardValidator_ZKDisputeGame_Test
@@ -2455,6 +2499,18 @@ contract OPContractsManagerStandardValidator_ZKValidation_Test is
             abi.encode(GameTypes.SUPER_CANNON_KONA)
         );
         assertEq("SPDG-ANCHORP-70,SCKDG-ANCHORP-70,ZKDG-ANCHORP-70", _validate(true));
+    }
+
+    /// @notice Tests ZKDG-120 when the AnchorStateRegistry the ZK game args point at has a zero
+    ///         anchor root. The super games share that registry, so they report it too.
+    function test_validate_zkDisputeGameZeroAnchorRoot_succeeds() public {
+        IOptimismPortal2 portal = IOptimismPortal2(payable(systemConfig.optimismPortal()));
+        vm.mockCall(
+            address(portal.anchorStateRegistry()),
+            abi.encodeCall(IAnchorStateRegistry.getAnchorRoot, ()),
+            abi.encode(Hash.wrap(bytes32(0)), uint256(0))
+        );
+        assertEq("SPDG-120,SCKDG-120,ZKDG-120", _validate(true));
     }
 }
 

--- a/packages/contracts-bedrock/test/L1/OPContractsManagerStandardValidator.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManagerStandardValidator.t.sol
@@ -2276,6 +2276,13 @@ abstract contract OPContractsManagerStandardValidator_ZKMode_TestInit is CommonT
                 abi.encodeCall(IDisputeGameFactory.gameArgs, (GameTypes.ZK_DISPUTE_GAME)),
                 abi.encode(zkArgs)
             );
+            // The real factory has no init bond for a game type that was never registered, so mock
+            // one alongside the implementation to keep ZKDG-160 satisfied.
+            vm.mockCall(
+                address(dgf),
+                abi.encodeCall(IDisputeGameFactory.initBonds, (GameTypes.ZK_DISPUTE_GAME)),
+                abi.encode(DEFAULT_DISPUTE_GAME_INIT_BOND)
+            );
 
             address l1PAOMultisig = standardValidator.l1PAOMultisig();
             vm.mockCall(address(proxyAdmin), abi.encodeCall(IProxyAdmin.owner, ()), abi.encode(l1PAOMultisig));
@@ -2545,6 +2552,15 @@ contract OPContractsManagerStandardValidator_ZKValidation_Test is
             address(dgf), abi.encodeCall(IDisputeGameFactory.gameImpls, (GameTypes.ZK_DISPUTE_GAME)), abi.encode(0)
         );
         assertEq("ASR-RGT", _validate(true));
+    }
+
+    /// @notice Tests ZKDG-160 when the ZK_DISPUTE_GAME init bond is zero. ZK game creation is
+    ///         permissionless, so a zero bond makes root claims free.
+    function test_validate_zkDisputeGameZeroInitBond_succeeds() public {
+        vm.mockCall(
+            address(dgf), abi.encodeCall(IDisputeGameFactory.initBonds, (GameTypes.ZK_DISPUTE_GAME)), abi.encode(0)
+        );
+        assertEq("ZKDG-160", _validate(true));
     }
 }
 

--- a/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerMigrationValidator.t.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerMigrationValidator.t.sol
@@ -510,7 +510,8 @@ contract OPContractsManagerMigrationValidator_SCKDG_Test is OPContractsManagerMi
     function test_validate_sckdgGargs30WrongWeth_succeeds() public {
         address badWeth = address(0xbad);
         DisputeGames.mockGameImplWeth(sharedDGF, GameTypes.SUPER_CANNON_KONA, badWeth);
-        // Mock the bad WETH to satisfy drill-down so only GARGS-30 (the cross-chain check) fires.
+        // Mock the bad WETH to satisfy drill-down, leaving GARGS-30 (the cross-chain check) and
+        // DWETH-70 (the SystemConfig binding), which no mock on the WETH itself can satisfy.
         vm.mockCall(badWeth, abi.encodeCall(ISemver.version, ()), abi.encode(ISemver(sharedWETH).version()));
         vm.mockCall(
             sharedProxyAdmin,
@@ -527,7 +528,7 @@ contract OPContractsManagerMigrationValidator_SCKDG_Test is OPContractsManagerMi
         );
         vm.mockCall(badWeth, abi.encodeCall(IDelayedWETH.systemConfig, ()), abi.encode(chainContracts1.systemConfig));
         vm.mockCall(badWeth, abi.encodeCall(IProxyAdminOwnedBase.proxyAdmin, ()), abi.encode(sharedProxyAdmin));
-        assertEq("MIG-SCKDG-GARGS-30", _validateMigration(true));
+        assertEq("MIG-SCKDG-GARGS-30,MIG-SCKDG-DWETH-70", _validateMigration(true));
     }
 
     /// @notice MIG-SCKDG-100: Wrong maxGameDepth on SCKDG game impl.


### PR DESCRIPTION
Adds five assertions the `StandardValidator` did not make, and removes one that could never fail.

**ASR-RGT** — the AnchorStateRegistry's respected game type must be one the selected branch actually validates. It gates withdrawal finalization, the guardian can change it at any time, and an OPCM upgrade carries the existing value forward rather than resetting it. A chain respecting an unregistered type validated clean while withdrawals were frozen. The migration validator and OPCM already enforce this; the standard validator was the only one that did not.

Super mode accepts `SUPER_PERMISSIONED`, `SUPER_CANNON_KONA`, and `ZK_DISPUTE_GAME`. ZK is a super game type, so a ZK-respecting chain stays on the super-mode branch, but it is a per-chain opt-in: it counts as validated only when the ZK dev feature is on and the factory registers an implementation. That closes the one gap nothing else covers — ZK validation returns early when no implementation is registered, so a chain respecting an opted-out ZK game would otherwise validate clean with withdrawals stuck behind a game type that cannot resolve.

**DWETH-70** — a game's DelayedWETH must equal `SystemConfig.delayedWETH()`. OPCM discovers the WETH for the next upgrade from that slot, so a disagreement silently repoints every game at a WETH whose delay, owner and implementation were never checked.

**-160** — permissionless game types must have a non-zero init bond. `setInitBond` is a separate call from `setImplementation`, so a partially applied upgrade can leave the implementation correct and root claims free to spam.

**ZKDG-120** — the ZK path now asserts a non-zero anchor root, which its sibling paths already did.

**ZKDG-160** — the ZK game needs a non-zero init bond too. `ZKDisputeGame.initialize` has no proposer allowlist and `DisputeGameFactory` forces `msg.value` to equal the type's init bond, so a zero bond leaves permissionless root claims free. It sits after the opt-out early return, so a chain without a registered ZK implementation is unaffected. The fork fixture mocks a ZK game onto a factory that never registered one, so it now mocks the init bond alongside the implementation.

**PORTAL-30 deleted.** It compared `_portal.disputeGameFactory()` against `_sysCfg.disputeGameFactory()`, but `SystemConfig.disputeGameFactory()` *is* `optimismPortal().disputeGameFactory()` on that same portal — both sides were the same call. Its test passed only because the mock returned a different address depending on `msg.sender`. `PORTAL-40` still binds portal to SystemConfig in the other direction.

The respected game type is read unconditionally. A registry without code cannot be special-cased usefully: `assertValidDisputeGameFactory` already discovers the factory through `portal.disputeGameFactory()`, which dereferences that same registry, so the run reverts before any guard here could report.

Checked against live OP Mainnet L1 state — respected type `8`, game WETH equal to `SystemConfig.delayedWETH()`, init bond 0.08 ETH — so none of the new assertions reject a valid chain.

Note: the non-super test suites are skipped because the harness always deploys a super-root chain, so tests added or changed there were verified by temporarily flipping `Config.devFeatureSuperRootGamesMigration()`. Equivalents were added to the super-mode and ZK suites, which do run. Two pre-existing expectations in the non-super suites are stale against `ANCHORP-70` on `develop`; they are left alone since that family goes away with #21662.

