### PR TITLE
rust-supernode: Add minimal CLI skeleton

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,7 @@ The OP Stack includes significant Rust implementations:
 - **op-reth**: OP Stack execution client built on reth
 - **op-alloy**: Rust crates providing OP Stack types and providers for the alloy ecosystem
 - **alloy-op-hardforks** / **alloy-op-evm**: OP Stack hardfork and EVM support for alloy
+- **rust-supernode**: Rust rewrite of op-supernode, in early development (`rust/supernode/`)
 
 ### Fault Proof System
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,8 @@ The Optimism Immunefi program offers up to $2,000,042 for in-scope critical vuln
     ├── <a href="./rust/op-revm">op-revm</a>: OP Stack EVM implementation (revm fork)
     ├── <a href="./rust/op-alloy">op-alloy</a>: OP Stack types and providers for the alloy ecosystem
     ├── <a href="./rust/alloy-op-evm">alloy-op-evm</a>: OP Stack EVM support for the alloy ecosystem
-    └── <a href="./rust/alloy-op-hardforks">alloy-op-hardforks</a>: OP Stack hardfork definitions for the alloy ecosystem
+    ├── <a href="./rust/alloy-op-hardforks">alloy-op-hardforks</a>: OP Stack hardfork definitions for the alloy ecosystem
+    └── <a href="./rust/supernode">supernode</a>: Rust rewrite of op-supernode, the multi-chain consensus-layer host (WIP)
 </pre>
 
 ## Development and Release Process

--- a/docs/ai/rust-dev.md
+++ b/docs/ai/rust-dev.md
@@ -48,9 +48,9 @@ just build-no-examples
 just build-release
 
 # Build specific binaries
-just build-node        # kona-node
-just build-op-reth     # op-reth
-just build-supernode   # rust-supernode
+just build-node             # kona-node
+just build-op-reth          # op-reth
+just build-rust-supernode   # rust-supernode
 ```
 
 ### superchain-registry submodule (op-reth)

--- a/docs/ai/rust-dev.md
+++ b/docs/ai/rust-dev.md
@@ -4,11 +4,12 @@ Guidance for AI agents working with Rust code in the Optimism monorepo. See [dev
 
 ## Workspace Layout
 
-All Rust code lives under `rust/`. This is a unified Cargo workspace — always run Rust commands from this directory. The workspace contains three main component groups:
+All Rust code lives under `rust/`. This is a unified Cargo workspace — always run Rust commands from this directory. The workspace contains four main component groups:
 
 - **Kona** — Proof system and rollup node (`rust/kona/`)
 - **Op-Reth** — OP Stack execution client built on reth (`rust/op-reth/`)
 - **Op-Alloy / Alloy extensions** — OP Stack types and providers
+- **Rust Supernode** — Rust rewrite of the Go `op-supernode` multi-chain consensus-layer host (`rust/supernode/`, binary `rust-supernode`). Early development: the crate currently builds a CLI skeleton only.
 
 Check `rust/Cargo.toml` for the full workspace member list, dependency versions, and lint configuration. The Rust toolchain version is pinned in `rust/rust-toolchain.toml`.
 
@@ -47,8 +48,9 @@ just build-no-examples
 just build-release
 
 # Build specific binaries
-just build-node      # kona-node
-just build-op-reth   # op-reth
+just build-node        # kona-node
+just build-op-reth     # op-reth
+just build-supernode   # rust-supernode
 ```
 
 ### superchain-registry submodule (op-reth)

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -15374,6 +15374,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 
 [[package]]
