### PR TITLE
kona: refresh offline Cannon witness

### DIFF
--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -608,11 +608,11 @@ jobs:
       - run:
           name: Set run environment
           command: |
-            echo 'export BLOCK_NUMBER=42427365' >> $BASH_ENV
-            echo 'export L2_CLAIM=0xaaf7cb1725cb9766899cbd78866270d8561e79b91c00be5c53adb7699e0e7715' >> $BASH_ENV
-            echo 'export L2_OUTPUT_ROOT=0xac90a2e8cfee33ecb47b73f3e83f9aa18ff7ecf28bc8d34b2de857919e50b6c6' >> $BASH_ENV
-            echo 'export L2_HEAD=0xc5fa07d52e83f7a2e68de356e7a7bfc9306a9b28666ec6c9cc6e4f8e1b268278' >> $BASH_ENV
-            echo 'export L1_HEAD=0xab33322985684f2c6fbcf375bdcb69cc0f10547e58cb5a7b889172ee9ea77aef' >> $BASH_ENV
+            echo 'export BLOCK_NUMBER=47600000' >> $BASH_ENV
+            echo 'export L2_CLAIM=0x6ac07d241d170ddd504532a2c8127bb85426e604a360f8ba2d976be3cc0aa7f0' >> $BASH_ENV
+            echo 'export L2_OUTPUT_ROOT=0x9c799a1b767f43d6c654f83e18ae20bfc2953e94e5093ef59664ae8244ffdc96' >> $BASH_ENV
+            echo 'export L2_HEAD=0x0084ac82023844b6f286783f3ea0ffddb8e597211ffbe01b56d8873f36a8bacb' >> $BASH_ENV
+            echo 'export L1_HEAD=0xf82badb3d56a53c373b501ec24e1e9ab2797feaab552c0d683849b1234308a2d' >> $BASH_ENV
             echo 'export L2_CHAIN_ID=11155420' >> $BASH_ENV
       - run:
           name: Run host + client offline

--- a/rust/kona/bin/client/justfile
+++ b/rust/kona/bin/client/justfile
@@ -249,7 +249,7 @@ prepare-witness-data witness_tar witness_tar_url:
 # `kona-YYYY-MM-DD` by the `prepare-witness-data` dependency. When regenerating
 # for a new block, upload a new release (see `generate-witness-tar`) and bump
 # the `witness_tar` / `witness_tar_url` defaults.
-run-client-cannon-offline block_number l2_claim l2_output_root l2_head l1_head l2_chain_id witness_tar='op-sepolia-42427365-witness.tar.zst' witness_tar_url='https://github.com/ethereum-optimism/chain-test-data/releases/download/kona-2026-04-21' verbosity='': (prepare-witness-data witness_tar witness_tar_url)
+run-client-cannon-offline block_number l2_claim l2_output_root l2_head l1_head l2_chain_id witness_tar='op-sepolia-47600000-witness.tar.zst' witness_tar_url='https://github.com/ethereum-optimism/chain-test-data/releases/download/kona-2026-08-13-op-sepolia-47600000-v2' verbosity='': (prepare-witness-data witness_tar witness_tar_url)
   #!/usr/bin/env bash
 
   HOST_BIN_PATH="{{KONA_CLIENT_ROOT}}/../../../target/debug/kona-host"


### PR DESCRIPTION
Refresh the pinned OP Sepolia witness so the offline Kona fault-proof job includes the preimages required by #22215.

- Moves the fixture boundary to block 47,600,000.
- Pins the sanitized immutable [chain-test-data release](https://github.com/ethereum-optimism/chain-test-data/releases/tag/kona-2026-08-13-op-sepolia-47600000-v2).
- Updates the claimed/agreed output roots and L1/L2 head hashes together.

Verification:
- Native host+client offline replay validated output root `0x6ac07d241d170ddd504532a2c8127bb85426e604a360f8ba2d976be3cc0aa7f0`.
- Full `run-client-cannon-offline` replay downloaded the release asset and exited MIPS64 Cannon with code 0.

Stacked on #22215.

🤖 *Co-created with openai-codex/gpt-5.6-sol*