### PR TITLE
kona-node: accept base64-encoded L1 chain configs

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -7288,6 +7288,7 @@ dependencies = [
  "alloy-transport-http",
  "anyhow",
  "backon",
+ "base64 0.22.1",
  "clap",
  "derive_more 2.1.1",
  "dirs 6.0.0",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -633,6 +633,7 @@ backon = { version = "1.6.0", default-features = false, features = [
   "std-blocking-sleep",
   "tokio-sleep",
 ] }
+base64 = "0.22.1"
 bitflags = "2.10"
 boyer-moore-magiclen = "0.2.22"
 buddy_system_allocator = "0.12.0"

--- a/rust/kona/bin/node/Cargo.toml
+++ b/rust/kona/bin/node/Cargo.toml
@@ -59,6 +59,7 @@ tabled.workspace = true
 libp2p.workspace = true
 derive_more.workspace = true
 anyhow.workspace = true
+base64.workspace = true
 futures.workspace = true
 metrics.workspace = true
 reqwest.workspace = true

--- a/rust/kona/bin/node/README.md
+++ b/rust/kona/bin/node/README.md
@@ -80,6 +80,7 @@ Many configuration options can be set via environment variables:
 - `KONA_NODE_L1_ETH_RPC` - L1 execution client RPC URL
 - `KONA_NODE_L1_TRUST_RPC` - Whether to trust the L1 RPC without verification (default: true)
 - `KONA_NODE_L1_BEACON` - L1 beacon API URL
+- `KONA_NODE_L1_CHAIN_CONFIG` - Path to a custom L1 chain config, or standard base64-encoded JSON; accepts a direct chain config or a genesis document with the config under `.config`
 - `KONA_NODE_L2_ENGINE_RPC` - L2 engine API URL
 - `KONA_NODE_L2_TRUST_RPC` - Whether to trust the L2 RPC without verification (default: true)
 - `KONA_NODE_L2_ENGINE_AUTH` - Path to L2 engine JWT secret file

--- a/rust/kona/bin/node/src/commands/node.rs
+++ b/rust/kona/bin/node/src/commands/node.rs
@@ -12,6 +12,7 @@ use alloy_rpc_types_engine::JwtSecret;
 use alloy_transport_http::Http;
 use anyhow::{Result, bail};
 use backon::{ExponentialBuilder, Retryable};
+use base64::{Engine as _, engine::general_purpose::STANDARD};
 use clap::Parser;
 use kona_cli::{LogConfig, MetricsArgs};
 use kona_engine::{HyperAuthClient, OpEngineClient};
@@ -21,8 +22,13 @@ use kona_node_service::{EngineConfig, L1ConfigBuilder, NodeMode, RollupNodeBuild
 use kona_registry::{L1Config, scr_rollup_config_by_alloy_ident};
 use op_alloy_network::Optimism;
 use op_alloy_provider::ext::engine::OpEngineApi;
-use serde_json::from_reader;
-use std::{fs::File, io::Write, path::PathBuf, sync::Arc};
+use serde_json::{Value, from_reader, from_value};
+use std::{
+    fs::File,
+    io::{Read, Write},
+    path::PathBuf,
+    sync::Arc,
+};
 use strum::IntoEnumIterator;
 use tracing::{debug, error, info};
 
@@ -103,8 +109,9 @@ pub struct NodeCommand {
     /// (overrides the default rollup configuration from the registry)
     #[arg(long, visible_alias = "rollup-cfg", env = "KONA_NODE_ROLLUP_CONFIG")]
     pub l2_config_file: Option<PathBuf>,
-    /// Path to a custom L1 rollup configuration file
-    /// (overrides the default rollup configuration from the registry)
+    /// Path to a custom L1 chain configuration file, or its base64-encoded JSON contents.
+    /// Accepts a direct chain config or a genesis document with the config under `.config`.
+    /// Overrides the default L1 chain configuration from the registry.
     #[arg(long, visible_alias = "rollup-l1-cfg", env = "KONA_NODE_L1_CHAIN_CONFIG")]
     pub l1_config_file: Option<PathBuf>,
     /// Path to a JSON file describing the interop dependency set for this
@@ -364,15 +371,40 @@ impl NodeCommand {
         }
     }
 
-    /// Get the L1 config, either from a file or the known chains.
+    /// Parses an L1 chain config from either a direct config or a genesis document.
+    fn parse_l1_config(reader: impl Read) -> serde_json::Result<L1ChainConfig> {
+        let value: Value = from_reader(reader)?;
+        let config = match value {
+            Value::Object(mut object) => object.remove("config").unwrap_or(Value::Object(object)),
+            value => value,
+        };
+        from_value(config)
+    }
+
+    /// Get the L1 config from a file, base64-encoded JSON, or the known chains.
     pub fn get_l1_config(&self, l1_chain_id: u64) -> Result<L1ChainConfig> {
         match &self.l1_config_file {
-            Some(path) => {
-                debug!("Loading l1 config from file: {:?}", path);
-                let file = File::open(path)
-                    .map_err(|e| anyhow::anyhow!("Failed to open l1 config file: {e}"))?;
-                from_reader(file).map_err(|e| anyhow::anyhow!("Failed to parse l1 config: {e}"))
-            }
+            Some(path) => match File::open(path) {
+                Ok(file) => {
+                    debug!("Loading l1 config from file: {:?}", path);
+                    Self::parse_l1_config(file)
+                        .map_err(|e| anyhow::anyhow!("Failed to parse l1 config file: {e}"))
+                }
+                Err(file_error) => {
+                    let encoded = path.to_str().ok_or_else(|| {
+                        anyhow::anyhow!("Failed to open l1 config file: {file_error}")
+                    })?;
+                    let bytes = STANDARD.decode(encoded).map_err(|decode_error| {
+                        anyhow::anyhow!(
+                            "Failed to open l1 config file: {file_error}; configured value is not valid base64: {decode_error}"
+                        )
+                    })?;
+                    debug!("Loading l1 config from base64-encoded JSON");
+                    Self::parse_l1_config(bytes.as_slice()).map_err(|e| {
+                        anyhow::anyhow!("Failed to parse base64-encoded l1 config: {e}")
+                    })
+                }
+            },
             None => {
                 debug!("Loading l1 config from known chains");
                 let cfg = L1Config::get_l1_genesis(l1_chain_id).map_err(|e| {
@@ -505,6 +537,42 @@ mod tests {
         ])
         .unwrap_err();
         assert!(err.to_string().contains("--l2-engine-rpc"));
+    }
+
+    #[test]
+    fn test_get_l1_config_from_direct_and_genesis_files() {
+        let documents = [
+            serde_json::json!({"chainId": 123}),
+            serde_json::json!({"config": {"chainId": 123}, "alloc": {}}),
+        ];
+
+        for document in documents {
+            let mut file = tempfile::NamedTempFile::new().unwrap();
+            serde_json::to_writer(&mut file, &document).unwrap();
+
+            let command =
+                NodeCommand { l1_config_file: Some(file.path().into()), ..Default::default() };
+            assert_eq!(command.get_l1_config(123).unwrap().chain_id, 123);
+        }
+    }
+
+    #[test]
+    fn test_get_l1_config_from_base64_direct_and_genesis() {
+        let documents = [
+            serde_json::json!({"chainId": 123}),
+            serde_json::json!({
+                "config": {"chainId": 123},
+                "alloc": {},
+                "extraData": "00".repeat(4096),
+            }),
+        ];
+
+        for document in documents {
+            let encoded = STANDARD.encode(serde_json::to_vec(&document).unwrap());
+            let command =
+                NodeCommand { l1_config_file: Some(encoded.into()), ..Default::default() };
+            assert_eq!(command.get_l1_config(123).unwrap().chain_id, 123);
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Description

Custom-L1 deployments can inject a base64-encoded genesis through `KONA_NODE_L1_CHAIN_CONFIG`. Kona currently treats the entire value as a path, which makes large configs fail with `File name too long` before JSON parsing.

This keeps readable file paths as the first choice, then falls back to standard base64-encoded JSON. Both inputs now accept either a direct chain config or a genesis document with the config under `.config`; the latter also brings file handling in line with the existing CLI documentation.

The base64 regression test deliberately exceeds filesystem path limits.

Closes #22491.

## Tests

- `cargo nextest run --package kona-node --no-fail-fast`
- `cargo clippy --package kona-node --all-targets --all-features -- -D warnings`
- `just lint`
