### PR TITLE
circleci: Drop unused host clang installs from Docker-only kona jobs

### DIFF
--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -646,10 +646,8 @@ jobs:
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
-      - apt-install:
-          packages: "clang llvm-dev libclang-dev"
-          extra_flags: "--no-install-recommends"
       - rust-prepare-and-restore-cache:
+          needs_clang: false
           directory: rust
           features: "all"
       - run:
@@ -672,10 +670,8 @@ jobs:
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
-      - apt-install:
-          packages: "clang llvm-dev libclang-dev"
-          extra_flags: "--no-install-recommends"
-      - rust-prepare
+      - rust-prepare:
+          needs_clang: false
       - run:
           name: Build <<parameters.target>>
           working_directory: rust/kona
@@ -768,15 +764,13 @@ jobs:
     steps:
       - utils/checkout-with-mise:
           checkout-method: blobless
-      - apt-install:
-          packages: "clang llvm-dev libclang-dev"
-          extra_flags: "--no-install-recommends"
       # No sccache here: the prestates are built reproducibly in Docker
       # (just build-kona-reproducible-prestate), so the host never compiles and
       # the job doesn't need the sccache-gcs-optimism context. That context also
       # defines GCP_SERVICE_ACCOUNT_EMAIL, which would otherwise shadow the
       # oplabs-network-data publisher SA used by the upload below.
       - rust-prepare-and-restore-cache:
+          needs_clang: false
           directory: rust
           profile: release
           enable_sccache: false


### PR DESCRIPTION
`kona-lint-cannon`, `kona-build-fpvm-cannon-client` and `kona-publish-prestate-artifacts` each `apt install clang llvm-dev libclang-dev` (118 MB) on every run, but none of them compiles on the host: `just lint-cannon` and `just build-cannon-client` run inside the `kona-cannon-env` container, and `just build-kona-reproducible-prestate` is a Docker build. The install existed only to satisfy the `needs_clang` assertion in `rust-prepare`, so this drops the step and passes `needs_clang: false`.

`kona-host-client-offline-cannon` keeps clang: it builds `kona-host` natively.

The download normally costs 20-30s per job. When the Ubuntu mirror degrades it is unbounded: on 2026-08-18 `us-east-1.ec2.archive.ubuntu.com` served the index at 6.5 kB/s and the packages at 81 kB/s, so these three jobs spent 13-46 min in apt (`kona-build-fpvm-cannon-client` build 5476865: 43.7 min of 48.0 min total, real work 4.0 min). Over 12:48-20:30 UTC that was 417 of 546 apt-minutes on develop.

Verified with `merge-configs.sh` plus `circleci config process`: the only change to the processed config is the removal of the three apt steps and their clang assertions.