+name = "rust-supernode"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "op-version",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -71,6 +71,9 @@ members = [
 
   # Shared build/version metadata (op-reth + kona-node)
   "op-version/",
+
+  # Rust supernode
+  "supernode/",
 ]
 default-members = [
   "kona/bin/host",

--- a/rust/justfile
+++ b/rust/justfile
@@ -89,8 +89,6 @@ build-rust-supernode:
 build-rust-supernode-debug:
   cargo build -p rust-supernode
 
-alias build-supernode := build-rust-supernode
-
 ############################### Test ################################
 
 # Run all outer-workspace tests. SP1 guests require generated vkeys and are tested by CI after

--- a/rust/justfile
+++ b/rust/justfile
@@ -80,6 +80,17 @@ build-op-reth:
 build-op-reth-debug:
   cargo build --bin op-reth
 
+# Build rust-supernode. The package is not a workspace default member, so `-p`
+# is required for `cargo` to resolve the binary.
+build-rust-supernode:
+  cargo build --release -p rust-supernode
+
+# Build rust-supernode in debug mode (faster compilation for local iteration)
+build-rust-supernode-debug:
+  cargo build -p rust-supernode
+
+alias build-supernode := build-rust-supernode
+
 ############################### Test ################################
 
 # Run all outer-workspace tests. SP1 guests require generated vkeys and are tested by CI after

--- a/rust/kona/bin/node/src/version.rs
+++ b/rust/kona/bin/node/src/version.rs
@@ -1,13 +1,6 @@
 //! Version information for kona-node.
 
-use std::sync::LazyLock;
-
-use op_version::BuildInfo;
-
-static BUILD_INFO: LazyLock<BuildInfo> = LazyLock::new(|| op_version::build_info!());
-
-static SHORT_VERSION: LazyLock<String> = LazyLock::new(|| BUILD_INFO.short_version());
-static LONG_VERSION: LazyLock<String> = LazyLock::new(|| BUILD_INFO.long_version());
+op_version::version_accessors!(pub(crate));
 
 /// The resolved release version (no leading `v`), e.g. `1.2.3` or `0.0.0-dev`.
 pub(crate) fn version() -> &'static str {
@@ -37,14 +30,4 @@ pub(crate) fn target_triple() -> &'static str {
 /// The build profile name.
 pub(crate) fn build_profile() -> &'static str {
     BUILD_INFO.build_profile()
-}
-
-/// The short version information, e.g. `1.2.3 (abc12345)`.
-pub(crate) fn short_version() -> &'static str {
-    &SHORT_VERSION
-}
-
-/// The long, multi-line version information.
-pub(crate) fn long_version() -> &'static str {
-    &LONG_VERSION
 }

--- a/rust/kona/docker/fpvm-prestates/cannon-repro.dockerfile
+++ b/rust/kona/docker/fpvm-prestates/cannon-repro.dockerfile
@@ -75,12 +75,13 @@ COPY rust/alloy-op-evm/ /app/rust/alloy-op-evm/
 COPY rust/alloy-op-hardforks/ /app/rust/alloy-op-hardforks/
 COPY rust/op-revm/ /app/rust/op-revm/
 COPY rust/op-version/ /app/rust/op-version/
-# op-reth, revm-ee-tests, and op-reth-test-engine are workspace members but
-# not kona-client dependencies. We need their Cargo.toml files so the
-# workspace resolves.
+# op-reth, revm-ee-tests, op-reth-test-engine, and supernode are workspace
+# members but not kona-client dependencies. We need their Cargo.toml files so
+# the workspace resolves.
 COPY rust/op-reth/ /app/rust/op-reth/
 COPY rust/revm-ee-tests/ /app/rust/revm-ee-tests/
 COPY rust/op-reth-test-engine/ /app/rust/op-reth-test-engine/
+COPY rust/supernode/ /app/rust/supernode/
 
 # kona-hardforks build.rs walks ancestors of CARGO_MANIFEST_DIR for
 # op-core/nuts/bundles. Stage the bundles at /app/op-core so the walk

--- a/rust/op-version/src/lib.rs
+++ b/rust/op-version/src/lib.rs
@@ -24,6 +24,46 @@ macro_rules! build_info {
     };
 }
 
+/// Declare a binary's cached version accessors: a `BUILD_INFO` static resolved
+/// via [`build_info!`], plus `short_version()` and `long_version()` at the given
+/// visibility.
+///
+/// This has to be a macro rather than a shared function: the `option_env!` reads
+/// in [`build_info!`] only see a binary's injected build values if they expand
+/// inside that binary's own crate.
+///
+/// `BUILD_INFO` is declared in the invoking module so a binary that needs more
+/// than the two version strings can add its own accessors over it.
+///
+/// ```
+/// mod version {
+///     op_version::version_accessors!(pub(crate));
+/// }
+///
+/// assert!(version::long_version().starts_with("Version: "));
+/// ```
+#[macro_export]
+macro_rules! version_accessors {
+    ($vis:vis) => {
+        static BUILD_INFO: ::std::sync::LazyLock<$crate::BuildInfo> =
+            ::std::sync::LazyLock::new(|| $crate::build_info!());
+
+        /// The short version information, e.g. `1.2.3 (abc12345)`.
+        $vis fn short_version() -> &'static str {
+            static SHORT_VERSION: ::std::sync::LazyLock<::std::string::String> =
+                ::std::sync::LazyLock::new(|| BUILD_INFO.short_version());
+            &SHORT_VERSION
+        }
+
+        /// The long, multi-line version information.
+        $vis fn long_version() -> &'static str {
+            static LONG_VERSION: ::std::sync::LazyLock<::std::string::String> =
+                ::std::sync::LazyLock::new(|| BUILD_INFO.long_version());
+            &LONG_VERSION
+        }
+    };
+}
+
 /// Resolved, normalized build metadata for a binary.
 ///
 /// Construct it with the [`build_info!`] macro (the normal entry point), or with

