### PR TITLE
circleci: Install apt packages from the Ubuntu CDN, not the EC2 mirror

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -360,8 +360,8 @@ commands:
           mentions: "<< parameters.mentions >>"
 
   apt-install:
-    description: "apt-get update + install, with retries to tolerate transient
-      Ubuntu mirror sync failures."
+    description: "apt-get update + install via .circleci/scripts/apt-install.sh,
+      which installs from the Ubuntu geo mirror list."
     parameters:
       packages:
         description: "Space-separated list of apt packages to install."
@@ -374,20 +374,8 @@ commands:
     steps:
       - run:
           name: "apt install << parameters.packages >>"
-          command: |
-            export NEEDRESTART_MODE=a
-            for i in 1 2 3; do
-              if sudo -E apt-get -o Acquire::Retries=5 update; then
-                break
-              fi
-              if [ "$i" = "3" ]; then
-                echo "apt-get update failed after 3 attempts" >&2
-                exit 1
-              fi
-              echo "apt-get update failed (attempt $i), retrying in 10s..." >&2
-              sleep 10
-            done
-            sudo -E apt-get -o Acquire::Retries=5 install -y << parameters.extra_flags >> << parameters.packages >>
+          command: bash .circleci/scripts/apt-install.sh << parameters.extra_flags
+            >> << parameters.packages >>
 
   # Kona-specific commands
   install-zstd:
@@ -955,18 +943,7 @@ jobs:
             echo "Cache miss - will build"
 
             if [ "<< parameters.needs_clang >>" = "true" ] && ! command -v clang >/dev/null; then
-              for i in 1 2 3; do
-                if sudo apt-get -o Acquire::Retries=5 update; then
-                  break
-                fi
-                if [ "$i" = "3" ]; then
-                  echo "apt-get update failed after 3 attempts" >&2
-                  exit 1
-                fi
-                echo "apt-get update failed (attempt $i), retrying in 10s..." >&2
-                sleep 10
-              done
-              sudo apt-get install -y --no-install-recommends clang
+              bash "$ROOT_DIR/.circleci/scripts/apt-install.sh" --no-install-recommends clang
             fi
 
             cd << parameters.directory >> && << parameters.build_command >>
@@ -1719,9 +1696,8 @@ jobs:
       - utils/checkout-with-mise:
           checkout-method: blobless
           enable-mise-cache: true
-      - run:
-          name: Install ripgrep
-          command: sudo apt-get install -y ripgrep
+      - apt-install:
+          packages: "ripgrep"
       - run:
           name: Check TODO issues
           command: ./ops/scripts/todo-checker.sh --verbose --strict
@@ -2095,15 +2071,16 @@ jobs:
     resource_class: 2xlarge+.gen2
     parallelism: <<parameters.parallelism>>
     steps:
+      # apt-install needs the working tree, so it runs after checkout.
+      - utils/checkout-with-mise:
+          checkout-method: blobless
+          enable-mise-cache: true
       - apt-install:
           extra_flags: "--no-install-recommends"
           packages: "eatmydata"
       - run:
           name: Disable fsync for all subprocesses
           command: echo 'export LD_PRELOAD=libeatmydata.so' >> "$BASH_ENV"
-      - utils/checkout-with-mise:
-          checkout-method: blobless
-          enable-mise-cache: true
       - attach_workspace:
           at: .
       - run:

--- a/.circleci/scripts/apt-install.sh
+++ b/.circleci/scripts/apt-install.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# apt-get update + install. Arguments are passed to `apt-get install`.
+set -euo pipefail
+
+# The machine images point apt at the single-region EC2 mirror
+# (us-east-1.ec2.archive.ubuntu.com), which is one set of AWS hosts with no
+# routing of its own: when it degrades, apt has nowhere else to go, and it is only
+# nearby when the runner happens to be in that region. archive.ubuntu.com is
+# Cloudflare anycast, so redundancy, geo-routing and caching are the CDN's job.
+# Third-party lists keep their own URIs.
+for f in /etc/apt/sources.list /etc/apt/sources.list.d/*.sources /etc/apt/sources.list.d/*.list; do
+  if [ -f "$f" ]; then
+    sudo sed -i -E "s#https?://[A-Za-z0-9.-]+\.ec2\.archive\.ubuntu\.com/ubuntu#http://archive.ubuntu.com/ubuntu#g" "$f"
+  fi
+done
+
+# Timeouts, so a mirror that stops responding errors out instead of being waited on.
+APT_OPTS=(-o Acquire::Retries=3 -o Acquire::http::Timeout=20 -o Acquire::https::Timeout=20)
+
+export NEEDRESTART_MODE=a
+export DEBIAN_FRONTEND=noninteractive
+
+sudo -E apt-get "${APT_OPTS[@]}" update
+sudo -E apt-get "${APT_OPTS[@]}" install -y "$@"


### PR DESCRIPTION
The machine images point apt at `us-east-1.ec2.archive.ubuntu.com`, and every job wrapped that in a retry loop around `apt-get update` that cannot help when the mirror itself is the problem. That mirror is one set of AWS hosts in one region with no routing of its own, and it is only nearby when the runner happens to sit in that region. On 2026-08-18 it served the package index at 6.5 kB/s and 118 MB of clang packages at 81 kB/s, returning 503s from 18.232.150.247; `kona-host-client-offline-cannon` build 5476848 spent 46.5 of 55.9 min in two apt steps, and apt took 562 of 5,661 develop job-minutes between 12:48 and 20:30 UTC.

`.circleci/scripts/apt-install.sh` repoints those entries at `archive.ubuntu.com`, which is Cloudflare anycast (104.20.28.246, 172.66.152.176, `2606:4700:10::/…`), so redundancy, geo-routing and caching are the CDN's job rather than the client's. Third-party lists keep their own URIs. Connection timeouts replace the retry loop.

Discarded alternatives: `mirror+http://mirrors.ubuntu.com/mirrors.txt` answers with a single entry (`http://archive.ubuntu.com/ubuntu/`), so it has nothing to fail over to; a `mirror+file` list built from `US.txt` does give apt 82 mirrors, but only fails over on hard errors, picks randomly among volunteer mirrors of varying freshness and throughput, and measured slower than the CDN.

Limit worth knowing: apt has no minimum-transfer-rate abort, so a host that is up but trickling still won't fail over. This removes the single-region mirror as a dependency; it does not make a slow fetch self-healing.

All apt call sites use the script, including the two that open-coded the loop (`rust-build-vendored`) and the one with no retry at all (`todo-issues` ripgrep). The `memory-all-*` jobs install eatmydata after checkout now, since the script lives in the working tree.

Measured on this branch, same jobs and same package sets:

| job | mirror | 118 MB clang set | apt step |
| --- | --- | --- | --- |
| kona-lint-cannon before | us-east-1.ec2 | 81 kB/s (incident) / 74.8 MB/s (healthy) | 43.7m / 0.39m |
| kona-lint-cannon build 5481797 | archive.ubuntu.com | 99.9 MB/s | 0.37m |
| kona-host-client-offline-cannon build 5481800 | archive.ubuntu.com | 114 MB/s | 0.27m + 0.15m |

Also shellcheck clean, and `merge-configs.sh` plus `circleci config process` with every workflow parameter enabled shows only the call-site swaps and the eatmydata reorder.
