### PR TITLE
op-alt-da: make input size limit configurable

### DIFF
--- a/op-alt-da/params.go
+++ b/op-alt-da/params.go
@@ -1,6 +1,6 @@
 package altda
 
-// MaxInputSize ensures the canonical chain cannot include input batches too large to
-// challenge in the Data Availability Challenge contract. Value in number of bytes.
-// This value can only be changed in a hard fork.
+// MaxInputSize is the default maximum input size in bytes. It ensures the canonical
+// chain cannot include input batches too large to challenge in the Data Availability
+// Challenge contract.
 const MaxInputSize = 130672

--- a/op-batcher/batcher/service.go
+++ b/op-batcher/batcher/service.go
@@ -288,8 +288,9 @@ func (bs *BatcherService) initChannelConfig(cfg *CLIConfig) error {
 		return fmt.Errorf("cannot use data availability type blobs or auto with Alt-DA")
 	}
 
-	if bs.UseAltDA && !bs.GenericDA && cc.MaxFrameSize > altda.MaxInputSize {
-		return fmt.Errorf("max frame size %d exceeds altDA max input size %d", cc.MaxFrameSize, altda.MaxInputSize)
+	maxInputSize := bs.RollupConfig.AltDAConfig.MaxInputSizeOrDefault()
+	if bs.UseAltDA && !bs.GenericDA && cc.MaxFrameSize > maxInputSize {
+		return fmt.Errorf("max frame size %d exceeds altDA max input size %d", cc.MaxFrameSize, maxInputSize)
 	}
 
 	cc.InitCompressorConfig(cfg.ApproxComprRatio, cfg.Compressor, cfg.CompressionAlgo)

--- a/op-node/rollup/derive/altda_data_source.go
+++ b/op-node/rollup/derive/altda_data_source.go
@@ -14,22 +14,24 @@ import (
 // AltDADataSource is a data source that fetches inputs from a AltDA provider given
 // their onchain commitments. Same as CalldataSource it will keep attempting to fetch.
 type AltDADataSource struct {
-	log     log.Logger
-	src     DataIter
-	fetcher AltDAInputFetcher
-	l1      L1Fetcher
-	id      eth.L1BlockRef
+	log          log.Logger
+	src          DataIter
+	fetcher      AltDAInputFetcher
+	l1           L1Fetcher
+	id           eth.L1BlockRef
+	maxInputSize uint64
 	// keep track of a pending commitment so we can keep trying to fetch the input.
 	comm altda.CommitmentData
 }
 
-func NewAltDADataSource(log log.Logger, src DataIter, l1 L1Fetcher, fetcher AltDAInputFetcher, id eth.L1BlockRef) *AltDADataSource {
+func NewAltDADataSource(log log.Logger, src DataIter, l1 L1Fetcher, fetcher AltDAInputFetcher, maxInputSize uint64, id eth.L1BlockRef) *AltDADataSource {
 	return &AltDADataSource{
-		log:     log,
-		src:     src,
-		fetcher: fetcher,
-		l1:      l1,
-		id:      id,
+		log:          log,
+		src:          src,
+		fetcher:      fetcher,
+		l1:           l1,
+		id:           id,
+		maxInputSize: maxInputSize,
 	}
 }
 
@@ -99,8 +101,8 @@ func (s *AltDADataSource) Next(ctx context.Context) (eth.Data, error) {
 		return nil, NewTemporaryError(fmt.Errorf("failed to fetch input data with comm %s from da service: %w", s.comm, err))
 	}
 	// inputs are limited to a max size to ensure they can be challenged in the DA contract.
-	if s.comm.CommitmentType() == altda.Keccak256CommitmentType && len(data) > altda.MaxInputSize {
-		s.log.Warn("input data exceeds max size", "size", len(data), "max", altda.MaxInputSize)
+	if s.comm.CommitmentType() == altda.Keccak256CommitmentType && uint64(len(data)) > s.maxInputSize {
+		s.log.Warn("input data exceeds max size", "size", len(data), "max", s.maxInputSize)
 		s.comm = nil
 		return s.Next(ctx)
 	}

--- a/op-node/rollup/derive/altda_data_source_test.go
+++ b/op-node/rollup/derive/altda_data_source_test.go
@@ -447,6 +447,7 @@ func TestAltDADataSourceInvalidData(t *testing.T) {
 	batcherPriv := testutils.RandomKey()
 	batcherAddr := crypto.PubkeyToAddress(batcherPriv.PublicKey)
 	batcherInbox := common.Address{42}
+	maxInputSize := uint64(3_000)
 	cfg := &rollup.Config{
 		L1ChainID: big.NewInt(42), // any, for L1Signer
 		Genesis: rollup.Genesis{
@@ -461,6 +462,7 @@ func TestAltDADataSourceInvalidData(t *testing.T) {
 			DAChallengeWindow: pcfg.ChallengeWindow,
 			DAResolveWindow:   pcfg.ResolveWindow,
 			CommitmentType:    altda.KeccakCommitmentString,
+			MaxInputSize:      &maxInputSize,
 		},
 	}
 
@@ -478,7 +480,7 @@ func TestAltDADataSourceInvalidData(t *testing.T) {
 	}
 	l1F.ExpectFetchReceipts(ref.Hash, nil, optypes.Receipts{}, nil)
 	// mock input commitments in l1 transactions with an oversized input
-	input := testutils.RandomData(rng, altda.MaxInputSize+1)
+	input := testutils.RandomData(rng, int(maxInputSize)+1)
 	comm, _ := storage.SetInput(ctx, input)
 
 	tx1, err := types.SignNewTx(batcherPriv, signer, &types.DynamicFeeTx{

--- a/op-node/rollup/derive/data_source.go
+++ b/op-node/rollup/derive/data_source.go
@@ -40,12 +40,13 @@ type AltDAInputFetcher interface {
 // batch submitter transactions.
 // This is not a stage in the pipeline, but a wrapper for another stage in the pipeline
 type DataSourceFactory struct {
-	log          log.Logger
-	dsCfg        DataSourceConfig
-	fetcher      L1Fetcher
-	blobsFetcher L1BlobsFetcher
-	altDAFetcher AltDAInputFetcher
-	ecotoneTime  *uint64
+	log               log.Logger
+	dsCfg             DataSourceConfig
+	fetcher           L1Fetcher
+	blobsFetcher      L1BlobsFetcher
+	altDAFetcher      AltDAInputFetcher
+	altDAMaxInputSize uint64
+	ecotoneTime       *uint64
 }
 
 func NewDataSourceFactory(log log.Logger, cfg *rollup.Config, fetcher L1Fetcher, blobsFetcher L1BlobsFetcher, altDAFetcher AltDAInputFetcher) *DataSourceFactory {
@@ -55,12 +56,13 @@ func NewDataSourceFactory(log log.Logger, cfg *rollup.Config, fetcher L1Fetcher,
 		altDAEnabled:      cfg.AltDAEnabled(),
 	}
 	return &DataSourceFactory{
-		log:          log,
-		dsCfg:        config,
-		fetcher:      fetcher,
-		blobsFetcher: blobsFetcher,
-		altDAFetcher: altDAFetcher,
-		ecotoneTime:  cfg.EcotoneTime,
+		log:               log,
+		dsCfg:             config,
+		fetcher:           fetcher,
+		blobsFetcher:      blobsFetcher,
+		altDAFetcher:      altDAFetcher,
+		altDAMaxInputSize: cfg.AltDAConfig.MaxInputSizeOrDefault(),
+		ecotoneTime:       cfg.EcotoneTime,
 	}
 }
 
@@ -79,7 +81,7 @@ func (ds *DataSourceFactory) OpenData(ctx context.Context, ref eth.L1BlockRef, b
 	}
 	if ds.dsCfg.altDAEnabled {
 		// altDA([calldata | blobdata](l1Ref)) -> data
-		return NewAltDADataSource(ds.log, src, ds.fetcher, ds.altDAFetcher, ref), nil
+		return NewAltDADataSource(ds.log, src, ds.fetcher, ds.altDAFetcher, ds.altDAMaxInputSize, ref), nil
 	}
 	return src, nil
 }

--- a/op-node/rollup/types.go
+++ b/op-node/rollup/types.go
@@ -444,6 +444,9 @@ func (cfg *Config) ProbablyMissingPectraBlobSchedule() bool {
 // If the legacy values are set, they are copied to the new location. If both are set, they are check for consistency.
 func validateAltDAConfig(cfg *Config) error {
 	if cfg.AltDAConfig != nil {
+		if cfg.AltDAConfig.CommitmentType == altda.GenericCommitmentString && cfg.AltDAConfig.MaxInputSize != nil {
+			return errors.New("altDA max input size must be omitted for generic commitments")
+		}
 		if cfg.AltDAConfig.MaxInputSize != nil && *cfg.AltDAConfig.MaxInputSize == 0 {
 			return errors.New("altDA max input size must be greater than zero")
 		}

--- a/op-node/rollup/types.go
+++ b/op-node/rollup/types.go
@@ -65,12 +65,23 @@ type AltDAConfig struct {
 	DAChallengeAddress common.Address `json:"da_challenge_contract_address,omitempty"`
 	// CommitmentType specifies which commitment type can be used. Defaults to Keccak (type 0) if not present
 	CommitmentType string `json:"da_commitment_type"`
+	// MaxInputSize is the maximum byte size accepted for Keccak commitments.
+	// It defaults to the protocol limit when omitted.
+	MaxInputSize *uint64 `json:"da_max_input_size,omitempty"`
 	// DA challenge window value set on the DAC contract. Used in alt-da mode
 	// to compute when a commitment can no longer be challenged.
 	DAChallengeWindow uint64 `json:"da_challenge_window"`
 	// DA resolve window value set on the DAC contract. Used in alt-da mode
 	// to compute when a challenge expires and trigger a reorg if needed.
 	DAResolveWindow uint64 `json:"da_resolve_window"`
+}
+
+// MaxInputSizeOrDefault returns the configured maximum input size or the protocol default.
+func (c *AltDAConfig) MaxInputSizeOrDefault() uint64 {
+	if c == nil || c.MaxInputSize == nil {
+		return altda.MaxInputSize
+	}
+	return *c.MaxInputSize
 }
 
 type Config struct {
@@ -433,6 +444,9 @@ func (cfg *Config) ProbablyMissingPectraBlobSchedule() bool {
 // If the legacy values are set, they are copied to the new location. If both are set, they are check for consistency.
 func validateAltDAConfig(cfg *Config) error {
 	if cfg.AltDAConfig != nil {
+		if cfg.AltDAConfig.MaxInputSize != nil && *cfg.AltDAConfig.MaxInputSize == 0 {
+			return errors.New("altDA max input size must be greater than zero")
+		}
 		if !(cfg.AltDAConfig.CommitmentType == altda.KeccakCommitmentString || cfg.AltDAConfig.CommitmentType == altda.GenericCommitmentString) {
 			return fmt.Errorf("invalid commitment type: %v", cfg.AltDAConfig.CommitmentType)
 		}

--- a/op-node/rollup/types_test.go
+++ b/op-node/rollup/types_test.go
@@ -84,13 +84,21 @@ func TestAltDAConfigMaxInputSize(t *testing.T) {
 	require.Equal(t, custom, (&AltDAConfig{MaxInputSize: &custom}).MaxInputSizeOrDefault())
 
 	cfg := randConfig()
-	zero := uint64(0)
 	cfg.AltDAConfig = &AltDAConfig{
 		DAChallengeAddress: common.Address{1},
 		CommitmentType:     altda.KeccakCommitmentString,
-		MaxInputSize:       &zero,
+		MaxInputSize:       ptr.Zero64,
 	}
 	require.EqualError(t, cfg.Check(), "altDA max input size must be greater than zero")
+
+	cfg.AltDAConfig = &AltDAConfig{
+		CommitmentType: altda.GenericCommitmentString,
+		MaxInputSize:   &custom,
+	}
+	require.EqualError(t, cfg.Check(), "altDA max input size must be omitted for generic commitments")
+
+	cfg.AltDAConfig.MaxInputSize = nil
+	require.NoError(t, cfg.Check())
 }
 
 // TestConfigChainOpConfigJSONWireFormat pins the on-the-wire serialization of the

--- a/op-node/rollup/types_test.go
+++ b/op-node/rollup/types_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 
+	altda "github.com/ethereum-optimism/optimism/op-alt-da"
 	"github.com/ethereum-optimism/optimism/op-core/forks"
 	opparams "github.com/ethereum-optimism/optimism/op-core/params"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -73,6 +74,23 @@ func TestConfigJSON(t *testing.T) {
 	var roundTripped Config
 	assert.NoError(t, json.Unmarshal(data, &roundTripped))
 	assert.Equal(t, &roundTripped, config)
+}
+
+func TestAltDAConfigMaxInputSize(t *testing.T) {
+	custom := uint64(1_000_000)
+
+	require.Equal(t, uint64(altda.MaxInputSize), (*AltDAConfig)(nil).MaxInputSizeOrDefault())
+	require.Equal(t, uint64(altda.MaxInputSize), (&AltDAConfig{}).MaxInputSizeOrDefault())
+	require.Equal(t, custom, (&AltDAConfig{MaxInputSize: &custom}).MaxInputSizeOrDefault())
+
+	cfg := randConfig()
+	zero := uint64(0)
+	cfg.AltDAConfig = &AltDAConfig{
+		DAChallengeAddress: common.Address{1},
+		CommitmentType:     altda.KeccakCommitmentString,
+		MaxInputSize:       &zero,
+	}
+	require.EqualError(t, cfg.Check(), "altDA max input size must be greater than zero")
 }
 
 // TestConfigChainOpConfigJSONWireFormat pins the on-the-wire serialization of the

--- a/rust/kona/crates/protocol/genesis/src/chain/altda.rs
+++ b/rust/kona/crates/protocol/genesis/src/chain/altda.rs
@@ -21,6 +21,7 @@ pub struct AltDAConfig {
     /// `AltDA` commitment type
     pub da_commitment_type: Option<String>,
     /// Maximum input size for Keccak commitments.
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub da_max_input_size: Option<u64>,
 }
 
@@ -69,5 +70,11 @@ mod tests {
 
         let err = serde_json::from_str::<AltDAConfig>(raw).unwrap_err();
         assert_eq!(err.classify(), serde_json::error::Category::Data);
+    }
+
+    #[test]
+    fn test_altda_serialize_omits_unset_max_input_size() {
+        let serialized = serde_json::to_value(AltDAConfig::default()).unwrap();
+        assert!(serialized.get("da_max_input_size").is_none());
     }
 }

--- a/rust/kona/crates/protocol/genesis/src/chain/altda.rs
+++ b/rust/kona/crates/protocol/genesis/src/chain/altda.rs
@@ -20,6 +20,8 @@ pub struct AltDAConfig {
     pub da_resolve_window: Option<u64>,
     /// `AltDA` commitment type
     pub da_commitment_type: Option<String>,
+    /// Maximum input size for Keccak commitments.
+    pub da_max_input_size: Option<u64>,
 }
 
 #[cfg(test)]
@@ -36,7 +38,8 @@ mod tests {
             "da_challenge_address": "0x12c6a7db25b20347ca6f5d47e56d5e8219871c6d",
             "da_challenge_window": 1,
             "da_resolve_window": 1,
-            "da_commitment_type": "KeccakCommitment"
+            "da_commitment_type": "KeccakCommitment",
+            "da_max_input_size": 1000000
         }
         "#;
 
@@ -45,6 +48,7 @@ mod tests {
             da_challenge_window: Some(1),
             da_resolve_window: Some(1),
             da_commitment_type: Some("KeccakCommitment".to_string()),
+            da_max_input_size: Some(1_000_000),
         };
 
         let deserialized: AltDAConfig = serde_json::from_str(raw).unwrap();


### PR DESCRIPTION
## What
- Add an optional AltDA input-size limit with the current limit as the default.
- Use the resolved limit for Keccak derivation and batcher validation.
- Keep Kona strict config parsing aligned.

## Why
- This lets operators configure the Keccak AltDA input limit without changing source. Existing configs keep current behavior.

## Validation
- `go test ./op-node/rollup/...`
- `go test ./op-batcher/batcher`
- `go test ./op-alt-da/...`
- `cd rust && cargo test -p kona-genesis chain::altda::tests`
- `cd rust && cargo +nightly-2026-08-18 fmt --package kona-genesis -- --check`