--- a/rust/supernode/Cargo.toml
+++ b/rust/supernode/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "rust-supernode"
+version = "0.1.0"
+description = "Rust implementation of the OP Stack supernode: a multi-chain consensus-layer host"
+
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+keywords.workspace = true
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
+rust-version.workspace = true
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+# workspace
+op-version.workspace = true
+
+# general
+clap = { workspace = true, features = ["derive"] }

--- a/rust/supernode/README.md
+++ b/rust/supernode/README.md
@@ -1,0 +1,36 @@
+# `rust-supernode`
+
+Rust implementation of the OP Stack supernode: a multi-chain consensus-layer host that runs several
+OP Stack chains in one process and verifies cross-chain safety in process.
+
+This crate is the skeleton for that rewrite. It currently builds a CLI that prints a greeting and
+exits; the operator flags, embedded kona virtual nodes, RPC server, metrics, and interop
+verification arrive in later changes. The Go implementation in
+[`op-supernode/`](../../op-supernode) remains the production component until then.
+
+## Usage
+
+```bash
+cd rust
+just build-rust-supernode-debug
+target/debug/rust-supernode
+```
+
+```console
+Hello Rust Supernode
+```
+
+`-V` prints the short version, `--version` prints the full build metadata block. Both come from
+[`op-version`](../op-version), so a release build reports the injected `GIT_VERSION`, `GIT_COMMIT`,
+`GIT_DATE`, and `BUILD_PROFILE`, and a local build reports `0.0.0-dev`.
+
+## Development
+
+The crate is a member of the unified `rust/` Cargo workspace, so the workspace-wide targets cover
+it:
+
+```bash
+cd rust
+just lint       # rustfmt, clippy, rustdoc
+just test-unit  # unit and integration tests
+```

--- a/rust/supernode/src/cli.rs
+++ b/rust/supernode/src/cli.rs
@@ -1,0 +1,25 @@
+//! The `rust-supernode` CLI.
+
+use crate::version;
+use clap::Parser;
+
+/// The greeting the CLI prints until the supernode has behaviour of its own.
+const GREETING: &str = "Hello Rust Supernode";
+
+/// The `rust-supernode` CLI.
+#[derive(Parser, Clone, Debug)]
+#[command(
+    author,
+    version = version::short_version(),
+    long_version = version::long_version(),
+    about,
+    long_about = None
+)]
+pub(crate) struct Cli {}
+
+impl Cli {
+    /// Runs the CLI.
+    pub(crate) fn run(self) {
+        println!("{GREETING}");
+    }
+}

--- a/rust/supernode/src/main.rs
+++ b/rust/supernode/src/main.rs
@@ -1,0 +1,12 @@
+#![doc = include_str!("../README.md")]
+#![doc(issue_tracker_base_url = "https://github.com/ethereum-optimism/optimism/issues/")]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
+mod cli;
+mod version;
+
+fn main() {
+    use clap::Parser;
+
+    cli::Cli::parse().run();
+}

--- a/rust/supernode/src/version.rs
+++ b/rust/supernode/src/version.rs
@@ -1,0 +1,23 @@
+//! Version information for `rust-supernode`.
+
+use op_version::BuildInfo;
+use std::sync::LazyLock;
+
+/// Build metadata resolved from the compile-time environment.
+static BUILD_INFO: LazyLock<BuildInfo> = LazyLock::new(|| op_version::build_info!());
+
+/// The single-line version string.
+static SHORT_VERSION: LazyLock<String> = LazyLock::new(|| BUILD_INFO.short_version());
+
+/// The multi-line build metadata block.
+static LONG_VERSION: LazyLock<String> = LazyLock::new(|| BUILD_INFO.long_version());
+
+/// The single-line version string, e.g. `0.1.0 (abc12345)`.
+pub(crate) fn short_version() -> &'static str {
+    &SHORT_VERSION
+}
+
+/// The multi-line build metadata block.
+pub(crate) fn long_version() -> &'static str {
+    &LONG_VERSION
+}

