### PR TITLE
kona-derive: Preserve reset errors during initial walk-back

### DIFF
--- a/rust/kona/crates/protocol/derive/src/pipeline/core.rs
+++ b/rust/kona/crates/protocol/derive/src/pipeline/core.rs
@@ -71,9 +71,7 @@ where
                 .l2_chain_provider
                 .l2_block_info_by_hash(current.block_info.parent_hash)
                 .await
-                .map_err(|e| {
-                    PipelineError::Provider(alloc::string::ToString::to_string(&e)).temp()
-                })?;
+                .map_err(Into::<PipelineErrorKind>::into)?;
         }
 
         let system_config = self
@@ -261,7 +259,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{DerivationPipeline, test_utils::*};
+    use crate::{DerivationPipeline, ResetError, test_utils::*};
     use alloc::{string::ToString, sync::Arc};
     use alloy_rpc_types_engine::PayloadAttributes;
     use kona_genesis::{RollupConfig, SystemConfig};
@@ -465,6 +463,29 @@ mod tests {
             address!("000000000000000000000000000000000000aaaa"),
             "Expected old batcher from walked-back block 90"
         );
+    }
+
+    #[tokio::test]
+    async fn test_initial_reset_preserves_parent_lookup_error_kind() {
+        let rollup_config = Arc::new(RollupConfig { channel_timeout: 1, ..Default::default() });
+        let l2_chain_provider = TestL2ChainProvider::default();
+        let attributes = TestNextAttributes::default();
+        let mut pipeline = DerivationPipeline::new(attributes, rollup_config, l2_chain_provider);
+
+        let parent_hash = test_block_hash(1);
+        let l2_safe_head = L2BlockInfo {
+            block_info: BlockInfo {
+                hash: test_block_hash(2),
+                number: 2,
+                parent_hash,
+                ..Default::default()
+            },
+            l1_origin: BlockNumHash { number: 2, ..Default::default() },
+            seq_num: 0,
+        };
+
+        let err = pipeline.initial_reset(l2_safe_head).await.unwrap_err();
+        assert_eq!(err, ResetError::BlockNotFound(parent_hash.into()).reset());
     }
 
     #[tokio::test]

--- a/rust/kona/crates/protocol/derive/src/test_utils/chain_providers.rs
+++ b/rust/kona/crates/protocol/derive/src/test_utils/chain_providers.rs
@@ -1,7 +1,7 @@
 //! Test Utilities for chain provider traits
 
 use crate::{
-    errors::{PipelineError, PipelineErrorKind},
+    errors::{PipelineError, PipelineErrorKind, ResetError},
     traits::{ChainProvider, L2ChainProvider},
 };
 use alloc::{boxed::Box, string::ToString, sync::Arc, vec::Vec};
@@ -91,6 +91,9 @@ pub enum TestProviderError {
     /// The L2 block was not found.
     #[error("L2 Block not found")]
     L2BlockNotFound,
+    /// The L2 block was not found by hash.
+    #[error("L2 block {0} not found by hash")]
+    L2BlockHashNotFound(B256),
     /// The system config was not found.
     #[error("System config not found")]
     SystemConfigNotFound(B256),
@@ -98,7 +101,12 @@ pub enum TestProviderError {
 
 impl From<TestProviderError> for PipelineErrorKind {
     fn from(val: TestProviderError) -> Self {
-        PipelineError::Provider(val.to_string()).temp()
+        match val {
+            TestProviderError::L2BlockHashNotFound(hash) => {
+                ResetError::BlockNotFound(hash.into()).reset()
+            }
+            other => PipelineError::Provider(other.to_string()).temp(),
+        }
     }
 }
 
@@ -191,13 +199,17 @@ impl BatchValidationProvider for TestL2ChainProvider {
 
     async fn l2_block_info_by_hash(&mut self, hash: B256) -> Result<L2BlockInfo, Self::Error> {
         if self.short_circuit {
-            return self.blocks.first().copied().ok_or(TestProviderError::BlockNotFound);
+            return self
+                .blocks
+                .first()
+                .copied()
+                .ok_or(TestProviderError::L2BlockHashNotFound(hash));
         }
         self.blocks
             .iter()
             .find(|b| b.block_info.hash == hash)
             .copied()
-            .ok_or(TestProviderError::BlockNotFound)
+            .ok_or(TestProviderError::L2BlockHashNotFound(hash))
     }
 
     async fn block_by_number(&mut self, number: u64) -> Result<OpBlock, Self::Error> {

--- a/rust/kona/crates/protocol/derive/src/traits/providers.rs
+++ b/rust/kona/crates/protocol/derive/src/traits/providers.rs
@@ -49,13 +49,14 @@ pub trait L2ChainProvider: BatchValidationProviderDerive {
 
 /// A super-trait for [`BatchValidationProvider`] that binds `Self::Error` to have a conversion into
 /// [`PipelineErrorKind`].
-pub trait BatchValidationProviderDerive: BatchValidationProvider {}
+pub trait BatchValidationProviderDerive:
+    BatchValidationProvider<Error: Into<PipelineErrorKind>>
+{
+}
 
 // Auto-implement the [BatchValidationProviderDerive] trait for all types that implement
 // [BatchValidationProvider] where the error can be converted into [PipelineErrorKind].
-impl<T> BatchValidationProviderDerive for T
-where
-    T: BatchValidationProvider,
-    <T as BatchValidationProvider>::Error: Into<PipelineErrorKind>,
+impl<T> BatchValidationProviderDerive for T where
+    T: BatchValidationProvider<Error: Into<PipelineErrorKind>>
 {
 }


### PR DESCRIPTION
Stacked on #22467.

`DerivationPipeline::initial_reset` flattened every parent lookup failure into a temporary provider error. This discarded provider classifications, including `BlockHashNotFound -> ResetError::BlockNotFound`, and diverged from op-node, which requests another reset when the walk-back parent is unavailable.

Preserve the provider error kind instead. Also express the existing `Into<PipelineErrorKind>` requirement as an associated-type bound on `BatchValidationProviderDerive`, so generic callers can use the conversion, and add a regression test for a missing hash-keyed parent.

## Tests

- `cargo nextest run -p kona-derive`
- `cargo clippy -p kona-derive --all-targets --all-features -- -D warnings`
- `cargo check -p kona-proof -p kona-node -p kona-driver`