### PR TITLE
op-node,kona: centralize Holocene span batch checks

### DIFF
--- a/op-node/rollup/derive/batch_stage.go
+++ b/op-node/rollup/derive/batch_stage.go
@@ -136,7 +136,7 @@ func (bs *BatchStage) nextSingularBatchCandidate(ctx context.Context, parent eth
 			return nil, NewCriticalError(errors.New("failed type assertion to SpanBatch"))
 		}
 
-		validity, parentBlock := checkSpanBatchPrefix(ctx, bs.config, bs.Log(), bs.l1Blocks, parent, spanBatch, bs.origin, bs.l2)
+		validity := checkSpanBatchHolocene(ctx, bs.config, bs.Log(), bs.l1Blocks, parent, spanBatch, bs.origin, bs.l2)
 		switch validity {
 		case BatchAccept: // continue
 			spanBatch.LogContext(bs.Log()).Info("Found next valid span batch")
@@ -145,7 +145,7 @@ func (bs *BatchStage) nextSingularBatchCandidate(ctx context.Context, parent eth
 			// NotEnoughData to read in next batch until we're through all past batches
 			return nil, NotEnoughData
 		case BatchDrop: // drop, try next
-			spanBatch.LogContext(bs.Log()).Warn("Dropping invalid span batch, flushing channel (span batch prefix checks)")
+			spanBatch.LogContext(bs.Log()).Warn("Dropping invalid span batch, flushing channel (span batch checks)")
 			bs.FlushChannel()
 			return nil, NotEnoughData
 		case BatchUndecided: // l2 fetcher error; the span was already consumed and is skipped, not retried
@@ -155,29 +155,10 @@ func (bs *BatchStage) nextSingularBatchCandidate(ctx context.Context, parent eth
 			return nil, NewCriticalError(errors.New("impossible future batch validity"))
 		}
 
-		// The prefix checks do not validate overlap contents against the safe chain. A span batch
-		// that disagrees with the safe chain — possible since interop block replacement — must be
-		// dropped as a whole, so that the remainder of an invalidated lineage cannot be spliced
-		// onto the canonical chain. See checkSpanBatchOverlap for details.
-		if parentBlock.Number < parent.Number {
-			switch validity := checkSpanBatchOverlap(ctx, bs.config, bs.Log(), spanBatch, parentBlock, parent, bs.l2); validity {
-			case BatchAccept: // continue
-			case BatchDrop:
-				spanBatch.LogContext(bs.Log()).Warn("Dropping invalid span batch, flushing channel (span batch overlap checks)")
-				bs.FlushChannel()
-				return nil, NotEnoughData
-			case BatchUndecided: // l2 fetcher error; the span was already consumed and is skipped, not retried
-				spanBatch.LogContext(bs.Log()).Warn("Undecided span batch (span batch overlap checks)")
-				return nil, NotEnoughData
-			default:
-				return nil, NewCriticalError(fmt.Errorf("unexpected overlap batch validity: %v", validity))
-			}
-		}
-
 		// If next batch is SpanBatch, convert it to SingularBatches.
 		singularBatches, err := spanBatch.GetSingularBatches(bs.l1Blocks, parent)
-		// Errors can happen here because the span batch prefix checks are not exhaustive (unlike the full span batch
-		// checks) so an error must be handled like an invalid span batch (DROP).
+		// Errors can happen here because the Holocene span batch checks are not exhaustive (unlike
+		// the full span batch checks) so an error must be handled like an invalid span batch (DROP).
 		if err != nil {
 			spanBatch.LogContext(bs.Log()).Warn("Dropping invalid span batch, flushing channel (singular batch extraction)", "error", err)
 			bs.FlushChannel()

--- a/op-node/rollup/derive/batches.go
+++ b/op-node/rollup/derive/batches.go
@@ -207,9 +207,8 @@ func checkSequencerTxData(log log.Logger, txIndex int, txBytes []byte, isIsthmus
 	return BatchAccept
 }
 
-// checkSpanBatchPrefix performs the span batch prefix rules for Holocene.
-// Next to the validity, it also returns the parent L2 block as determined during the checks for
-// further consumption.
+// checkSpanBatchPrefix performs the span batch prefix rules shared by the legacy full checks and
+// the Holocene checks. It also returns the parent L2 block determined during validation.
 func checkSpanBatchPrefix(ctx context.Context, cfg *rollup.Config, log log.Logger, l1Blocks []eth.L1BlockRef, l2SafeHead eth.L2BlockRef,
 	batch *SpanBatch, l1InclusionBlock eth.L1BlockRef, l2Fetcher SafeBlockFetcher,
 ) (BatchValidity, eth.L2BlockRef) {
@@ -318,6 +317,18 @@ func checkSpanBatchPrefix(ctx context.Context, cfg *rollup.Config, log log.Logge
 		return BatchDrop, parentBlock
 	}
 	return BatchAccept, parentBlock
+}
+
+// checkSpanBatchHolocene validates the span batch prefix followed by its overlap with the safe
+// chain. Holocene validates batches as they are loaded, so the legacy full checks are not run.
+func checkSpanBatchHolocene(ctx context.Context, cfg *rollup.Config, log log.Logger, l1Blocks []eth.L1BlockRef, l2SafeHead eth.L2BlockRef,
+	batch *SpanBatch, l1InclusionBlock eth.L1BlockRef, l2Fetcher SafeBlockFetcher,
+) BatchValidity {
+	prefixValidity, parentBlock := checkSpanBatchPrefix(ctx, cfg, log, l1Blocks, l2SafeHead, batch, l1InclusionBlock, l2Fetcher)
+	if prefixValidity != BatchAccept {
+		return prefixValidity
+	}
+	return checkSpanBatchOverlap(ctx, cfg, log, batch, parentBlock, l2SafeHead, l2Fetcher)
 }
 
 // checkSpanBatch checks the full SpanBatch semantic validation rules on a syntactically-correct
@@ -430,8 +441,9 @@ func checkSpanBatch(ctx context.Context, cfg *rollup.Config, log log.Logger, l1B
 // overlapped element's transactions and L1 origin must match the canonical block at the same
 // height. A batch whose overlap disagrees with the safe chain — possible since interop block
 // replacement — describes a different history and is dropped as a whole, so that its elements
-// past the safe head cannot be applied. Returns BatchUndecided if a canonical payload cannot be
-// fetched right now.
+// past the safe head cannot be applied. The prefix rules must have accepted the batch first:
+// parentBlock must be the prefix-determined parent (an ancestor of, or equal to, l2SafeHead), and
+// the batch must extend past the safe head. Returns BatchUndecided if a payload cannot be fetched.
 func checkSpanBatchOverlap(ctx context.Context, cfg *rollup.Config, log log.Logger, batch *SpanBatch,
 	parentBlock, l2SafeHead eth.L2BlockRef, l2Fetcher SafeBlockFetcher,
 ) BatchValidity {

--- a/op-node/rollup/derive/overlap_content_test.go
+++ b/op-node/rollup/derive/overlap_content_test.go
@@ -94,7 +94,7 @@ func TestBatchStage_OverlapContent(t *testing.T) {
 		require.ErrorIs(t, err, NotEnoughData)
 		require.Nil(t, batch)
 		logs.RequireMessageContainedOnce(t, "overlapped block's tx count does not match")
-		logs.RequireMessageContainedOnce(t, "Dropping invalid span batch, flushing channel (span batch overlap checks)")
+		logs.RequireMessageContainedOnce(t, "Dropping invalid span batch, flushing channel (span batch checks)")
 
 		// The flush must have discarded the unread sentinel along with the rest of the channel.
 		batch, _, err = stage.NextBatch(context.Background(), safeHead)
@@ -148,7 +148,7 @@ func TestBatchStage_OverlapContent(t *testing.T) {
 		require.ErrorIs(t, err, NotEnoughData)
 		require.Nil(t, batch)
 		logs.RequireMessageContainedOnce(t, "overlapped block's tx count does not match")
-		logs.RequireMessageContainedOnce(t, "Dropping invalid span batch, flushing channel (span batch overlap checks)")
+		logs.RequireMessageContainedOnce(t, "Dropping invalid span batch, flushing channel (span batch checks)")
 
 		// The flush must have discarded the unread sentinel along with the rest of the channel.
 		batch, _, err = stage.NextBatch(context.Background(), safe2Ref)
@@ -177,7 +177,7 @@ func TestBatchStage_OverlapContent(t *testing.T) {
 		require.ErrorIs(t, err, NotEnoughData)
 		require.Nil(t, batch)
 		logs.RequireMessageContainedOnce(t, "overlapped block's L1 origin number does not match")
-		logs.RequireMessageContainedOnce(t, "Dropping invalid span batch, flushing channel (span batch overlap checks)")
+		logs.RequireMessageContainedOnce(t, "Dropping invalid span batch, flushing channel (span batch checks)")
 	})
 
 	t.Run("payload fetch error is undecided", func(t *testing.T) {
@@ -190,6 +190,6 @@ func TestBatchStage_OverlapContent(t *testing.T) {
 		batch, _, err := stage.NextBatch(context.Background(), safeHead)
 		require.ErrorIs(t, err, NotEnoughData)
 		require.Nil(t, batch)
-		logs.RequireMessageContainedOnce(t, "Undecided span batch (span batch overlap checks)")
+		logs.RequireMessageContainedOnce(t, "Undecided span batch")
 	})
 }

--- a/rust/kona/crates/protocol/derive/src/stages/batch/batch_stream.rs
+++ b/rust/kona/crates/protocol/derive/src/stages/batch/batch_stream.rs
@@ -148,8 +148,8 @@ where
                 Batch::Span(b) => {
                     #[cfg(feature = "metrics")]
                     let start = std::time::Instant::now();
-                    let (mut validity, parent_block) = b
-                        .check_batch_prefix(
+                    let validity = b
+                        .check_batch_holocene(
                             self.config.as_ref(),
                             l1_origins,
                             parent,
@@ -162,26 +162,6 @@ where
                         crate::metrics::Metrics::PIPELINE_CHECK_BATCH_PREFIX,
                         start.elapsed().as_secs_f64()
                     );
-
-                    // The prefix checks do not validate overlap contents against the safe
-                    // chain. A span batch that disagrees with the safe chain — possible since
-                    // interop block replacement — must be dropped as a whole, so that the
-                    // remainder of an invalidated lineage cannot be spliced onto the canonical
-                    // chain. See [`SpanBatch::check_batch_overlap`] for details.
-                    if validity.is_accept() {
-                        let parent_block =
-                            parent_block.expect("accepted prefix checks return a parent block");
-                        if parent_block.block_info.number < parent.block_info.number {
-                            validity = b
-                                .check_batch_overlap(
-                                    self.config.as_ref(),
-                                    parent_block,
-                                    parent,
-                                    &mut self.fetcher,
-                                )
-                                .await;
-                        }
-                    }
 
                     kona_macros::inc!(
                         gauge,
@@ -221,8 +201,8 @@ where
             Ok(None) => Err(PipelineError::NotEnoughData.temp()),
             Err(e) => {
                 warn!(target: "batch_span", "Extracting singular batches from span batch failed: {}", e);
-                // If singular batch extraction fails, it should be handled the same as a
-                // dropped batch during span batch prefix checks.
+                // If singular batch extraction fails, handle it like a batch dropped during the
+                // Holocene span batch checks.
                 self.flush();
                 Err(PipelineError::NotEnoughData.temp())
             }

--- a/rust/kona/crates/protocol/protocol/src/batch/span.rs
+++ b/rust/kona/crates/protocol/protocol/src/batch/span.rs
@@ -609,11 +609,8 @@ impl SpanBatch {
         BatchValidity::Accept
     }
 
-    /// Checks the validity of the batch's prefix.
-    ///
-    /// This function is used for post-Holocene hardfork to perform batch validation
-    /// as each batch is being loaded in. Next to the validity, it also returns the parent L2
-    /// block as determined during the checks for further consumption.
+    /// Checks the span batch prefix rules shared by the legacy full checks and the Holocene
+    /// checks. It also returns the parent L2 block determined during validation.
     pub async fn check_batch_prefix<BF: BatchValidationProvider>(
         &self,
         cfg: &RollupConfig,
@@ -773,6 +770,29 @@ impl SpanBatch {
         }
 
         (BatchValidity::Accept, Some(parent_block))
+    }
+
+    /// Checks the Holocene span batch rules: prefix validity followed by overlap validity.
+    pub async fn check_batch_holocene<BV: BatchValidationProvider>(
+        &self,
+        cfg: &RollupConfig,
+        l1_origins: &[BlockInfo],
+        l2_safe_head: L2BlockInfo,
+        inclusion_block: &BlockInfo,
+        fetcher: &mut BV,
+    ) -> BatchValidity {
+        let (prefix_validity, parent_block) =
+            self.check_batch_prefix(cfg, l1_origins, l2_safe_head, inclusion_block, fetcher).await;
+        if !prefix_validity.is_accept() {
+            return prefix_validity;
+        }
+        self.check_batch_overlap(
+            cfg,
+            parent_block.expect("accepted prefix checks return a parent block"),
+            l2_safe_head,
+            fetcher,
+        )
+        .await
     }
 }
 

--- a/rust/kona/tests/proofs/span_batch_overlap_test.go
+++ b/rust/kona/tests/proofs/span_batch_overlap_test.go
@@ -101,7 +101,7 @@ func TestSpanBatchOverlapContent(gt *testing.T) {
 		expectedLogs := []string{"overlapped block's tx count does not match"}
 		if isHolocene {
 			expectedLogs = append(expectedLogs,
-				"Dropping invalid span batch, flushing channel (span batch overlap checks)")
+				"Dropping invalid span batch, flushing channel (span batch checks)")
 		}
 		for _, filter := range expectedLogs {
 			recs := env.Logs.FindLogs(


### PR DESCRIPTION
## Summary

- Add one Holocene span-batch validator per client: prefix checks, then overlap checks.
- Keep the legacy full validator order unchanged: prefix, full checks, then overlap.
- Reduce each Holocene stage to one validity switch and align stage-level log assertions.

Kona's existing `kona_derive_check_batch_prefix_duration` metric now times the combined Holocene helper, including overlap fetches. The series name is unchanged to avoid a dashboard and history cutover in this focused refactor.

## Verification

- `go test ./op-node/rollup/derive -count=1`
- `cargo test -p kona-protocol -p kona-derive`
- `go test ./rust/kona/tests/proofs -run '^$' -count=1`

🤖 *Co-created with openai-codex/gpt-5.6-sol*