### PR TITLE
circleci: Target the previous day's nightly in the rust bump

### DIFF
--- a/.circleci/continue/rust-nightly-bump.yml
+++ b/.circleci/continue/rust-nightly-bump.yml
@@ -36,11 +36,14 @@ jobs:
           name: Open PR if the pinned nightly is outdated
           command: |
             set -euo pipefail
-            TODAY=$(date -u +%Y-%m-%d)
-            LATEST="nightly-${TODAY}"
+            # The weekly schedule fires just after 00:00 UTC, but a given day's
+            # nightly only lands on the dist server around 01:30 UTC that day, so
+            # today's date always 404s. Target the previous day.
+            TARGET=$(date -u -d yesterday +%Y-%m-%d)
+            LATEST="nightly-${TARGET}"
             CURRENT=$(grep -oE 'nightly-[0-9]{4}-[0-9]{2}-[0-9]{2}' mise.toml | head -1)
 
-            echo "Latest nightly: ${LATEST}"
+            echo "Target nightly: ${LATEST}"
             echo "Current pin:    ${CURRENT}"
 
             # Recorded for the Slack success notification so the message can
@@ -54,13 +57,13 @@ jobs:
             fi
 
             # Nightly is not guaranteed to be published every day (builds can be
-            # skipped when broken). Only proceed if today's toolchain actually
+            # skipped when broken). Only proceed if the target toolchain actually
             # exists on the dist server, otherwise we would open a PR pinning a
             # nightly that rustup cannot install.
-            MANIFEST_URL="https://static.rust-lang.org/dist/${TODAY}/channel-rust-nightly.toml"
+            MANIFEST_URL="https://static.rust-lang.org/dist/${TARGET}/channel-rust-nightly.toml"
             if ! curl -fsSL --retry 5 --retry-delay 2 --retry-connrefused -o /dev/null "${MANIFEST_URL}"; then
-              echo "No nightly published for ${TODAY} yet (${MANIFEST_URL} unavailable). Nothing to do."
-              record_summary "No nightly published for ${TODAY}; no PR opened."
+              echo "No nightly published for ${TARGET} (${MANIFEST_URL} unavailable). Nothing to do."
+              record_summary "No nightly published for ${TARGET}; no PR opened."
               exit 0
             fi
 


### PR DESCRIPTION
The weekly `scheduled-rust-nightly-bump` job has never bumped the pin. It probes `dist/$(date -u +%F)/channel-rust-nightly.toml`, but the schedule fires at 00:00:33 UTC and a given day's manifest only lands about 01:32 UTC that same day, so the check always got a 404 and took the "nothing to do" branch. `mise.toml` is still on `nightly-2026-02-20`.

Measured `Last-Modified` on the dist server: 2026-08-16 01:33:03, 2026-08-17 01:32:42, 2026-08-18 01:32:27 GMT.

This targets the previous day instead of moving the schedule, so the job stays correct if the schedule time changes. The manifest check stays, because nightly builds are still skipped when broken.

Both failed runs ([132268](https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/132268), [132702](https://app.circleci.com/pipelines/github/ethereum-optimism/optimism/132702)) went red on the Slack orb, not on this logic; #22438 fixed that part.

After this merges, the first run opens one large `2026-02-20` -> current PR, then weekly steps become small again.