--- a/rust/supernode/src/version.rs
+++ b/rust/supernode/src/version.rs
@@ -1,23 +1,3 @@
 //! Version information for `rust-supernode`.
 
-use op_version::BuildInfo;
-use std::sync::LazyLock;
-
-/// Build metadata resolved from the compile-time environment.
-static BUILD_INFO: LazyLock<BuildInfo> = LazyLock::new(|| op_version::build_info!());
-
-/// The single-line version string.
-static SHORT_VERSION: LazyLock<String> = LazyLock::new(|| BUILD_INFO.short_version());
-
-/// The multi-line build metadata block.
-static LONG_VERSION: LazyLock<String> = LazyLock::new(|| BUILD_INFO.long_version());
-
-/// The single-line version string, e.g. `0.1.0 (abc12345)`.
-pub(crate) fn short_version() -> &'static str {
-    &SHORT_VERSION
-}
-
-/// The multi-line build metadata block.
-pub(crate) fn long_version() -> &'static str {
-    &LONG_VERSION
-}
+op_version::version_accessors!(pub(crate));

--- a/rust/supernode/tests/cli.rs
+++ b/rust/supernode/tests/cli.rs
@@ -1,0 +1,45 @@
+//! End-to-end specification for the `rust-supernode` binary.
+
+use std::process::{Command, Output};
+
+/// Runs the binary under test with `args` and returns its output.
+fn run(args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_rust-supernode"))
+        .args(args)
+        .output()
+        .expect("failed to run the rust-supernode binary")
+}
+
+/// Asserts the command succeeded and returns its stdout.
+fn stdout_of(output: &Output) -> &str {
+    assert!(
+        output.status.success(),
+        "exited with {:?}, stderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    std::str::from_utf8(&output.stdout).expect("stdout is not utf-8")
+}
+
+#[test]
+fn prints_the_greeting() {
+    let output = run(&[]);
+    assert_eq!(stdout_of(&output), "Hello Rust Supernode\n");
+}
+
+#[test]
+fn short_version_flag_reports_one_line() {
+    let output = run(&["-V"]);
+    let stdout = stdout_of(&output);
+    let version = stdout.strip_prefix("rust-supernode ").expect("version is prefixed by the name");
+    assert_eq!(version.lines().count(), 1, "unexpected short version: {stdout}");
+}
+
+#[test]
+fn long_version_flag_reports_build_metadata() {
+    let output = run(&["--version"]);
+    let stdout = stdout_of(&output);
+    for field in ["Version:", "Commit SHA:", "Build Timestamp:", "Build Profile:"] {
+        assert!(stdout.contains(field), "{field} missing from long version: {stdout}");
+    }
+}


### PR DESCRIPTION
First step of the Rust supernode rewrite ([task breakdown](https://app.notion.com/p/oplabs/Rust-Supernode-Task-Breakdown-395f153ee162818aa512e45e17ca2665), Milestone 1). This is the smallest thing that can be built, run, and tested, so later work has somewhere to land.

`rust/supernode/` holds a new `rust-supernode` binary. It prints `Hello Rust Supernode` and reports its version. Nothing else.

The crate joins the unified `rust/` Cargo workspace, which is the only switch needed for CI. Every CircleCI Rust gate runs with `--workspace`, and the routing regex in `.circleci/routing.yml` already matches `^rust/`, so formatting, clippy, rustdoc, tests, zepter, typos, udeps, cargo-hack, cargo-deny, and both workspace builds now cover the crate with no CI config change. `just build-supernode` and `just build-rust-supernode-debug` are added beside the kona-node and op-reth recipes.

Version strings come from `op-version`, so a container build can inject `GIT_VERSION`, `GIT_COMMIT`, `GIT_DATE`, and `BUILD_PROFILE` later. Docker images are deliberately out of scope.

An integration test runs the built binary and asserts the greeting and both version flags. Later milestones extend that file with the end-to-end CLI specs the plan calls for.

Two notes for review:

- The directory is `rust/supernode/` but the package and binary are `rust-supernode`, matching the name used in the plan and avoiding a `rust/rust-supernode/` path. Easy to rename now if you prefer the names to match.
- `just release` in `rust/justfile` has an `ALL_SUBDIRS` guard that already fails on `develop`, because `op-version`, `revm-ee-tests`, and `op-reth-test-engine` are workspace members that the hardcoded list omits. This crate adds a fourth unlisted name. Left alone here; the guard needs a `publish != false` filter, which is a separate change.
