### PR TITLE
op-devstack: Remove FlakyOnOpReth test helper

### DIFF
--- a/op-acceptance-tests/tests/sync/elsync/reorg/sync_test.go
+++ b/op-acceptance-tests/tests/sync/elsync/reorg/sync_test.go
@@ -124,15 +124,6 @@ func TestUnsafeGapFillAfterUnsafeReorg_RestartL2CL(gt *testing.T) {
 	// assertions.go:387:             	            	operation failed permanently after 30 attempts: expected head to reorg 0x893d77533b0ff9b37a92090679bf256d987b4535f06186ec71f29e68ddccd9a5:14, but got 0x893d77533b0ff9b37a92090679bf256d987b4535f06186ec71f29e68ddccd9a5:14
 	// assertions.go:387:             	Test:       	TestUnsafeGapFillAfterUnsafeReorg_RestartL2CL
 	sysgo.SkipOnKonaNode(t, "not supported (timeout)")
-	// Example error with op-reth:
-	//
-	// assertions.go:387:
-	// Error Trace:	/op-devstack/dsl/l2_el.go:430
-	//             				/op-acceptance-tests/tests/sync/elsync/reorg/sync_test.go:218
-	// Error:      	Received unexpected error:
-	//             	operation failed permanently after 50 attempts: expected head to match: unsafe
-	// Test:       	TestUnsafeGapFillAfterUnsafeReorg_RestartL2CL
-	sysgo.FlakyOnOpReth(t, "")
 	sys := newReorgSystem(t)
 	require := t.Require()
 	logger := t.Logger()

--- a/op-acceptance-tests/tests/sync/follow_l2/sync_test.go
+++ b/op-acceptance-tests/tests/sync/follow_l2/sync_test.go
@@ -28,7 +28,6 @@ func TestFollowL2_Safe_Finalized_CurrentL1(gt *testing.T) {
 	// assertions.go:387:             	Test:       	TestFollowL2_Safe_Finalized_CurrentL1
 	// assertions.go:387:             	Messages:   	single-chain test sequencer requires an op-node CL node
 	sysgo.SkipOnKonaNode(t, "not supported")
-	sysgo.FlakyOnOpReth(t, "timeouts in merge queue but not locally")
 	sys := newSingleChainTwoVerifiersFollowL2(t)
 	logger := t.Logger()
 

--- a/op-devstack/sysgo/mixed_runtime.go
+++ b/op-devstack/sysgo/mixed_runtime.go
@@ -85,12 +85,6 @@ func SkipOnKonaNode(t devtest.T, reason string) {
 	}
 }
 
-func FlakyOnOpReth(t devtest.T, reason string) {
-	if devstackL2ELKind() == MixedL2ELOpReth {
-		t.MarkFlaky(reason)
-	}
-}
-
 func FlakyOnKonaNode(t devtest.T, reason string) {
 	if devstackL2CLKind() == MixedL2CLKona {
 		t.MarkFlaky(reason)


### PR DESCRIPTION
Remove `FlakyOnOpReth` and its two call sites. All acceptance tests now run with op-reth, so the helper marked its callers flaky on every run — equivalent to an unconditional `MarkFlaky`.

`TestUnsafeGapFillAfterUnsafeReorg_RestartL2CL` has been stable on `develop` since 2026-04-21 — about 4 months and 900+ passing runs with zero flaky failures (cci-stats) — so it no longer needs the flaky mark. It keeps its `SkipOnKonaNode` guard.

`TestFollowL2_Safe_Finalized_CurrentL1` is skipped on `develop` (its op-node variant no longer runs to completion), so the mark had no effect. Removing it is a no-op for coverage.

`FlakyOnKonaNode` is currently unused but left in place.