### PR TITLE
ci: bump rust nightly pin to nightly-2026-08-18

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -8,7 +8,7 @@ gotestsum = "1.12.3"
 mockery = "2.53.6"
 rust = [
   { version = "1.95.0", components = "clippy,rustfmt,llvm-tools", targets = "riscv32imac-unknown-none-elf,wasm32-unknown-unknown,wasm32-wasip1" },
-  { version = "nightly-2026-02-20", components = "rustfmt,clippy" },
+  { version = "nightly-2026-08-18", components = "rustfmt,clippy" },
 ]
 python = "3.12.13"
 uv = "0.5.5"

--- a/rust/kona/crates/node/engine/README.md
+++ b/rust/kona/crates/node/engine/README.md
@@ -22,8 +22,8 @@ The `kona-engine` crate provides a task-based engine client for interacting with
 
 The engine implements a task-driven architecture where forkchoice synchronization is handled automatically:
 
-- **Automatic Forkchoice Handling**: The [`BuildTask`](crate::BuildTask) automatically performs forkchoice updates during block building, eliminating the need for explicit forkchoice management in user code.
-- **Internal Synchronization**: [`SynchronizeTask`](crate::SynchronizeTask) handles internal execution layer synchronization and is primarily used by other tasks rather than directly by users.
+- **Automatic Forkchoice Handling**: The [`BuildTask`] automatically performs forkchoice updates during block building, eliminating the need for explicit forkchoice management in user code.
+- **Internal Synchronization**: [`SynchronizeTask`] handles internal execution layer synchronization and is primarily used by other tasks rather than directly by users.
 - **Priority-Based Execution**: Tasks are executed in priority order to ensure optimal sequencer performance and block processing efficiency.
 
 ## Engine API Compatibility

--- a/rust/kona/crates/proof/preimage/src/traits.rs
+++ b/rust/kona/crates/proof/preimage/src/traits.rs
@@ -1,3 +1,7 @@
+// `#[async_trait]` adds `#[must_use]` to every async trait method it expands, which
+// nightly clippy flags as `double_must_use` on the `Pin<Box<dyn Future>>` return type.
+#![allow(clippy::double_must_use)]
+
 use crate::{
     PreimageKey,
     errors::{ChannelResult, PreimageOracleResult},

--- a/rust/kona/docker/cannon/mips64-unknown-none.json
+++ b/rust/kona/docker/cannon/mips64-unknown-none.json
@@ -7,6 +7,7 @@
   "target-pointer-width": 64,
   "target-c-int-width": 32,
   "os": "none",
+  "abi": "abi64",
   "llvm-abiname": "n64",
   "features": "+soft-float,+mips64",
   "max-atomic-width": 64,


### PR DESCRIPTION
Automated weekly bump of the pinned nightly Rust toolchain from `nightly-2026-02-20` to `nightly-2026-08-18`. CI on this PR will validate the new toolchain compiles cleanly.