### PR TITLE
op-devstack: fix L1 HTTP poll interval interpreted as nanoseconds

### DIFF
--- a/op-devstack/sysgo/singlechain_build.go
+++ b/op-devstack/sysgo/singlechain_build.go
@@ -370,7 +370,7 @@ func startL2CLNode(
 			L1RPCKind:        sources.RPCKindDebugGeth,
 			RateLimit:        0,
 			BatchSize:        20,
-			HttpPollInterval: 100,
+			HttpPollInterval: 100 * time.Millisecond,
 			MaxConcurrency:   10,
 			CacheSize:        0,
 		},


### PR DESCRIPTION
**Description**

In the singlechain devstack (`op-devstack/sysgo/singlechain_build.go`), the op-node L1 endpoint config sets:

```go
HttpPollInterval: 100,
```

`HttpPollInterval` is a `time.Duration`, so the bare literal `100` is **100 nanoseconds**, not the intended 100 milliseconds. The polling client (`op-service/client/polling.go`) schedules the next poll via `time.AfterFunc(pollRate, ...)`, so a 100ns interval effectively polls the L1 RPC continuously. This produces an unbounded number of outbound connections and can exhaust local ports on the host running devstack tests.

This changes it to `100 * time.Millisecond`, matching:
- the multichain devstack (`op-devstack/sysgo/multichain_supernode_runtime.go`)
- `op-e2e/interop/supersystem_l2.go`
- `op-deployer/pkg/deployer/integration_test/cli/pcd_boot.go`

**Tests**

This is a one-line config value change in test/devstack infrastructure. `gofmt` passes; the expression is identical to the existing `100 * time.Millisecond` usages listed above.

**Additional context**

The op-node CLI default for `--l1.http-poll-interval` is 12s; 100ms is a reasonable fast-polling value for devstack, consistent with the multichain path.