### PR TITLE
op-conductor: avoid blocking WebSocket registration during shutdown

### DIFF
--- a/op-conductor/rpc/ws/server.go
+++ b/op-conductor/rpc/ws/server.go
@@ -204,8 +204,18 @@ func (h *Handler) serveWs(w http.ResponseWriter, r *http.Request) {
 
 	client := newClient(conn, r.Context(), h.hub, h.log)
 
-	// Register the client with the hub
-	h.hub.register <- client
+	// Register the client with the hub, but do not wait forever if shutdown has
+	// already stopped the hub or the request has been cancelled.
+	select {
+	case h.hub.register <- client:
+		// registered
+	case <-h.hub.done:
+		client.Close()
+		return
+	case <-r.Context().Done():
+		client.Close()
+		return
+	}
 	h.log.Info("WebSocket client connected")
 
 	// Start client handling

--- a/op-conductor/rpc/ws/server_test.go
+++ b/op-conductor/rpc/ws/server_test.go
@@ -589,3 +589,49 @@ func TestHubShutdown(t *testing.T) {
 
 	t.Log("Hub shutdown completed successfully")
 }
+
+// TestWebSocketRegistrationAfterHubShutdown verifies that a request accepted
+// while the HTTP server is still running after hub shutdown is not left
+// blocked on the hub's unbuffered registration channel.
+func TestWebSocketRegistrationAfterHubShutdown(t *testing.T) {
+	handler, tracker, server, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	// Stop the hub while keeping the HTTP listener alive to reproduce the
+	// shutdown window in Handler.Stop.
+	// The test server's handler must still be able to accept the request.
+	// Wait for stopped so the registration channel has no receiver.
+	//
+	// setupTestServer starts the hub before returning.
+	close(handler.hub.done)
+	select {
+	case <-handler.hub.stopped:
+	case <-time.After(2 * time.Second):
+		t.Fatal("hub shutdown timed out")
+	}
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/ws"
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	conn, resp, err := websocket.Dial(ctx, wsURL, nil)
+	if resp != nil && resp.Body != nil {
+		resp.Body.Close()
+	}
+	if err != nil {
+		t.Fatalf("failed to connect during hub shutdown: %v", err)
+	}
+	defer conn.CloseNow()
+
+	readCtx, readCancel := context.WithTimeout(context.Background(), time.Second)
+	defer readCancel()
+	_, _, err = conn.Read(readCtx)
+	if err == nil {
+		t.Fatal("expected the server to close the connection after hub shutdown")
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		t.Fatal("WebSocket handler remained blocked during hub shutdown")
+	}
+	if got := tracker.getClientCount(); got != 0 {
+		t.Fatalf("expected no clients to be registered after hub shutdown, got %d", got)
+	}
+}


### PR DESCRIPTION

**Description**

Prevent WebSocket handlers from blocking indefinitely when a connection is accepted while the op-conductor WebSocket hub is shutting down.

The hub uses an unbuffered registration channel. During shutdown, the hub may stop before the HTTP server finishes accepting requests. A newly upgraded WebSocket request could then block forever while sending the client to the registration channel.

This change makes WebSocket registration observe:

- Successful hub registration
- Hub shutdown
- Request context cancellation

When registration is rejected during shutdown or cancellation, the upgraded WebSocket connection is closed immediately.

**Tests**

Added `TestWebSocketRegistrationAfterHubShutdown`, which:

- Stops the WebSocket hub while keeping the HTTP listener active.
- Establishes a new WebSocket connection.
- Verifies that the handler does not remain blocked.
- Verifies that the connection is closed.
- Verifies that the client is not registered with the stopped hub.

Tests run:

```text
go test ./op-conductor/rpc/ws
go test -race ./op-conductor/rpc/ws -run 'TestWebSocketRegistrationAfterHubShutdown|TestHubShutdown' -count=1
```

**Additional context**

The existing shutdown ordering is preserved because `HTTPServer.Stop()` may wait for active WebSocket handlers. Closing the hub first allows existing clients and handlers to exit.

Changing the shutdown order alone would not eliminate the concurrent registration race, so registration now explicitly selects on the hub shutdown signal and request context.

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->

- Fixes https://github.com/ethereum-optimism/optimism/issues/22472
