### PR TITLE
rust: Fix the release recipe subdir guard

### DIFF
--- a/rust/justfile
+++ b/rust/justfile
@@ -497,9 +497,9 @@ hack-tests-default partition="" shuffle="false" seed="default":
 ########################### Release #################################
 
 # Release crates at the given version.
-# target: either "workspace" (releases every subdir under rust/ except op-reth,
-#         in dependency order) or one of the subdir names (op-alloy,
-#         alloy-op-hardforks, alloy-op-evm, op-revm, kona).
+# target: either "workspace" (releases every subdir under rust/ that
+#         RELEASED_SUBDIRS covers, in dependency order) or one of those subdir
+#         names (op-alloy, alloy-op-hardforks, alloy-op-evm, op-revm, kona).
 # mode: "dry" (default, prints changes without applying) or "execute"
 # Extra args are forwarded to `cargo release`.
 # kona is split into two topologically-ordered batches to stay under the
@@ -542,27 +542,32 @@ release TARGET VERSION MODE="dry" *ARGS="":
     fi
 
     # Release order is dependency-driven: foundational crates first, kona last.
-    ALL_SUBDIRS="op-alloy alloy-op-hardforks alloy-op-evm op-revm kona"
+    RELEASED_SUBDIRS="op-alloy alloy-op-hardforks alloy-op-evm op-revm kona"
 
-    EXPECTED_SUBDIRS=$(echo "$ALL_SUBDIRS" | tr ' ' '\n' | sort -u)
-    ACTUAL_SUBDIRS=$(echo "$METADATA" \
-      | jq -r '.packages[].manifest_path' \
-      | sed -nE 's|.*/rust/([^/]+)/.*|\1|p' \
-      | grep -vx 'op-reth' \
-      | sort -u)
-    if [[ "$EXPECTED_SUBDIRS" != "$ACTUAL_SUBDIRS" ]]; then
-      echo "error: hardcoded ALL_SUBDIRS list doesn't match actual subdirs under rust/." >&2
-      echo "  diff (expected vs actual):" >&2
-      diff <(echo "$EXPECTED_SUBDIRS") <(echo "$ACTUAL_SUBDIRS") >&2 || true
-      echo "  Update ALL_SUBDIRS in rust/justfile." >&2
+    # Subdirs this recipe deliberately does not release: op-reth releases on its
+    # own cadence, and the others hold internal crates (build metadata, test
+    # support, work in progress) that no workspace release covers.
+    SKIPPED_SUBDIRS="op-reth op-version revm-ee-tests op-reth-test-engine"
+
+    # Every subdir has to be classified, so a new one fails here rather than
+    # being silently left out of a release. Only unclassified subdirs are an
+    # error; a stale name in either list releases nothing, because its package
+    # list comes out empty below.
+    UNCLASSIFIED=$(comm -23 \
+      <(echo "$METADATA" | jq -r '.packages[].manifest_path' | sed -nE 's|.*/rust/([^/]+)/.*|\1|p' | sort -u) \
+      <(echo "$RELEASED_SUBDIRS $SKIPPED_SUBDIRS" | tr ' ' '\n' | sort -u))
+    if [[ -n "$UNCLASSIFIED" ]]; then
+      echo "error: subdirs under rust/ that neither release list covers:" >&2
+      echo "$UNCLASSIFIED" | sed 's/^/    /' >&2
+      echo "  Add each to RELEASED_SUBDIRS (in dependency order) or SKIPPED_SUBDIRS in rust/justfile." >&2
       exit 1
     fi
 
     case "{{TARGET}}" in
-      workspace) SUBDIRS="$ALL_SUBDIRS" ;;
+      workspace) SUBDIRS="$RELEASED_SUBDIRS" ;;
       *)
-        if ! echo " $ALL_SUBDIRS " | grep -q " {{TARGET}} "; then
-          echo "error: unknown target '{{TARGET}}'. Must be 'workspace' or one of: $ALL_SUBDIRS" >&2
+        if ! echo " $RELEASED_SUBDIRS " | grep -q " {{TARGET}} "; then
+          echo "error: unknown target '{{TARGET}}'. Must be 'workspace' or one of: $RELEASED_SUBDIRS" >&2
           exit 1
         fi
         SUBDIRS="{{TARGET}}"

--- a/rust/justfile
+++ b/rust/justfile
@@ -547,7 +547,7 @@ release TARGET VERSION MODE="dry" *ARGS="":
     # Subdirs this recipe deliberately does not release: op-reth releases on its
     # own cadence, and the others hold internal crates (build metadata, test
     # support, work in progress) that no workspace release covers.
-    SKIPPED_SUBDIRS="op-reth op-version revm-ee-tests op-reth-test-engine"
+    SKIPPED_SUBDIRS="op-reth op-version revm-ee-tests op-reth-test-engine lokahi"
 
     # Every subdir has to be classified, so a new one fails here rather than
     # being silently left out of a release. Only unclassified subdirs are an

--- a/rust/justfile
+++ b/rust/justfile
@@ -524,12 +524,12 @@ release TARGET VERSION MODE="dry" *ARGS="":
 
     METADATA=$(cargo metadata --format-version=1 --no-deps)
 
-    # Hardcoded split for kona: 32 crates exceeds crates.io's "existing crates"
+    # Hardcoded split for kona: 33 crates exceeds crates.io's "existing crates"
     # rate limit of 30, so we publish in two topologically-ordered batches.
     # When adding a new crate under rust/kona/, append it to whichever batch
     # leaves both <= 30 (preserving topo order: deps before dependents).
     KONA_BATCH_1="kona-genesis kona-macros kona-mpt kona-preimage kona-serde kona-sources kona-registry kona-std-fpvm kona-cli kona-peers kona-protocol kona-std-fpvm-proc kona-disc kona-engine kona-executor kona-hardforks"
-    KONA_BATCH_2="kona-interop example-discovery kona-gossip execution-fixture kona-derive kona-rpc kona-driver kona-providers-alloy kona-providers-local kona-proof kona-node-service kona-proof-interop example-gossip kona-node kona-client kona-host"
+    KONA_BATCH_2="kona-safedb kona-interop example-discovery kona-gossip execution-fixture kona-derive kona-rpc kona-driver kona-providers-alloy kona-providers-local kona-proof kona-node-service kona-proof-interop example-gossip kona-node kona-client kona-host"
 
     ACTUAL_KONA=$(echo "$METADATA" | jq -r '.packages[] | select((.manifest_path | contains("/rust/kona/")) and (.manifest_path | contains("/rust/kona/sp1/") | not)) | .name' | sort -u)
     EXPECTED_KONA=$(echo "$KONA_BATCH_1 $KONA_BATCH_2" | tr ' ' '\n' | sort -u)


### PR DESCRIPTION
`just release` in `rust/` has been unusable since #20611. The recipe asserts that the hardcoded `ALL_SUBDIRS` list equals every subdir under `rust/` that `cargo metadata` reports, but three workspace members joined later without an update: `revm-ee-tests` (#20611), `op-reth-test-engine` (#21216), and `op-version` (#21645). Every target, including a single-subdir one, aborted at the guard:

```
error: hardcoded ALL_SUBDIRS list doesn't match actual subdirs under rust/.
  diff (expected vs actual):
4a5
> op-reth-test-engine
5a7,8
> op-version
> revm-ee-tests
```

Those three hold internal crates that no workspace release covers, so they belong in a skip list rather than in the release order. This splits the one list in two, `RELEASED_SUBDIRS` and `SKIPPED_SUBDIRS`, and moves `op-reth` into the skip list in place of the `grep -vx 'op-reth'` filter that expressed the same intent less visibly.

After rebasing onto current `develop`, this also classifies the subsequently-added `lokahi` subdir as skipped and adds the publishable `kona-safedb` crate to Kona batch 2.

The guard now reports only subdirs that neither list covers. A new subdir still has to be classified deliberately, which is the point of the check, but a stale entry is harmless: its package list comes out empty and the existing `continue` skips it.

Verified against current `cargo metadata`: all 10 top-level Rust subdirs are classified, all 33 non-SP1 Kona crates are present in the two release batches, and no batch-1 package depends on a batch-2 package. `just release op-revm 999.0.0 dry` reaches `cargo release` instead of failing either guard.

Unrelated finding while testing: `cargo release` itself fails in a linked git worktree with `failed to get package content for .../alloy-op-hardforks/Cargo.toml`, with or without this change. Releases have to run from the main checkout.