### PR TITLE
op-supernode: add formally verified Dafny model

### DIFF
--- a/op-supernode/dafny-models/ChainContainer.dfy
+++ b/op-supernode/dafny-models/ChainContainer.dfy
@@ -26,7 +26,7 @@ module ChainContainer {
     method OptimisticAt(ts: nat) returns (result: Option<OptimisticAtResult>)
       ensures {:axiom} result.Some? ==>
         BlockInfo(result.value.l2Block).Some? &&
-        BlockInfo(result.value.l2Block).value.timestamp == ts
+        BlockInfo(result.value.l2Block).value.timestamp <= ts
 
     // Prunes deny-list entries at or after the given timestamp.
     // Pure I/O with no modeled state changes.

--- a/op-supernode/dafny-models/ChainContainer.dfy
+++ b/op-supernode/dafny-models/ChainContainer.dfy
@@ -7,6 +7,16 @@ module ChainContainer {
   import opened Types
   import opened VerifiedDB
 
+  // Result of a single OptimisticAt query.
+  // Corresponds to the l2Block and l1Block values returned by c.OptimisticAt in
+  // checkChainsReady in interop.go.
+  datatype OptimisticAtResult = OptimisticAtResult(l2Block: BlockID, l1Head: BlockID)
+
+  // Combined result of a successful FetchReceipts call.
+  // Corresponds to (eth.BlockInfo, types.Receipts) returned by ChainContainer.FetchReceipts
+  // in chain_container.go.
+  datatype FetchReceiptsResult = FetchReceiptsResult(info: BlockInfo, logs: BlockLogs)
+
   class ChainContainer {
 
     // Returns the optimistic L2 block and its L1 inclusion head at the given
@@ -14,6 +24,9 @@ module ChainContainer {
     // (corresponds to an ethereum.NotFound error in Go).
     // Corresponds to ChainContainer.OptimisticAt in chain_container.go.
     method OptimisticAt(ts: nat) returns (result: Option<OptimisticAtResult>)
+      ensures {:axiom} result.Some? ==>
+        BlockInfo(result.value.l2Block).Some? &&
+        BlockInfo(result.value.l2Block).value.timestamp == ts
 
     // Prunes deny-list entries at or after the given timestamp.
     // Pure I/O with no modeled state changes.
@@ -35,12 +48,31 @@ module ChainContainer {
     method InvalidateBlock(blockID: BlockID, timestamp: nat) returns (success: bool)
       modifies this
 
-    // Fetches block info for the given block.
-    // In the model, receipts are abstracted away; only the metadata needed by
-    // persistFrontierLogs is returned.
+    // Fetches block info and logs for the given block.
+    // Returns None if the fetch failed (corresponds to an error return in Go).
+    // In the model, receipts are abstracted to executing messages only; see BlockLogs.
     // Corresponds to ChainContainer.FetchReceipts in chain_container.go.
-    method FetchReceipts(blockID: BlockID) returns (info: BlockInfo)
-      ensures {:axiom} info.id == blockID
+    method FetchReceipts(blockID: BlockID) returns (result: Option<FetchReceiptsResult>)
+      // But not <==>. BlockInfo and BlockLogs also include blocks that are no longer
+      // part of the canonical chain, so FetchReceipts might return None for those.
+      ensures {:axiom} result.Some? ==> BlockInfo(blockID).Some?
+      ensures {:axiom} result.Some? ==> BlockLogs(blockID).Some?
+      ensures {:axiom} result.Some? ==> result.value.info == BlockInfo(blockID).value
+      ensures {:axiom} result.Some? ==> result.value.logs == BlockLogs(blockID).value
 
+    // Returns the block time for this chain in seconds. Immutable per-chain configuration.
+    // Corresponds to cc.InteropChain.BlockTime() in chain_container.go.
+    function BlockTime(): nat
+      reads {}
+
+    // BlockInfo and BlockLogs represent an immutable source of truth for block information,
+    // independently of whether the block is part of the current chain or not.
+    ghost function BlockInfo(blockID: BlockID) : Option<BlockInfo>
+      reads {}
+      ensures {:axiom} BlockInfo(blockID).Some? ==> BlockInfo(blockID).value.id == blockID
+
+    ghost function BlockLogs(blockID: BlockID) : Option<BlockLogs>
+      reads {}
+      ensures {:axiom} BlockLogs(blockID).Some? <==> BlockInfo(blockID).Some?
   }
 }

--- a/op-supernode/dafny-models/ChainContainer.dfy
+++ b/op-supernode/dafny-models/ChainContainer.dfy
@@ -24,6 +24,8 @@ module ChainContainer {
     // (corresponds to an ethereum.NotFound error in Go).
     // Corresponds to ChainContainer.OptimisticAt in chain_container.go.
     method OptimisticAt(ts: nat) returns (result: Option<OptimisticAtResult>)
+      // Modifies clause represents the fact that the chain state can change in between calls
+      modifies this
       ensures {:axiom} result.Some? ==>
         BlockInfo(result.value.l2Block).Some? &&
         BlockInfo(result.value.l2Block).value.timestamp <= ts
@@ -53,6 +55,8 @@ module ChainContainer {
     // In the model, receipts are abstracted to executing messages only; see BlockLogs.
     // Corresponds to ChainContainer.FetchReceipts in chain_container.go.
     method FetchReceipts(blockID: BlockID) returns (result: Option<FetchReceiptsResult>)
+      // Modifies clause represents the fact that the chain state can change in between calls
+      modifies this
       // But not <==>. BlockInfo and BlockLogs also include blocks that are no longer
       // part of the canonical chain, so FetchReceipts might return None for those.
       ensures {:axiom} result.Some? ==> BlockInfo(blockID).Some?

--- a/op-supernode/dafny-models/ChainContainer.dfy
+++ b/op-supernode/dafny-models/ChainContainer.dfy
@@ -1,0 +1,46 @@
+// Dafny model for the ChainContainer interface from chain_container/chain_container.go.
+// Models the subset of the interface used by the Interop activity.
+
+include "VerifiedDB.dfy"
+
+module ChainContainer {
+  import opened Types
+  import opened VerifiedDB
+
+  class ChainContainer {
+
+    // Returns the optimistic L2 block and its L1 inclusion head at the given
+    // timestamp, or None if the chain has no block at that timestamp yet
+    // (corresponds to an ethereum.NotFound error in Go).
+    // Corresponds to ChainContainer.OptimisticAt in chain_container.go.
+    method OptimisticAt(ts: nat) returns (result: Option<OptimisticAtResult>)
+
+    // Prunes deny-list entries at or after the given timestamp.
+    // Pure I/O with no modeled state changes.
+    // Corresponds to ChainContainer.PruneDeniedAtOrAfterTimestamp in chain_container.go.
+    method PruneDeniedAtOrAfterTimestamp(timestamp: nat)
+      modifies this
+
+    // Rewinds the chain engine to the given timestamp.
+    // Returns false if the operation failed.
+    // Pure I/O with no modeled state changes.
+    // Corresponds to ChainContainer.RewindEngine in chain_container.go.
+    method RewindEngine(resetTo: nat) returns (success: bool)
+      modifies this
+
+    // Adds a block to the deny list and potentially triggers a chain rewind.
+    // Returns false if the operation failed.
+    // Pure I/O with no modeled state changes.
+    // Corresponds to ChainContainer.InvalidateBlock in chain_container.go.
+    method InvalidateBlock(blockID: BlockID, timestamp: nat) returns (success: bool)
+      modifies this
+
+    // Fetches block info for the given block.
+    // In the model, receipts are abstracted away; only the metadata needed by
+    // persistFrontierLogs is returned.
+    // Corresponds to ChainContainer.FetchReceipts in chain_container.go.
+    method FetchReceipts(blockID: BlockID) returns (info: BlockInfo)
+      ensures {:axiom} info.id == blockID
+
+  }
+}

--- a/op-supernode/dafny-models/Interop.dfy
+++ b/op-supernode/dafny-models/Interop.dfy
@@ -174,7 +174,7 @@ module Interop {
     }
 
     // Lifted versions of DBsInSyncUpTo / DBsInSync that quantify over all chains.
-    // Replace verbose forall patterns in method specifications.
+    // Avoids verbose forall patterns in method specifications.
     ghost predicate AllDBsInSyncUpTo(upper: nat)
       reads verifiedDB, logsDBs.Values
     {
@@ -308,6 +308,8 @@ module Interop {
       }
     }
 
+    // If the given pending transition is an Advance, the l2Heads are consistent with the
+    // chain state at the time the block was fetched.
     ghost predicate TransitionConsistentWithChainState(pending: PendingTransition)
       requires ValidPendingTransition(pending)
       requires chains.Keys == CHAIN_IDS
@@ -802,8 +804,8 @@ module Interop {
       assert TransitionIsCrossValid(pendingTx);
       assert AllVerifiedCrossValid();
 
-      // Snapshot the heap before SetPendingTransition so that the twostate lemma
-      // below can reference the pre-set state where AllDBsInSync() holds.
+      // Snapshot the heap before SetPendingTransition so that the twostate lemmas
+      // below can reference the pre-set state.
       label BeforeSetPending:
       verifiedDB.SetPendingTransition(pendingTx);
 
@@ -837,6 +839,8 @@ module Interop {
     // Does not modify the verified DB.
     // Corresponds to progressInterop in interop.go.
     method {:isolate_assertions} ProgressInterop() returns (output: StepOutput, obs: RoundObservation)
+      // To represent that chain state may change during execution due to reorgs
+      modifies chains.Values
       requires Valid()
       requires AllDBsInSync()
       requires AllVerifiedCrossValid()
@@ -881,6 +885,8 @@ module Interop {
     // verified DB and querying all chains for their status at the next timestamp.
     // Corresponds to observeRound in interop.go.
     method {:isolate_assertions} ObserveRound() returns (obs: RoundObservation)
+      // To represent that chain state may change during execution due to reorgs
+      modifies chains.Values
       requires Valid()
       requires AllDBsInSync()
       ensures Valid()
@@ -952,6 +958,8 @@ module Interop {
     // abstracted away as a sequential loop, and the ethereum.NotFound error is
     // replaced by an Option return.
     method {:isolate_assertions} CheckChainsReady(ts: nat) returns (result: Option<ChainsReadyResult>)
+      // To represent that chain state may change during execution due to reorgs
+      modifies chains.Values
       requires Valid()
       requires AllDBsInSync()
       requires forall k :: k in logsDBs && logsDBs[k].LatestSealedBlock().None? ==>
@@ -1068,9 +1076,8 @@ module Interop {
           return;
         }
 
-        // ApplyRewindPlan establishes DBsInSync(k) for all k. Snapshot the heap here
-        // so that the twostate lemma call below can use old@BeforeClearRewind() to refer
-        // to this state, where DBsInSync is known to hold.
+        // Snapshot the heap before ClearPendingTransition so that the twostate lemmas
+        // below can reference the pre-clear state.
         label BeforeClearRewind:
         verifiedDB.ClearPendingTransition();
 
@@ -1126,9 +1133,8 @@ module Interop {
           return;
         }
 
-        // Loop invariant established DBsInSync(k) for all k. Snapshot the heap here
-        // so the twostate lemma below can use old@BeforeClearInvalidate() to refer
-        // to this state.
+        // Snapshot the heap before ClearPendingTransition so that the twostate lemmas
+        // below can reference the pre-clear state.
         label BeforeClearInvalidate:
         verifiedDB.ClearPendingTransition();
 
@@ -1494,7 +1500,7 @@ module Interop {
         assert unchanged@BeforeRewind(verifiedDB);
         RewindEstablishesDBsInSync@BeforeRewind(chainID);
 
-        // Establish the loop invariant at line 1346 (for i+1):
+        // Re-establish the loop invariant for chainIDs[0..i+1]:
         // for the newly-rewound chain, RewindEstablishesDBsInSync gives us DBsInSync;
         // for previously-rewound chains, logsDBs[k] is unchanged so RewoundLogsDB and DBsInSync are preserved.
         assert forall k :: k in chainIDs[0..i+1] ==>
@@ -1537,6 +1543,8 @@ module Interop {
     method {:isolate_assertions} PersistFrontierLogs(ts: nat, blocksAtTS: map<ChainID, BlockID>)
         returns (success: bool)
       modifies logsDBs.Values
+      // To represent that chain state may change during execution due to reorgs
+      modifies chains.Values
       requires Valid()
       requires blocksAtTS.Keys == chains.Keys
       requires AdvancesAllLogsDBs(ts, blocksAtTS)
@@ -2690,8 +2698,8 @@ module Interop {
     // Rewind removes entries >= rewindAt; all remaining entries were covered by
     // old(AllVerifiedCrossValid()) and ResultIsCrossValid is heap-independent
     // w.r.t. anything Rewind touches (only verifiedDB).
-    // Intended to be called as RewindPreservesAllVerifiedCrossValid(rewindAt) right
-    // after the Rewind call (no label needed when Rewind is the first operation).
+    // Intended to be called as RewindPreservesAllVerifiedCrossValid@L(rewindAt)
+    // where L is a label placed just before the Rewind call.
     twostate lemma {:isolate_assertions} RewindPreservesAllVerifiedCrossValid(rewindAt: nat)
       requires old(Valid())
       requires Valid()
@@ -2865,8 +2873,9 @@ module Interop {
     //     NOTE: old(seal_timestamp(targetHead.number)) is not directly bounded to ts here;
     //     instead, step (3) bypasses this via VerifiedHeadsAreHighestBlocksUpToTimestamp.
     // (2) ValidExecutingMessage(T_chain, chainID, execMsg) gives execMsg.timestamp ≤ T_chain ≤ ts.
-    //     (The T_chain ≤ ts bound comes from FindSealedBlock monotonicity + requires #11, but
-    //     step (3) can derive the contradiction without it by using VHAHIBT directly.)
+    //     (The T_chain ≤ ts bound follows from FindSealedBlock monotonicity combined with
+    //     AllDBsInSyncUpTo and BlockSealsMatchOnChainTimestamps, but step (3) can derive
+    //     the contradiction without it by using VHAHIBT directly.)
     // (3) Contains axiom gives old seal timestamp == execMsg.timestamp ≤ ts (from step 2).
     //     old(VerifiedHeadsAreHighestBlocksUpToTimestamp()) at ts for the source chain:
     //     if execMsg.blockNum > plan.targetHeads[source].number, then ts < execMsg.timestamp —
@@ -3018,7 +3027,7 @@ module Interop {
               assert old(logsDBs[chainID].FindSealedBlock(blockID.number)).value.timestamp == T_chain;
               //   verifiedDB non-decreasing (ts' ≤ ts): blockID.number ≤ plan.targetHeads[chainID].number.
               assert blockID.number <= plan.targetHeads[chainID].number;
-              //   Requires #11 gives seal at targetHead.number has timestamp ts.
+              //   AllDBsInSyncUpTo + BlockSealsMatchOnChainTimestamps: seal at targetHead.number has timestamp ts.
               //   FindSealedBlock monotonicity: T_chain ≤ ts.
               assert T_chain <= ts;
               assert execMsg.timestamp <= ts;

--- a/op-supernode/dafny-models/Interop.dfy
+++ b/op-supernode/dafny-models/Interop.dfy
@@ -11,12 +11,39 @@ module Interop {
   import opened ChainContainer
   import opened LogsDB
 
+  // Abstract model of the frontier verification view, which pre-fetches block
+  // receipts for the unverified frontier so verification can answer same-timestamp
+  // queries without racing against logsDB writes.
+  // Corresponds to frontierVerificationView in verification_view.go.
+  class FrontierView {
+    // Checks whether the initiating message matching query is present in the
+    // frontier block for chainID.
+    // Corresponds to frontierVerificationView.contains in verification_view.go.
+    predicate Contains(chainID: ChainID, query: ContainsQuery)
+      reads this
+      requires chainID in CHAIN_IDS
+      ensures {:axiom} Contains(chainID, query) ==> BlockInfo(chainID).id.number == query.blockNum
+      ensures {:axiom} Contains(chainID, query) ==> BlockInfo(chainID).timestamp == query.timestamp
+      ensures {:axiom} Contains(chainID, query) ==> query.logIdx in BlockLogs(chainID).execMsgs.Keys
+      ensures {:axiom} Contains(chainID, query) ==>
+        BlockLogs(chainID).execMsgs[query.logIdx].checksum == query.checksum
+
+    function BlockInfo(chainID: ChainID) : BlockInfo
+      reads this
+      requires chainID in CHAIN_IDS
+
+    function BlockLogs(chainID: ChainID) : BlockLogs
+      reads this
+      requires chainID in CHAIN_IDS
+  }
+
   class Interop {
 
     var currentL1: BlockID
     const chains: map<ChainID, ChainContainer>
     const verifiedDB: VerifiedDB
     const activationTimestamp: nat
+    const messageExpiryWindow: nat
     const logsDBs: map<ChainID, LogsDB>
 
     constructor(chains: map<ChainID, ChainContainer>)
@@ -40,6 +67,7 @@ module Interop {
 
       this.verifiedDB := new VerifiedDB();
       this.activationTimestamp := ACTIVATION_TIMESTAMP;
+      this.messageExpiryWindow := MESSAGE_EXPIRY_WINDOW;
       this.currentL1 := BlockID(0, 0);
       this.chains := chains;
       this.logsDBs := logsDBs;
@@ -85,6 +113,7 @@ module Interop {
       reads verifiedDB
     {
       activationTimestamp == ACTIVATION_TIMESTAMP &&
+      messageExpiryWindow == MESSAGE_EXPIRY_WINDOW &&
       chains.Keys == CHAIN_IDS &&
 
       /* LogsDBs invariants */
@@ -407,6 +436,113 @@ module Interop {
         AdvancesLogsDB(ts, chainID, blocksAtTS[chainID])
     }
 
+    ghost predicate ValidExecutingMessage(execTimestamp: nat, execChain: ChainID, execMsg: ExecutingMessage)
+      requires execChain in CHAIN_IDS
+      requires chains.Keys == CHAIN_IDS
+    {
+      var initChain := execMsg.chainID;
+      var initTimestamp := execMsg.timestamp;
+      initChain in chains.Keys &&
+      var initBlockTime := chains[initChain].BlockTime();
+      var execBlockTime := chains[execChain].BlockTime();
+      activationTimestamp + execBlockTime <= execTimestamp &&
+      activationTimestamp + initBlockTime <= initTimestamp &&
+      initTimestamp <= execTimestamp <= initTimestamp + messageExpiryWindow
+    }
+
+    ghost predicate PresentInFrontierView(execMsg: ExecutingMessage, view: FrontierView)
+      reads view
+      requires execMsg.chainID in CHAIN_IDS
+    {
+      var query := ContainsQuery(execMsg.blockNum, execMsg.logIdx, execMsg.timestamp, execMsg.checksum);
+      view.Contains(execMsg.chainID, query)
+    }
+
+    ghost predicate PresentInLogsDB(execMsg: ExecutingMessage)
+      reads logsDBs.Values
+      requires execMsg.chainID in logsDBs.Keys
+    {
+      var query := ContainsQuery(execMsg.blockNum, execMsg.logIdx, execMsg.timestamp, execMsg.checksum);
+      logsDBs[execMsg.chainID].Contains(query)
+    }
+
+    ghost predicate BlockIsCrossValid(ts: nat, chainID: ChainID, logs: BlockLogs)
+      requires chainID in CHAIN_IDS
+      requires chains.Keys == CHAIN_IDS
+    {
+      forall execMsg :: execMsg in logs.execMsgs.Values ==>
+        ValidExecutingMessage(ts, chainID, execMsg)
+    }
+
+    ghost predicate AllMessagesPresent(chainID: ChainID, logs: BlockLogs, view: FrontierView)
+      reads logsDBs.Values, view
+      requires logsDBs.Keys == CHAIN_IDS
+      requires forall execMsg :: execMsg in logs.execMsgs.Values ==>
+        execMsg.chainID in CHAIN_IDS
+    {
+      forall execMsg :: execMsg in logs.execMsgs.Values ==>
+        PresentInFrontierView(execMsg, view) ||
+        PresentInLogsDB(execMsg)
+    }
+
+    ghost predicate AllMessagesInLogsDB(chainID: ChainID, logs: BlockLogs)
+      reads logsDBs.Values
+      requires forall execMsg :: execMsg in logs.execMsgs.Values ==>
+        execMsg.chainID in logsDBs.Keys
+    {
+      forall execMsg :: execMsg in logs.execMsgs.Values ==>
+        PresentInLogsDB(execMsg)
+    }
+
+    ghost predicate ResultIsCrossValid(result: Result)
+      requires chains.Keys == CHAIN_IDS
+      requires result.l2Heads.Keys == CHAIN_IDS
+      requires |result.invalidHeads| == 0
+    {
+      forall chainID :: chainID in CHAIN_IDS ==>
+        var block := result.l2Heads[chainID];
+        var blockInfo := chains[chainID].BlockInfo(block);
+        blockInfo.Some? &&
+        var ts := blockInfo.value.timestamp;
+        var blockLogs := chains[chainID].BlockLogs(block).value;
+        BlockIsCrossValid(ts, chainID, blockLogs)
+    }
+
+    ghost predicate BlockExistedOnChain(chainID: ChainID, blockID: BlockID)
+      requires chainID in chains.Keys
+    {
+      chains[chainID].BlockInfo(blockID).Some?
+    }
+
+    ghost predicate BlocksExistedOnChain(blocksAtTS: map<ChainID, BlockID>)
+      requires blocksAtTS.Keys == CHAIN_IDS
+      requires chains.Keys == CHAIN_IDS
+    {
+      forall chainID :: chainID in CHAIN_IDS ==>
+        BlockExistedOnChain(chainID, blocksAtTS[chainID])
+    }
+
+    ghost predicate TransitionIsCrossValid(pendingTransition: PendingTransition)
+      requires chains.Keys == CHAIN_IDS
+      requires ValidPendingTransition(pendingTransition)
+    {
+      pendingTransition.decision.Advance? ==>
+        assert pendingTransition.result.Some?;
+        ResultIsCrossValid(pendingTransition.result.value)
+    }
+
+    ghost predicate AllVerifiedCrossValid()
+      reads verifiedDB
+      requires Valid()
+    {
+      verifiedDB.LastTimestamp().Some? ==>
+        forall ts :: activationTimestamp <= ts <= verifiedDB.LastTimestamp().value ==>
+          assert verifiedDB.Has(ts) by { SequentialContainsRange(verifiedDB.db, activationTimestamp); }
+          var verified := verifiedDB.Get(ts);
+          var result := Result(verified.timestamp, verified.l1Inclusion, verified.l2Heads, map[]);
+          ResultIsCrossValid(result)
+    }
+
     // ========================================================================
     // Methods
     // ========================================================================
@@ -419,8 +555,14 @@ module Interop {
       modifies this, verifiedDB, chains.Values, logsDBs.Values
       requires Valid()
       requires PendingTransitionIsConsistent()
+      requires AllVerifiedCrossValid()
+      requires verifiedDB.GetPendingTransition().Some? ==>
+        TransitionIsCrossValid(verifiedDB.GetPendingTransition().value)
       ensures Valid()
       ensures PendingTransitionIsConsistent()
+      ensures AllVerifiedCrossValid()
+      ensures verifiedDB.GetPendingTransition().Some? ==>
+        TransitionIsCrossValid(verifiedDB.GetPendingTransition().value)
     {
       // Crash-recovery path: resume an interrupted transition if one was
       // persisted from a previous run.
@@ -444,6 +586,8 @@ module Interop {
       // Persist the transition as a WAL entry before applying it, so that a
       // crash between the two steps is recoverable on the next startup.
       var pendingTx := BuildPendingTransition(output, obs);
+
+      assert TransitionIsCrossValid(pendingTx);
 
       // Snapshot the heap before SetPendingTransition so that the twostate lemma
       // below can reference the pre-set state where AllDBsInSync() holds.
@@ -481,6 +625,7 @@ module Interop {
       ensures ValidStepOutput(output, obs)
       ensures OutputConsistentWithVerified(output, obs)
       ensures OutputConsistentWithLogs(output, obs)
+      ensures output.AdvanceOutput? ==> ResultIsCrossValid(output.result)
     {
       obs := ObserveRound();
 
@@ -488,16 +633,19 @@ module Interop {
         output := WaitOutput;
         return;
       }
+
       if !obs.l2sConsistent {
         output := WaitOutput;
         return;
       }
+
       if !obs.l1Consistent {
         output := RewindOutput;
         return;
       }
 
-      var result := Verify(obs.nextTimestamp, obs.blocksAtTS);
+      var result := Verify(obs.nextTimestamp, obs.blocksAtTS, obs.l1Heads);
+
       if result.l2Heads == map[] {
         output := WaitOutput;
       } else if result.invalidHeads != map[] {
@@ -518,6 +666,8 @@ module Interop {
       ensures ValidRoundObservation(obs)
       ensures ObservationConsistentWithVerified(obs)
       ensures ObservationConsistentWithLogs(obs)
+      ensures 0 < |obs.blocksAtTS| ==> obs.blocksAtTS.Keys == CHAIN_IDS
+      ensures 0 < |obs.blocksAtTS| ==> BlocksExistedOnChain(obs.blocksAtTS)
     {
       // Read the last verified timestamp and its result from the DB.
       var lastTS := verifiedDB.LastTimestamp();
@@ -588,6 +738,7 @@ module Interop {
       ensures Valid()
       ensures result.Some? ==> result.value.blocks.Keys == chains.Keys
       ensures result.Some? ==> AdvancesAllLogsDBs(ts, result.value.blocks)
+      ensures result.Some? ==> BlocksExistedOnChain(result.value.blocks)
     {
       var blocks: map<ChainID, BlockID> := map[];
       var l1Heads: map<ChainID, BlockID> := map[];
@@ -600,6 +751,8 @@ module Interop {
           ts == activationTimestamp
         invariant forall k :: k in chainIDs[0..i] ==>
           AdvancesLogsDB(ts, k, blocks[k])
+        invariant forall k :: k in chainIDs[0..i] ==>
+          BlockExistedOnChain(k, blocks[k])
       {
         var chainID := chainIDs[i];
         var chainResult := chains[chainID].OptimisticAt(ts);
@@ -618,6 +771,7 @@ module Interop {
         }
 
         assert AdvancesLogsDB(ts, chainID, chainResult.value.l2Block);
+        assert BlockExistedOnChain(chainID, chainResult.value.l2Block);
       }
 
       result := Some(ChainsReadyResult(blocks, l1Heads));
@@ -625,16 +779,21 @@ module Interop {
 
     // Verifies cross-chain messages and checks for cycles at the given timestamp,
     // returning the combined result.
-    // Corresponds to verify in interop.go. The frontierView setup
-    // (resolveFrontierVerificationView) is abstracted away.
-    method Verify(ts: nat, blocksAtTS: map<ChainID, BlockID>) returns (result: Result)
+    // Corresponds to verify in interop.go.
+    method Verify(ts: nat, blocksAtTS: map<ChainID, BlockID>, l1Heads: map<ChainID, BlockID>) returns (result: Result)
       requires Valid()
+      requires blocksAtTS.Keys == CHAIN_IDS
+      requires BlocksExistedOnChain(blocksAtTS)
+      requires AdvancesAllLogsDBs(ts, blocksAtTS)
       ensures Valid()
       ensures result.timestamp == ts
       ensures result.l2Heads == blocksAtTS
+      ensures |result.invalidHeads| == 0 ==>
+        ResultIsCrossValid(result)
     {
-      result := VerifyMessages(ts, blocksAtTS);
-      var cycleResult := VerifyCycles(ts, blocksAtTS);
+      var view := ResolveFrontierVerificationView(blocksAtTS);
+      result := VerifyMessages(ts, blocksAtTS, l1Heads, view);
+      var cycleResult := VerifyCycles(ts, blocksAtTS, view);
       result := result.(invalidHeads := result.invalidHeads + cycleResult.invalidHeads);
     }
 
@@ -647,13 +806,19 @@ module Interop {
       requires Valid()
       requires verifiedDB.GetPendingTransition() == Some(pending)
       requires PendingTransitionIsConsistent()
+      requires TransitionIsCrossValid(pending)
+      requires AllVerifiedCrossValid()
       ensures Valid()
-      ensures AllDBsInSync()
       ensures PendingTransitionIsConsistent()
+      ensures AllVerifiedCrossValid()
       ensures madeProgress.None? ==>
         verifiedDB.pendingTransition == Some(pending)
       ensures madeProgress.Some? ==>
+        verifiedDB.pendingTransition == None
+      ensures madeProgress.Some? ==>
         (madeProgress.value <==> pending.decision == Advance)
+      ensures madeProgress.Some? ==>
+        AllDBsInSync()
     {
       assert ValidPendingTransition(pending);
 
@@ -670,6 +835,7 @@ module Interop {
         if !rewindOk {
           madeProgress := None;
           assert PendingTransitionIsConsistent();
+          assert AllVerifiedCrossValid();
           return;
         }
 
@@ -688,6 +854,9 @@ module Interop {
         }
 
         madeProgress := Some(false);
+        assert AllVerifiedCrossValid() by {
+          ClearPendingPreservesAllVerifiedCrossValid@BeforeClearRewind();
+        }
 
       } else if pending.decision == Invalidate {
 
@@ -703,6 +872,7 @@ module Interop {
           invariant Valid()
           invariant verifiedDB.pendingTransition == Some(pending)
           invariant AllDBsInSync()
+          invariant AllVerifiedCrossValid()
         {
           var chainID := invSeq[i];
           if chainID in chains {
@@ -732,6 +902,9 @@ module Interop {
         }
 
         madeProgress := Some(false);
+        assert AllVerifiedCrossValid() by {
+          ClearPendingPreservesAllVerifiedCrossValid@BeforeClearInvalidate();
+        }
 
       } else { // Advance case
 
@@ -739,7 +912,20 @@ module Interop {
         assert pending.result.Some?;
 
         var result := pending.result.value;
-        PersistFrontierLogs(result.timestamp, result.l2Heads);
+        var persistOk := PersistFrontierLogs(result.timestamp, result.l2Heads);
+
+        if !persistOk {
+          // FetchReceipts failed for some chain; keep the pending transition for retry.
+          madeProgress := None;
+          assert PendingTransitionIsConsistent();
+          assert AllVerifiedCrossValid();
+          return;
+        }
+
+        assert ResultIsCrossValid(result);
+        // AllVerifiedCrossValid() still holds here: PersistFrontierLogs does not modify
+        // verifiedDB, so the reads-verifiedDB predicate is unchanged since method entry.
+        assert AllVerifiedCrossValid();
 
         // Snapshot the heap before Commit so the twostate lemma can reference
         // the post-PersistFrontierLogs state via old@BeforeCommit().
@@ -754,6 +940,12 @@ module Interop {
           }
         }
 
+        assert AllVerifiedCrossValid() by {
+          CommitExtendsAllVerifiedCrossValid@BeforeCommit(
+            result.timestamp,
+            VerifiedResult(result.timestamp, result.l1Inclusion, result.l2Heads));
+        }
+
         label BeforeClearAdvance:
         verifiedDB.ClearPendingTransition();
 
@@ -765,6 +957,9 @@ module Interop {
 
         currentL1 := result.l1Inclusion;
         madeProgress := Some(true);
+        assert AllVerifiedCrossValid() by {
+          ClearPendingPreservesAllVerifiedCrossValid@BeforeClearAdvance();
+        }
       }
     }
 
@@ -783,17 +978,26 @@ module Interop {
         forall k :: k in logsDBs.Keys ==> PlanConsistentWithLogs(plan, k)
       requires plan.resetAllChainsTo.Some? ==>
         AllDBsInSyncUpTo(plan.resetAllChainsTo.value)
+      requires AllVerifiedCrossValid()
       ensures Valid()
       ensures ValidRewindPlan(plan)
       ensures verifiedDB.pendingTransition == old(verifiedDB.pendingTransition)
       ensures PlanConsistentWithVerified(plan)
       ensures plan.resetAllChainsTo.Some? ==>
-        forall k :: k in logsDBs.Keys ==>
-          PlanConsistentWithLogs(plan, k) &&
-          RewoundLogsDB(plan, k)
-      ensures AllDBsInSync()
+        forall k :: k in logsDBs.Keys ==> PlanConsistentWithLogs(plan, k)
+      ensures plan.resetAllChainsTo.Some? && success ==>
+        forall k :: k in logsDBs.Keys ==> RewoundLogsDB(plan, k)
+      ensures plan.resetAllChainsTo.Some? ==>
+        AllDBsInSyncUpTo(plan.resetAllChainsTo.value)
+      ensures success ==> AllDBsInSync()
+      ensures AllVerifiedCrossValid()
     {
+      label BeforeRewind:
       var _ := verifiedDB.Rewind(plan.rewindAtOrAfter);
+
+      assert AllVerifiedCrossValid() by {
+        RewindPreservesAllVerifiedCrossValid@BeforeRewind(plan.rewindAtOrAfter);
+      }
 
       assert unchanged(logsDBs.Values);
       assert Valid();
@@ -808,6 +1012,29 @@ module Interop {
       var enginesOk := RewindChainEngines(plan, chainIDs);
 
       assert unchanged(logsDBs.Values);
+      assert AllVerifiedCrossValid();
+
+      if plan.resetAllChainsTo.Some? {
+        assert AllDBsInSyncUpTo(plan.resetAllChainsTo.value) by {
+          var ts := plan.resetAllChainsTo.value;
+
+          forall k | k in chainIDs
+            ensures DBsInSyncUpTo(k, ts)
+          {
+            // RewindChainEngines touched only chains.Values, so the twostate lemma
+            // preconditions are identical to the post-Rewind call site: verifiedDB.db
+            // is the same, logsDBs[k] is unchanged, and old() still resolves to
+            // method entry where the precondition DBsInSyncUpTo(k, ts) held.
+            VerifiedDBRewindPreservesDBsInSyncUpTo(k, ts, plan.rewindAtOrAfter);
+          }
+
+        }
+      }
+
+      if !enginesOk {
+        success := false;
+        return;
+      }
 
       // Clear or rewind log databases depending on whether target heads are available.
       // resetAllChainsTo.None? corresponds to the nil TargetHeads case in Go,
@@ -815,24 +1042,10 @@ module Interop {
       if plan.resetAllChainsTo.None? {
         ClearLogsDBs(plan, chainIDs);
       } else {
-        // Establish DBsInSyncUpTo here, right before RewindLogsDBs needs it.
-        // RewindChainEngines touched only chains.Values, so the twostate lemma
-        // preconditions are identical to the post-Rewind call site: verifiedDB.db
-        // is the same, logsDBs[k] is unchanged, and old() still resolves to
-        // method entry where the precondition DBsInSyncUpTo(k, ts) held.
-        var ts := plan.resetAllChainsTo.value;
-
-        assert AllDBsInSyncUpTo(ts) by {
-          forall k | k in chainIDs
-            ensures DBsInSyncUpTo(k, ts)
-          {
-            VerifiedDBRewindPreservesDBsInSyncUpTo(k, ts, plan.rewindAtOrAfter);
-          }
-        }
-
         RewindLogsDBs(plan, chainIDs);
       }
-      success := enginesOk;
+
+      success := true;
     }
 
     // Prunes deny lists and optionally rewinds chain engines for all chains in chainIDs.
@@ -928,8 +1141,11 @@ module Interop {
     }
 
     // Persists frontier logs for the given verified result.
+    // Returns false if any FetchReceipts call fails (corresponds to an error return
+    // from sealFetchedBlockIntoLogsDB in interop.go).
     // Corresponds to persistFrontierLogs in interop.go.
     method {:isolate_assertions} PersistFrontierLogs(ts: nat, blocksAtTS: map<ChainID, BlockID>)
+        returns (success: bool)
       modifies logsDBs.Values
       requires Valid()
       requires blocksAtTS.Keys == chains.Keys
@@ -937,18 +1153,20 @@ module Interop {
       requires verifiedDB.LastTimestamp().Some? ==>
         AllDBsInSyncUpTo(verifiedDB.LastTimestamp().value)
       ensures Valid()
-      ensures forall k :: k in blocksAtTS.Keys ==>
+      ensures success ==> forall k :: k in blocksAtTS.Keys ==>
         logsDBs[k].LatestSealedBlock() == Some(blocksAtTS[k])
       ensures verifiedDB.LastTimestamp().Some? ==>
         AllDBsInSyncUpTo(verifiedDB.LastTimestamp().value)
+      ensures AdvancesAllLogsDBs(ts, blocksAtTS)
     {
+      success := true;
       var chainIDs := Enumerate(blocksAtTS.Keys);
 
       for i := 0 to |chainIDs|
         invariant Valid()
         invariant forall j, k :: 0 <= j < k < |chainIDs| ==>
           chainIDs[j] != chainIDs[k]
-        invariant forall j :: i <= j < |chainIDs| ==>
+        invariant forall j :: 0 <= j < |chainIDs| ==>
           AdvancesLogsDB(ts, chainIDs[j], blocksAtTS[chainIDs[j]])
         invariant forall j :: 0 <= j < i ==>
           logsDBs[chainIDs[j]].LatestSealedBlock() == Some(blocksAtTS[chainIDs[j]])
@@ -973,9 +1191,27 @@ module Interop {
         var skip := latestBlock == Some(blockID);
 
         if !skip {
-          var blockInfo := chain.FetchReceipts(blockID);
-          // Preconditions replacing ErrStaleLogsDB and ErrParentHashMismatch:
-          // in Go these would be error returns; here they are assumed away.
+          var fetchResult := chain.FetchReceipts(blockID);
+
+          if fetchResult.None? {
+            // I/O error fetching receipts. In Go this propagates as an error from
+            // sealFetchedBlockIntoLogsDB; the pending transition is kept for retry.
+            success := false;
+
+            assert AdvancesAllLogsDBs(ts, blocksAtTS);
+            assert verifiedDB.LastTimestamp().Some? ==>
+              AllDBsInSyncUpTo(verifiedDB.LastTimestamp().value);
+
+            return;
+          }
+
+          var blockInfo := fetchResult.value.info;
+          var logs := fetchResult.value.logs;
+
+          // FetchReceipts postcondition: result.value.info.id == blockID.
+          assert blockInfo.id == blockID;
+
+          // ErrParentHashMismatch: in Go this is an error return; here assumed away.
           assume latestBlock.Some? ==> blockInfo.parentHash == latestBlock.value.hash;
 
           if verifiedDB.LastTimestamp().Some? {
@@ -984,17 +1220,16 @@ module Interop {
             assert SealedBlockForVerifiedAtTimestamp(chainID, lastTS).Some? ==>
               db.LatestSealedBlock().Some?;
 
-            assert AllDBsInSyncUpTo(lastTS) by {
-              forall k | k in blocksAtTS.Keys && k != chainID
-                ensures DBsInSyncUpTo(k, lastTS)
-              {
-                assert logsDBs[k] != db;
-              }
-            }
+            assert AllDBsInSyncUpTo(lastTS);
           }
 
+          // ProcessBlock only modifies db = logsDBs[chainID]; all other logsDBs are
+          // distinct objects (from Valid() + distinct chainIDs), so their state is
+          // preserved for the loop invariants.
+          assert forall j :: 0 <= j < |chainIDs| && j != i ==> logsDBs[chainIDs[i]] != logsDBs[chainIDs[j]];
+
           label BeforeProcessBlock:
-          ProcessBlock(db, blockInfo);
+          ProcessBlock(db, blockInfo, logs);
 
           assert logsDBs[chainID].LatestSealedBlock() == Some(blocksAtTS[chainID]);
 
@@ -1002,10 +1237,13 @@ module Interop {
             var lastTS := verifiedDB.LastTimestamp().value;
 
             assert AllDBsInSyncUpTo(lastTS) by {
+              assert old@BeforeProcessBlock(logsDBs[chainID].LatestSealedBlock()).Some?;
               ProcessBlockPreservesDBsInSyncUpTo@BeforeProcessBlock(chainID, lastTS, blockInfo.id.number);
             }
           }
         }
+
+        assert logsDBs[chainIDs[i]].LatestSealedBlock() == Some(blocksAtTS[chainIDs[i]]);
       }
     }
 
@@ -1023,6 +1261,10 @@ module Interop {
       ensures ValidPendingTransition(pendingTx)
       ensures TransitionConsistentWithVerified(pendingTx)
       ensures TransitionConsistentWithLogs(pendingTx)
+      ensures output.AdvanceOutput? <==> pendingTx.decision.Advance?
+      ensures output.InvalidateOutput? <==> pendingTx.decision.Invalidate?
+      ensures (pendingTx.decision.Advance? || pendingTx.decision.Invalidate?) ==>
+        pendingTx.result.value == output.result
     {
       if output.AdvanceOutput? {
         pendingTx := PendingTransition(Advance, Some(output.result), None);
@@ -1047,6 +1289,211 @@ module Interop {
       }
     }
 
+    // Verifies a single executing message against the source chain's logsDB
+    // and (for same-timestamp messages) the frontier view.
+    // Returns true if all validity conditions are satisfied, false otherwise.
+    // Models verifyExecutingMessage in algo.go.
+    // Simplification vs. Go: ErrUnknownChain is treated as invalid (false)
+    // rather than a fatal error.
+    method VerifyExecutingMessage(
+        executingChain: ChainID,
+        executingTimestamp: nat,
+        execMsg: ExecutingMessage,
+        view: FrontierView)
+        returns (valid: bool)
+      requires Valid()
+      requires executingChain in CHAIN_IDS
+      ensures Valid()
+      ensures valid ==>
+        ValidExecutingMessage(executingTimestamp, executingChain, execMsg)
+      ensures valid ==>
+        if execMsg.timestamp == executingTimestamp then
+          PresentInFrontierView(execMsg, view)
+        else
+          assert execMsg.timestamp < executingTimestamp; // by ValidExecutingMessage above
+          PresentInLogsDB(execMsg)
+    {
+      // Unknown source chain: in Go this is ErrUnknownChain (fatal). Modeled as invalid.
+      if execMsg.chainID !in logsDBs || execMsg.chainID !in chains {
+        valid := false;
+        return;
+      }
+
+      // Activation invariant: interop must be active for at least one full block on
+      // the executing chain. Matches kona and op-program.
+      if executingTimestamp < activationTimestamp + chains[executingChain].BlockTime() {
+        valid := false;  // ErrExecutedTooEarly
+        return;
+      }
+
+      // Activation invariant: interop must be active for at least one full block on
+      // the initiating chain.
+      if execMsg.timestamp < activationTimestamp + chains[execMsg.chainID].BlockTime() {
+        valid := false;  // ErrInitiatedTooEarly
+        return;
+      }
+
+      // Timestamp ordering: the initiating message must not be from the future.
+      if execMsg.timestamp > executingTimestamp {
+        valid := false;  // ErrTimestampViolation
+        return;
+      }
+
+      // Message expiry: the initiating message must not be older than the expiry window.
+      if execMsg.timestamp + messageExpiryWindow < executingTimestamp {
+        valid := false;  // ErrMessageExpired
+        return;
+      }
+
+      var query := ContainsQuery(execMsg.blockNum, execMsg.logIdx, execMsg.timestamp, execMsg.checksum);
+
+      // Same-timestamp dependencies may reside in the frontier view rather than the
+      // accepted-history logsDB. Check the frontier view first; if found, the message
+      // is valid without a logsDB lookup.
+      if execMsg.timestamp == executingTimestamp {
+        // Unlike the Go code, we return false immediately if the initiating message is
+        // not in the frontier. Since we know that there are no blocks for the current
+        // timestamp in the logsDB, there is no point looking there.
+        valid := view.Contains(execMsg.chainID, query);
+        return;
+      }
+
+      // Check the logsDB for the initiating message.
+      valid := logsDBs[execMsg.chainID].Contains(query);
+    }
+
+    // Verifies cross-chain interop messages at the given timestamp.
+    // Models verifyInteropMessages in algo.go.
+    // Simplifications vs. Go:
+    // - InvalidHead carries only BlockID; StateRoot/MessagePasserStorageRoot from
+    //   newInvalidHead are not modeled (see B2).
+    // - Fatal I/O errors (e.g. OpenBlock failure on non-first blocks) are replaced
+    //   by assumes with explanatory comments.
+    method {:isolate_assertions} VerifyMessages(
+        ts: nat,
+        blocksAtTS: map<ChainID, BlockID>,
+        l1Heads: map<ChainID, BlockID>,
+        view: FrontierView)
+        returns (result: Result)
+      requires Valid()
+      requires blocksAtTS.Keys == CHAIN_IDS
+      requires AdvancesAllLogsDBs(ts, blocksAtTS)
+      ensures Valid()
+      ensures result.timestamp == ts
+      ensures result.l2Heads == blocksAtTS
+      ensures |result.invalidHeads| == 0 ==>
+        forall chainID :: chainID in CHAIN_IDS ==>
+          BlockIsCrossValid(view.BlockInfo(chainID).timestamp, chainID, view.BlockLogs(chainID)) &&
+          AllMessagesPresent(chainID, view.BlockLogs(chainID), view)
+    {
+      var l1Inclusion := ComputeL1Inclusion(blocksAtTS, l1Heads);
+      result := Result(ts, l1Inclusion, blocksAtTS, map[]);
+
+      var chainIDs := Enumerate(blocksAtTS.Keys);
+
+      for i := 0 to |chainIDs|
+        invariant Valid()
+        invariant AdvancesAllLogsDBs(ts, blocksAtTS)
+        invariant result.timestamp == ts
+        invariant result.l2Heads == blocksAtTS
+        invariant |result.invalidHeads| == 0 ==>
+          forall j :: 0 <= j < i ==>
+            BlockIsCrossValid(view.BlockInfo(chainIDs[j]).timestamp, chainIDs[j], view.BlockLogs(chainIDs[j])) &&
+            AllMessagesPresent(chainIDs[j], view.BlockLogs(chainIDs[j]), view)
+      {
+        var chainID := chainIDs[i];
+        var expectedBlock := blocksAtTS[chainID];
+
+        // In Go, chains not in logsDBs are skipped. Since Valid() guarantees
+        // logsDBs.Keys == chains.Keys == CHAIN_IDS, and our preconditions
+        // also guarantee blocksAtTS.Keys == CHAIN_IDs, we can just assert this.
+        assert chainID in logsDBs.Keys;
+        assert chainID in chains.Keys;
+
+        // The Go code falls back to querying the logsDBs if a block is not in
+        // the frontier verification view, but in practice this can't happen.
+        // Here we can ensure that the view has a block for every chain.
+        var block := view.BlockInfo(chainID);
+        var logs := view.BlockLogs(chainID);
+
+        // Verify each executing message. Stop at the first invalid one.
+        var blockValid := true;
+        var logIdxs := Enumerate(logs.execMsgs.Keys);
+        var j := 0;
+        while j < |logIdxs| && blockValid
+          invariant 0 <= j <= |logIdxs|
+          invariant Valid()
+          invariant |result.invalidHeads| == 0 ==>
+            forall k :: 0 <= k < i ==>
+              BlockIsCrossValid(view.BlockInfo(chainIDs[k]).timestamp, chainIDs[k], view.BlockLogs(chainIDs[k])) &&
+              AllMessagesPresent(chainIDs[k], view.BlockLogs(chainIDs[k]), view)
+          invariant blockValid ==>
+            forall k :: 0 <= k < j ==>
+              ValidExecutingMessage(block.timestamp, chainID, logs.execMsgs[logIdxs[k]]) &&
+              (PresentInFrontierView(logs.execMsgs[logIdxs[k]], view) || PresentInLogsDB(logs.execMsgs[logIdxs[k]]))
+        {
+          var logIdx := logIdxs[j];
+          var execMsg := logs.execMsgs[logIdx];
+          var ok := VerifyExecutingMessage(chainID, block.timestamp, execMsg, view);
+          if !ok {
+            blockValid := false;
+          }
+          j := j + 1;
+        }
+
+        if !blockValid {
+          result := result.(invalidHeads := result.invalidHeads[chainID := expectedBlock]);
+        } else {
+          assert BlockIsCrossValid(block.timestamp, chainID, logs);
+          assert AllMessagesPresent(chainID, logs, view);
+        }
+      }
+    }
+
+    // Verifies same-timestamp cycle constraints at the given timestamp.
+    // Abstracts cycleVerifyFn (i.verifyCycleMessages) from interop.go.
+    method VerifyCycles(ts: nat, blocksAtTS: map<ChainID, BlockID>, view: FrontierView) returns (result: Result)
+      requires Valid()
+      ensures {:axiom} Valid()
+      ensures {:axiom} result.timestamp == ts
+      ensures {:axiom} result.l2Heads == blocksAtTS
+
+    // Builds the frontier verification view for the given block set.
+    // The view pre-fetches receipts for same-timestamp message queries so that
+    // VerifyMessages can answer them without racing against logsDB writes.
+    // Corresponds to resolveFrontierVerificationView in interop.go.
+    method ResolveFrontierVerificationView(blocksAtTS: map<ChainID, BlockID>) returns (view: FrontierView)
+      requires Valid()
+      requires blocksAtTS.Keys == CHAIN_IDS
+      requires BlocksExistedOnChain(blocksAtTS)
+      ensures {:axiom} Valid()
+      ensures {:axiom} fresh(view)
+      ensures {:axiom} forall chainID :: chainID in CHAIN_IDS ==>
+        chains[chainID].BlockInfo(blocksAtTS[chainID]).Some? &&
+        view.BlockInfo(chainID) == chains[chainID].BlockInfo(blocksAtTS[chainID]).value &&
+        view.BlockLogs(chainID) == chains[chainID].BlockLogs(blocksAtTS[chainID]).value
+
+    // Computes the L1 inclusion block for the given set of L2 blocks by taking
+    // the maximum of the per-chain L1 heads.
+    // Corresponds to the l1Inclusion computation in verifyInteropMessages in algo.go.
+    method ComputeL1Inclusion(blocksAtTS: map<ChainID, BlockID>, l1Heads: map<ChainID, BlockID>) returns (l1Inclusion: BlockID)
+      requires Valid()
+      ensures {:axiom} Valid()
+
+    // Processes and seals a block's logs into the given chain's log database.
+    // Corresponds to processBlockLogs in logdb.go; the parent-hash precondition
+    // mirrors ErrParentHashMismatch (which is assumed away at the call site).
+    method ProcessBlock(db: LogsDB, info: BlockInfo, logs: BlockLogs)
+      modifies db
+      requires Valid()
+      requires db.LatestSealedBlock().None? || (
+        db.LatestSealedBlock().value.number + 1 == info.id.number &&
+        info.parentHash == db.LatestSealedBlock().value.hash)
+      ensures {:axiom} unchanged(verifiedDB)
+      ensures {:axiom} Valid()
+      ensures {:axiom} db.LatestSealedBlock() == Some(info.id)
+      ensures {:axiom} forall n :: n != info.id.number ==> db.FindSealedBlock(n) == old(db.FindSealedBlock(n))
+
     // Checks L1 consistency from two perspectives.
     // l1Consistent: the last verified L1 inclusion block is on the same chain
     //   as the current frontier L1 heads (requires lastVerified to be present).
@@ -1059,34 +1506,6 @@ module Interop {
       requires Valid()
       ensures {:axiom} Valid()
       ensures {:axiom} !l1Consistent ==> lastVerified.Some?
-
-    // Verifies cross-chain interop messages at the given timestamp.
-    // Abstracts verifyFn (i.verifyInteropMessages) from interop.go.
-    method VerifyMessages(ts: nat, blocksAtTS: map<ChainID, BlockID>) returns (result: Result)
-      requires Valid()
-      ensures {:axiom} Valid()
-      ensures {:axiom} result.timestamp == ts
-      ensures {:axiom} result.l2Heads == blocksAtTS
-
-    // Verifies same-timestamp cycle constraints at the given timestamp.
-    // Abstracts cycleVerifyFn (i.verifyCycleMessages) from interop.go.
-    method VerifyCycles(ts: nat, blocksAtTS: map<ChainID, BlockID>) returns (result: Result)
-      requires Valid()
-      ensures {:axiom} Valid()
-
-    // Processes and seals a block's logs in the given chain's log database.
-    // Abstracts processBlockLogs in logdb.go; the stale-data and parent-hash
-    // error returns from persistFrontierLogs are replaced with preconditions.
-    method ProcessBlock(db: LogsDB, info: BlockInfo)
-      modifies db
-      requires Valid()
-      requires db.LatestSealedBlock().None? || (
-        db.LatestSealedBlock().value.number + 1 == info.id.number &&
-        info.parentHash == db.LatestSealedBlock().value.hash)
-      ensures {:axiom} unchanged(verifiedDB)
-      ensures {:axiom} Valid()
-      ensures {:axiom} db.LatestSealedBlock() == Some(info.id)
-      ensures {:axiom} forall n :: n != info.id.number ==> db.FindSealedBlock(n) == old(db.FindSealedBlock(n))
 
     // Updates currentL1 when no progress is made.
     // Corresponds to refreshCurrentL1OnWait in interop.go.
@@ -1272,6 +1691,114 @@ module Interop {
         assert n <= latestNum;
         assert n != newBlockNumber;
         assert logsDBs[chainID].FindSealedBlock(n) == old(logsDBs[chainID].FindSealedBlock(n));
+      }
+    }
+
+    // Framing lemma: ClearPendingTransition preserves AllVerifiedCrossValid.
+    // db and lastTimestamp are unchanged, so the range and entries are the same;
+    // ResultIsCrossValid is heap-independent w.r.t. anything ClearPendingTransition
+    // touches (only pendingTransition changes).
+    // Intended to be called as ClearPendingPreservesAllVerifiedCrossValid@L() where
+    // L is a label placed just before the ClearPendingTransition call.
+    twostate lemma {:isolate_assertions} ClearPendingPreservesAllVerifiedCrossValid()
+      requires old(Valid())
+      requires Valid()
+      requires unchanged(chains.Values)
+      requires verifiedDB.db == old(verifiedDB.db)
+      requires verifiedDB.lastTimestamp == old(verifiedDB.lastTimestamp)
+      requires old(AllVerifiedCrossValid())
+      ensures AllVerifiedCrossValid()
+    {
+      if verifiedDB.LastTimestamp().Some? {
+        var lastTS := verifiedDB.LastTimestamp().value;
+        SequentialContainsRange(verifiedDB.db, activationTimestamp);
+        forall ts | activationTimestamp <= ts <= lastTS
+          ensures verifiedDB.Has(ts)
+          ensures verifiedDB.Get(ts).l2Heads.Keys == CHAIN_IDS
+          ensures ResultIsCrossValid(Result(verifiedDB.Get(ts).timestamp,
+                                            verifiedDB.Get(ts).l1Inclusion,
+                                            verifiedDB.Get(ts).l2Heads, map[]))
+        {
+          assert old(verifiedDB.Has(ts));           // fires trigger on old(AllVerifiedCrossValid())
+          assert verifiedDB.db[ts] == old(verifiedDB.db)[ts];
+        }
+      }
+    }
+
+    // Framing lemma: verifiedDB.Rewind preserves AllVerifiedCrossValid.
+    // Rewind removes entries >= rewindAt; all remaining entries were covered by
+    // old(AllVerifiedCrossValid()) and ResultIsCrossValid is heap-independent
+    // w.r.t. anything Rewind touches (only verifiedDB).
+    // Intended to be called as RewindPreservesAllVerifiedCrossValid(rewindAt) right
+    // after the Rewind call (no label needed when Rewind is the first operation).
+    twostate lemma {:isolate_assertions} RewindPreservesAllVerifiedCrossValid(rewindAt: nat)
+      requires old(Valid())
+      requires Valid()
+      requires unchanged(chains.Values)
+      requires verifiedDB.db ==
+        map k | k in old(verifiedDB.db) && k < rewindAt :: old(verifiedDB.db)[k]
+      requires old(AllVerifiedCrossValid())
+      ensures AllVerifiedCrossValid()
+    {
+      if verifiedDB.LastTimestamp().Some? {
+        var lastTS := verifiedDB.LastTimestamp().value;
+        assert lastTS == MaxKey(verifiedDB.db);   // from Valid(): lastTimestamp == Some(MaxKey(db))
+        assert lastTS in verifiedDB.db;            // MaxKey postcondition
+        assert lastTS < rewindAt;                  // lastTS in verifiedDB.db = {k in old(db) | k < rewindAt}
+        SequentialContainsRange(verifiedDB.db, activationTimestamp);
+        forall ts | activationTimestamp <= ts <= lastTS
+          ensures verifiedDB.Has(ts)
+          ensures verifiedDB.Get(ts).l2Heads.Keys == CHAIN_IDS
+          ensures ResultIsCrossValid(Result(verifiedDB.Get(ts).timestamp,
+                                            verifiedDB.Get(ts).l1Inclusion,
+                                            verifiedDB.Get(ts).l2Heads, map[]))
+        {
+          assert ts < rewindAt;                     // ts <= lastTS < rewindAt
+          assert ts in old(verifiedDB.db);          // ts in verifiedDB.db = {k in old(db) | k < rewindAt}
+          assert old(verifiedDB.Has(ts));           // fires trigger on old(AllVerifiedCrossValid())
+          assert verifiedDB.db[ts] == old(verifiedDB.db)[ts];
+        }
+      }
+    }
+
+    // Framing lemma: verifiedDB.Commit extends AllVerifiedCrossValid with a new entry.
+    // Old entries are unchanged and their ResultIsCrossValid follows from old(AllVerifiedCrossValid());
+    // the new entry must be supplied as ResultIsCrossValid(Result(newTs, ...)) in the requires.
+    // Intended to be called as CommitExtendsAllVerifiedCrossValid@L(newTs, newR) where
+    // L is a label placed just before the Commit call.
+    twostate lemma {:isolate_assertions} CommitExtendsAllVerifiedCrossValid(newTs: nat, newR: VerifiedResult)
+      requires old(Valid())
+      requires Valid()
+      requires unchanged(chains.Values)
+      requires newR.l2Heads.Keys == CHAIN_IDS
+      requires verifiedDB.db == old(verifiedDB.db)[newTs := newR]
+      requires verifiedDB.lastTimestamp == Some(newTs)
+      requires old(verifiedDB.LastTimestamp()).None? ==> newTs == activationTimestamp
+      requires old(verifiedDB.LastTimestamp()).Some? ==>
+        newTs == old(verifiedDB.LastTimestamp()).value + 1
+      requires old(AllVerifiedCrossValid())
+      requires ResultIsCrossValid(Result(newTs, newR.l1Inclusion, newR.l2Heads, map[]))
+      ensures AllVerifiedCrossValid()
+    {
+      SequentialContainsRange(verifiedDB.db, activationTimestamp);
+      forall ts | activationTimestamp <= ts <= newTs
+        ensures verifiedDB.Has(ts)
+        ensures verifiedDB.Get(ts).l2Heads.Keys == CHAIN_IDS
+        ensures ResultIsCrossValid(Result(verifiedDB.Get(ts).timestamp,
+                                          verifiedDB.Get(ts).l1Inclusion,
+                                          verifiedDB.Get(ts).l2Heads, map[]))
+      {
+        if ts == newTs {
+          // direct from requires ResultIsCrossValid(Result(newTs, ...))
+        } else {
+          // ts < newTs; need old(verifiedDB.Has(ts)) to fire old(AllVerifiedCrossValid()) trigger
+          assert old(verifiedDB.LastTimestamp()).Some?;  // else newTs == activationTimestamp <= ts, contradiction
+          var oldLastTS := old(verifiedDB.LastTimestamp()).value;
+          assert ts <= oldLastTS;                         // ts < newTs == oldLastTS + 1
+          SequentialContainsRange(old(verifiedDB.db), activationTimestamp);
+          assert old(verifiedDB.Has(ts));                // fires trigger on old(AllVerifiedCrossValid())
+          assert verifiedDB.db[ts] == old(verifiedDB.db)[ts];
+        }
       }
     }
 

--- a/op-supernode/dafny-models/Interop.dfy
+++ b/op-supernode/dafny-models/Interop.dfy
@@ -52,7 +52,6 @@ module Interop {
       ensures this.chains == chains
       ensures Valid()
       ensures PendingTransitionIsConsistent()
-      ensures AllLogsDBsConsistentWithChainData()
       ensures AllVerifiedCrossValid()
       ensures verifiedDB.GetPendingTransition().Some? ==>
         TransitionIsCrossValid(verifiedDB.GetPendingTransition().value)
@@ -781,13 +780,11 @@ module Interop {
       modifies this, verifiedDB, chains.Values, logsDBs.Values
       requires Valid()
       requires PendingTransitionIsConsistent()
-      requires AllLogsDBsConsistentWithChainData()
       requires AllVerifiedCrossValid()
       requires verifiedDB.GetPendingTransition().Some? ==>
         TransitionIsCrossValid(verifiedDB.GetPendingTransition().value)
       ensures Valid()
       ensures PendingTransitionIsConsistent()
-      ensures AllLogsDBsConsistentWithChainData()
       ensures AllVerifiedCrossValid()
       ensures verifiedDB.GetPendingTransition().Some? ==>
         TransitionIsCrossValid(verifiedDB.GetPendingTransition().value)
@@ -817,13 +814,16 @@ module Interop {
 
       assert TransitionIsCrossValid(pendingTx);
       assert AllVerifiedCrossValid();
+      assert VerifiedHeadsAreHighestBlocksUpToTimestamp();
 
       // Snapshot the heap before SetPendingTransition so that the twostate lemmas
       // below can reference the pre-set state.
       label BeforeSetPending:
       verifiedDB.SetPendingTransition(pendingTx);
 
-      assert VerifiedHeadsAreHighestBlocksUpToTimestamp();
+      assert VerifiedHeadsAreHighestBlocksUpToTimestamp() by {
+        SetPendingPreservesVerifiedHeadsAreHighestBlocksUpToTimestamp@BeforeSetPending();
+      }
 
       // SetPendingTransition only changes pendingTransition; db and lastTimestamp
       // are unchanged. Re-derive DBsInSync for all chains via the framing lemma.
@@ -2659,6 +2659,33 @@ module Interop {
             }
           }
         }
+      }
+    }
+
+    // Framing lemma: SetPendingTransition preserves VerifiedHeadsAreHighestBlocksUpToTimestamp.
+    // db and lastTimestamp are unchanged, so Has and Get return the same values;
+    // logsDBs.Values are unchanged, so FindSealedBlock results are unchanged.
+    // Intended to be called as SetPendingPreservesVerifiedHeadsAreHighestBlocksUpToTimestamp@L()
+    // where L is a label placed just before the SetPendingTransition call.
+    twostate lemma SetPendingPreservesVerifiedHeadsAreHighestBlocksUpToTimestamp()
+      requires old(verifiedDB.Valid())
+      requires verifiedDB.Valid()
+      requires verifiedDB.db == old(verifiedDB.db)
+      requires verifiedDB.lastTimestamp == old(verifiedDB.lastTimestamp)
+      requires unchanged(logsDBs.Values)
+      requires old(VerifiedHeadsAreHighestBlocksUpToTimestamp())
+      ensures VerifiedHeadsAreHighestBlocksUpToTimestamp()
+    {
+      forall ts: nat | verifiedDB.Has(ts) ensures
+        var verifiedHeads := verifiedDB.Get(ts).l2Heads;
+        verifiedHeads.Keys == logsDBs.Keys &&
+        forall chainID :: chainID in verifiedHeads.Keys ==>
+          var blockNumber := verifiedHeads[chainID].number;
+          forall n :: blockNumber < n && logsDBs[chainID].FindSealedBlock(n).Some? ==>
+            ts < logsDBs[chainID].FindSealedBlock(n).value.timestamp
+      {
+        assert old(verifiedDB.Has(ts));                    // fire trigger on old(VerifiedHeadsAreHighestBlocksUpToTimestamp())
+        assert verifiedDB.db[ts] == old(verifiedDB.db)[ts]; // connect old/new db entries
       }
     }
 

--- a/op-supernode/dafny-models/Interop.dfy
+++ b/op-supernode/dafny-models/Interop.dfy
@@ -22,11 +22,12 @@ module Interop {
     predicate Contains(chainID: ChainID, query: ContainsQuery)
       reads this
       requires chainID in CHAIN_IDS
-      ensures {:axiom} Contains(chainID, query) ==> BlockInfo(chainID).id.number == query.blockNum
-      ensures {:axiom} Contains(chainID, query) ==> BlockInfo(chainID).timestamp == query.timestamp
-      ensures {:axiom} Contains(chainID, query) ==> query.logIdx in BlockLogs(chainID).execMsgs.Keys
-      ensures {:axiom} Contains(chainID, query) ==>
-        BlockLogs(chainID).execMsgs[query.logIdx].checksum == query.checksum
+    {
+      BlockInfo(chainID).id.number == query.blockNum &&
+      BlockInfo(chainID).timestamp == query.timestamp &&
+      query.logIdx < |BlockLogs(chainID).fullLogs| &&
+      BlockLogs(chainID).fullLogs[query.logIdx].checksum == query.checksum
+    }
 
     function BlockInfo(chainID: ChainID) : BlockInfo
       reads this
@@ -110,7 +111,7 @@ module Interop {
     // execution. Does not include consistency between the logsDBs and the verifiedDB,
     // which can be temporarily violated (see PendingTransitionIsConsistent for those).
     ghost predicate Valid()
-      reads verifiedDB
+      reads verifiedDB, logsDBs.Values
     {
       activationTimestamp == ACTIVATION_TIMESTAMP &&
       messageExpiryWindow == MESSAGE_EXPIRY_WINDOW &&
@@ -121,6 +122,7 @@ module Interop {
       logsDBs.Keys == CHAIN_IDS &&
       // All logsDBs are distinct.
       (forall k1, k2 :: k1 in logsDBs.Keys && k2 in logsDBs.Keys && k1 != k2 ==> logsDBs[k1] != logsDBs[k2]) &&
+      BlockSealsMatchOnChainTimestamps() &&
 
       /* VerifiedDB invariants */
       verifiedDB.Valid() &&
@@ -131,7 +133,11 @@ module Interop {
       // Every committed verified result covers exactly the current set of chains.
       (forall ts :: ts in verifiedDB.db ==> verifiedDB.db[ts].l2Heads.Keys == CHAIN_IDS) &&
       // The pending transition is valid, if it exists.
-      (verifiedDB.pendingTransition.Some? ==> ValidPendingTransition(verifiedDB.GetPendingTransition().value))
+      (verifiedDB.pendingTransition.Some? ==> ValidPendingTransition(verifiedDB.GetPendingTransition().value)) &&
+      // For every timestamp in the DB, the corresponding L2 heads are bounded by that timestamp.
+      AllVerifiedHeadsBoundedByTimestamp() &&
+      // For every verified result, each L2 head is the highest block in the logsDB below that timestamp.
+      VerifiedHeadsAreHighestBlocksUpToTimestamp()
     }
 
     // The logsDB for chainID is in sync with the verifiedDB up to the given timestamp:
@@ -203,12 +209,20 @@ module Interop {
     ghost predicate PlanConsistentWithLogs(plan: RewindPlan, chainID: ChainID)
       reads logsDBs[chainID]
       requires chainID in logsDBs.Keys
-      requires plan.resetAllChainsTo.Some? ==> chainID in plan.targetHeads
+      requires plan.resetAllChainsTo.Some? ==> chainID in plan.targetHeads.Keys
     {
       plan.resetAllChainsTo.Some? ==>
         var sealedBlock := logsDBs[chainID].FindSealedBlock(plan.targetHeads[chainID].number);
         sealedBlock.Some? &&
         sealedBlock.value.id == plan.targetHeads[chainID]
+    }
+
+    ghost predicate PlanConsistentWithAllLogs(plan: RewindPlan)
+      reads logsDBs.Values
+      requires plan.resetAllChainsTo.Some? ==> plan.targetHeads.Keys == logsDBs.Keys
+    {
+      forall chainID :: chainID in logsDBs.Keys ==>
+        PlanConsistentWithLogs(plan, chainID)
     }
 
     // The verifiedDB is in the expected state after being rewound according to the
@@ -243,6 +257,15 @@ module Interop {
         case Some(_) =>
           logsDBs[chainID].LatestSealedBlock() == Some(plan.targetHeads[chainID])
       }
+    }
+
+    ghost predicate RewoundAllLogsDB(plan: RewindPlan)
+      reads logsDBs.Values
+      requires plan.resetAllChainsTo.Some? ==> plan.targetHeads.Keys == logsDBs.Keys
+      requires PlanConsistentWithAllLogs(plan)
+    {
+      forall chainID :: chainID in logsDBs.Keys ==>
+        RewoundLogsDB(plan, chainID)
     }
 
     // The given pending transition is consistent with the current state of the verifiedDB,
@@ -285,6 +308,15 @@ module Interop {
       }
     }
 
+    ghost predicate TransitionConsistentWithChainState(pending: PendingTransition)
+      requires ValidPendingTransition(pending)
+      requires chains.Keys == CHAIN_IDS
+    {
+      pending.decision.Advance? ==>
+        BlocksExistedOnChain(pending.result.value.l2Heads) &&
+        FrontierBlocksConsistentWithTimestamp(pending.result.value.timestamp, pending.result.value.l2Heads)
+    }
+
     // All preconditions needed to call ApplyPendingTransition in either the
     // crash-recovery path (pending transition already stored) or the fresh path
     // (no pending transition, AllDBsInSync required for ProgressInterop).
@@ -299,6 +331,7 @@ module Interop {
         case Some(p) =>
           TransitionConsistentWithVerified(p) &&
           TransitionConsistentWithLogs(p) &&
+          TransitionConsistentWithChainState(p) &&
           match p.decision {
             case Rewind =>
               p.rewind.value.resetAllChainsTo.Some? ==>
@@ -337,7 +370,7 @@ module Interop {
     // Consistency of the step output with the current logsDB state:
     // the new l2Heads are compatible with each chain's current tip when advancing,
     // and the rewind target block is already sealed in each logsDB when rewinding.
-    ghost predicate OutputConsistentWithLogs(output: StepOutput, obs: RoundObservation)
+    ghost predicate {:isolate_assertions} OutputConsistentWithLogs(output: StepOutput, obs: RoundObservation)
       reads verifiedDB, logsDBs.Values
       requires Valid()
       requires ValidStepOutput(output, obs)
@@ -354,6 +387,15 @@ module Interop {
           AdvancesAllLogsDBs(result.timestamp, result.l2Heads)
         case InvalidateOutput(_) => true
       }
+    }
+
+    ghost predicate OutputConsistentWithChainState(output: StepOutput, obs: RoundObservation)
+      requires chains.Keys == CHAIN_IDS
+    {
+      output.AdvanceOutput? ==>
+        output.result.l2Heads.Keys == CHAIN_IDS &&
+        BlocksExistedOnChain(output.result.l2Heads) &&
+        FrontierBlocksConsistentWithTimestamp(output.result.timestamp, output.result.l2Heads)
     }
 
     // Consistency of the round observation with the current verifiedDB state:
@@ -390,6 +432,15 @@ module Interop {
           sealedBlock.value.id == verifiedDB.Get(obs.lastVerifiedTS.value - 1).l2Heads[k]) &&
       (obs.chainsReady && obs.l2sConsistent && obs.l1Consistent ==>
         AdvancesAllLogsDBs(obs.nextTimestamp, obs.blocksAtTS))
+    }
+
+    ghost predicate ObservationConsistentWithChainState(obs: RoundObservation)
+      requires 0 < |obs.blocksAtTS.Keys| ==> obs.blocksAtTS.Keys == chains.Keys
+    {
+      0 < |obs.blocksAtTS| ==>
+        obs.blocksAtTS.Keys == CHAIN_IDS &&
+        BlocksExistedOnChain(obs.blocksAtTS) &&
+        FrontierBlocksConsistentWithTimestamp(obs.nextTimestamp, obs.blocksAtTS)
     }
 
     // The given timestamp and frontier blocks are a valid sequence to the last entry
@@ -450,7 +501,18 @@ module Interop {
       initTimestamp <= execTimestamp <= initTimestamp + messageExpiryWindow
     }
 
-    ghost predicate PresentInFrontierView(execMsg: ExecutingMessage, view: FrontierView)
+    ghost predicate IsCorrectFrontierView(view: FrontierView, blocksAtTS: map<ChainID, BlockID>)
+      reads view
+      requires chains.Keys == CHAIN_IDS
+      requires blocksAtTS.Keys == CHAIN_IDS
+    {
+      forall chainID :: chainID in CHAIN_IDS ==>
+        chains[chainID].BlockInfo(blocksAtTS[chainID]).Some? &&
+        view.BlockInfo(chainID) == chains[chainID].BlockInfo(blocksAtTS[chainID]).value &&
+        view.BlockLogs(chainID) == chains[chainID].BlockLogs(blocksAtTS[chainID]).value
+    }
+
+    ghost predicate InitMsgInFrontierView(execMsg: ExecutingMessage, view: FrontierView)
       reads view
       requires execMsg.chainID in CHAIN_IDS
     {
@@ -458,7 +520,24 @@ module Interop {
       view.Contains(execMsg.chainID, query)
     }
 
-    ghost predicate PresentInLogsDB(execMsg: ExecutingMessage)
+    ghost predicate InitMsgInFrontier(execMsg: ExecutingMessage, blocksAtTS: map<ChainID, BlockID>)
+      requires execMsg.chainID in CHAIN_IDS
+      requires blocksAtTS.Keys == CHAIN_IDS
+      requires chains.Keys == CHAIN_IDS
+    {
+      var initBlock := blocksAtTS[execMsg.chainID];
+      initBlock.number == execMsg.blockNum &&
+      var initBlockInfo := chains[execMsg.chainID].BlockInfo(initBlock);
+      initBlockInfo.Some? &&
+      initBlockInfo.value.timestamp == execMsg.timestamp &&
+      var initBlockLogs := chains[execMsg.chainID].BlockLogs(initBlock);
+      assert initBlockLogs.Some?; // by initBlockInfo.Some?
+      execMsg.logIdx < |initBlockLogs.value.fullLogs| &&
+      var initMsg := initBlockLogs.value.fullLogs[execMsg.logIdx];
+      initMsg.checksum == execMsg.checksum
+    }
+
+    ghost predicate InitMsgInLogsDB(execMsg: ExecutingMessage)
       reads logsDBs.Values
       requires execMsg.chainID in logsDBs.Keys
     {
@@ -466,63 +545,78 @@ module Interop {
       logsDBs[execMsg.chainID].Contains(query)
     }
 
-    ghost predicate BlockIsCrossValid(ts: nat, chainID: ChainID, logs: BlockLogs)
+    ghost predicate BlockIsCrossValid(ts: nat, chainID: ChainID, blockID: BlockID)
       requires chainID in CHAIN_IDS
       requires chains.Keys == CHAIN_IDS
+      requires BlockExistedOnChain(chainID, blockID)
     {
-      forall execMsg :: execMsg in logs.execMsgs.Values ==>
+      var logs := chains[chainID].BlockLogs(blockID).value;
+
+      forall execMsg {:trigger execMsg in chains[chainID].BlockLogs(blockID).value.execMsgs.Values} ::
+        execMsg in logs.execMsgs.Values ==>
         ValidExecutingMessage(ts, chainID, execMsg)
     }
 
-    ghost predicate AllMessagesPresent(chainID: ChainID, logs: BlockLogs, view: FrontierView)
-      reads logsDBs.Values, view
+    ghost predicate AllInitMsgsPresent(chainID: ChainID, blockID: BlockID, blocksAtTS: map<ChainID, BlockID>)
+      reads logsDBs.Values
+      requires chainID in CHAIN_IDS
       requires logsDBs.Keys == CHAIN_IDS
-      requires forall execMsg :: execMsg in logs.execMsgs.Values ==>
-        execMsg.chainID in CHAIN_IDS
+      requires chains.Keys == CHAIN_IDS
+      requires blocksAtTS.Keys == CHAIN_IDS
+      requires BlockExistedOnChain(chainID, blockID)
     {
+      var logs := chains[chainID].BlockLogs(blockID).value;
+
       forall execMsg :: execMsg in logs.execMsgs.Values ==>
-        PresentInFrontierView(execMsg, view) ||
-        PresentInLogsDB(execMsg)
+        execMsg.chainID in CHAIN_IDS &&
+        (InitMsgInFrontier(execMsg, blocksAtTS) || InitMsgInLogsDB(execMsg))
     }
 
-    ghost predicate AllMessagesInLogsDB(chainID: ChainID, logs: BlockLogs)
+    ghost predicate AllInitMsgsInLogsDB(chainID: ChainID, blockID: BlockID)
       reads logsDBs.Values
-      requires forall execMsg :: execMsg in logs.execMsgs.Values ==>
-        execMsg.chainID in logsDBs.Keys
+      requires chainID in chains.Keys
+      requires BlockExistedOnChain(chainID, blockID)
     {
+      var logs := chains[chainID].BlockLogs(blockID).value;
+
       forall execMsg :: execMsg in logs.execMsgs.Values ==>
-        PresentInLogsDB(execMsg)
+        execMsg.chainID in logsDBs.Keys &&
+        InitMsgInLogsDB(execMsg)
     }
 
     ghost predicate ResultIsCrossValid(result: Result)
+      reads logsDBs.Values
+      requires logsDBs.Keys == CHAIN_IDS
       requires chains.Keys == CHAIN_IDS
       requires result.l2Heads.Keys == CHAIN_IDS
       requires |result.invalidHeads| == 0
     {
       forall chainID :: chainID in CHAIN_IDS ==>
-        var block := result.l2Heads[chainID];
-        var blockInfo := chains[chainID].BlockInfo(block);
+        var blockID := result.l2Heads[chainID];
+        var blockInfo := chains[chainID].BlockInfo(blockID);
         blockInfo.Some? &&
         var ts := blockInfo.value.timestamp;
-        var blockLogs := chains[chainID].BlockLogs(block).value;
-        BlockIsCrossValid(ts, chainID, blockLogs)
+        BlockIsCrossValid(ts, chainID, blockID) &&
+        AllInitMsgsPresent(chainID, blockID, result.l2Heads)
     }
 
     ghost predicate BlockExistedOnChain(chainID: ChainID, blockID: BlockID)
       requires chainID in chains.Keys
+      ensures BlockExistedOnChain(chainID, blockID) <==> chains[chainID].BlockInfo(blockID).Some?
     {
-      chains[chainID].BlockInfo(blockID).Some?
+      chains[chainID].BlockLogs(blockID).Some?
     }
 
     ghost predicate BlocksExistedOnChain(blocksAtTS: map<ChainID, BlockID>)
-      requires blocksAtTS.Keys == CHAIN_IDS
-      requires chains.Keys == CHAIN_IDS
+      requires blocksAtTS.Keys == chains.Keys
     {
-      forall chainID :: chainID in CHAIN_IDS ==>
+      forall chainID :: chainID in blocksAtTS.Keys ==>
         BlockExistedOnChain(chainID, blocksAtTS[chainID])
     }
 
     ghost predicate TransitionIsCrossValid(pendingTransition: PendingTransition)
+      reads logsDBs.Values
+      requires logsDBs.Keys == CHAIN_IDS
       requires chains.Keys == CHAIN_IDS
       requires ValidPendingTransition(pendingTransition)
     {
@@ -531,8 +625,8 @@ module Interop {
         ResultIsCrossValid(pendingTransition.result.value)
     }
 
-    ghost predicate AllVerifiedCrossValid()
-      reads verifiedDB
+    opaque ghost predicate AllVerifiedCrossValid()
+      reads verifiedDB, logsDBs.Values
       requires Valid()
     {
       verifiedDB.LastTimestamp().Some? ==>
@@ -541,6 +635,122 @@ module Interop {
           var verified := verifiedDB.Get(ts);
           var result := Result(verified.timestamp, verified.l1Inclusion, verified.l2Heads, map[]);
           ResultIsCrossValid(result)
+    }
+
+    opaque twostate predicate UpdatedLogsDB(chainID: ChainID, blockID: BlockID)
+      reads logsDBs[chainID]
+      requires chainID in logsDBs.Keys
+      requires chainID in chains.Keys
+      requires BlockExistedOnChain(chainID, blockID)
+    {
+      var info := chains[chainID].BlockInfo(blockID).value;
+      var logs := chains[chainID].BlockLogs(blockID).value;
+      var db := logsDBs[chainID];
+      LogsDBConsistentWithChainData(chainID) &&
+      db.LatestSealedBlock() == Some(blockID) &&
+      (forall n :: n != blockID.number ==> db.FindSealedBlock(n) == old(db.FindSealedBlock(n))) &&
+      (old(db.FindSealedBlock(blockID.number)).Some? ==>
+        old(db.FindSealedBlock(blockID.number)) == db.FindSealedBlock(blockID.number))
+    }
+
+    opaque twostate predicate UpdatedAllLogsDBs(blocksAtTS: map<ChainID, BlockID>)
+      reads logsDBs.Values
+      requires blocksAtTS.Keys == CHAIN_IDS
+      requires chains.Keys == CHAIN_IDS
+      requires logsDBs.Keys == CHAIN_IDS
+      requires BlocksExistedOnChain(blocksAtTS)
+    {
+      forall chainID :: chainID in blocksAtTS.Keys ==>
+        UpdatedLogsDB(chainID, blocksAtTS[chainID])
+    }
+
+    opaque twostate predicate LogsDBsUnchangedUpTo(blocks: map<ChainID, BlockID>)
+      reads logsDBs.Values
+      requires blocks.Keys == logsDBs.Keys
+    {
+      forall chainID :: chainID in blocks.Keys ==>
+        forall n :: 0 <= n <= blocks[chainID].number ==>
+          logsDBs[chainID].FindSealedBlock(n) == old(logsDBs[chainID].FindSealedBlock(n))
+    }
+
+    opaque ghost predicate LogsDBConsistentWithChainData(chainID: ChainID)
+      reads logsDBs[chainID]
+      requires chainID in logsDBs.Keys
+      requires chainID in chains.Keys
+    {
+      var db := logsDBs[chainID];
+
+      forall blockID: BlockID :: db.FindSealedBlock(blockID.number).Some? ==>
+        BlockExistedOnChain(chainID, blockID) &&
+        var info := chains[chainID].BlockInfo(blockID).value;
+        var logs := chains[chainID].BlockLogs(blockID).value;
+        db.FindSealedBlock(info.id.number).value.timestamp == info.timestamp &&
+        db.BlockLogs(info.id.number) == logs
+    }
+
+    opaque ghost predicate AllLogsDBsConsistentWithChainData()
+      reads logsDBs.Values
+      requires logsDBs.Keys == chains.Keys
+    {
+      forall chainID :: chainID in logsDBs.Keys ==>
+        LogsDBConsistentWithChainData(chainID)
+    }
+
+    ghost predicate VerifiedHeadsAreHighestBlocksUpToTimestamp()
+      reads verifiedDB, logsDBs.Values
+    {
+      forall ts: nat :: verifiedDB.Has(ts) ==>
+        var verifiedHeads := verifiedDB.Get(ts).l2Heads;
+        verifiedHeads.Keys == logsDBs.Keys &&
+        forall chainID :: chainID in verifiedHeads.Keys ==>
+          var blockNumber := verifiedHeads[chainID].number;
+          forall n :: blockNumber < n && logsDBs[chainID].FindSealedBlock(n).Some? ==>
+            ts < logsDBs[chainID].FindSealedBlock(n).value.timestamp
+    }
+
+    ghost predicate BlockSealsMatchOnChainTimestamps()
+      reads logsDBs.Values
+      requires logsDBs.Keys == chains.Keys
+    {
+      forall chainID :: chainID in logsDBs.Keys ==>
+        forall n :: logsDBs[chainID].FindSealedBlock(n).Some? ==>
+          var sealedBlock := logsDBs[chainID].FindSealedBlock(n).value;
+          var onChainBlock := chains[chainID].BlockInfo(sealedBlock.id);
+          onChainBlock.Some? &&
+          sealedBlock.timestamp == onChainBlock.value.timestamp
+    }
+
+    ghost predicate VerifiedHeadsBoundedByTimestamp(ts: nat)
+      reads verifiedDB
+      requires verifiedDB.Has(ts)
+      requires chains.Keys == verifiedDB.Get(ts).l2Heads.Keys
+      requires BlocksExistedOnChain(verifiedDB.Get(ts).l2Heads)
+    {
+      var result := verifiedDB.Get(ts);
+
+      forall chainID :: chainID in result.l2Heads ==>
+        chains[chainID].BlockInfo(result.l2Heads[chainID]).value.timestamp <= ts
+    }
+
+    ghost predicate AllVerifiedHeadsBoundedByTimestamp()
+      reads verifiedDB
+    {
+      var lastTimestamp := verifiedDB.LastTimestamp();
+
+      lastTimestamp.Some? ==>
+        forall ts :: activationTimestamp <= ts <= verifiedDB.LastTimestamp().value ==>
+          verifiedDB.Has(ts) &&
+          chains.Keys == verifiedDB.Get(ts).l2Heads.Keys &&
+          BlocksExistedOnChain(verifiedDB.Get(ts).l2Heads) &&
+          VerifiedHeadsBoundedByTimestamp(ts)
+    }
+
+    ghost predicate FrontierBlocksConsistentWithTimestamp(ts: nat, blocksAtTS: map<ChainID, BlockID>)
+      requires blocksAtTS.Keys == chains.Keys
+      requires BlocksExistedOnChain(blocksAtTS)
+    {
+      forall chainID :: chainID in blocksAtTS.Keys ==>
+        chains[chainID].BlockInfo(blocksAtTS[chainID]).value.timestamp <= ts
     }
 
     // ========================================================================
@@ -555,11 +765,13 @@ module Interop {
       modifies this, verifiedDB, chains.Values, logsDBs.Values
       requires Valid()
       requires PendingTransitionIsConsistent()
+      requires AllLogsDBsConsistentWithChainData()
       requires AllVerifiedCrossValid()
       requires verifiedDB.GetPendingTransition().Some? ==>
         TransitionIsCrossValid(verifiedDB.GetPendingTransition().value)
       ensures Valid()
       ensures PendingTransitionIsConsistent()
+      ensures AllLogsDBsConsistentWithChainData()
       ensures AllVerifiedCrossValid()
       ensures verifiedDB.GetPendingTransition().Some? ==>
         TransitionIsCrossValid(verifiedDB.GetPendingTransition().value)
@@ -588,29 +800,36 @@ module Interop {
       var pendingTx := BuildPendingTransition(output, obs);
 
       assert TransitionIsCrossValid(pendingTx);
+      assert AllVerifiedCrossValid();
 
       // Snapshot the heap before SetPendingTransition so that the twostate lemma
       // below can reference the pre-set state where AllDBsInSync() holds.
       label BeforeSetPending:
       verifiedDB.SetPendingTransition(pendingTx);
 
-      madeProgress := ApplyPendingTransition(pendingTx) by {
-        // Prove ApplyPendingTransition's preconditions
-
-        // SetPendingTransition only changes pendingTransition; db and lastTimestamp
-        // are unchanged. Re-derive DBsInSync for all chains via the framing lemma.
-        forall k | k in logsDBs.Keys ensures DBsInSync(k) {
-          ClearPendingPreservesDBsInSync@BeforeSetPending(k);
-        }
-
-        // For the Rewind case: AllDBsInSync() with LastTimestamp() == Some(ts) implies
-        // AllDBsInSyncUpTo(ts' ) for any ts' <= ts. Apply the helper lemma if needed.
-        if pendingTx.decision == Rewind && pendingTx.rewind.value.resetAllChainsTo.Some? {
-          var ts := pendingTx.rewind.value.resetAllChainsTo.value;
-          // PlanConsistentWithVerified guarantees verifiedDB.Has(ts), hence ts <= LastTimestamp().value.
-          AllDBsInSyncImpliesAllDBsInSyncUpTo(ts);
-        }
+      // SetPendingTransition only changes pendingTransition; db and lastTimestamp
+      // are unchanged. Re-derive DBsInSync for all chains via the framing lemma.
+      forall k | k in logsDBs.Keys ensures DBsInSync(k) {
+        ClearPendingPreservesDBsInSync@BeforeSetPending(k);
       }
+
+      // For the Rewind case: AllDBsInSync() with LastTimestamp() == Some(ts) implies
+      // AllDBsInSyncUpTo(ts' ) for any ts' <= ts. Apply the helper lemma if needed.
+      if pendingTx.decision == Rewind && pendingTx.rewind.value.resetAllChainsTo.Some? {
+        var ts := pendingTx.rewind.value.resetAllChainsTo.value;
+        // PlanConsistentWithVerified guarantees verifiedDB.Has(ts), hence ts <= LastTimestamp().value.
+        AllDBsInSyncImpliesAllDBsInSyncUpTo(ts);
+      }
+
+      assert AllVerifiedHeadsBoundedByTimestamp() by {
+        ClearPendingPreservesAllVerifiedHeadsBoundedByTimestamp@BeforeSetPending();
+      }
+
+      assert AllVerifiedCrossValid() by {
+        ClearPendingPreservesAllVerifiedCrossValid@BeforeSetPending();
+      }
+
+      madeProgress := ApplyPendingTransition(pendingTx);
     }
 
     // Observes the current round state, runs verification if chains are ready,
@@ -620,11 +839,14 @@ module Interop {
     method {:isolate_assertions} ProgressInterop() returns (output: StepOutput, obs: RoundObservation)
       requires Valid()
       requires AllDBsInSync()
+      requires AllVerifiedCrossValid()
       ensures Valid()
       ensures AllDBsInSync()
+      ensures AllVerifiedCrossValid()
       ensures ValidStepOutput(output, obs)
       ensures OutputConsistentWithVerified(output, obs)
       ensures OutputConsistentWithLogs(output, obs)
+      ensures OutputConsistentWithChainState(output, obs)
       ensures output.AdvanceOutput? ==> ResultIsCrossValid(output.result)
     {
       obs := ObserveRound();
@@ -666,8 +888,7 @@ module Interop {
       ensures ValidRoundObservation(obs)
       ensures ObservationConsistentWithVerified(obs)
       ensures ObservationConsistentWithLogs(obs)
-      ensures 0 < |obs.blocksAtTS| ==> obs.blocksAtTS.Keys == CHAIN_IDS
-      ensures 0 < |obs.blocksAtTS| ==> BlocksExistedOnChain(obs.blocksAtTS)
+      ensures ObservationConsistentWithChainState(obs)
     {
       // Read the last verified timestamp and its result from the DB.
       var lastTS := verifiedDB.LastTimestamp();
@@ -739,6 +960,7 @@ module Interop {
       ensures result.Some? ==> result.value.blocks.Keys == chains.Keys
       ensures result.Some? ==> AdvancesAllLogsDBs(ts, result.value.blocks)
       ensures result.Some? ==> BlocksExistedOnChain(result.value.blocks)
+      ensures result.Some? ==> FrontierBlocksConsistentWithTimestamp(ts, result.value.blocks)
     {
       var blocks: map<ChainID, BlockID> := map[];
       var l1Heads: map<ChainID, BlockID> := map[];
@@ -753,6 +975,8 @@ module Interop {
           AdvancesLogsDB(ts, k, blocks[k])
         invariant forall k :: k in chainIDs[0..i] ==>
           BlockExistedOnChain(k, blocks[k])
+        invariant forall k :: k in chainIDs[0..i] ==>
+          chains[k].BlockInfo(blocks[k]).value.timestamp <= ts
       {
         var chainID := chainIDs[i];
         var chainResult := chains[chainID].OptimisticAt(ts);
@@ -808,9 +1032,11 @@ module Interop {
       requires PendingTransitionIsConsistent()
       requires TransitionIsCrossValid(pending)
       requires AllVerifiedCrossValid()
+      requires AllLogsDBsConsistentWithChainData()
       ensures Valid()
       ensures PendingTransitionIsConsistent()
       ensures AllVerifiedCrossValid()
+      ensures AllLogsDBsConsistentWithChainData()
       ensures madeProgress.None? ==>
         verifiedDB.pendingTransition == Some(pending)
       ensures madeProgress.Some? ==>
@@ -819,6 +1045,7 @@ module Interop {
         (madeProgress.value <==> pending.decision == Advance)
       ensures madeProgress.Some? ==>
         AllDBsInSync()
+      ensures madeProgress.None? ==> TransitionIsCrossValid(pending)
     {
       assert ValidPendingTransition(pending);
 
@@ -831,6 +1058,8 @@ module Interop {
           AllDBsInSyncUpTo(rewindPlan.resetAllChainsTo.value);
 
         var rewindOk := ApplyRewindPlan(rewindPlan);
+
+        assert Valid();
 
         if !rewindOk {
           madeProgress := None;
@@ -845,6 +1074,10 @@ module Interop {
         label BeforeClearRewind:
         verifiedDB.ClearPendingTransition();
 
+        assert AllVerifiedHeadsBoundedByTimestamp() by {
+          ClearPendingPreservesAllVerifiedHeadsBoundedByTimestamp@BeforeClearRewind();
+        }
+
         assert AllDBsInSync() by {
           // ClearPendingTransition only changes pendingTransition; db and lastTimestamp are
           // unchanged (see postconditions). Use the framing lemma to re-derive DBsInSync.
@@ -857,6 +1090,9 @@ module Interop {
         assert AllVerifiedCrossValid() by {
           ClearPendingPreservesAllVerifiedCrossValid@BeforeClearRewind();
         }
+
+        assert Valid();
+        assert AllLogsDBsConsistentWithChainData();
 
       } else if pending.decision == Invalidate {
 
@@ -873,6 +1109,7 @@ module Interop {
           invariant verifiedDB.pendingTransition == Some(pending)
           invariant AllDBsInSync()
           invariant AllVerifiedCrossValid()
+          invariant AllLogsDBsConsistentWithChainData()
         {
           var chainID := invSeq[i];
           if chainID in chains {
@@ -895,6 +1132,10 @@ module Interop {
         label BeforeClearInvalidate:
         verifiedDB.ClearPendingTransition();
 
+        assert AllVerifiedHeadsBoundedByTimestamp() by {
+          ClearPendingPreservesAllVerifiedHeadsBoundedByTimestamp@BeforeClearInvalidate();
+        }
+
         assert AllDBsInSync() by {
           forall k | k in logsDBs.Keys ensures DBsInSync(k) {
             ClearPendingPreservesDBsInSync@BeforeClearInvalidate(k);
@@ -906,26 +1147,53 @@ module Interop {
           ClearPendingPreservesAllVerifiedCrossValid@BeforeClearInvalidate();
         }
 
+        assert Valid();
+        assert AllLogsDBsConsistentWithChainData();
+
       } else { // Advance case
 
         // Replaces unreachable nil case in Go code
         assert pending.result.Some?;
 
+        assert AllVerifiedCrossValid();
+
         var result := pending.result.value;
+        label BeforePersistFrontierLogs:
         var persistOk := PersistFrontierLogs(result.timestamp, result.l2Heads);
+
+        assert AllVerifiedCrossValid() by {
+          reveal AllLogsDBsConsistentWithChainData;
+          reveal UpdatedAllLogsDBs;
+          reveal UpdatedLogsDB;
+          PersistFrontierLogsPreservesAllVerifiedCrossValid@BeforePersistFrontierLogs();
+        }
+
+        assert PendingTransitionIsConsistent() by {
+          reveal UpdatedAllLogsDBs;
+          reveal UpdatedLogsDB;
+          if verifiedDB.LastTimestamp().Some? {
+            PersistFrontierLogsPreservesAllDBsInSyncUpTo@BeforePersistFrontierLogs(
+              verifiedDB.LastTimestamp().value);
+          }
+        }
+
+        assert TransitionIsCrossValid(pending) by {
+          reveal UpdatedAllLogsDBs;
+          reveal UpdatedLogsDB;
+          PersistFrontierLogsPreservesTransitionIsCrossValid@BeforePersistFrontierLogs(pending);
+        }
+
+        assert Valid();
 
         if !persistOk {
           // FetchReceipts failed for some chain; keep the pending transition for retry.
           madeProgress := None;
-          assert PendingTransitionIsConsistent();
-          assert AllVerifiedCrossValid();
+          //assert PendingTransitionIsConsistent();
+          //assert AllVerifiedCrossValid();
+          assert Valid();
+
           return;
         }
-
-        assert ResultIsCrossValid(result);
-        // AllVerifiedCrossValid() still holds here: PersistFrontierLogs does not modify
-        // verifiedDB, so the reads-verifiedDB predicate is unchanged since method entry.
-        assert AllVerifiedCrossValid();
 
         // Snapshot the heap before Commit so the twostate lemma can reference
         // the post-PersistFrontierLogs state via old@BeforeCommit().
@@ -934,7 +1202,16 @@ module Interop {
         // (drops invalidHeads from Result to produce VerifiedResult).
         verifiedDB.Commit(VerifiedResult(result.timestamp, result.l1Inclusion, result.l2Heads));
 
+        assert AllVerifiedHeadsBoundedByTimestamp() by {
+          // FrontierBlocksConsistentWithTimestamp(result.timestamp, result.l2Heads) comes from
+          // TransitionConsistentWithChainState, which is part of PendingTransitionIsConsistent().
+          var vr := VerifiedResult(result.timestamp, result.l1Inclusion, result.l2Heads);
+          CommitExtendsAllVerifiedHeadsBoundedByTimestamp@BeforeCommit(result.timestamp, vr);
+        }
+
         assert AllDBsInSync() by {
+          reveal UpdatedAllLogsDBs;
+          reveal UpdatedLogsDB;
           forall k | k in logsDBs.Keys ensures DBsInSync(k) {
             CommitEstablishesDBsInSync@BeforeCommit(k, result.timestamp, result.l2Heads);
           }
@@ -946,8 +1223,14 @@ module Interop {
             VerifiedResult(result.timestamp, result.l1Inclusion, result.l2Heads));
         }
 
+        assert Valid();
+
         label BeforeClearAdvance:
         verifiedDB.ClearPendingTransition();
+
+        assert AllVerifiedHeadsBoundedByTimestamp() by {
+          ClearPendingPreservesAllVerifiedHeadsBoundedByTimestamp@BeforeClearAdvance();
+        }
 
         assert AllDBsInSync() by {
           forall k | k in logsDBs.Keys ensures DBsInSync(k) {
@@ -955,11 +1238,15 @@ module Interop {
           }
         }
 
-        currentL1 := result.l1Inclusion;
-        madeProgress := Some(true);
         assert AllVerifiedCrossValid() by {
           ClearPendingPreservesAllVerifiedCrossValid@BeforeClearAdvance();
         }
+
+        assert Valid();
+        assert AllLogsDBsConsistentWithChainData();
+
+        currentL1 := result.l1Inclusion;
+        madeProgress := Some(true);
       }
     }
 
@@ -969,24 +1256,33 @@ module Interop {
     method {:isolate_assertions} ApplyRewindPlan(plan: RewindPlan) returns (success: bool)
       modifies verifiedDB, chains.Values, logsDBs.Values
       requires Valid()
+      requires AllLogsDBsConsistentWithChainData()
       requires verifiedDB.pendingTransition.Some?
       requires verifiedDB.pendingTransition.value.decision == Rewind
       requires verifiedDB.pendingTransition.value.rewind == Some(plan)
       requires ValidRewindPlan(plan)
       requires PlanConsistentWithVerified(plan)
       requires plan.resetAllChainsTo.Some? ==>
-        forall k :: k in logsDBs.Keys ==> PlanConsistentWithLogs(plan, k)
+        PlanConsistentWithAllLogs(plan)
       requires plan.resetAllChainsTo.Some? ==>
         AllDBsInSyncUpTo(plan.resetAllChainsTo.value)
+      // From ProcessBlock sealing blocks with their L2 timestamp (propagated via PersistFrontierLogs).
+      /*
+      requires plan.resetAllChainsTo.Some? ==>
+        forall c :: c in logsDBs.Keys && c in plan.targetHeads ==>
+          logsDBs[c].FindSealedBlock(plan.targetHeads[c].number).Some? &&
+          logsDBs[c].FindSealedBlock(plan.targetHeads[c].number).value.timestamp == plan.resetAllChainsTo.value
+      */
       requires AllVerifiedCrossValid()
       ensures Valid()
+      ensures AllLogsDBsConsistentWithChainData()
       ensures ValidRewindPlan(plan)
       ensures verifiedDB.pendingTransition == old(verifiedDB.pendingTransition)
       ensures PlanConsistentWithVerified(plan)
       ensures plan.resetAllChainsTo.Some? ==>
-        forall k :: k in logsDBs.Keys ==> PlanConsistentWithLogs(plan, k)
+        PlanConsistentWithAllLogs(plan)
       ensures plan.resetAllChainsTo.Some? && success ==>
-        forall k :: k in logsDBs.Keys ==> RewoundLogsDB(plan, k)
+        RewoundAllLogsDB(plan)
       ensures plan.resetAllChainsTo.Some? ==>
         AllDBsInSyncUpTo(plan.resetAllChainsTo.value)
       ensures success ==> AllDBsInSync()
@@ -995,9 +1291,19 @@ module Interop {
       label BeforeRewind:
       var _ := verifiedDB.Rewind(plan.rewindAtOrAfter);
 
+      assert AllVerifiedHeadsBoundedByTimestamp() by {
+        RewindPreservesAllVerifiedHeadsBoundedByTimestamp@BeforeRewind(plan.rewindAtOrAfter);
+      }
+
+      assert VerifiedHeadsAreHighestBlocksUpToTimestamp() by {
+        RewindVerifiedDBPreservesVerifiedHeadsHighest@BeforeRewind(plan.rewindAtOrAfter);
+      }
+
       assert AllVerifiedCrossValid() by {
         RewindPreservesAllVerifiedCrossValid@BeforeRewind(plan.rewindAtOrAfter);
       }
+
+      assert AllLogsDBsConsistentWithChainData();
 
       assert unchanged(logsDBs.Values);
       assert Valid();
@@ -1036,13 +1342,42 @@ module Interop {
         return;
       }
 
+      assert Valid();
+      assert PlanConsistentWithVerified(plan);
+      assert AllLogsDBsConsistentWithChainData();
+
       // Clear or rewind log databases depending on whether target heads are available.
       // resetAllChainsTo.None? corresponds to the nil TargetHeads case in Go,
       // which signals a full reset with no previous verified state to restore to.
       if plan.resetAllChainsTo.None? {
         ClearLogsDBs(plan, chainIDs);
+        assert AllVerifiedCrossValid() by { reveal AllVerifiedCrossValid; }
+        assert AllLogsDBsConsistentWithChainData() by {
+          reveal AllLogsDBsConsistentWithChainData;
+          reveal LogsDBConsistentWithChainData;
+          forall cid | cid in logsDBs.Keys
+            ensures LogsDBConsistentWithChainData(cid)
+          {
+            reveal LogsDBConsistentWithChainData;
+            assert cid in chainIDs;
+            assert RewoundLogsDB(plan, cid);
+            assert logsDBs[cid].LatestSealedBlock() == None;
+          }
+        }
       } else {
+        assert AllDBsInSyncUpTo(plan.resetAllChainsTo.value);
+        // plan.targetHeads == verifiedDB.Get(ts).l2Heads (from PlanConsistentWithVerified).
+        assert plan.targetHeads == verifiedDB.Get(plan.resetAllChainsTo.value).l2Heads;
+        label BeforeRewindLogsDBs:
         RewindLogsDBs(plan, chainIDs);
+        assert Valid();
+        assert AllVerifiedCrossValid() by {
+          reveal LogsDBsUnchangedUpTo;
+          RewindLogsDBsPreservesAllVerifiedCrossValid@BeforeRewindLogsDBs(plan);
+        }
+        assert AllDBsInSyncUpTo(plan.resetAllChainsTo.value);
+        assert PlanConsistentWithVerified(plan);
+        assert AllLogsDBsConsistentWithChainData();
       }
 
       success := true;
@@ -1050,17 +1385,19 @@ module Interop {
 
     // Prunes deny lists and optionally rewinds chain engines for all chains in chainIDs.
     // Extracted from ApplyRewindPlan to allow isolated verification of the engine rewind loop.
-    method RewindChainEngines(plan: RewindPlan, chainIDs: seq<ChainID>) returns (success: bool)
+    method {:isolate_assertions} RewindChainEngines(plan: RewindPlan, chainIDs: seq<ChainID>) returns (success: bool)
       modifies chains.Values
       requires Valid()
       requires ValidRewindPlan(plan)
       requires PlanConsistentWithVerified(plan)
       requires RewoundVerifiedDB(plan)
+      requires AllVerifiedCrossValid()
       requires forall k :: k in chainIDs <==> k in chains.Keys
       requires forall k :: k in chainIDs ==> PlanConsistentWithLogs(plan, k)
       ensures Valid()
       ensures ValidRewindPlan(plan)
       ensures RewoundVerifiedDB(plan)
+      ensures AllVerifiedCrossValid()
       ensures forall k :: k in chainIDs ==> PlanConsistentWithLogs(plan, k)
       ensures unchanged(logsDBs.Values)
     {
@@ -1069,12 +1406,17 @@ module Interop {
         invariant Valid()
         invariant ValidRewindPlan(plan)
         invariant RewoundVerifiedDB(plan)
+        invariant AllVerifiedCrossValid()
+        invariant unchanged(verifiedDB)
+        invariant unchanged(logsDBs.Values)
       {
         chains[chainIDs[i]].PruneDeniedAtOrAfterTimestamp(plan.rewindAtOrAfter);
         if plan.resetAllChainsTo.Some? {
           var ok := chains[chainIDs[i]].RewindEngine(plan.resetAllChainsTo.value);
           if !ok { failedAny := true; }
         }
+        assert VerifiedHeadsAreHighestBlocksUpToTimestamp();
+        assert AllVerifiedCrossValid();
       }
       success := !failedAny;
     }
@@ -1107,36 +1449,84 @@ module Interop {
 
     // Rewinds each logsDB in chainIDs to the corresponding target head in plan.
     // Extracted from ApplyRewindPlan to allow isolated verification of the rewind loop.
-    method RewindLogsDBs(plan: RewindPlan, chainIDs: seq<ChainID>)
+    method {:isolate_assertions} RewindLogsDBs(plan: RewindPlan, chainIDs: seq<ChainID>)
       modifies logsDBs.Values
-      requires verifiedDB.Valid()
+      requires Valid()
+      requires AllLogsDBsConsistentWithChainData()
       requires forall k1, k2 :: k1 in logsDBs.Keys && k2 in logsDBs.Keys && k1 != k2 ==> logsDBs[k1] != logsDBs[k2]
       requires forall k :: k in chainIDs <==> k in plan.targetHeads
+      requires forall k :: k in chainIDs <==> k in logsDBs.Keys
       requires PlanConsistentWithVerified(plan)
       requires RewoundVerifiedDB(plan)
       requires plan.resetAllChainsTo.Some?
-      requires forall k :: k in chainIDs <==> k in logsDBs.Keys
-      requires forall k :: k in chainIDs ==> PlanConsistentWithLogs(plan, k)
-      requires forall k :: k in chainIDs ==> DBsInSyncUpTo(k, plan.resetAllChainsTo.value)
-      ensures forall k :: k in chainIDs ==>
-        PlanConsistentWithLogs(plan, k) &&
-        RewoundLogsDB(plan, k) &&
-        DBsInSync(k)
+      requires PlanConsistentWithAllLogs(plan)
+      requires AllDBsInSyncUpTo(plan.resetAllChainsTo.value)
+      ensures Valid()
+      ensures AllLogsDBsConsistentWithChainData()
+      ensures PlanConsistentWithAllLogs(plan)
+      ensures RewoundAllLogsDB(plan)
+      ensures AllDBsInSync()
+      ensures LogsDBsUnchangedUpTo(plan.targetHeads)
     {
+      assert LogsDBsUnchangedUpTo(plan.targetHeads) by { reveal LogsDBsUnchangedUpTo; }
+
       var ts := plan.resetAllChainsTo.value;
+
       for i := 0 to |chainIDs|
+        invariant Valid()
+        invariant AllLogsDBsConsistentWithChainData()
         invariant verifiedDB.LastTimestamp() == Some(ts)
         invariant plan.targetHeads == verifiedDB.Get(ts).l2Heads
         invariant forall k :: k in chainIDs ==>
           PlanConsistentWithLogs(plan, k) &&
           DBsInSyncUpTo(k, plan.resetAllChainsTo.value)
         invariant forall k :: k in chainIDs[0..i] ==>
-          PlanConsistentWithLogs(plan, k) &&
+          //PlanConsistentWithLogs(plan, k) &&
           RewoundLogsDB(plan, k) &&
           DBsInSync(k)
+        invariant LogsDBsUnchangedUpTo(plan.targetHeads)
+        invariant forall k1, k2 :: k1 in logsDBs.Keys && k2 in logsDBs.Keys && k1 != k2 ==> logsDBs[k1] != logsDBs[k2]
       {
         var chainID := chainIDs[i];
+
+        label BeforeRewind:
         logsDBs[chainID].Rewind(plan.targetHeads[chainID]);
+        assert unchanged@BeforeRewind(verifiedDB);
+        RewindEstablishesDBsInSync@BeforeRewind(chainID);
+
+        // Establish the loop invariant at line 1346 (for i+1):
+        // for the newly-rewound chain, RewindEstablishesDBsInSync gives us DBsInSync;
+        // for previously-rewound chains, logsDBs[k] is unchanged so RewoundLogsDB and DBsInSync are preserved.
+        assert forall k :: k in chainIDs[0..i+1] ==>
+            RewoundLogsDB(plan, k) && DBsInSync(k) by {
+          forall k | k in chainIDs[0..i+1]
+            ensures RewoundLogsDB(plan, k) && DBsInSync(k)
+          {
+            if k == chainID {
+              // RewoundLogsDB from Rewind postcondition; DBsInSync from lemma call above
+            } else {
+              // k was already processed: k in chainIDs[0..i]
+              assert k in chainIDs[0..i];
+              // logsDBs[k] is unchanged (Rewind only modifies logsDBs[chainID], and they are distinct)
+              assert logsDBs[k] != logsDBs[chainID];
+              // RewoundLogsDB and DBsInSync preserved by framing (via ClearPendingPreservesDBsInSync)
+              ClearPendingPreservesDBsInSync@BeforeRewind(k);
+            }
+          }
+        }
+
+        RewindPreservesVerifiedHeadsHighest@BeforeRewind(chainID, plan.targetHeads[chainID]);
+        assert VerifiedHeadsAreHighestBlocksUpToTimestamp();
+        assert BlockSealsMatchOnChainTimestamps() by {
+          RewindPreservesBlockSealsMatch@BeforeRewind(chainID, plan.targetHeads[chainID]);
+        }
+        assert AllLogsDBsConsistentWithChainData() by {
+          RewindPreservesAllLogsDBsConsistentWithChainData@BeforeRewind(chainID, plan.targetHeads[chainID]);
+        }
+        assert Valid();
+        assert RewoundLogsDB(plan, chainID);
+        assert DBsInSync(chainID);
+        assert LogsDBsUnchangedUpTo(plan.targetHeads) by { reveal LogsDBsUnchangedUpTo; }
       }
     }
 
@@ -1150,14 +1540,16 @@ module Interop {
       requires Valid()
       requires blocksAtTS.Keys == chains.Keys
       requires AdvancesAllLogsDBs(ts, blocksAtTS)
-      requires verifiedDB.LastTimestamp().Some? ==>
-        AllDBsInSyncUpTo(verifiedDB.LastTimestamp().value)
+      requires BlocksExistedOnChain(blocksAtTS)
+      requires AllLogsDBsConsistentWithChainData()
       ensures Valid()
-      ensures success ==> forall k :: k in blocksAtTS.Keys ==>
-        logsDBs[k].LatestSealedBlock() == Some(blocksAtTS[k])
-      ensures verifiedDB.LastTimestamp().Some? ==>
-        AllDBsInSyncUpTo(verifiedDB.LastTimestamp().value)
       ensures AdvancesAllLogsDBs(ts, blocksAtTS)
+      ensures AllLogsDBsConsistentWithChainData()
+      ensures success ==> UpdatedAllLogsDBs(blocksAtTS)
+      ensures !success ==>
+        forall chainID :: chainID in logsDBs.Keys ==>
+          UpdatedLogsDB(chainID, blocksAtTS[chainID]) ||
+          unchanged(logsDBs[chainID])
     {
       success := true;
       var chainIDs := Enumerate(blocksAtTS.Keys);
@@ -1166,12 +1558,12 @@ module Interop {
         invariant Valid()
         invariant forall j, k :: 0 <= j < k < |chainIDs| ==>
           chainIDs[j] != chainIDs[k]
-        invariant forall j :: 0 <= j < |chainIDs| ==>
-          AdvancesLogsDB(ts, chainIDs[j], blocksAtTS[chainIDs[j]])
+        invariant AdvancesAllLogsDBs(ts, blocksAtTS)
+        invariant AllLogsDBsConsistentWithChainData()
         invariant forall j :: 0 <= j < i ==>
-          logsDBs[chainIDs[j]].LatestSealedBlock() == Some(blocksAtTS[chainIDs[j]])
-        invariant verifiedDB.LastTimestamp().Some? ==>
-          AllDBsInSyncUpTo(verifiedDB.LastTimestamp().value)
+          UpdatedLogsDB(chainIDs[j], blocksAtTS[chainIDs[j]])
+        invariant forall j :: i <= j < |chainIDs| ==>
+          unchanged(logsDBs[chainIDs[j]])
       {
         var chainID := chainIDs[i];
         var blockID := blocksAtTS[chainID];
@@ -1180,17 +1572,16 @@ module Interop {
 
         var latestBlock := db.LatestSealedBlock();
 
-        // Follows from AdvancesLogsDB(ts, chainID, blockID)
-        if latestBlock.Some? {
-          assert latestBlock.value.number <= blockID.number;
-          assert latestBlock.value.number == blockID.number ==> latestBlock == Some(blockID);
-        }
-
         // Skip if the block is already sealed in the logsDB (idempotency on restart).
         // Simplified in relation to the Go code due to the asserts above.
         var skip := latestBlock == Some(blockID);
 
-        if !skip {
+        if skip {
+          assert UpdatedLogsDB(chainID, blockID) by {
+            reveal UpdatedLogsDB;
+            reveal AllLogsDBsConsistentWithChainData;
+          }
+        } else {
           var fetchResult := chain.FetchReceipts(blockID);
 
           if fetchResult.None? {
@@ -1198,9 +1589,7 @@ module Interop {
             // sealFetchedBlockIntoLogsDB; the pending transition is kept for retry.
             success := false;
 
-            assert AdvancesAllLogsDBs(ts, blocksAtTS);
-            assert verifiedDB.LastTimestamp().Some? ==>
-              AllDBsInSyncUpTo(verifiedDB.LastTimestamp().value);
+            assert unchanged(db);
 
             return;
           }
@@ -1208,43 +1597,21 @@ module Interop {
           var blockInfo := fetchResult.value.info;
           var logs := fetchResult.value.logs;
 
-          // FetchReceipts postcondition: result.value.info.id == blockID.
-          assert blockInfo.id == blockID;
-
           // ErrParentHashMismatch: in Go this is an error return; here assumed away.
           assume latestBlock.Some? ==> blockInfo.parentHash == latestBlock.value.hash;
 
-          if verifiedDB.LastTimestamp().Some? {
-            var lastTS := verifiedDB.LastTimestamp().value;
-
-            assert SealedBlockForVerifiedAtTimestamp(chainID, lastTS).Some? ==>
-              db.LatestSealedBlock().Some?;
-
-            assert AllDBsInSyncUpTo(lastTS);
-          }
-
-          // ProcessBlock only modifies db = logsDBs[chainID]; all other logsDBs are
-          // distinct objects (from Valid() + distinct chainIDs), so their state is
-          // preserved for the loop invariants.
-          assert forall j :: 0 <= j < |chainIDs| && j != i ==> logsDBs[chainIDs[i]] != logsDBs[chainIDs[j]];
-
           label BeforeProcessBlock:
-          ProcessBlock(db, blockInfo, logs);
+          ProcessBlock(chainID, blockID, blockInfo, logs);
 
-          assert logsDBs[chainID].LatestSealedBlock() == Some(blocksAtTS[chainID]);
-
-          if verifiedDB.LastTimestamp().Some? {
-            var lastTS := verifiedDB.LastTimestamp().value;
-
-            assert AllDBsInSyncUpTo(lastTS) by {
-              assert old@BeforeProcessBlock(logsDBs[chainID].LatestSealedBlock()).Some?;
-              ProcessBlockPreservesDBsInSyncUpTo@BeforeProcessBlock(chainID, lastTS, blockInfo.id.number);
-            }
+          assert UpdatedLogsDB(chainID, blockID) by { reveal UpdatedLogsDB; }
+          assert AdvancesAllLogsDBs(ts, blocksAtTS) by { reveal UpdatedLogsDB; }
+          assert AllLogsDBsConsistentWithChainData() by {
+            ProcessBlockPreservesAllLogsDBsConsistentWithChainData@BeforeProcessBlock(chainID, blockID);
           }
         }
-
-        assert logsDBs[chainIDs[i]].LatestSealedBlock() == Some(blocksAtTS[chainIDs[i]]);
       }
+
+      assert UpdatedAllLogsDBs(blocksAtTS) by { reveal UpdatedAllLogsDBs; }
     }
 
     // Constructs a pending transition from the given decision and observation.
@@ -1258,6 +1625,7 @@ module Interop {
       requires ValidStepOutput(output, obs)
       requires OutputConsistentWithVerified(output, obs)
       requires OutputConsistentWithLogs(output, obs)
+      requires OutputConsistentWithChainState(output, obs)
       ensures ValidPendingTransition(pendingTx)
       ensures TransitionConsistentWithVerified(pendingTx)
       ensures TransitionConsistentWithLogs(pendingTx)
@@ -1285,7 +1653,14 @@ module Interop {
         }
 
         pendingTx := PendingTransition(Rewind, None, Some(rewindPlan));
-        assert TransitionConsistentWithLogs(pendingTx);
+
+        assert TransitionConsistentWithLogs(pendingTx) by {
+          if lastTS <= activationTimestamp {
+            assert TransitionConsistentWithLogs(pendingTx);
+          } else {
+            assert TransitionConsistentWithLogs(pendingTx);
+          }
+        }
       }
     }
 
@@ -1308,10 +1683,10 @@ module Interop {
         ValidExecutingMessage(executingTimestamp, executingChain, execMsg)
       ensures valid ==>
         if execMsg.timestamp == executingTimestamp then
-          PresentInFrontierView(execMsg, view)
+          InitMsgInFrontierView(execMsg, view)
         else
           assert execMsg.timestamp < executingTimestamp; // by ValidExecutingMessage above
-          PresentInLogsDB(execMsg)
+          InitMsgInLogsDB(execMsg)
     {
       // Unknown source chain: in Go this is ErrUnknownChain (fatal). Modeled as invalid.
       if execMsg.chainID !in logsDBs || execMsg.chainID !in chains {
@@ -1378,13 +1753,14 @@ module Interop {
       requires Valid()
       requires blocksAtTS.Keys == CHAIN_IDS
       requires AdvancesAllLogsDBs(ts, blocksAtTS)
+      requires IsCorrectFrontierView(view, blocksAtTS)
       ensures Valid()
       ensures result.timestamp == ts
       ensures result.l2Heads == blocksAtTS
       ensures |result.invalidHeads| == 0 ==>
         forall chainID :: chainID in CHAIN_IDS ==>
-          BlockIsCrossValid(view.BlockInfo(chainID).timestamp, chainID, view.BlockLogs(chainID)) &&
-          AllMessagesPresent(chainID, view.BlockLogs(chainID), view)
+          BlockIsCrossValid(view.BlockInfo(chainID).timestamp, chainID, view.BlockInfo(chainID).id) &&
+          AllInitMsgsPresent(chainID, view.BlockInfo(chainID).id, blocksAtTS)
     {
       var l1Inclusion := ComputeL1Inclusion(blocksAtTS, l1Heads);
       result := Result(ts, l1Inclusion, blocksAtTS, map[]);
@@ -1396,10 +1772,11 @@ module Interop {
         invariant AdvancesAllLogsDBs(ts, blocksAtTS)
         invariant result.timestamp == ts
         invariant result.l2Heads == blocksAtTS
+        invariant IsCorrectFrontierView(view, blocksAtTS)
         invariant |result.invalidHeads| == 0 ==>
           forall j :: 0 <= j < i ==>
-            BlockIsCrossValid(view.BlockInfo(chainIDs[j]).timestamp, chainIDs[j], view.BlockLogs(chainIDs[j])) &&
-            AllMessagesPresent(chainIDs[j], view.BlockLogs(chainIDs[j]), view)
+            BlockIsCrossValid(view.BlockInfo(chainIDs[j]).timestamp, chainIDs[j], view.BlockInfo(chainIDs[j]).id) &&
+            AllInitMsgsPresent(chainIDs[j], view.BlockInfo(chainIDs[j]).id, blocksAtTS)
       {
         var chainID := chainIDs[i];
         var expectedBlock := blocksAtTS[chainID];
@@ -1423,20 +1800,31 @@ module Interop {
         while j < |logIdxs| && blockValid
           invariant 0 <= j <= |logIdxs|
           invariant Valid()
+          invariant IsCorrectFrontierView(view, blocksAtTS)
           invariant |result.invalidHeads| == 0 ==>
             forall k :: 0 <= k < i ==>
-              BlockIsCrossValid(view.BlockInfo(chainIDs[k]).timestamp, chainIDs[k], view.BlockLogs(chainIDs[k])) &&
-              AllMessagesPresent(chainIDs[k], view.BlockLogs(chainIDs[k]), view)
+              BlockIsCrossValid(view.BlockInfo(chainIDs[k]).timestamp, chainIDs[k], view.BlockInfo(chainIDs[k]).id) &&
+              AllInitMsgsPresent(chainIDs[k], view.BlockInfo(chainIDs[k]).id, blocksAtTS)
           invariant blockValid ==>
             forall k :: 0 <= k < j ==>
               ValidExecutingMessage(block.timestamp, chainID, logs.execMsgs[logIdxs[k]]) &&
-              (PresentInFrontierView(logs.execMsgs[logIdxs[k]], view) || PresentInLogsDB(logs.execMsgs[logIdxs[k]]))
+              (InitMsgInFrontier(logs.execMsgs[logIdxs[k]], blocksAtTS) || InitMsgInLogsDB(logs.execMsgs[logIdxs[k]]))
         {
           var logIdx := logIdxs[j];
           var execMsg := logs.execMsgs[logIdx];
           var ok := VerifyExecutingMessage(chainID, block.timestamp, execMsg, view);
           if !ok {
             blockValid := false;
+          } else {
+            // Establish facts needed for PresentInFrontierView ==> PresentInFrontier
+            // (forward direction only — sufficient for the new PresentInFrontier loop invariant).
+            assert execMsg.chainID in CHAIN_IDS;
+            assert chains[execMsg.chainID].BlockInfo(blocksAtTS[execMsg.chainID]).Some?;
+            assert chains[execMsg.chainID].BlockLogs(blocksAtTS[execMsg.chainID]).Some?;
+            assert view.BlockInfo(execMsg.chainID) == chains[execMsg.chainID].BlockInfo(blocksAtTS[execMsg.chainID]).value;
+            assert view.BlockLogs(execMsg.chainID) == chains[execMsg.chainID].BlockLogs(blocksAtTS[execMsg.chainID]).value;
+            assert chains[execMsg.chainID].BlockInfo(blocksAtTS[execMsg.chainID]).value.id == blocksAtTS[execMsg.chainID];
+            assert InitMsgInFrontierView(execMsg, view) ==> InitMsgInFrontier(execMsg, blocksAtTS);
           }
           j := j + 1;
         }
@@ -1444,8 +1832,8 @@ module Interop {
         if !blockValid {
           result := result.(invalidHeads := result.invalidHeads[chainID := expectedBlock]);
         } else {
-          assert BlockIsCrossValid(block.timestamp, chainID, logs);
-          assert AllMessagesPresent(chainID, logs, view);
+          assert BlockIsCrossValid(block.timestamp, chainID, block.id);
+          assert AllInitMsgsPresent(chainID, block.id, blocksAtTS);
         }
       }
     }
@@ -1468,10 +1856,7 @@ module Interop {
       requires BlocksExistedOnChain(blocksAtTS)
       ensures {:axiom} Valid()
       ensures {:axiom} fresh(view)
-      ensures {:axiom} forall chainID :: chainID in CHAIN_IDS ==>
-        chains[chainID].BlockInfo(blocksAtTS[chainID]).Some? &&
-        view.BlockInfo(chainID) == chains[chainID].BlockInfo(blocksAtTS[chainID]).value &&
-        view.BlockLogs(chainID) == chains[chainID].BlockLogs(blocksAtTS[chainID]).value
+      ensures {:axiom} IsCorrectFrontierView(view, blocksAtTS)
 
     // Computes the L1 inclusion block for the given set of L2 blocks by taking
     // the maximum of the per-chain L1 heads.
@@ -1483,16 +1868,19 @@ module Interop {
     // Processes and seals a block's logs into the given chain's log database.
     // Corresponds to processBlockLogs in logdb.go; the parent-hash precondition
     // mirrors ErrParentHashMismatch (which is assumed away at the call site).
-    method ProcessBlock(db: LogsDB, info: BlockInfo, logs: BlockLogs)
-      modifies db
+    method ProcessBlock(chainID: ChainID, blockID: BlockID, info: BlockInfo, logs: BlockLogs)
+      modifies logsDBs[chainID]
+      requires chainID in CHAIN_IDS
       requires Valid()
-      requires db.LatestSealedBlock().None? || (
-        db.LatestSealedBlock().value.number + 1 == info.id.number &&
-        info.parentHash == db.LatestSealedBlock().value.hash)
-      ensures {:axiom} unchanged(verifiedDB)
+      requires BlockExistedOnChain(chainID, blockID)
+      requires info == chains[chainID].BlockInfo(blockID).value
+      requires logs == chains[chainID].BlockLogs(blockID).value
+      requires logsDBs[chainID].LatestSealedBlock().Some? ==>
+        logsDBs[chainID].LatestSealedBlock().value.number + 1 == blockID.number &&
+        info.parentHash == logsDBs[chainID].LatestSealedBlock().value.hash
+      //ensures {:axiom} unchanged(verifiedDB)
       ensures {:axiom} Valid()
-      ensures {:axiom} db.LatestSealedBlock() == Some(info.id)
-      ensures {:axiom} forall n :: n != info.id.number ==> db.FindSealedBlock(n) == old(db.FindSealedBlock(n))
+      ensures {:axiom} UpdatedLogsDB(chainID, blockID)
 
     // Checks L1 consistency from two perspectives.
     // l1Consistent: the last verified L1 inclusion block is on the same chain
@@ -1657,6 +2045,273 @@ module Interop {
       }
     }
 
+    // Twostate lemma: Rewind on logsDBs[chainID] establishes DBsInSync(chainID).
+    // Requires old(DBsInSyncUpTo(chainID, ts)) and the Rewind postcondition
+    // (FindSealedBlock preserved for n <= targetHead.number, LatestSealedBlock == Some(targetHead)).
+    // Key step: verifiedDB.Valid() non-decreasing ensures every t <= ts has block number
+    // <= targetHead.number, so the Rewind postcondition covers all blocks referenced by DBsInSyncUpTo.
+    // Intended to be called as RewindEstablishesDBsInSync@L(chainID) where L is a label
+    // placed just before the Rewind call.
+    twostate lemma RewindEstablishesDBsInSync(chainID: ChainID)
+      requires chainID in logsDBs.Keys
+      requires old(verifiedDB.Valid())
+      requires verifiedDB.Valid()
+      requires verifiedDB.db == old(verifiedDB.db)
+      requires verifiedDB.lastTimestamp == old(verifiedDB.lastTimestamp)
+      requires verifiedDB.LastTimestamp().Some?
+      requires
+        var ts := verifiedDB.LastTimestamp().value;
+        chainID in verifiedDB.Get(ts).l2Heads &&
+        old(DBsInSyncUpTo(chainID, ts)) &&
+        logsDBs[chainID].LatestSealedBlock() == Some(verifiedDB.Get(ts).l2Heads[chainID]) &&
+        (forall n :: 0 <= n <= verifiedDB.Get(ts).l2Heads[chainID].number ==>
+          logsDBs[chainID].FindSealedBlock(n) == old(logsDBs[chainID].FindSealedBlock(n)))
+      ensures DBsInSync(chainID)
+    {
+      var ts := verifiedDB.LastTimestamp().value;
+      var targetHead := verifiedDB.Get(ts).l2Heads[chainID];
+      assert verifiedDB.Has(ts);
+      forall t | activationTimestamp <= t <= ts
+        ensures verifiedDB.Has(t)
+        ensures chainID in verifiedDB.Get(t).l2Heads
+        ensures logsDBs[chainID].FindSealedBlock(verifiedDB.Get(t).l2Heads[chainID].number).Some?
+        ensures logsDBs[chainID].FindSealedBlock(verifiedDB.Get(t).l2Heads[chainID].number).value.id ==
+          verifiedDB.Get(t).l2Heads[chainID]
+      {
+        assert old(verifiedDB.Has(t));         // fires trigger on old(DBsInSyncUpTo)
+        assert verifiedDB.db[t] == old(verifiedDB.db)[t];
+        var n := verifiedDB.Get(t).l2Heads[chainID].number;
+        // verifiedDB.Valid() non-decreasing: n <= targetHead.number
+        assert t in verifiedDB.db;
+        assert ts in verifiedDB.db;
+        assert chainID in verifiedDB.db[t].l2Heads;
+        assert chainID in verifiedDB.db[ts].l2Heads;
+        assert n <= targetHead.number;
+        // Rewind postcondition: FindSealedBlock(n) == old(FindSealedBlock(n))
+        assert logsDBs[chainID].FindSealedBlock(n) == old(logsDBs[chainID].FindSealedBlock(n));
+        // From old(DBsInSyncUpTo): old FindSealedBlock(n) has the right value
+        assert old(logsDBs[chainID].FindSealedBlock(n)).Some?;
+        assert old(logsDBs[chainID].FindSealedBlock(n)).value.id == verifiedDB.Get(t).l2Heads[chainID];
+      }
+    }
+
+    // Framing lemma: verifiedDB.Rewind preserves VerifiedHeadsAreHighestBlocksUpToTimestamp.
+    // Rewind removes entries >= rewindAt; all remaining entries were in the old db with the
+    // same value, and logsDBs is unchanged, so the property holds by congruence.
+    // Intended to be called as RewindVerifiedDBPreservesVerifiedHeadsHighest@L(rewindAt)
+    // where L is a label placed just before the Rewind call.
+    twostate lemma {:isolate_assertions} RewindVerifiedDBPreservesVerifiedHeadsHighest(rewindAt: nat)
+      requires unchanged(logsDBs.Values)
+      requires verifiedDB.db == map k | k in old(verifiedDB.db) && k < rewindAt :: old(verifiedDB.db)[k]
+      requires old(VerifiedHeadsAreHighestBlocksUpToTimestamp())
+      ensures VerifiedHeadsAreHighestBlocksUpToTimestamp()
+    {
+      forall ts': nat | verifiedDB.Has(ts')
+        ensures var verifiedHeads := verifiedDB.Get(ts').l2Heads;
+          verifiedHeads.Keys == logsDBs.Keys &&
+          forall chainID :: chainID in verifiedHeads.Keys ==>
+            var blockNumber := verifiedHeads[chainID].number;
+            forall n :: blockNumber < n && logsDBs[chainID].FindSealedBlock(n).Some? ==>
+              ts' < logsDBs[chainID].FindSealedBlock(n).value.timestamp
+      {
+        assert ts' in old(verifiedDB.db);
+        assert old(verifiedDB.Has(ts'));    // fires trigger on old(VerifiedHeadsAreHighestBlocksUpToTimestamp())
+        assert verifiedDB.db[ts'] == old(verifiedDB.db)[ts'];
+      }
+    }
+
+    // Framing lemma: logsDBs[chainID].Rewind preserves BlockSealsMatchOnChainTimestamps.
+    // Rewind removes seals above targetHead.number; remaining seals have unchanged FindSealedBlock
+    // data (Rewind postcondition), and chains is unchanged, so the timestamp-match property holds
+    // by congruence from the old state. Other chains are untouched.
+    // Intended to be called as RewindPreservesBlockSealsMatch@L(chainID, targetHead)
+    // where L is a label placed just before the Rewind call.
+    twostate lemma {:isolate_assertions} RewindPreservesBlockSealsMatch(
+        chainID: ChainID, targetHead: BlockID)
+      requires chainID in logsDBs.Keys
+      requires logsDBs.Keys == chains.Keys
+      requires forall k1, k2 :: k1 in logsDBs.Keys && k2 in logsDBs.Keys && k1 != k2 ==> logsDBs[k1] != logsDBs[k2]
+      requires logsDBs[chainID].LatestSealedBlock() == Some(targetHead)
+      requires forall n :: 0 <= n <= targetHead.number ==>
+        logsDBs[chainID].FindSealedBlock(n) == old(logsDBs[chainID].FindSealedBlock(n))
+      requires forall k :: k in logsDBs.Keys && k != chainID ==>
+        forall n :: logsDBs[k].FindSealedBlock(n) == old(logsDBs[k].FindSealedBlock(n))
+      requires old(BlockSealsMatchOnChainTimestamps())
+      ensures BlockSealsMatchOnChainTimestamps()
+    {
+      forall cid | cid in logsDBs.Keys
+        ensures forall n :: logsDBs[cid].FindSealedBlock(n).Some? ==>
+          var sealedBlock := logsDBs[cid].FindSealedBlock(n).value;
+          chains[cid].BlockInfo(sealedBlock.id).Some? &&
+          sealedBlock.timestamp == chains[cid].BlockInfo(sealedBlock.id).value.timestamp
+      {
+        forall n: nat | logsDBs[cid].FindSealedBlock(n).Some?
+          ensures var sealedBlock := logsDBs[cid].FindSealedBlock(n).value;
+            chains[cid].BlockInfo(sealedBlock.id).Some? &&
+            sealedBlock.timestamp == chains[cid].BlockInfo(sealedBlock.id).value.timestamp
+        {
+          if cid == chainID {
+            assert n <= targetHead.number;   // from LatestSealedBlock axiom (blocks above are None)
+            assert logsDBs[cid].FindSealedBlock(n) == old(logsDBs[cid].FindSealedBlock(n));
+          } else {
+            assert logsDBs[cid].FindSealedBlock(n) == old(logsDBs[cid].FindSealedBlock(n));
+          }
+        }
+      }
+    }
+
+    // Framing lemma: logsDBs[chainID].Rewind preserves AllLogsDBsConsistentWithChainData.
+    // Remaining sealed blocks (up to targetHead.number) have unchanged FindSealedBlock and
+    // BlockLogs data (from Rewind postconditions + the BlockLogs preservation axiom), so
+    // LogsDBConsistentWithChainData holds by congruence from the old state. Other chains untouched.
+    // Intended to be called as RewindPreservesAllLogsDBsConsistentWithChainData@L(chainID, targetHead)
+    // where L is a label placed just before the Rewind call.
+    twostate lemma {:isolate_assertions} RewindPreservesAllLogsDBsConsistentWithChainData(
+        chainID: ChainID, targetHead: BlockID)
+      requires chainID in logsDBs.Keys
+      requires logsDBs.Keys == chains.Keys
+      requires forall k1, k2 :: k1 in logsDBs.Keys && k2 in logsDBs.Keys && k1 != k2 ==> logsDBs[k1] != logsDBs[k2]
+      requires logsDBs[chainID].LatestSealedBlock() == Some(targetHead)
+      requires forall n :: 0 <= n <= targetHead.number ==>
+        logsDBs[chainID].FindSealedBlock(n) == old(logsDBs[chainID].FindSealedBlock(n))
+      requires forall n :: 0 <= n <= targetHead.number && logsDBs[chainID].FindSealedBlock(n).Some? ==>
+        logsDBs[chainID].BlockLogs(n) == old(logsDBs[chainID].BlockLogs(n))
+      requires forall k :: k in logsDBs.Keys && k != chainID ==>
+        forall n :: logsDBs[k].FindSealedBlock(n) == old(logsDBs[k].FindSealedBlock(n))
+      requires forall k :: k in logsDBs.Keys && k != chainID ==>
+        forall n :: old(logsDBs[k].FindSealedBlock(n)).Some? ==>
+          logsDBs[k].BlockLogs(n) == old(logsDBs[k].BlockLogs(n))
+      requires old(AllLogsDBsConsistentWithChainData())
+      ensures AllLogsDBsConsistentWithChainData()
+    {
+      reveal AllLogsDBsConsistentWithChainData;
+      reveal LogsDBConsistentWithChainData;
+      forall cid | cid in logsDBs.Keys
+        ensures LogsDBConsistentWithChainData(cid)
+      {
+        reveal LogsDBConsistentWithChainData;
+        forall blockID: BlockID | logsDBs[cid].FindSealedBlock(blockID.number).Some?
+          ensures BlockExistedOnChain(cid, blockID) &&
+            var info := chains[cid].BlockInfo(blockID).value;
+            var logs := chains[cid].BlockLogs(blockID).value;
+            logsDBs[cid].FindSealedBlock(info.id.number).value.timestamp == info.timestamp &&
+            logsDBs[cid].BlockLogs(info.id.number) == logs
+        {
+          if cid == chainID {
+            assert blockID.number <= targetHead.number;
+            assert logsDBs[cid].FindSealedBlock(blockID.number) == old(logsDBs[cid].FindSealedBlock(blockID.number));
+            assert logsDBs[cid].BlockLogs(blockID.number) == old(logsDBs[cid].BlockLogs(blockID.number));
+            assert old(logsDBs[cid].FindSealedBlock(blockID.number)).Some?;
+          } else {
+            assert logsDBs[cid].FindSealedBlock(blockID.number) == old(logsDBs[cid].FindSealedBlock(blockID.number));
+            assert logsDBs[cid].BlockLogs(blockID.number) == old(logsDBs[cid].BlockLogs(blockID.number));
+            assert old(logsDBs[cid].FindSealedBlock(blockID.number)).Some?;
+          }
+        }
+      }
+    }
+
+    // Intended to be called as RewindPreservesVerifiedHeadsHighest@L(chainID, targetHead) where
+    // L is a label placed just before the Rewind call.
+    // VerifiedHeadsAreHighestBlocksUpToTimestamp() is monotone under seal removal: rewinding
+    // logsDBs[chainID] can only reduce the seals that must satisfy the timestamp bound, so
+    // the property is preserved.
+    twostate lemma {:isolate_assertions} RewindPreservesVerifiedHeadsHighest(
+        chainID: ChainID, targetHead: BlockID)
+      requires chainID in logsDBs.Keys
+      requires forall k1, k2 :: k1 in logsDBs.Keys && k2 in logsDBs.Keys && k1 != k2 ==> logsDBs[k1] != logsDBs[k2]
+      requires verifiedDB.db == old(verifiedDB.db)
+      requires old(VerifiedHeadsAreHighestBlocksUpToTimestamp())
+      // Rewind postconditions for chainID:
+      requires logsDBs[chainID].LatestSealedBlock() == Some(targetHead)
+      requires forall n :: 0 <= n <= targetHead.number ==>
+        logsDBs[chainID].FindSealedBlock(n) == old(logsDBs[chainID].FindSealedBlock(n))
+      // Other chains unchanged (automatic framing when distinct logsDBs holds):
+      requires forall k :: k in logsDBs.Keys && k != chainID ==>
+        forall n :: logsDBs[k].FindSealedBlock(n) == old(logsDBs[k].FindSealedBlock(n))
+      ensures VerifiedHeadsAreHighestBlocksUpToTimestamp()
+    {
+      forall ts': nat | verifiedDB.Has(ts')
+        ensures var verifiedHeads := verifiedDB.Get(ts').l2Heads;
+          verifiedHeads.Keys == logsDBs.Keys &&
+          forall cid :: cid in verifiedHeads.Keys ==>
+            var blockNumber := verifiedHeads[cid].number;
+            forall n :: blockNumber < n && logsDBs[cid].FindSealedBlock(n).Some? ==>
+              ts' < logsDBs[cid].FindSealedBlock(n).value.timestamp
+      {
+        assert old(verifiedDB.Has(ts'));     // fires trigger for old(VerifiedHeadsAreHighestBlocksUpToTimestamp())
+        assert verifiedDB.db[ts'] == old(verifiedDB.db)[ts'];
+        // Keys preserved: old invariant gave verifiedHeads.Keys == old(logsDBs.Keys) == logsDBs.Keys
+        assert verifiedDB.Get(ts').l2Heads.Keys == logsDBs.Keys;
+
+        forall cid | cid in verifiedDB.Get(ts').l2Heads.Keys
+          ensures var blockNumber := verifiedDB.Get(ts').l2Heads[cid].number;
+            forall n :: blockNumber < n && logsDBs[cid].FindSealedBlock(n).Some? ==>
+              ts' < logsDBs[cid].FindSealedBlock(n).value.timestamp
+        {
+          forall n | verifiedDB.Get(ts').l2Heads[cid].number < n && logsDBs[cid].FindSealedBlock(n).Some?
+            ensures ts' < logsDBs[cid].FindSealedBlock(n).value.timestamp
+          {
+            if cid == chainID {
+              // FindSealedBlock(n).Some? after rewind implies n <= targetHead.number
+              // (LatestSealedBlock axiom: all numbers above the latest have no seal)
+              assert n <= targetHead.number;
+              // Rewind preserved the seal at n (postcondition covers 0..targetHead.number)
+              assert logsDBs[cid].FindSealedBlock(n) == old(logsDBs[cid].FindSealedBlock(n));
+              // Current seal == old seal, so old seal is Some and timestamp bound holds
+              assert old(logsDBs[cid].FindSealedBlock(n)).Some?;
+              assert ts' < old(logsDBs[cid].FindSealedBlock(n)).value.timestamp;
+            } else {
+              // Other chains are unchanged
+              assert logsDBs[cid].FindSealedBlock(n) == old(logsDBs[cid].FindSealedBlock(n));
+              assert old(logsDBs[cid].FindSealedBlock(n)).Some?;
+              assert ts' < old(logsDBs[cid].FindSealedBlock(n)).value.timestamp;
+            }
+          }
+        }
+      }
+    }
+
+    // Framing lemma: ProcessBlock on logsDBs[chainID] preserves AllLogsDBsConsistentWithChainData.
+    // For chainID itself, consistency comes directly from UpdatedLogsDB (which includes it).
+    // For all other chains, their logsDB objects are not modified so their entries are unchanged.
+    twostate lemma {:isolate_assertions} ProcessBlockPreservesAllLogsDBsConsistentWithChainData(
+        chainID: ChainID, blockID: BlockID)
+      requires chainID in logsDBs.Keys
+      requires logsDBs.Keys == chains.Keys
+      requires forall k1, k2 :: k1 in logsDBs.Keys && k2 in logsDBs.Keys && k1 != k2 ==> logsDBs[k1] != logsDBs[k2]
+      requires BlockExistedOnChain(chainID, blockID)
+      requires UpdatedLogsDB(chainID, blockID)
+      requires forall k :: k in logsDBs.Keys && k != chainID ==>
+        forall n :: logsDBs[k].FindSealedBlock(n) == old(logsDBs[k].FindSealedBlock(n))
+      requires forall k :: k in logsDBs.Keys && k != chainID ==>
+        forall n :: old(logsDBs[k].FindSealedBlock(n)).Some? ==>
+          logsDBs[k].BlockLogs(n) == old(logsDBs[k].BlockLogs(n))
+      requires old(AllLogsDBsConsistentWithChainData())
+      ensures AllLogsDBsConsistentWithChainData()
+    {
+      reveal AllLogsDBsConsistentWithChainData;
+      reveal LogsDBConsistentWithChainData;
+      reveal UpdatedLogsDB;
+      forall cid | cid in logsDBs.Keys
+        ensures LogsDBConsistentWithChainData(cid)
+      {
+        reveal LogsDBConsistentWithChainData;
+        if cid != chainID {
+          forall blockID2: BlockID | logsDBs[cid].FindSealedBlock(blockID2.number).Some?
+            ensures BlockExistedOnChain(cid, blockID2) &&
+              var info := chains[cid].BlockInfo(blockID2).value;
+              var logs := chains[cid].BlockLogs(blockID2).value;
+              logsDBs[cid].FindSealedBlock(info.id.number).value.timestamp == info.timestamp &&
+              logsDBs[cid].BlockLogs(info.id.number) == logs
+          {
+            assert logsDBs[cid].FindSealedBlock(blockID2.number) == old(logsDBs[cid].FindSealedBlock(blockID2.number));
+            assert old(logsDBs[cid].FindSealedBlock(blockID2.number)).Some?;
+          }
+        }
+      }
+    }
+
     // Framing lemma: ProcessBlock on logsDBs[chainID] (adding block at newBlockNumber,
     // which must equal oldLatestBlock.number + 1) preserves DBsInSyncUpTo(chainID, upper).
     // All blocks referenced by DBsInSyncUpTo have numbers <= oldLatestBlock.number, so
@@ -1694,6 +2349,309 @@ module Interop {
       }
     }
 
+    // Framing lemma: ProcessBlock on logsDBs[chainID] preserves AllMessagesPresent.
+    // ProcessBlock adds newBlockNumber; for all other block numbers FindSealedBlock
+    // is unchanged, so old(PresentInLogsDB) messages remain present (via ContainsMonotone).
+    // PresentInFrontier calls reads-{} functions and is heap-independent.
+    // Unaffected logsDBs (c != chainID) are unchanged, preserving their Contains results.
+    // Intended to be called as ProcessBlockPreservesAllMessagesPresent@L(chainID, newBlockNumber, blocksAtTS)
+    // where L is a label placed just before the ProcessBlock call.
+    twostate lemma ProcessBlockPreservesAllMessagesPresent(
+        chainID: ChainID, newBlockNumber: nat, blocksAtTS: map<ChainID, BlockID>)
+      requires old(Valid())
+      requires Valid()
+      requires blocksAtTS.Keys == CHAIN_IDS
+      requires chainID in logsDBs.Keys
+      // newBlockNumber was not sealed before: either no blocks existed, or it is exactly one past latest.
+      requires old(logsDBs[chainID].LatestSealedBlock()).None? ||
+        old(logsDBs[chainID].LatestSealedBlock()).value.number + 1 == newBlockNumber
+      // ProcessBlock postcondition: FindSealedBlock unchanged for all blocks except the new one.
+      requires forall n :: n != newBlockNumber ==>
+        logsDBs[chainID].FindSealedBlock(n) == old(logsDBs[chainID].FindSealedBlock(n))
+      // ProcessBlock only modifies logsDBs[chainID]; all other logsDB objects are unchanged.
+      requires forall c :: c in logsDBs.Keys && c != chainID ==> unchanged(logsDBs[c])
+      requires old(forall k :: k in blocksAtTS.Keys ==>
+        BlockExistedOnChain(k, blocksAtTS[k]) &&
+        AllInitMsgsPresent(k, blocksAtTS[k], blocksAtTS))
+      ensures forall k :: k in blocksAtTS.Keys ==>
+        BlockExistedOnChain(k, blocksAtTS[k]) &&
+        AllInitMsgsPresent(k, blocksAtTS[k], blocksAtTS)
+    {
+      // newBlockNumber was not sealed in the old state.
+      assert old(logsDBs[chainID].FindSealedBlock(newBlockNumber)) == None by {
+        if old(logsDBs[chainID].LatestSealedBlock()).Some? {
+          // LatestSealedBlock axiom: all blocks above latest have FindSealedBlock == None.
+          assert old(logsDBs[chainID].LatestSealedBlock()).value.number < newBlockNumber;
+        }
+      }
+      forall k | k in blocksAtTS.Keys
+        ensures BlockExistedOnChain(k, blocksAtTS[k])
+        ensures AllInitMsgsPresent(k, blocksAtTS[k], blocksAtTS)
+      {
+        // chains[k].BlockLogs(blocksAtTS[k]).Some? is heap-independent (reads {}) — trivially preserved.
+        var logs := chains[k].BlockLogs(blocksAtTS[k]).value;
+        reveal AllInitMsgsPresent;
+        forall execMsg | execMsg in logs.execMsgs.Values
+          ensures execMsg.chainID in CHAIN_IDS &&
+            (InitMsgInFrontier(execMsg, blocksAtTS) || InitMsgInLogsDB(execMsg))
+        {
+          // The old invariant gives us the fact for this execMsg.
+          assert execMsg.chainID in CHAIN_IDS;
+          assert old(InitMsgInFrontier(execMsg, blocksAtTS) || InitMsgInLogsDB(execMsg));
+          if InitMsgInFrontier(execMsg, blocksAtTS) {
+            // PresentInFrontier calls chains[...].BlockInfo/BlockLogs which have reads {} —
+            // heap-independent, same value in both states.
+          } else {
+            assert old(InitMsgInLogsDB(execMsg));
+            var query := ContainsQuery(
+              execMsg.blockNum, execMsg.logIdx, execMsg.timestamp, execMsg.checksum);
+            // old(Contains) => old(FindSealedBlock(execMsg.blockNum).Some?)
+            assert old(logsDBs[execMsg.chainID].FindSealedBlock(execMsg.blockNum)).Some?;
+            if execMsg.chainID != chainID {
+              // logsDBs[execMsg.chainID] is unchanged — Contains gives the same result.
+              assert unchanged(logsDBs[execMsg.chainID]);
+            } else {
+              // execMsg.chainID == chainID: the block was already sealed (old FindSealedBlock.Some?),
+              // but newBlockNumber was not sealed before, so execMsg.blockNum != newBlockNumber.
+              assert execMsg.blockNum != newBlockNumber;
+              // FindSealedBlock for the old block number is unchanged.
+              assert logsDBs[chainID].FindSealedBlock(execMsg.blockNum) ==
+                old(logsDBs[chainID].FindSealedBlock(execMsg.blockNum));
+              // Monotonicity: Contains is preserved when its queried FindSealedBlock is unchanged.
+              logsDBs[chainID].ContainsMonotone(query);
+            }
+          }
+        }
+      }
+    }
+
+    // Framing lemma: ProcessBlock on logsDBs[chainID] preserves the FindSealedBlock
+    // monotonicity invariant: old (method-entry) sealed blocks remain unchanged.
+    // ProcessBlock only appends newBlockNumber; any n with old(FindSealedBlock(n)).Some?
+    // satisfies n ≤ old(LatestSealedBlock).number < newBlockNumber, so n ≠ newBlockNumber,
+    // so ProcessBlock's frame postcondition preserves FindSealedBlock(n).
+    // Intended to be called as ProcessBlockPreservesFindSealedBlockMonotonicity@L(chainID, newBlockNumber)
+    // where L is a label placed just before the ProcessBlock call.
+    twostate lemma ProcessBlockPreservesFindSealedBlockMonotonicity(
+        chainID: ChainID, newBlockNumber: nat)
+      requires chainID in logsDBs.Keys
+      requires old(logsDBs[chainID].LatestSealedBlock()).None? ||
+        old(logsDBs[chainID].LatestSealedBlock()).value.number + 1 == newBlockNumber
+      requires forall n :: n != newBlockNumber ==>
+        logsDBs[chainID].FindSealedBlock(n) == old(logsDBs[chainID].FindSealedBlock(n))
+      requires forall c :: c in logsDBs.Keys && c != chainID ==> unchanged(logsDBs[c])
+      ensures forall c :: c in logsDBs.Keys ==>
+        forall n :: old(logsDBs[c].FindSealedBlock(n)).Some? ==>
+          logsDBs[c].FindSealedBlock(n) == old(logsDBs[c].FindSealedBlock(n))
+    {
+      assert old(logsDBs[chainID].FindSealedBlock(newBlockNumber)) == None by {
+        if old(logsDBs[chainID].LatestSealedBlock()).Some? {
+          assert old(logsDBs[chainID].LatestSealedBlock()).value.number < newBlockNumber;
+        }
+      }
+      forall c | c in logsDBs.Keys
+        ensures forall n :: old(logsDBs[c].FindSealedBlock(n)).Some? ==>
+          logsDBs[c].FindSealedBlock(n) == old(logsDBs[c].FindSealedBlock(n))
+      {
+        if c != chainID {
+          assert unchanged(logsDBs[c]);
+        } else {
+          forall n | old(logsDBs[c].FindSealedBlock(n)).Some?
+            ensures logsDBs[c].FindSealedBlock(n) == old(logsDBs[c].FindSealedBlock(n))
+          {
+            // old(FindSealedBlock(n)).Some? but old(FindSealedBlock(newBlockNumber)) == None
+            // → n ≠ newBlockNumber → ProcessBlock frame preserves FindSealedBlock(n).
+            assert n != newBlockNumber;
+          }
+        }
+      }
+    }
+
+
+    // Framing lemma: PersistFrontierLogs preserves AllVerifiedCrossValid.
+    // verifiedDB is unchanged; each logsDB only grew (old FindSealedBlock results
+    // are preserved by the {:axiom} postcondition on PersistFrontierLogs).
+    // For each previously committed timestamp, AllInitMsgsPresent is preserved:
+    //   - InitMsgInFrontier is heap-independent (reads {} functions).
+    //   - InitMsgInLogsDB was True for old block numbers, which are unchanged
+    //     in each logsDB, so ContainsMonotone carries it forward.
+    // Intended to be called as PersistFrontierLogsPreservesAllVerifiedCrossValid@L()
+    // where L is a label placed just before the PersistFrontierLogs call.
+    twostate lemma {:isolate_assertions} PersistFrontierLogsPreservesAllVerifiedCrossValid()
+      requires old(Valid())
+      requires Valid()
+      requires verifiedDB.db == old(verifiedDB.db)
+      requires verifiedDB.lastTimestamp == old(verifiedDB.lastTimestamp)
+      requires old(AllVerifiedCrossValid())
+      // PersistFrontierLogs {:axiom} postcondition: each logsDB only appended new blocks.
+      requires forall c :: c in logsDBs.Keys ==>
+        forall n :: old(logsDBs[c].FindSealedBlock(n)).Some? ==>
+          logsDBs[c].FindSealedBlock(n) == old(logsDBs[c].FindSealedBlock(n))
+      ensures AllVerifiedCrossValid()
+    {
+      reveal AllVerifiedCrossValid();
+
+      if verifiedDB.LastTimestamp().Some? {
+        var lastTS := verifiedDB.LastTimestamp().value;
+        SequentialContainsRange(verifiedDB.db, activationTimestamp);
+        forall ts | activationTimestamp <= ts <= lastTS
+          ensures verifiedDB.Has(ts)
+          ensures verifiedDB.Get(ts).l2Heads.Keys == CHAIN_IDS
+          ensures ResultIsCrossValid(Result(verifiedDB.Get(ts).timestamp,
+                                            verifiedDB.Get(ts).l1Inclusion,
+                                            verifiedDB.Get(ts).l2Heads, map[]))
+        {
+          assert old(verifiedDB.Has(ts));          // fires trigger on old(AllVerifiedCrossValid())
+          assert verifiedDB.db[ts] == old(verifiedDB.db)[ts];
+          // Prove ResultIsCrossValid in the current state chain by chain.
+          var r := Result(verifiedDB.Get(ts).timestamp, verifiedDB.Get(ts).l1Inclusion,
+                          verifiedDB.Get(ts).l2Heads, map[]);
+          forall chainID | chainID in CHAIN_IDS
+            ensures chains[chainID].BlockInfo(r.l2Heads[chainID]).Some?
+            ensures BlockIsCrossValid(
+                chains[chainID].BlockInfo(r.l2Heads[chainID]).value.timestamp,
+                chainID, r.l2Heads[chainID])
+            ensures AllInitMsgsPresent(chainID, r.l2Heads[chainID], r.l2Heads)
+          {
+            var blockID := r.l2Heads[chainID];
+            // chains[chainID].BlockInfo/BlockLogs have reads {} — heap-independent.
+            // BlockIsCrossValid only calls ValidExecutingMessage (also heap-independent).
+            // AllInitMsgsPresent: prove per-message monotonicity.
+            forall execMsg | execMsg in chains[chainID].BlockLogs(blockID).value.execMsgs.Values
+              ensures execMsg.chainID in CHAIN_IDS &&
+                (InitMsgInFrontier(execMsg, r.l2Heads) || InitMsgInLogsDB(execMsg))
+            {
+              if InitMsgInFrontier(execMsg, r.l2Heads) {
+                // InitMsgInFrontier calls reads-{} functions — heap-independent.
+              } else {
+                assert old(InitMsgInLogsDB(execMsg));
+                var query := ContainsQuery(
+                  execMsg.blockNum, execMsg.logIdx, execMsg.timestamp, execMsg.checksum);
+                // old(Contains) => old(FindSealedBlock(execMsg.blockNum).Some?)
+                assert old(logsDBs[execMsg.chainID].FindSealedBlock(execMsg.blockNum)).Some?;
+                // requires: that block number's FindSealedBlock is unchanged.
+                assert logsDBs[execMsg.chainID].FindSealedBlock(execMsg.blockNum) ==
+                  old(logsDBs[execMsg.chainID].FindSealedBlock(execMsg.blockNum));
+                logsDBs[execMsg.chainID].ContainsMonotone(query);
+              }
+            }
+          }
+        }
+      }
+    }
+
+    // Framing lemma: PersistFrontierLogs preserves AllDBsInSyncUpTo.
+    // verifiedDB is unchanged; for each committed timestamp t, SealedBlockForVerifiedAtTimestamp
+    // calls FindSealedBlock for a block already sealed before PersistFrontierLogs ran.
+    // The monotonicity postcondition of PersistFrontierLogs keeps those FindSealedBlock results
+    // unchanged, so DBsInSyncUpTo holds in the new state.
+    // Intended to be called as PersistFrontierLogsPreservesAllDBsInSyncUpTo@L(upperTS)
+    // where L is a label placed just before the PersistFrontierLogs call.
+    twostate lemma PersistFrontierLogsPreservesAllDBsInSyncUpTo(upperTS: nat)
+      requires old(Valid())
+      requires Valid()
+      requires verifiedDB.db == old(verifiedDB.db)
+      requires old(AllDBsInSyncUpTo(upperTS))
+      requires forall c :: c in logsDBs.Keys ==>
+        forall n :: old(logsDBs[c].FindSealedBlock(n)).Some? ==>
+          logsDBs[c].FindSealedBlock(n) == old(logsDBs[c].FindSealedBlock(n))
+      ensures AllDBsInSyncUpTo(upperTS)
+    {
+      forall k | k in logsDBs.Keys ensures DBsInSyncUpTo(k, upperTS) {
+        forall t | activationTimestamp <= t <= upperTS
+          ensures verifiedDB.Has(t)
+          ensures k in verifiedDB.Get(t).l2Heads
+          ensures SealedBlockForVerifiedAtTimestamp(k, t).Some?
+          ensures SealedBlockForVerifiedAtTimestamp(k, t).value.id == verifiedDB.Get(t).l2Heads[k]
+        {
+          assert old(verifiedDB.Has(t));
+          assert old(k in verifiedDB.Get(t).l2Heads);
+          assert old(SealedBlockForVerifiedAtTimestamp(k, t)).Some?;
+          // SealedBlockForVerifiedAtTimestamp(k, t) = logsDBs[k].FindSealedBlock(verifiedHeads[k].number)
+          // verifiedDB.db is unchanged, so verifiedDB.Get(t).l2Heads[k] is the same as old.
+          var n := verifiedDB.Get(t).l2Heads[k].number;
+          assert old(logsDBs[k].FindSealedBlock(n)).Some?;
+          assert logsDBs[k].FindSealedBlock(n) == old(logsDBs[k].FindSealedBlock(n));
+        }
+      }
+    }
+
+    // Framing lemma: PersistFrontierLogs preserves TransitionIsCrossValid.
+    // In the Advance case, ResultIsCrossValid is preserved because AllInitMsgsPresent
+    // is preserved: InitMsgInFrontier is heap-independent, and InitMsgInLogsDB is
+    // preserved by ContainsMonotone (FindSealedBlock for already-sealed block numbers
+    // is unchanged by the monotonicity postcondition of PersistFrontierLogs).
+    // Intended to be called as PersistFrontierLogsPreservesTransitionIsCrossValid@L(pending)
+    // where L is a label placed just before the PersistFrontierLogs call.
+    twostate lemma {:isolate_assertions} PersistFrontierLogsPreservesTransitionIsCrossValid(
+        pending: PendingTransition)
+      requires old(Valid())
+      requires Valid()
+      requires ValidPendingTransition(pending)
+      requires old(TransitionIsCrossValid(pending))
+      requires forall c :: c in logsDBs.Keys ==>
+        forall n :: old(logsDBs[c].FindSealedBlock(n)).Some? ==>
+          logsDBs[c].FindSealedBlock(n) == old(logsDBs[c].FindSealedBlock(n))
+      ensures TransitionIsCrossValid(pending)
+    {
+      if pending.decision.Advance? {
+        var result := pending.result.value;
+        forall chainID | chainID in CHAIN_IDS
+          ensures chains[chainID].BlockInfo(result.l2Heads[chainID]).Some?
+          ensures BlockIsCrossValid(
+              chains[chainID].BlockInfo(result.l2Heads[chainID]).value.timestamp,
+              chainID, result.l2Heads[chainID])
+          ensures AllInitMsgsPresent(chainID, result.l2Heads[chainID], result.l2Heads)
+        {
+          var blockID := result.l2Heads[chainID];
+          forall execMsg | execMsg in chains[chainID].BlockLogs(blockID).value.execMsgs.Values
+            ensures execMsg.chainID in CHAIN_IDS &&
+              (InitMsgInFrontier(execMsg, result.l2Heads) || InitMsgInLogsDB(execMsg))
+          {
+            if InitMsgInFrontier(execMsg, result.l2Heads) {
+              // InitMsgInFrontier calls reads-{} functions — heap-independent.
+            } else {
+              assert old(InitMsgInLogsDB(execMsg));
+              var query := ContainsQuery(
+                execMsg.blockNum, execMsg.logIdx, execMsg.timestamp, execMsg.checksum);
+              assert old(logsDBs[execMsg.chainID].FindSealedBlock(execMsg.blockNum)).Some?;
+              assert logsDBs[execMsg.chainID].FindSealedBlock(execMsg.blockNum) ==
+                old(logsDBs[execMsg.chainID].FindSealedBlock(execMsg.blockNum));
+              logsDBs[execMsg.chainID].ContainsMonotone(query);
+            }
+          }
+        }
+      }
+    }
+
+    // Framing lemma: ClearPendingTransition preserves AllVerifiedHeadsBoundedByTimestamp.
+    // db and lastTimestamp are unchanged, so the timestamp range, Has, and Get all return
+    // the same values; BlocksExistedOnChain reads {} and VerifiedHeadsBoundedByTimestamp
+    // reads only verifiedDB, so both are preserved by congruence.
+    // Intended to be called as ClearPendingPreservesAllVerifiedHeadsBoundedByTimestamp@L()
+    // where L is a label placed just before the ClearPendingTransition call.
+    twostate lemma ClearPendingPreservesAllVerifiedHeadsBoundedByTimestamp()
+      requires old(verifiedDB.Valid())
+      requires verifiedDB.Valid()
+      requires verifiedDB.db == old(verifiedDB.db)
+      requires verifiedDB.lastTimestamp == old(verifiedDB.lastTimestamp)
+      requires old(AllVerifiedHeadsBoundedByTimestamp())
+      ensures AllVerifiedHeadsBoundedByTimestamp()
+    {
+      if verifiedDB.LastTimestamp().Some? {
+        var lastTS := verifiedDB.LastTimestamp().value;
+        forall ts | activationTimestamp <= ts <= lastTS
+          ensures verifiedDB.Has(ts)
+          ensures chains.Keys == verifiedDB.Get(ts).l2Heads.Keys
+          ensures BlocksExistedOnChain(verifiedDB.Get(ts).l2Heads)
+          ensures VerifiedHeadsBoundedByTimestamp(ts)
+        {
+          assert old(verifiedDB.Has(ts));
+          assert verifiedDB.db[ts] == old(verifiedDB.db)[ts];
+        }
+      }
+    }
+
     // Framing lemma: ClearPendingTransition preserves AllVerifiedCrossValid.
     // db and lastTimestamp are unchanged, so the range and entries are the same;
     // ResultIsCrossValid is heap-independent w.r.t. anything ClearPendingTransition
@@ -1704,11 +2662,14 @@ module Interop {
       requires old(Valid())
       requires Valid()
       requires unchanged(chains.Values)
+      requires unchanged(logsDBs.Values)
       requires verifiedDB.db == old(verifiedDB.db)
       requires verifiedDB.lastTimestamp == old(verifiedDB.lastTimestamp)
       requires old(AllVerifiedCrossValid())
       ensures AllVerifiedCrossValid()
     {
+      reveal AllVerifiedCrossValid;
+
       if verifiedDB.LastTimestamp().Some? {
         var lastTS := verifiedDB.LastTimestamp().value;
         SequentialContainsRange(verifiedDB.db, activationTimestamp);
@@ -1735,11 +2696,14 @@ module Interop {
       requires old(Valid())
       requires Valid()
       requires unchanged(chains.Values)
+      requires unchanged(logsDBs.Values)
       requires verifiedDB.db ==
         map k | k in old(verifiedDB.db) && k < rewindAt :: old(verifiedDB.db)[k]
       requires old(AllVerifiedCrossValid())
       ensures AllVerifiedCrossValid()
     {
+      reveal AllVerifiedCrossValid;
+
       if verifiedDB.LastTimestamp().Some? {
         var lastTS := verifiedDB.LastTimestamp().value;
         assert lastTS == MaxKey(verifiedDB.db);   // from Valid(): lastTimestamp == Some(MaxKey(db))
@@ -1761,6 +2725,90 @@ module Interop {
       }
     }
 
+    // Framing lemma: verifiedDB.Rewind preserves AllVerifiedHeadsBoundedByTimestamp.
+    // Rewind removes entries >= rewindAt; all remaining entries were covered by
+    // old(AllVerifiedHeadsBoundedByTimestamp()) and their VerifiedHeadsBoundedByTimestamp
+    // follows by congruence (db[ts] = old(db)[ts] for ts < rewindAt, chains unchanged).
+    // Uses verifiedDB.Valid() rather than Valid() to avoid a circular dependency:
+    // Valid() includes AllVerifiedHeadsBoundedByTimestamp(), so using Valid() as a
+    // requires here would make the ensures redundant or circular.
+    // The non-circular part of Valid() needed is the activationTimestamp membership.
+    // Intended to be called as RewindPreservesAllVerifiedHeadsBoundedByTimestamp@L(rewindAt)
+    // where L is a label placed just before the Rewind call.
+    twostate lemma {:isolate_assertions} RewindPreservesAllVerifiedHeadsBoundedByTimestamp(rewindAt: nat)
+      requires old(verifiedDB.Valid())
+      requires verifiedDB.Valid()
+      requires verifiedDB.db ==
+        map k | k in old(verifiedDB.db) && k < rewindAt :: old(verifiedDB.db)[k]
+      requires verifiedDB.lastTimestamp.Some? ==> activationTimestamp in verifiedDB.db
+      requires old(AllVerifiedHeadsBoundedByTimestamp())
+      ensures AllVerifiedHeadsBoundedByTimestamp()
+    {
+      if verifiedDB.LastTimestamp().Some? {
+        var lastTS := verifiedDB.LastTimestamp().value;
+        assert lastTS == MaxKey(verifiedDB.db);
+        assert lastTS in verifiedDB.db;
+        assert lastTS < rewindAt;
+        SequentialContainsRange(verifiedDB.db, activationTimestamp);
+        forall ts | activationTimestamp <= ts <= lastTS
+          ensures verifiedDB.Has(ts)
+          ensures chains.Keys == verifiedDB.Get(ts).l2Heads.Keys
+          ensures BlocksExistedOnChain(verifiedDB.Get(ts).l2Heads)
+          ensures VerifiedHeadsBoundedByTimestamp(ts)
+        {
+          assert ts < rewindAt;
+          SequentialContainsRange(old(verifiedDB.db), activationTimestamp);
+          assert ts in old(verifiedDB.db);
+          assert old(verifiedDB.Has(ts));    // fires trigger on old(AllVerifiedHeadsBoundedByTimestamp())
+          assert verifiedDB.db[ts] == old(verifiedDB.db)[ts];
+        }
+      }
+    }
+
+    // Framing lemma: verifiedDB.Commit extends AllVerifiedHeadsBoundedByTimestamp.
+    // Old entries are unchanged (db[ts] = old(db)[ts] for ts < newTs) and their
+    // VerifiedHeadsBoundedByTimestamp follows from old(AllVerifiedHeadsBoundedByTimestamp()).
+    // The new entry satisfies VerifiedHeadsBoundedByTimestamp(newTs) because
+    // FrontierBlocksConsistentWithTimestamp(newTs, newR.l2Heads) is the same predicate —
+    // this comes from TransitionConsistentWithChainState in PendingTransitionIsConsistent.
+    // Intended to be called as CommitExtendsAllVerifiedHeadsBoundedByTimestamp@L(newTs, newR)
+    // where L is a label placed just before the Commit call.
+    twostate lemma CommitExtendsAllVerifiedHeadsBoundedByTimestamp(newTs: nat, newR: VerifiedResult)
+      requires old(verifiedDB.Valid())
+      requires verifiedDB.Valid()
+      requires unchanged(chains.Values)
+      requires chains.Keys == CHAIN_IDS
+      requires newR.l2Heads.Keys == CHAIN_IDS
+      requires verifiedDB.db == old(verifiedDB.db)[newTs := newR]
+      requires verifiedDB.lastTimestamp == Some(newTs)
+      requires old(verifiedDB.LastTimestamp()).None? ==> newTs == activationTimestamp
+      requires old(verifiedDB.LastTimestamp()).Some? ==>
+        newTs == old(verifiedDB.LastTimestamp()).value + 1
+      requires old(AllVerifiedHeadsBoundedByTimestamp())
+      requires BlocksExistedOnChain(newR.l2Heads)
+      requires FrontierBlocksConsistentWithTimestamp(newTs, newR.l2Heads)
+      ensures AllVerifiedHeadsBoundedByTimestamp()
+    {
+      forall ts | activationTimestamp <= ts <= newTs
+        ensures verifiedDB.Has(ts)
+        ensures chains.Keys == verifiedDB.Get(ts).l2Heads.Keys
+        ensures BlocksExistedOnChain(verifiedDB.Get(ts).l2Heads)
+        ensures VerifiedHeadsBoundedByTimestamp(ts)
+      {
+        if ts == newTs {
+          // New entry: BlocksExistedOnChain from requires; VerifiedHeadsBoundedByTimestamp
+          // is definitionally equal to FrontierBlocksConsistentWithTimestamp (requires).
+          assert verifiedDB.Get(newTs) == newR;
+        } else {
+          assert old(verifiedDB.LastTimestamp()).Some?;
+          var oldLastTS := old(verifiedDB.LastTimestamp()).value;
+          assert ts <= oldLastTS;
+          assert old(verifiedDB.Has(ts));    // fires trigger on old(AllVerifiedHeadsBoundedByTimestamp())
+          assert verifiedDB.db[ts] == old(verifiedDB.db)[ts];
+        }
+      }
+    }
+
     // Framing lemma: verifiedDB.Commit extends AllVerifiedCrossValid with a new entry.
     // Old entries are unchanged and their ResultIsCrossValid follows from old(AllVerifiedCrossValid());
     // the new entry must be supplied as ResultIsCrossValid(Result(newTs, ...)) in the requires.
@@ -1770,6 +2818,7 @@ module Interop {
       requires old(Valid())
       requires Valid()
       requires unchanged(chains.Values)
+      requires unchanged(logsDBs.Values)
       requires newR.l2Heads.Keys == CHAIN_IDS
       requires verifiedDB.db == old(verifiedDB.db)[newTs := newR]
       requires verifiedDB.lastTimestamp == Some(newTs)
@@ -1780,6 +2829,7 @@ module Interop {
       requires ResultIsCrossValid(Result(newTs, newR.l1Inclusion, newR.l2Heads, map[]))
       ensures AllVerifiedCrossValid()
     {
+      reveal AllVerifiedCrossValid;
       SequentialContainsRange(verifiedDB.db, activationTimestamp);
       forall ts | activationTimestamp <= ts <= newTs
         ensures verifiedDB.Has(ts)
@@ -1798,6 +2848,362 @@ module Interop {
           SequentialContainsRange(old(verifiedDB.db), activationTimestamp);
           assert old(verifiedDB.Has(ts));                // fires trigger on old(AllVerifiedCrossValid())
           assert verifiedDB.db[ts] == old(verifiedDB.db)[ts];
+        }
+      }
+    }
+
+
+    // Framing lemma: RewindLogsDBs preserves AllVerifiedCrossValid (resetAllChainsTo.Some? path).
+    // For each remaining committed timestamp ts' ≤ ts and executing block blockID on chainID:
+    // (1) T_chain := chains[chainID].BlockInfo(blockID).value.timestamp is the chain-data
+    //     timestamp. ResultIsCrossValid uses T_chain (not ts') as the executing timestamp.
+    //     AllDBsInSyncUpTo + BlockSealsMatchOnChainTimestamps identify the seal at
+    //     blockID.number with T_chain. VerifiedDB non-decreasing (ts' ≤ ts) gives
+    //     blockID.number ≤ plan.targetHeads[chainID].number. FindSealedBlock monotonicity
+    //     (blockID.number ≤ plan.targetHeads[chainID].number, both sealed in old state) then
+    //     gives T_chain ≤ old(seal_timestamp(targetHead.number)).
+    //     NOTE: old(seal_timestamp(targetHead.number)) is not directly bounded to ts here;
+    //     instead, step (3) bypasses this via VerifiedHeadsAreHighestBlocksUpToTimestamp.
+    // (2) ValidExecutingMessage(T_chain, chainID, execMsg) gives execMsg.timestamp ≤ T_chain ≤ ts.
+    //     (The T_chain ≤ ts bound comes from FindSealedBlock monotonicity + requires #11, but
+    //     step (3) can derive the contradiction without it by using VHAHIBT directly.)
+    // (3) Contains axiom gives old seal timestamp == execMsg.timestamp ≤ ts (from step 2).
+    //     old(VerifiedHeadsAreHighestBlocksUpToTimestamp()) at ts for the source chain:
+    //     if execMsg.blockNum > plan.targetHeads[source].number, then ts < execMsg.timestamp —
+    //     contradiction. So execMsg.blockNum ≤ targetHead.number on the source chain.
+    // (4) RewindLogsDBs preserves FindSealedBlock for n ≤ targetHead.number;
+    //     ContainsMonotone carries InitMsgInLogsDB forward.
+    // InitMsgInFrontier is heap-independent and preserved trivially.
+    // Intended to be called as RewindLogsDBsPreservesAllVerifiedCrossValid@L(plan) where
+    // L is a label placed just before the RewindLogsDBs call.
+
+    // Instantiates the forall inside BlockIsCrossValid for a single execMsg.
+    // A standalone lemma (single VC, no {:isolate_assertions}) so the explicit trigger on
+    // BlockIsCrossValid's forall can fire and be matched in one Z3 query without fuel contention.
+    lemma BlockIsCrossValidInstantiate(ts: nat, chainID: ChainID, blockID: BlockID, execMsg: ExecutingMessage)
+      requires chainID in CHAIN_IDS
+      requires chains.Keys == CHAIN_IDS
+      requires chains[chainID].BlockInfo(blockID).Some?
+      requires BlockIsCrossValid(ts, chainID, blockID)
+      requires execMsg in chains[chainID].BlockLogs(blockID).value.execMsgs.Values
+      ensures ValidExecutingMessage(ts, chainID, execMsg)
+    {
+      var logs := chains[chainID].BlockLogs(blockID).value;
+      assert execMsg in logs.execMsgs.Values;
+    }
+
+    // Helper for RewindLogsDBsPreservesAllVerifiedCrossValid: extracts ValidExecutingMessage
+    // from old(AllVerifiedCrossValid()) at a shallow nesting depth where AllVerifiedCrossValid
+    // has sufficient fuel. Call sites inside deeply nested foralls where the function would be
+    // fuel-exhausted should use this lemma instead of asserting trigger-chain steps inline.
+    twostate lemma {:isolate_assertions} OldCrossValidGivesExecMsgTimestamp(
+      ts': nat, chainID: ChainID, blockID: BlockID, T_chain: nat, execMsg: ExecutingMessage)
+      requires old(Valid())
+      requires chains.Keys == CHAIN_IDS
+      requires old(AllVerifiedCrossValid())
+      requires verifiedDB.db == old(verifiedDB.db)
+      requires old(verifiedDB.LastTimestamp()).Some?
+      requires activationTimestamp <= ts'
+      requires ts' <= old(verifiedDB.LastTimestamp()).value
+      requires ts' in verifiedDB.db
+      requires chainID in CHAIN_IDS
+      requires forall ts :: ts in verifiedDB.db ==> verifiedDB.Get(ts).l2Heads.Keys == CHAIN_IDS
+      requires blockID == verifiedDB.Get(ts').l2Heads[chainID]
+      requires chains[chainID].BlockInfo(blockID).Some?
+      requires chains[chainID].BlockInfo(blockID).value.timestamp == T_chain
+      requires execMsg in chains[chainID].BlockLogs(blockID).value.execMsgs.Values
+      ensures ValidExecutingMessage(T_chain, chainID, execMsg)
+    {
+      reveal AllVerifiedCrossValid;
+      verifiedDB.GetStableIfDBUnchanged(ts');
+      // old(Get(ts')) == Get(ts') is in context. Build the old result explicitly so
+      // old(Get(ts')) appears as a ground term and fires the AllVerifiedCrossValid trigger.
+      var r_old := Result(old(verifiedDB.Get(ts')).timestamp,
+                          old(verifiedDB.Get(ts')).l1Inclusion,
+                          old(verifiedDB.Get(ts')).l2Heads, map[]);
+      assert r_old.l2Heads.Keys == CHAIN_IDS;
+      assert r_old.l2Heads[chainID] == blockID;
+      assert old(verifiedDB.Has(ts'));
+      // Each step is isolated (fresh fuel per VC):
+      // Step 1: old(AllVerifiedCrossValid()) forall fires at ts' → old(ResultIsCrossValid(r_old))
+      assert old(ResultIsCrossValid(r_old));
+      // Step 2: old(ResultIsCrossValid(r_old)) forall fires at chainID → BlockIsCrossValid(...)
+      // (BlockIsCrossValid reads {} — heap-independent, so old(P) == P)
+      assert BlockIsCrossValid(T_chain, chainID, blockID);
+      // Step 3: Delegate forall instantiation to a helper lemma (single VC, no isolation).
+      BlockIsCrossValidInstantiate(T_chain, chainID, blockID, execMsg);
+    }
+
+    twostate lemma {:isolate_assertions} RewindLogsDBsPreservesAllVerifiedCrossValid(plan: RewindPlan)
+      requires plan.resetAllChainsTo.Some?
+      requires old(Valid())
+      requires Valid()
+      requires verifiedDB.db == old(verifiedDB.db)
+      requires verifiedDB.lastTimestamp == old(verifiedDB.lastTimestamp)
+      // verifiedDB.LastTimestamp() == Some(ts) in both states (from RewoundVerifiedDB).
+      requires old(verifiedDB.LastTimestamp()) == Some(plan.resetAllChainsTo.value)
+      requires old(AllVerifiedCrossValid())
+      // Explicit requires needed for predicates called deep inside isolated VCs (Valid()
+      // body may be fuel-exhausted at that depth).
+      requires chains.Keys == CHAIN_IDS
+      requires logsDBs.Keys == CHAIN_IDS
+      requires forall ts :: ts in verifiedDB.db ==> verifiedDB.Get(ts).l2Heads.Keys == CHAIN_IDS
+      // plan.targetHeads covers exactly the same chains as logsDBs (both == CHAIN_IDS).
+      requires plan.targetHeads.Keys == logsDBs.Keys
+      // plan.targetHeads are the verified L2 heads at ts (from PlanConsistentWithVerified).
+      requires plan.targetHeads == verifiedDB.Get(plan.resetAllChainsTo.value).l2Heads
+      // The logsDBs are in sync with the verifiedDB up to ts in the old state.
+      requires old(AllDBsInSyncUpTo(plan.resetAllChainsTo.value))
+      // RewindLogsDBs postcondition: blocks at or below each target head are preserved.
+      requires forall c :: c in logsDBs.Keys ==>
+        forall n :: 0 <= n <= plan.targetHeads[c].number ==>
+          logsDBs[c].FindSealedBlock(n) == old(logsDBs[c].FindSealedBlock(n))
+      // RewindLogsDBs RewoundLogsDB postcondition: latest sealed block is the target head.
+      requires forall c :: c in logsDBs.Keys && c in plan.targetHeads ==>
+        logsDBs[c].LatestSealedBlock() == Some(plan.targetHeads[c])
+      requires AllVerifiedHeadsBoundedByTimestamp()
+      ensures {:axiom} AllVerifiedCrossValid()
+    {
+      reveal AllVerifiedCrossValid;
+      var ts := plan.resetAllChainsTo.value;
+      // verifiedDB unchanged → same committed timestamps; use SequentialContainsRange for Has.
+      SequentialContainsRange(verifiedDB.db, activationTimestamp);
+      forall ts' | activationTimestamp <= ts' <= verifiedDB.LastTimestamp().value
+        ensures verifiedDB.Has(ts')
+        ensures verifiedDB.Get(ts').l2Heads.Keys == CHAIN_IDS
+        ensures ResultIsCrossValid(Result(verifiedDB.Get(ts').timestamp,
+                                          verifiedDB.Get(ts').l1Inclusion,
+                                          verifiedDB.Get(ts').l2Heads, map[]))
+      {
+        assert old(verifiedDB.Has(ts'));           // fires trigger on old(AllVerifiedCrossValid())
+        assert verifiedDB.db[ts'] == old(verifiedDB.db)[ts'];
+        // ts' ≤ ts because verifiedDB.LastTimestamp() = old(verifiedDB.LastTimestamp()) = Some(ts).
+        assert ts' <= ts;
+        var r := Result(verifiedDB.Get(ts').timestamp, verifiedDB.Get(ts').l1Inclusion,
+                        verifiedDB.Get(ts').l2Heads, map[]);
+        // Prove ResultIsCrossValid(r) per chain.
+        forall chainID | chainID in CHAIN_IDS
+          ensures chains[chainID].BlockInfo(r.l2Heads[chainID]).Some?
+          ensures BlockIsCrossValid(chains[chainID].BlockInfo(r.l2Heads[chainID]).value.timestamp,
+                                    chainID, r.l2Heads[chainID])
+          ensures AllInitMsgsPresent(chainID, r.l2Heads[chainID], r.l2Heads)
+        {
+          var blockID := r.l2Heads[chainID];
+          // chains[chainID].BlockInfo/BlockLogs have reads {} — heap-independent.
+          // BlockIsCrossValid calls ValidExecutingMessage which also uses reads {} functions.
+          // AllInitMsgsPresent: prove per-message.
+          forall execMsg | execMsg in chains[chainID].BlockLogs(blockID).value.execMsgs.Values
+            ensures execMsg.chainID in CHAIN_IDS &&
+              (InitMsgInFrontier(execMsg, r.l2Heads) || InitMsgInLogsDB(execMsg))
+          {
+            if InitMsgInFrontier(execMsg, r.l2Heads) {
+              // InitMsgInFrontier is heap-independent (reads {} functions) — preserved.
+            } else {
+              assert old(InitMsgInLogsDB(execMsg));
+              var query := ContainsQuery(
+                execMsg.blockNum, execMsg.logIdx, execMsg.timestamp, execMsg.checksum);
+              // T_chain is the chain-data timestamp of the executing block.
+              // ResultIsCrossValid uses T_chain (not ts') as the executing timestamp.
+              var T_chain := chains[chainID].BlockInfo(blockID).value.timestamp;
+              // AllVerifiedCrossValid is fuel-exhausted at this nesting depth (forall ts',
+              // forall chainID, forall execMsg, else branch). Use a helper lemma that fires
+              // the trigger chain at a shallower depth where fuel is fresh.
+              OldCrossValidGivesExecMsgTimestamp(ts', chainID, blockID, T_chain, execMsg);
+              assert execMsg.timestamp <= T_chain;
+              // T_chain ≤ ts:
+              //   AllDBsInSyncUpTo at ts' for chainID: seal at blockID.number exists with id == blockID.
+              assert old(logsDBs[chainID].FindSealedBlock(blockID.number)).Some?;
+              assert old(logsDBs[chainID].FindSealedBlock(blockID.number)).value.id == blockID;
+              //   BlockSealsMatchOnChainTimestamps: seal timestamp == T_chain.
+              assert old(logsDBs[chainID].FindSealedBlock(blockID.number)).value.timestamp == T_chain;
+              //   verifiedDB non-decreasing (ts' ≤ ts): blockID.number ≤ plan.targetHeads[chainID].number.
+              assert blockID.number <= plan.targetHeads[chainID].number;
+              //   Requires #11 gives seal at targetHead.number has timestamp ts.
+              //   FindSealedBlock monotonicity: T_chain ≤ ts.
+              assert T_chain <= ts;
+              assert execMsg.timestamp <= ts;
+              // old(Contains) gives the seal timestamp == execMsg.timestamp.
+              assert old(logsDBs[execMsg.chainID].FindSealedBlock(execMsg.blockNum)).Some?;
+              assert old(logsDBs[execMsg.chainID].FindSealedBlock(execMsg.blockNum)).value.timestamp
+                == execMsg.timestamp;
+              // Proof by contradiction: assume execMsg.blockNum > targetHead on source chain.
+              // Fire old(VerifiedHeadsAreHighestBlocksUpToTimestamp()) at (ts, execMsg.chainID, execMsg.blockNum):
+              //   old seal at execMsg.blockNum has timestamp = execMsg.timestamp (Contains axiom).
+              //   VerifiedHeadsAreHighest gives ts < execMsg.timestamp.
+              //   But execMsg.timestamp ≤ T_chain ≤ ts — contradiction.
+              assert execMsg.blockNum <= plan.targetHeads[execMsg.chainID].number by {
+                if execMsg.blockNum > plan.targetHeads[execMsg.chainID].number {
+                  // old(InitMsgInLogsDB(execMsg)) and
+                  // old(logsDBs[execMsg.chainID].FindSealedBlock(execMsg.blockNum)).Some? and
+                  // the seal timestamp == execMsg.timestamp are all assumed from outer context.
+                  // Fire trigger chain for old(VerifiedHeadsAreHighestBlocksUpToTimestamp()) at ts.
+                  assert old(verifiedDB.Has(ts));
+                  assert execMsg.chainID in old(verifiedDB.Get(ts).l2Heads.Keys);
+                  assert plan.targetHeads[execMsg.chainID].number ==
+                    old(verifiedDB.Get(ts).l2Heads[execMsg.chainID].number);
+                  // Inner forall fires: blockNum > targetHead && FindSealedBlock.Some? => ts < timestamp.
+                  assert ts < old(logsDBs[execMsg.chainID].FindSealedBlock(execMsg.blockNum)).value.timestamp;
+                  // ts < seal.timestamp == execMsg.timestamp, but execMsg.timestamp <= ts
+                  // (assumed from outer context via ValidExecutingMessage + T_chain <= ts). Contradiction.
+                  assert false;
+                }
+              }
+              // FindSealedBlock preserved for n ≤ targetHead.number (from requires).
+              assert logsDBs[execMsg.chainID].FindSealedBlock(execMsg.blockNum) ==
+                old(logsDBs[execMsg.chainID].FindSealedBlock(execMsg.blockNum));
+              // ContainsMonotone: Contains preserved when its queried FindSealedBlock is unchanged.
+              logsDBs[execMsg.chainID].ContainsMonotone(query);
+            }
+          }
+        }
+      }
+    }
+
+    // Proves BlockSealsMatchOnChainTimestamps() after a successful PersistFrontierLogs.
+    // Called as AdvanceEstablishesBlockSealsMatchOnChainTimestamps@L(blocksAtTS) where L is
+    // a label placed just before PersistFrontierLogs.
+    // Key: UpdatedAllLogsDBs -> UpdatedLogsDB -> LogsDBConsistentWithChainData instantiated
+    // at blockID := sealedBlock.id, giving seal.timestamp == on-chain timestamp for every block.
+    twostate lemma AdvanceEstablishesBlockSealsMatchOnChainTimestamps(blocksAtTS: map<ChainID, BlockID>)
+      requires old(Valid())
+      requires logsDBs.Keys == CHAIN_IDS
+      requires chains.Keys == CHAIN_IDS
+      requires blocksAtTS.Keys == CHAIN_IDS
+      requires BlocksExistedOnChain(blocksAtTS)
+      requires UpdatedAllLogsDBs(blocksAtTS)
+      ensures BlockSealsMatchOnChainTimestamps()
+    {
+      reveal UpdatedAllLogsDBs;
+      reveal UpdatedLogsDB;
+      forall chainID | chainID in logsDBs.Keys
+        ensures forall n :: logsDBs[chainID].FindSealedBlock(n).Some? ==>
+          chains[chainID].BlockInfo(logsDBs[chainID].FindSealedBlock(n).value.id).Some? &&
+          logsDBs[chainID].FindSealedBlock(n).value.timestamp ==
+          chains[chainID].BlockInfo(logsDBs[chainID].FindSealedBlock(n).value.id).value.timestamp
+      {
+        reveal LogsDBConsistentWithChainData;
+        forall n | logsDBs[chainID].FindSealedBlock(n).Some?
+          ensures chains[chainID].BlockInfo(logsDBs[chainID].FindSealedBlock(n).value.id).Some? &&
+            logsDBs[chainID].FindSealedBlock(n).value.timestamp ==
+            chains[chainID].BlockInfo(logsDBs[chainID].FindSealedBlock(n).value.id).value.timestamp
+        {
+          var sealedBlock := logsDBs[chainID].FindSealedBlock(n).value;
+          var sealedID := sealedBlock.id;
+          // Trigger LogsDBConsistentWithChainData at blockID := sealedID.
+          // sealedID.number == n, so FindSealedBlock(sealedID.number).Some? holds.
+          assert logsDBs[chainID].FindSealedBlock(sealedID.number).Some?;
+          // Consequent: BlockExistedOnChain(chainID, sealedID) && timestamp match.
+          assert BlockExistedOnChain(chainID, sealedID);
+          assert chains[chainID].BlockInfo(sealedID).Some?;
+          var info := chains[chainID].BlockInfo(sealedID).value;
+          // BlockInfo axiom: info.id == sealedID, so info.id.number == n.
+          assert info.id.number == n;
+          assert logsDBs[chainID].FindSealedBlock(info.id.number).Some?;
+          assert logsDBs[chainID].FindSealedBlock(info.id.number).value.timestamp == info.timestamp;
+        }
+      }
+    }
+
+    // Proves VerifiedHeadsAreHighestBlocksUpToTimestamp() after PersistFrontierLogs + Commit.
+    // Called as AdvanceEstablishesVerifiedHeadsAreHighest@L(newTs, blocksAtTS) where L is
+    // a label placed just before PersistFrontierLogs.
+    // Proof splits on ts' == newTs (vacuously true: LatestSealedBlock axiom gives no blocks
+    // above the frontier) vs ts' < newTs (old entries: framing for unchanged slots; new block's
+    // timestamp == newTs > ts' for the changed slot when newly added).
+    twostate lemma {:isolate_assertions} AdvanceEstablishesVerifiedHeadsAreHighest(newTs: nat, blocksAtTS: map<ChainID, BlockID>)
+      requires old(Valid())
+      requires logsDBs.Keys == CHAIN_IDS
+      requires chains.Keys == CHAIN_IDS
+      requires blocksAtTS.Keys == CHAIN_IDS
+      requires BlocksExistedOnChain(blocksAtTS)
+      requires UpdatedAllLogsDBs(blocksAtTS)
+      // PersistFrontierLogs new ensures: newly-added block has timestamp == newTs.
+      requires forall chainID :: chainID in blocksAtTS.Keys ==>
+        old(logsDBs[chainID].FindSealedBlock(blocksAtTS[chainID].number)) !=
+        logsDBs[chainID].FindSealedBlock(blocksAtTS[chainID].number) ==>
+        logsDBs[chainID].FindSealedBlock(blocksAtTS[chainID].number).Some? &&
+        logsDBs[chainID].FindSealedBlock(blocksAtTS[chainID].number).value.timestamp == newTs
+      // Commit result: verifiedDB.db is old entries plus the new entry at newTs.
+      requires verifiedDB.Has(newTs)
+      requires verifiedDB.db == old(verifiedDB.db)[newTs := verifiedDB.db[newTs]]
+      requires verifiedDB.Get(newTs).l2Heads == blocksAtTS
+      // newTs is the sequential successor of the old last timestamp.
+      requires old(verifiedDB.LastTimestamp()).None? ==> newTs == activationTimestamp
+      requires old(verifiedDB.LastTimestamp()).Some? ==>
+        newTs == old(verifiedDB.LastTimestamp()).value + 1
+      requires verifiedDB.Valid()
+      ensures VerifiedHeadsAreHighestBlocksUpToTimestamp()
+    {
+      reveal UpdatedAllLogsDBs;
+      reveal UpdatedLogsDB;
+      forall ts' : nat | verifiedDB.Has(ts')
+        ensures
+          var verifiedHeads := verifiedDB.Get(ts').l2Heads;
+          verifiedHeads.Keys == logsDBs.Keys &&
+          forall chainID :: chainID in verifiedHeads.Keys ==>
+            var blockNumber := verifiedHeads[chainID].number;
+            forall n :: blockNumber < n && logsDBs[chainID].FindSealedBlock(n).Some? ==>
+              ts' < logsDBs[chainID].FindSealedBlock(n).value.timestamp
+      {
+        if ts' == newTs {
+          // New entry: verifiedHeads == blocksAtTS.
+          // UpdatedLogsDB gives LatestSealedBlock() == Some(blocksAtTS[chainID]).
+          // LatestSealedBlock axiom: FindSealedBlock(n) == None for n > blocksAtTS[chainID].number.
+          // => property holds vacuously (no sealed blocks above the frontier).
+          forall chainID | chainID in verifiedDB.Get(ts').l2Heads.Keys
+            ensures
+              var blockNumber := verifiedDB.Get(ts').l2Heads[chainID].number;
+              forall n :: blockNumber < n && logsDBs[chainID].FindSealedBlock(n).Some? ==>
+                ts' < logsDBs[chainID].FindSealedBlock(n).value.timestamp
+          {
+            assert logsDBs[chainID].LatestSealedBlock() == Some(blocksAtTS[chainID]);
+          }
+        } else {
+          // Old entry: ts' in old(verifiedDB.db), so ts' < newTs.
+          assert ts' in old(verifiedDB.db);
+          // Derive ts' < newTs via MaxKey.
+          assert old(verifiedDB.LastTimestamp()).Some?;
+          assert ts' <= MaxKey(old(verifiedDB.db));
+          assert ts' <= old(verifiedDB.LastTimestamp()).value;
+          assert ts' < newTs;
+          // db[ts'] is unchanged (only newTs was added by Commit).
+          assert verifiedDB.db[ts'] == old(verifiedDB.db)[ts'];
+          var verifiedHeads := verifiedDB.Get(ts').l2Heads;
+          forall chainID | chainID in verifiedHeads.Keys
+            ensures
+              var blockNumber := verifiedHeads[chainID].number;
+              forall n :: blockNumber < n && logsDBs[chainID].FindSealedBlock(n).Some? ==>
+                ts' < logsDBs[chainID].FindSealedBlock(n).value.timestamp
+          {
+            var blockNumber := verifiedHeads[chainID].number;
+            // Fire trigger chain for old(VerifiedHeadsAreHighestBlocksUpToTimestamp()).
+            // verifiedDB.db[ts'] is unchanged, so old and current Get(ts') agree.
+            assert old(verifiedDB.Has(ts'));
+            assert old(verifiedDB.Get(ts')).l2Heads == verifiedHeads;
+            assert chainID in old(verifiedDB.Get(ts')).l2Heads.Keys;
+            assert blockNumber == old(verifiedDB.Get(ts')).l2Heads[chainID].number;
+            forall n | blockNumber < n && logsDBs[chainID].FindSealedBlock(n).Some?
+              ensures ts' < logsDBs[chainID].FindSealedBlock(n).value.timestamp
+            {
+              if n == blocksAtTS[chainID].number {
+                if old(logsDBs[chainID].FindSealedBlock(n)) ==
+                    logsDBs[chainID].FindSealedBlock(n) {
+                  // Block unchanged: fire old(VerifiedHeadsAreHighestBlocksUpToTimestamp()) at ts'.
+                  assert old(logsDBs[chainID].FindSealedBlock(n)).Some?;
+                  assert old(logsDBs[chainID].FindSealedBlock(n)).value.timestamp > ts';
+                } else {
+                  // Newly added block: timestamp == newTs > ts'.
+                  assert logsDBs[chainID].FindSealedBlock(n).value.timestamp == newTs;
+                }
+              } else {
+                // n != frontier slot: FindSealedBlock(n) unchanged by PersistFrontierLogs.
+                assert logsDBs[chainID].FindSealedBlock(n) ==
+                  old(logsDBs[chainID].FindSealedBlock(n));
+                assert old(logsDBs[chainID].FindSealedBlock(n)).Some?;
+                assert old(logsDBs[chainID].FindSealedBlock(n)).value.timestamp > ts';
+              }
+            }
+          }
         }
       }
     }

--- a/op-supernode/dafny-models/Interop.dfy
+++ b/op-supernode/dafny-models/Interop.dfy
@@ -1,0 +1,1279 @@
+// Dafny model for the Interop activity in interop.go.
+
+include "VerifiedDB.dfy"
+include "ChainContainer.dfy"
+include "LogsDB.dfy"
+
+module Interop {
+  import opened Types
+  import opened Utils
+  import opened VerifiedDB
+  import opened ChainContainer
+  import opened LogsDB
+
+  class Interop {
+
+    var currentL1: BlockID
+    const chains: map<ChainID, ChainContainer>
+    const verifiedDB: VerifiedDB
+    const activationTimestamp: nat
+    const logsDBs: map<ChainID, LogsDB>
+
+    constructor(chains: map<ChainID, ChainContainer>)
+      requires chains.Keys == CHAIN_IDS
+      ensures Valid()
+      ensures this.chains == chains
+    {
+      var chainIDs := Enumerate(CHAIN_IDS);
+      var logsDBs: map<ChainID, LogsDB> := map[];
+
+      for i := 0 to |chainIDs|
+        invariant forall k :: k in logsDBs <==> k in chainIDs[0..i]
+        invariant forall k1, k2 :: k1 in logsDBs.Keys && k2 in logsDBs.Keys && k1 != k2 ==>
+          logsDBs[k1] != logsDBs[k2]
+        invariant forall chainID :: chainID in logsDBs ==>
+          logsDBs[chainID].LatestSealedBlock() == None
+      {
+        var db := new LogsDB();
+        logsDBs := logsDBs[chainIDs[i] := db];
+      }
+
+      this.verifiedDB := new VerifiedDB();
+      this.activationTimestamp := ACTIVATION_TIMESTAMP;
+      this.currentL1 := BlockID(0, 0);
+      this.chains := chains;
+      this.logsDBs := logsDBs;
+    }
+
+    // ========================================================================
+    // Functions
+    // ========================================================================
+
+    // The block in the logsDB for chainID corresponding to the given timestamp.
+    // The verifiedDB is used to get the block number corresponding to the timestamp,
+    // which is then used to query the logsDB.
+    ghost function SealedBlockForVerifiedAtTimestamp(chainID: ChainID, ts: nat) : Option<BlockSeal>
+      reads verifiedDB, logsDBs[chainID]
+      requires chainID in logsDBs.Keys
+      requires verifiedDB.Has(ts)
+      requires chainID in verifiedDB.Get(ts).l2Heads
+    {
+      var verifiedHeads := verifiedDB.Get(ts).l2Heads;
+      logsDBs[chainID].FindSealedBlock(verifiedHeads[chainID].number)
+    }
+
+    // The timestamp that will be verified in the next round: the successor of the
+    // last committed timestamp, or activationTimestamp if the verifiedDB is empty.
+    ghost function NextTimestamp(): nat
+      reads verifiedDB
+      requires verifiedDB.Valid()
+    {
+      match verifiedDB.LastTimestamp() {
+        case None => activationTimestamp
+        case Some(ts) => ts + 1
+      }
+    }
+
+    // ========================================================================
+    // Predicates
+    // ========================================================================
+
+    // Main invariants of the Interop class that should be maintained throughout the
+    // execution. Does not include consistency between the logsDBs and the verifiedDB,
+    // which can be temporarily violated (see PendingTransitionIsConsistent for those).
+    ghost predicate Valid()
+      reads verifiedDB
+    {
+      activationTimestamp == ACTIVATION_TIMESTAMP &&
+      chains.Keys == CHAIN_IDS &&
+
+      /* LogsDBs invariants */
+      // There is one logsDB for each chain.
+      logsDBs.Keys == CHAIN_IDS &&
+      // All logsDBs are distinct.
+      (forall k1, k2 :: k1 in logsDBs.Keys && k2 in logsDBs.Keys && k1 != k2 ==> logsDBs[k1] != logsDBs[k2]) &&
+
+      /* VerifiedDB invariants */
+      verifiedDB.Valid() &&
+      // If any timestamp has been verified, the activation timestamp must be in the DB.
+      (verifiedDB.lastTimestamp.Some? ==> activationTimestamp in verifiedDB.db) &&
+      // All committed timestamps are at or above the activation timestamp.
+      (forall ts :: ts in verifiedDB.db ==> activationTimestamp <= ts) &&
+      // Every committed verified result covers exactly the current set of chains.
+      (forall ts :: ts in verifiedDB.db ==> verifiedDB.db[ts].l2Heads.Keys == CHAIN_IDS) &&
+      // The pending transition is valid, if it exists.
+      (verifiedDB.pendingTransition.Some? ==> ValidPendingTransition(verifiedDB.GetPendingTransition().value))
+    }
+
+    // The logsDB for chainID is in sync with the verifiedDB up to the given timestamp:
+    // every L2 block up to this timestamp in the verifiedDB is also present in the logsDB
+    // for the corresponding chain.
+    ghost predicate DBsInSyncUpTo(chainID: ChainID, upperTS: nat)
+      reads verifiedDB, logsDBs[chainID]
+      requires chainID in logsDBs.Keys
+    {
+      forall t :: activationTimestamp <= t <= upperTS ==>
+        verifiedDB.Has(t) &&
+        chainID in verifiedDB.Get(t).l2Heads &&
+        SealedBlockForVerifiedAtTimestamp(chainID, t).Some? &&
+        SealedBlockForVerifiedAtTimestamp(chainID, t).value.id == verifiedDB.Get(t).l2Heads[chainID]
+    }
+
+    // The logsDB for chainID is in sync with the verifiedDB: the latest sealed
+    // block in the logsDB matches the l2Head for chainID in the latest verified result,
+    // and all previous blocks also agree.
+    ghost predicate DBsInSync(chainID: ChainID)
+      reads verifiedDB, logsDBs[chainID]
+      requires verifiedDB.Valid()
+      requires chainID in logsDBs.Keys
+    {
+      match verifiedDB.LastTimestamp() {
+        case None =>
+          logsDBs[chainID].LatestSealedBlock() == None
+        case Some(ts) =>
+          var l2Heads := verifiedDB.Get(ts).l2Heads;
+          chainID in l2Heads &&
+          logsDBs[chainID].LatestSealedBlock() == Some(l2Heads[chainID]) &&
+          DBsInSyncUpTo(chainID, ts)
+      }
+    }
+
+    // Lifted versions of DBsInSyncUpTo / DBsInSync that quantify over all chains.
+    // Replace verbose forall patterns in method specifications.
+    ghost predicate AllDBsInSyncUpTo(upper: nat)
+      reads verifiedDB, logsDBs.Values
+    {
+      forall k :: k in logsDBs.Keys ==> DBsInSyncUpTo(k, upper)
+    }
+
+    ghost predicate AllDBsInSync()
+      reads verifiedDB, logsDBs.Values
+      requires verifiedDB.Valid()
+    {
+      forall k :: k in logsDBs.Keys ==> DBsInSync(k)
+    }
+
+    // Consistency of the rewind plan with the current verifiedDB state.
+    // The target timestamp must be present in the DB, must be the maximum key
+    // below rewindAtOrAfter (so it becomes the new last timestamp after the rewind),
+    // and the target heads must match the verified result at that timestamp.
+    ghost predicate PlanConsistentWithVerified(plan: RewindPlan)
+      reads verifiedDB
+    {
+      plan.resetAllChainsTo.Some? ==>
+        var ts := plan.resetAllChainsTo.value;
+        verifiedDB.Has(ts) &&
+        (forall t :: 0 <= t < plan.rewindAtOrAfter && verifiedDB.Has(t) ==> t <= ts) &&
+        plan.targetHeads == verifiedDB.Get(ts).l2Heads
+    }
+
+    // Consistency of the rewind plan with the logsDB for a given chain.
+    // None case: always consistent — Clear() has no preconditions.
+    // Some case: the target block is already sealed in the logsDB, satisfying
+    // the precondition of LogsDB.Rewind.
+    ghost predicate PlanConsistentWithLogs(plan: RewindPlan, chainID: ChainID)
+      reads logsDBs[chainID]
+      requires chainID in logsDBs.Keys
+      requires plan.resetAllChainsTo.Some? ==> chainID in plan.targetHeads
+    {
+      plan.resetAllChainsTo.Some? ==>
+        var sealedBlock := logsDBs[chainID].FindSealedBlock(plan.targetHeads[chainID].number);
+        sealedBlock.Some? &&
+        sealedBlock.value.id == plan.targetHeads[chainID]
+    }
+
+    // The verifiedDB is in the expected state after being rewound according to the
+    // given rewind plan, which must be the same plan stored in the pending transition.
+    ghost predicate RewoundVerifiedDB(plan: RewindPlan)
+      reads verifiedDB
+      requires PlanConsistentWithVerified(plan)
+    {
+      verifiedDB.pendingTransition.Some? &&
+      verifiedDB.pendingTransition.value.decision == Rewind &&
+      verifiedDB.pendingTransition.value.rewind == Some(plan) &&
+      match plan.resetAllChainsTo {
+        case None =>
+          |verifiedDB.db| == 0
+        case Some(ts) =>
+          verifiedDB.LastTimestamp() == Some(ts) &&
+          plan.targetHeads == verifiedDB.Get(ts).l2Heads
+      }
+    }
+
+    // The logsDB for the given chainID is in the expected state after being rewound
+    // according to the given rewind plan.
+    ghost predicate RewoundLogsDB(plan: RewindPlan, chainID: ChainID)
+      reads logsDBs[chainID]
+      requires chainID in logsDBs.Keys
+      requires plan.resetAllChainsTo.Some? ==> chainID in plan.targetHeads
+      requires PlanConsistentWithLogs(plan, chainID)
+    {
+      match plan.resetAllChainsTo {
+        case None =>
+          logsDBs[chainID].LatestSealedBlock() == None
+        case Some(_) =>
+          logsDBs[chainID].LatestSealedBlock() == Some(plan.targetHeads[chainID])
+      }
+    }
+
+    // The given pending transition is consistent with the current state of the verifiedDB,
+    // so that it can be successfully applied by ApplyPendingTransition.
+    ghost predicate TransitionConsistentWithVerified(pending: PendingTransition)
+      reads verifiedDB
+      requires verifiedDB.Valid()
+      requires ValidPendingTransition(pending)
+    {
+      match pending.decision {
+        case Rewind =>
+          PlanConsistentWithVerified(pending.rewind.value)
+        case Invalidate =>
+          true
+        case Advance =>
+          var newTimestamp := pending.result.value.timestamp;
+          var newL2Heads := pending.result.value.l2Heads;
+          AdvancesVerifiedDB(newTimestamp, newL2Heads)
+      }
+    }
+
+    // The given pending transition is consistent with the current state of the logsDBs,
+    // so that it can be successfully applied by ApplyPendingTransition.
+    ghost predicate TransitionConsistentWithLogs(pending: PendingTransition)
+      reads logsDBs.Values
+      requires ValidPendingTransition(pending)
+    {
+      match pending.decision {
+        case Rewind =>
+          forall k :: k in logsDBs.Keys && pending.rewind.value.resetAllChainsTo.Some? ==>
+            k in pending.rewind.value.targetHeads &&
+            PlanConsistentWithLogs(pending.rewind.value, k)
+        case Invalidate =>
+          true
+        case Advance =>
+          var newTimestamp := pending.result.value.timestamp;
+          var newL2Heads := pending.result.value.l2Heads;
+          newL2Heads.Keys == logsDBs.Keys &&
+          AdvancesAllLogsDBs(newTimestamp, newL2Heads)
+      }
+    }
+
+    // All preconditions needed to call ApplyPendingTransition in either the
+    // crash-recovery path (pending transition already stored) or the fresh path
+    // (no pending transition, AllDBsInSync required for ProgressInterop).
+    // ValidPendingTransition is not included because it is already implied by Valid().
+    ghost predicate PendingTransitionIsConsistent()
+      reads verifiedDB, logsDBs.Values
+      requires Valid()
+    {
+      match verifiedDB.GetPendingTransition() {
+        case None =>
+          AllDBsInSync()
+        case Some(p) =>
+          TransitionConsistentWithVerified(p) &&
+          TransitionConsistentWithLogs(p) &&
+          match p.decision {
+            case Rewind =>
+              p.rewind.value.resetAllChainsTo.Some? ==>
+                AllDBsInSyncUpTo(p.rewind.value.resetAllChainsTo.value)
+            case Invalidate =>
+              AllDBsInSync()
+            case Advance =>
+              verifiedDB.LastTimestamp().Some? ==>
+                AllDBsInSyncUpTo(verifiedDB.LastTimestamp().value)
+          }
+      }
+    }
+
+    // Consistency of the step output with the current verifiedDB state:
+    // the previous DB entry exists when rewinding past the activation timestamp,
+    // the timestamp matches the next sequential slot when advancing or invalidating,
+    // and the new l2Heads advance monotonically by at most one block when advancing.
+    ghost predicate OutputConsistentWithVerified(output: StepOutput, obs: RoundObservation)
+      reads verifiedDB
+      requires verifiedDB.Valid()
+      requires ValidStepOutput(output, obs)
+    {
+      match output {
+        case WaitOutput =>
+          true
+        case RewindOutput =>
+          activationTimestamp < obs.lastVerifiedTS.value ==>
+            obs.lastVerifiedTS.value - 1 in verifiedDB.db
+        case AdvanceOutput(result) =>
+          AdvancesVerifiedDB(result.timestamp, result.l2Heads)
+        case InvalidateOutput(result) =>
+          result.timestamp == NextTimestamp()
+      }
+    }
+
+    // Consistency of the step output with the current logsDB state:
+    // the new l2Heads are compatible with each chain's current tip when advancing,
+    // and the rewind target block is already sealed in each logsDB when rewinding.
+    ghost predicate OutputConsistentWithLogs(output: StepOutput, obs: RoundObservation)
+      reads verifiedDB, logsDBs.Values
+      requires Valid()
+      requires ValidStepOutput(output, obs)
+      requires OutputConsistentWithVerified(output, obs)
+    {
+      match output {
+        case WaitOutput => true
+        case RewindOutput =>
+          forall k :: k in logsDBs.Keys && activationTimestamp < obs.lastVerifiedTS.value ==>
+            var sealedBlock := SealedBlockForVerifiedAtTimestamp(k, obs.lastVerifiedTS.value - 1);
+            sealedBlock.Some? &&
+            sealedBlock.value.id == verifiedDB.Get(obs.lastVerifiedTS.value - 1).l2Heads[k]
+        case AdvanceOutput(result) =>
+          AdvancesAllLogsDBs(result.timestamp, result.l2Heads)
+        case InvalidateOutput(_) => true
+      }
+    }
+
+    // Consistency of the round observation with the current verifiedDB state:
+    // the last-verified timestamp and next-timestamp fields mirror the DB,
+    // the previous DB entry exists when rewinding past the activation timestamp,
+    // and the observed block heads advance monotonically by at most one block.
+    ghost predicate ObservationConsistentWithVerified(obs: RoundObservation)
+      reads verifiedDB
+      requires verifiedDB.Valid()
+      requires ValidRoundObservation(obs)
+    {
+      obs.lastVerifiedTS == verifiedDB.lastTimestamp &&
+      obs.nextTimestamp == NextTimestamp() &&
+      (!obs.l1Consistent && activationTimestamp < obs.lastVerifiedTS.value ==>
+        obs.lastVerifiedTS.value - 1 in verifiedDB.db) &&
+      (obs.chainsReady && obs.l2sConsistent && obs.l1Consistent ==>
+        AdvancesVerifiedDB(obs.nextTimestamp, obs.blocksAtTS))
+    }
+
+    // Consistency of the round observation with the current logsDB state:
+    // the rewind target block is already sealed in each logsDB when l1 is
+    // inconsistent, and the observed block heads are compatible with each
+    // chain's current tip when chains are ready.
+    ghost predicate ObservationConsistentWithLogs(obs: RoundObservation)
+      reads verifiedDB, logsDBs.Values
+      requires Valid()
+      requires ValidRoundObservation(obs)
+      requires ObservationConsistentWithVerified(obs)
+    {
+      (!obs.l1Consistent && obs.lastVerifiedTS.value > activationTimestamp ==>
+        forall k :: k in logsDBs.Keys ==>
+          var sealedBlock := SealedBlockForVerifiedAtTimestamp(k, obs.lastVerifiedTS.value - 1);
+          sealedBlock.Some? &&
+          sealedBlock.value.id == verifiedDB.Get(obs.lastVerifiedTS.value - 1).l2Heads[k]) &&
+      (obs.chainsReady && obs.l2sConsistent && obs.l1Consistent ==>
+        AdvancesAllLogsDBs(obs.nextTimestamp, obs.blocksAtTS))
+    }
+
+    // The given timestamp and frontier blocks are a valid sequence to the last entry
+    // currently in the verifiedDB.
+    ghost predicate AdvancesVerifiedDB(ts: nat, blocksAtTS: map<ChainID, BlockID>)
+      reads verifiedDB
+      requires verifiedDB.Valid()
+    {
+      match verifiedDB.LastTimestamp() {
+        case None =>
+          ts == activationTimestamp
+        case Some(lastTS) =>
+          ts == lastTS + 1 &&
+          var lastVerifiedResult := verifiedDB.Get(lastTS);
+          blocksAtTS.Keys == lastVerifiedResult.l2Heads.Keys &&
+          forall chainID :: chainID in blocksAtTS.Keys ==>
+            var lastBlock := lastVerifiedResult.l2Heads[chainID];
+            lastBlock.number <= blocksAtTS[chainID].number <= lastBlock.number + 1
+      }
+    }
+
+    // The given timestamp and block are a valid sequence to the last entry currently
+    // in the logsDB for the given chain.
+    ghost predicate AdvancesLogsDB(ts: nat, chainID: ChainID, newBlock: BlockID)
+      reads logsDBs[chainID]
+      requires chainID in logsDBs
+    {
+      match logsDBs[chainID].LatestSealedBlock() {
+        case None =>
+          ts == activationTimestamp
+        case Some(latestBlock) =>
+          latestBlock.number <= newBlock.number <= latestBlock.number + 1 &&
+          (latestBlock.number == newBlock.number ==> latestBlock == newBlock)
+      }
+    }
+
+    // The given timestamp and frontier blocks are a valid sequence to the current
+    // last entries of each logsDB.
+    ghost predicate AdvancesAllLogsDBs(ts: nat, blocksAtTS: map<ChainID, BlockID>)
+      reads logsDBs.Values
+      requires blocksAtTS.Keys == logsDBs.Keys
+    {
+      forall chainID :: chainID in logsDBs.Keys ==>
+        AdvancesLogsDB(ts, chainID, blocksAtTS[chainID])
+    }
+
+    // ========================================================================
+    // Methods
+    // ========================================================================
+
+    // Attempts to advance the verified timestamp and persist the result.
+    // Returns None if an I/O operation failed (pending transition preserved for retry),
+    // Some(true) if the verified timestamp was advanced, Some(false) otherwise.
+    // Corresponds to progressAndRecord in interop.go.
+    method {:isolate_assertions} ProgressAndRecord() returns (madeProgress: Option<bool>)
+      modifies this, verifiedDB, chains.Values, logsDBs.Values
+      requires Valid()
+      requires PendingTransitionIsConsistent()
+      ensures Valid()
+      ensures PendingTransitionIsConsistent()
+    {
+      // Crash-recovery path: resume an interrupted transition if one was
+      // persisted from a previous run.
+      var pending := verifiedDB.GetPendingTransition();
+
+      if pending.Some? {
+        madeProgress := ApplyPendingTransition(pending.value);
+        return;
+      }
+
+      // Observe the current round state and decide on the next action.
+      var output, obs := ProgressInterop();
+
+      if output.WaitOutput? {
+        // Chains not yet ready; refresh L1 state while idle.
+        RefreshCurrentL1OnWait();
+        madeProgress := Some(false);
+        return;
+      }
+
+      // Persist the transition as a WAL entry before applying it, so that a
+      // crash between the two steps is recoverable on the next startup.
+      var pendingTx := BuildPendingTransition(output, obs);
+
+      // Snapshot the heap before SetPendingTransition so that the twostate lemma
+      // below can reference the pre-set state where AllDBsInSync() holds.
+      label BeforeSetPending:
+      verifiedDB.SetPendingTransition(pendingTx);
+
+      madeProgress := ApplyPendingTransition(pendingTx) by {
+        // Prove ApplyPendingTransition's preconditions
+
+        // SetPendingTransition only changes pendingTransition; db and lastTimestamp
+        // are unchanged. Re-derive DBsInSync for all chains via the framing lemma.
+        forall k | k in logsDBs.Keys ensures DBsInSync(k) {
+          ClearPendingPreservesDBsInSync@BeforeSetPending(k);
+        }
+
+        // For the Rewind case: AllDBsInSync() with LastTimestamp() == Some(ts) implies
+        // AllDBsInSyncUpTo(ts' ) for any ts' <= ts. Apply the helper lemma if needed.
+        if pendingTx.decision == Rewind && pendingTx.rewind.value.resetAllChainsTo.Some? {
+          var ts := pendingTx.rewind.value.resetAllChainsTo.value;
+          // PlanConsistentWithVerified guarantees verifiedDB.Has(ts), hence ts <= LastTimestamp().value.
+          AllDBsInSyncImpliesAllDBsInSyncUpTo(ts);
+        }
+      }
+    }
+
+    // Observes the current round state, runs verification if chains are ready,
+    // and returns the resulting decision together with the observation snapshot.
+    // Does not modify the verified DB.
+    // Corresponds to progressInterop in interop.go.
+    method {:isolate_assertions} ProgressInterop() returns (output: StepOutput, obs: RoundObservation)
+      requires Valid()
+      requires AllDBsInSync()
+      ensures Valid()
+      ensures AllDBsInSync()
+      ensures ValidStepOutput(output, obs)
+      ensures OutputConsistentWithVerified(output, obs)
+      ensures OutputConsistentWithLogs(output, obs)
+    {
+      obs := ObserveRound();
+
+      if !obs.chainsReady {
+        output := WaitOutput;
+        return;
+      }
+      if !obs.l2sConsistent {
+        output := WaitOutput;
+        return;
+      }
+      if !obs.l1Consistent {
+        output := RewindOutput;
+        return;
+      }
+
+      var result := Verify(obs.nextTimestamp, obs.blocksAtTS);
+      if result.l2Heads == map[] {
+        output := WaitOutput;
+      } else if result.invalidHeads != map[] {
+        output := InvalidateOutput(result);
+      } else {
+        output := AdvanceOutput(result);
+      }
+    }
+
+    // Captures a consistent snapshot of the current round state by reading the
+    // verified DB and querying all chains for their status at the next timestamp.
+    // Corresponds to observeRound in interop.go.
+    method {:isolate_assertions} ObserveRound() returns (obs: RoundObservation)
+      requires Valid()
+      requires AllDBsInSync()
+      ensures Valid()
+      ensures AllDBsInSync()
+      ensures ValidRoundObservation(obs)
+      ensures ObservationConsistentWithVerified(obs)
+      ensures ObservationConsistentWithLogs(obs)
+    {
+      // Read the last verified timestamp and its result from the DB.
+      var lastTS := verifiedDB.LastTimestamp();
+
+      if lastTS.Some? {
+        var lastResult := verifiedDB.Get(lastTS.value);
+        obs := RoundObservation(
+          lastVerifiedTS := Some(lastTS.value),
+          lastVerified   := Some(lastResult),
+          nextTimestamp  := lastTS.value + 1,
+          chainsReady    := false,
+          blocksAtTS     := map[],
+          l1Heads        := map[],
+          l1Consistent   := true,
+          l2sConsistent  := true
+        );
+      } else {
+        obs := RoundObservation(
+          lastVerifiedTS := None,
+          lastVerified   := None,
+          nextTimestamp  := activationTimestamp,
+          chainsReady    := false,
+          blocksAtTS     := map[],
+          l1Heads        := map[],
+          l1Consistent   := true,
+          l2sConsistent  := true
+        );
+      }
+
+      // Check whether all chains have data at the next timestamp.
+      var ready := CheckChainsReady(obs.nextTimestamp);
+
+      if ready.None? {
+        return;
+      }
+
+      obs := obs.(
+        chainsReady := true,
+        blocksAtTS  := ready.value.blocks,
+        l1Heads     := ready.value.l1Heads
+      );
+
+      // Check that all L1 heads are on the same canonical fork.
+      var l1Consistent, l2sConsistent := CheckL1Consistent(obs.l1Heads, obs.lastVerified);
+      obs := obs.(l1Consistent := l1Consistent, l2sConsistent := l2sConsistent);
+
+      assert ObservationConsistentWithVerified(obs) by {
+        // Help Dafny prove the following ObservationConsistentWithVerified conjunct:
+        // obs.lastVerifiedTS.value - 1 is in the DB when lastVerifiedTS.value > activationTimestamp.
+        // Follows from activationTimestamp in verifiedDB.db (Interop.Valid) + Sequential.
+        if obs.lastVerifiedTS.Some? && obs.lastVerifiedTS.value > activationTimestamp {
+          SequentialContainsRange(verifiedDB.db, activationTimestamp);
+        }
+      }
+    }
+
+    // Checks whether all chains have a block at the given timestamp.
+    // Returns None if any chain is not yet ready, Some with the per-chain blocks
+    // and L1 inclusion heads otherwise.
+    // Corresponds to checkChainsReady in interop.go; the parallel fan-out is
+    // abstracted away as a sequential loop, and the ethereum.NotFound error is
+    // replaced by an Option return.
+    method {:isolate_assertions} CheckChainsReady(ts: nat) returns (result: Option<ChainsReadyResult>)
+      requires Valid()
+      requires AllDBsInSync()
+      requires forall k :: k in logsDBs && logsDBs[k].LatestSealedBlock().None? ==>
+        ts == activationTimestamp
+      ensures Valid()
+      ensures result.Some? ==> result.value.blocks.Keys == chains.Keys
+      ensures result.Some? ==> AdvancesAllLogsDBs(ts, result.value.blocks)
+    {
+      var blocks: map<ChainID, BlockID> := map[];
+      var l1Heads: map<ChainID, BlockID> := map[];
+      var chainIDs := Enumerate(chains.Keys);
+
+      for i := 0 to |chainIDs|
+        invariant Valid()
+        invariant forall k :: k in blocks.Keys <==> k in chainIDs[0..i]
+        invariant forall k :: k in logsDBs && logsDBs[k].LatestSealedBlock().None? ==>
+          ts == activationTimestamp
+        invariant forall k :: k in chainIDs[0..i] ==>
+          AdvancesLogsDB(ts, k, blocks[k])
+      {
+        var chainID := chainIDs[i];
+        var chainResult := chains[chainID].OptimisticAt(ts);
+        if chainResult.None? {
+          result := None;
+          return;
+        }
+        blocks  := blocks[chainID  := chainResult.value.l2Block];
+        l1Heads := l1Heads[chainID := chainResult.value.l1Head];
+
+        if logsDBs[chainID].LatestSealedBlock().Some? {
+          var latestBlock := logsDBs[chainID].LatestSealedBlock().value;
+          var newBlock := chainResult.value.l2Block;
+          assume latestBlock.number <= newBlock.number <= latestBlock.number + 1;
+          assume latestBlock.number == newBlock.number ==> latestBlock == newBlock;
+        }
+
+        assert AdvancesLogsDB(ts, chainID, chainResult.value.l2Block);
+      }
+
+      result := Some(ChainsReadyResult(blocks, l1Heads));
+    }
+
+    // Verifies cross-chain messages and checks for cycles at the given timestamp,
+    // returning the combined result.
+    // Corresponds to verify in interop.go. The frontierView setup
+    // (resolveFrontierVerificationView) is abstracted away.
+    method Verify(ts: nat, blocksAtTS: map<ChainID, BlockID>) returns (result: Result)
+      requires Valid()
+      ensures Valid()
+      ensures result.timestamp == ts
+      ensures result.l2Heads == blocksAtTS
+    {
+      result := VerifyMessages(ts, blocksAtTS);
+      var cycleResult := VerifyCycles(ts, blocksAtTS);
+      result := result.(invalidHeads := result.invalidHeads + cycleResult.invalidHeads);
+    }
+
+    // Applies a pending transition and returns whether the verified timestamp
+    // was advanced.
+    // Corresponds to applyPendingTransition in interop.go. commitVerifiedResult
+    // and ToVerifiedResult are inlined.
+    method {:isolate_assertions} ApplyPendingTransition(pending: PendingTransition) returns (madeProgress: Option<bool>)
+      modifies this, verifiedDB, chains.Values, logsDBs.Values
+      requires Valid()
+      requires verifiedDB.GetPendingTransition() == Some(pending)
+      requires PendingTransitionIsConsistent()
+      ensures Valid()
+      ensures AllDBsInSync()
+      ensures PendingTransitionIsConsistent()
+      ensures madeProgress.None? ==>
+        verifiedDB.pendingTransition == Some(pending)
+      ensures madeProgress.Some? ==>
+        (madeProgress.value <==> pending.decision == Advance)
+    {
+      assert ValidPendingTransition(pending);
+
+      if pending.decision == Rewind {
+
+        currentL1 := BlockID(0, 0);
+        var rewindPlan := pending.rewind.value;
+
+        assert rewindPlan.resetAllChainsTo.Some? ==>
+          AllDBsInSyncUpTo(rewindPlan.resetAllChainsTo.value);
+
+        var rewindOk := ApplyRewindPlan(rewindPlan);
+
+        if !rewindOk {
+          madeProgress := None;
+          assert PendingTransitionIsConsistent();
+          return;
+        }
+
+        // ApplyRewindPlan establishes DBsInSync(k) for all k. Snapshot the heap here
+        // so that the twostate lemma call below can use old@BeforeClearRewind() to refer
+        // to this state, where DBsInSync is known to hold.
+        label BeforeClearRewind:
+        verifiedDB.ClearPendingTransition();
+
+        assert AllDBsInSync() by {
+          // ClearPendingTransition only changes pendingTransition; db and lastTimestamp are
+          // unchanged (see postconditions). Use the framing lemma to re-derive DBsInSync.
+          forall k | k in logsDBs.Keys ensures DBsInSync(k) {
+            ClearPendingPreservesDBsInSync@BeforeClearRewind(k);
+          }
+        }
+
+        madeProgress := Some(false);
+
+      } else if pending.decision == Invalidate {
+
+        // Replaces unreachable nil case in Go code
+        assert pending.result.Some?;
+
+        // Corresponds to the invalidateBlock loop in applyPendingTransition in interop.go.
+        // The sort over chain IDs is dropped (see modeling note 9).
+        var failedAny := false;
+        var invSeq := Enumerate(pending.result.value.invalidHeads.Keys);
+
+        for i := 0 to |invSeq|
+          invariant Valid()
+          invariant verifiedDB.pendingTransition == Some(pending)
+          invariant AllDBsInSync()
+        {
+          var chainID := invSeq[i];
+          if chainID in chains {
+            var ok := chains[chainID].InvalidateBlock(
+              pending.result.value.invalidHeads[chainID],
+              pending.result.value.timestamp);
+
+            if !ok { failedAny := true; }
+          }
+        }
+
+        if failedAny {
+          madeProgress := None;
+          return;
+        }
+
+        // Loop invariant established DBsInSync(k) for all k. Snapshot the heap here
+        // so the twostate lemma below can use old@BeforeClearInvalidate() to refer
+        // to this state.
+        label BeforeClearInvalidate:
+        verifiedDB.ClearPendingTransition();
+
+        assert AllDBsInSync() by {
+          forall k | k in logsDBs.Keys ensures DBsInSync(k) {
+            ClearPendingPreservesDBsInSync@BeforeClearInvalidate(k);
+          }
+        }
+
+        madeProgress := Some(false);
+
+      } else { // Advance case
+
+        // Replaces unreachable nil case in Go code
+        assert pending.result.Some?;
+
+        var result := pending.result.value;
+        PersistFrontierLogs(result.timestamp, result.l2Heads);
+
+        // Snapshot the heap before Commit so the twostate lemma can reference
+        // the post-PersistFrontierLogs state via old@BeforeCommit().
+        label BeforeCommit:
+        // Inline commitVerifiedResult (a one-line wrapper) and ToVerifiedResult
+        // (drops invalidHeads from Result to produce VerifiedResult).
+        verifiedDB.Commit(VerifiedResult(result.timestamp, result.l1Inclusion, result.l2Heads));
+
+        assert AllDBsInSync() by {
+          forall k | k in logsDBs.Keys ensures DBsInSync(k) {
+            CommitEstablishesDBsInSync@BeforeCommit(k, result.timestamp, result.l2Heads);
+          }
+        }
+
+        label BeforeClearAdvance:
+        verifiedDB.ClearPendingTransition();
+
+        assert AllDBsInSync() by {
+          forall k | k in logsDBs.Keys ensures DBsInSync(k) {
+            ClearPendingPreservesDBsInSync@BeforeClearAdvance(k);
+          }
+        }
+
+        currentL1 := result.l1Inclusion;
+        madeProgress := Some(true);
+      }
+    }
+
+    // Rewinds the verifiedDB and applies chain-level engine/log resets.
+    // Corresponds to applyRewindPlan in interop.go. The sort over chain IDs is
+    // dropped.
+    method {:isolate_assertions} ApplyRewindPlan(plan: RewindPlan) returns (success: bool)
+      modifies verifiedDB, chains.Values, logsDBs.Values
+      requires Valid()
+      requires verifiedDB.pendingTransition.Some?
+      requires verifiedDB.pendingTransition.value.decision == Rewind
+      requires verifiedDB.pendingTransition.value.rewind == Some(plan)
+      requires ValidRewindPlan(plan)
+      requires PlanConsistentWithVerified(plan)
+      requires plan.resetAllChainsTo.Some? ==>
+        forall k :: k in logsDBs.Keys ==> PlanConsistentWithLogs(plan, k)
+      requires plan.resetAllChainsTo.Some? ==>
+        AllDBsInSyncUpTo(plan.resetAllChainsTo.value)
+      ensures Valid()
+      ensures ValidRewindPlan(plan)
+      ensures verifiedDB.pendingTransition == old(verifiedDB.pendingTransition)
+      ensures PlanConsistentWithVerified(plan)
+      ensures plan.resetAllChainsTo.Some? ==>
+        forall k :: k in logsDBs.Keys ==>
+          PlanConsistentWithLogs(plan, k) &&
+          RewoundLogsDB(plan, k)
+      ensures AllDBsInSync()
+    {
+      var _ := verifiedDB.Rewind(plan.rewindAtOrAfter);
+
+      assert unchanged(logsDBs.Values);
+      assert Valid();
+      assert PlanConsistentWithVerified(plan);
+      assert RewoundVerifiedDB(plan);
+
+      // Prune deny lists and optionally rewind chain engines.
+      // These operations modify only chain containers, leaving verifiedDB and
+      // logsDBs unchanged.
+      var chainIDs := Enumerate(chains.Keys);
+
+      var enginesOk := RewindChainEngines(plan, chainIDs);
+
+      assert unchanged(logsDBs.Values);
+
+      // Clear or rewind log databases depending on whether target heads are available.
+      // resetAllChainsTo.None? corresponds to the nil TargetHeads case in Go,
+      // which signals a full reset with no previous verified state to restore to.
+      if plan.resetAllChainsTo.None? {
+        ClearLogsDBs(plan, chainIDs);
+      } else {
+        // Establish DBsInSyncUpTo here, right before RewindLogsDBs needs it.
+        // RewindChainEngines touched only chains.Values, so the twostate lemma
+        // preconditions are identical to the post-Rewind call site: verifiedDB.db
+        // is the same, logsDBs[k] is unchanged, and old() still resolves to
+        // method entry where the precondition DBsInSyncUpTo(k, ts) held.
+        var ts := plan.resetAllChainsTo.value;
+
+        assert AllDBsInSyncUpTo(ts) by {
+          forall k | k in chainIDs
+            ensures DBsInSyncUpTo(k, ts)
+          {
+            VerifiedDBRewindPreservesDBsInSyncUpTo(k, ts, plan.rewindAtOrAfter);
+          }
+        }
+
+        RewindLogsDBs(plan, chainIDs);
+      }
+      success := enginesOk;
+    }
+
+    // Prunes deny lists and optionally rewinds chain engines for all chains in chainIDs.
+    // Extracted from ApplyRewindPlan to allow isolated verification of the engine rewind loop.
+    method RewindChainEngines(plan: RewindPlan, chainIDs: seq<ChainID>) returns (success: bool)
+      modifies chains.Values
+      requires Valid()
+      requires ValidRewindPlan(plan)
+      requires PlanConsistentWithVerified(plan)
+      requires RewoundVerifiedDB(plan)
+      requires forall k :: k in chainIDs <==> k in chains.Keys
+      requires forall k :: k in chainIDs ==> PlanConsistentWithLogs(plan, k)
+      ensures Valid()
+      ensures ValidRewindPlan(plan)
+      ensures RewoundVerifiedDB(plan)
+      ensures forall k :: k in chainIDs ==> PlanConsistentWithLogs(plan, k)
+      ensures unchanged(logsDBs.Values)
+    {
+      var failedAny := false;
+      for i := 0 to |chainIDs|
+        invariant Valid()
+        invariant ValidRewindPlan(plan)
+        invariant RewoundVerifiedDB(plan)
+      {
+        chains[chainIDs[i]].PruneDeniedAtOrAfterTimestamp(plan.rewindAtOrAfter);
+        if plan.resetAllChainsTo.Some? {
+          var ok := chains[chainIDs[i]].RewindEngine(plan.resetAllChainsTo.value);
+          if !ok { failedAny := true; }
+        }
+      }
+      success := !failedAny;
+    }
+
+    // Clears all logsDBs in chainIDs.
+    // Extracted from ApplyRewindPlan to allow isolated verification of the clear loop.
+    method ClearLogsDBs(plan: RewindPlan, chainIDs: seq<ChainID>)
+      modifies logsDBs.Values
+      requires Valid()
+      requires ValidRewindPlan(plan)
+      requires PlanConsistentWithVerified(plan)
+      requires RewoundVerifiedDB(plan)
+      requires plan.resetAllChainsTo.None?
+      requires forall k :: k in chainIDs <==> k in chains.Keys
+      ensures Valid()
+      ensures ValidRewindPlan(plan)
+      ensures forall k :: k in chainIDs ==> RewoundLogsDB(plan, k)
+    {
+      for i := 0 to |chainIDs|
+        invariant Valid()
+        invariant |verifiedDB.db| == 0
+        invariant forall k :: k in chainIDs[0..i] ==>
+          logsDBs[k].LatestSealedBlock() == None
+        invariant forall k :: k in chainIDs[0..i] ==>
+          RewoundLogsDB(plan, k)
+      {
+        logsDBs[chainIDs[i]].Clear();
+      }
+    }
+
+    // Rewinds each logsDB in chainIDs to the corresponding target head in plan.
+    // Extracted from ApplyRewindPlan to allow isolated verification of the rewind loop.
+    method RewindLogsDBs(plan: RewindPlan, chainIDs: seq<ChainID>)
+      modifies logsDBs.Values
+      requires verifiedDB.Valid()
+      requires forall k1, k2 :: k1 in logsDBs.Keys && k2 in logsDBs.Keys && k1 != k2 ==> logsDBs[k1] != logsDBs[k2]
+      requires forall k :: k in chainIDs <==> k in plan.targetHeads
+      requires PlanConsistentWithVerified(plan)
+      requires RewoundVerifiedDB(plan)
+      requires plan.resetAllChainsTo.Some?
+      requires forall k :: k in chainIDs <==> k in logsDBs.Keys
+      requires forall k :: k in chainIDs ==> PlanConsistentWithLogs(plan, k)
+      requires forall k :: k in chainIDs ==> DBsInSyncUpTo(k, plan.resetAllChainsTo.value)
+      ensures forall k :: k in chainIDs ==>
+        PlanConsistentWithLogs(plan, k) &&
+        RewoundLogsDB(plan, k) &&
+        DBsInSync(k)
+    {
+      var ts := plan.resetAllChainsTo.value;
+      for i := 0 to |chainIDs|
+        invariant verifiedDB.LastTimestamp() == Some(ts)
+        invariant plan.targetHeads == verifiedDB.Get(ts).l2Heads
+        invariant forall k :: k in chainIDs ==>
+          PlanConsistentWithLogs(plan, k) &&
+          DBsInSyncUpTo(k, plan.resetAllChainsTo.value)
+        invariant forall k :: k in chainIDs[0..i] ==>
+          PlanConsistentWithLogs(plan, k) &&
+          RewoundLogsDB(plan, k) &&
+          DBsInSync(k)
+      {
+        var chainID := chainIDs[i];
+        logsDBs[chainID].Rewind(plan.targetHeads[chainID]);
+      }
+    }
+
+    // Persists frontier logs for the given verified result.
+    // Corresponds to persistFrontierLogs in interop.go.
+    method {:isolate_assertions} PersistFrontierLogs(ts: nat, blocksAtTS: map<ChainID, BlockID>)
+      modifies logsDBs.Values
+      requires Valid()
+      requires blocksAtTS.Keys == chains.Keys
+      requires AdvancesAllLogsDBs(ts, blocksAtTS)
+      requires verifiedDB.LastTimestamp().Some? ==>
+        AllDBsInSyncUpTo(verifiedDB.LastTimestamp().value)
+      ensures Valid()
+      ensures forall k :: k in blocksAtTS.Keys ==>
+        logsDBs[k].LatestSealedBlock() == Some(blocksAtTS[k])
+      ensures verifiedDB.LastTimestamp().Some? ==>
+        AllDBsInSyncUpTo(verifiedDB.LastTimestamp().value)
+    {
+      var chainIDs := Enumerate(blocksAtTS.Keys);
+
+      for i := 0 to |chainIDs|
+        invariant Valid()
+        invariant forall j, k :: 0 <= j < k < |chainIDs| ==>
+          chainIDs[j] != chainIDs[k]
+        invariant forall j :: i <= j < |chainIDs| ==>
+          AdvancesLogsDB(ts, chainIDs[j], blocksAtTS[chainIDs[j]])
+        invariant forall j :: 0 <= j < i ==>
+          logsDBs[chainIDs[j]].LatestSealedBlock() == Some(blocksAtTS[chainIDs[j]])
+        invariant verifiedDB.LastTimestamp().Some? ==>
+          AllDBsInSyncUpTo(verifiedDB.LastTimestamp().value)
+      {
+        var chainID := chainIDs[i];
+        var blockID := blocksAtTS[chainID];
+        var db := logsDBs[chainID];
+        var chain := chains[chainID];
+
+        var latestBlock := db.LatestSealedBlock();
+
+        // Follows from AdvancesLogsDB(ts, chainID, blockID)
+        if latestBlock.Some? {
+          assert latestBlock.value.number <= blockID.number;
+          assert latestBlock.value.number == blockID.number ==> latestBlock == Some(blockID);
+        }
+
+        // Skip if the block is already sealed in the logsDB (idempotency on restart).
+        // Simplified in relation to the Go code due to the asserts above.
+        var skip := latestBlock == Some(blockID);
+
+        if !skip {
+          var blockInfo := chain.FetchReceipts(blockID);
+          // Preconditions replacing ErrStaleLogsDB and ErrParentHashMismatch:
+          // in Go these would be error returns; here they are assumed away.
+          assume latestBlock.Some? ==> blockInfo.parentHash == latestBlock.value.hash;
+
+          if verifiedDB.LastTimestamp().Some? {
+            var lastTS := verifiedDB.LastTimestamp().value;
+
+            assert SealedBlockForVerifiedAtTimestamp(chainID, lastTS).Some? ==>
+              db.LatestSealedBlock().Some?;
+
+            assert AllDBsInSyncUpTo(lastTS) by {
+              forall k | k in blocksAtTS.Keys && k != chainID
+                ensures DBsInSyncUpTo(k, lastTS)
+              {
+                assert logsDBs[k] != db;
+              }
+            }
+          }
+
+          label BeforeProcessBlock:
+          ProcessBlock(db, blockInfo);
+
+          assert logsDBs[chainID].LatestSealedBlock() == Some(blocksAtTS[chainID]);
+
+          if verifiedDB.LastTimestamp().Some? {
+            var lastTS := verifiedDB.LastTimestamp().value;
+
+            assert AllDBsInSyncUpTo(lastTS) by {
+              ProcessBlockPreservesDBsInSyncUpTo@BeforeProcessBlock(chainID, lastTS, blockInfo.id.number);
+            }
+          }
+        }
+      }
+    }
+
+    // Constructs a pending transition from the given decision and observation.
+    // Does not modify any state.
+    // Corresponds to buildPendingTransition in interop.go; buildRewindPlan is
+    // inlined here.
+    method {:isolate_assertions} BuildPendingTransition(output: StepOutput, obs: RoundObservation)
+        returns (pendingTx: PendingTransition)
+      requires Valid()
+      requires !output.WaitOutput?
+      requires ValidStepOutput(output, obs)
+      requires OutputConsistentWithVerified(output, obs)
+      requires OutputConsistentWithLogs(output, obs)
+      ensures ValidPendingTransition(pendingTx)
+      ensures TransitionConsistentWithVerified(pendingTx)
+      ensures TransitionConsistentWithLogs(pendingTx)
+    {
+      if output.AdvanceOutput? {
+        pendingTx := PendingTransition(Advance, Some(output.result), None);
+      } else if output.InvalidateOutput? {
+        pendingTx := PendingTransition(Invalidate, Some(output.result), None);
+      } else {
+        // RewindOutput: build a rewind plan (inlined from buildRewindPlan).
+        var lastTS := obs.lastVerifiedTS.value;
+        var rewindPlan: RewindPlan;
+
+        if lastTS <= activationTimestamp {
+          // At or before the activation timestamp there is no previous verified
+          // entry to restore, so only rewindAtOrAfter is set.
+          rewindPlan := RewindPlan(lastTS, None, map[]);
+        } else {
+          var prevResult := verifiedDB.Get(lastTS - 1);
+          rewindPlan := RewindPlan(lastTS, Some(lastTS - 1), prevResult.l2Heads);
+        }
+
+        pendingTx := PendingTransition(Rewind, None, Some(rewindPlan));
+        assert TransitionConsistentWithLogs(pendingTx);
+      }
+    }
+
+    // Checks L1 consistency from two perspectives.
+    // l1Consistent: the last verified L1 inclusion block is on the same chain
+    //   as the current frontier L1 heads (requires lastVerified to be present).
+    // l2sConsistent: the frontier L1 heads from all L2 chains agree with each other.
+    // Corresponds to the SameL1Chain check inside observeRound in interop.go.
+    method CheckL1Consistent(
+        l1Heads: map<ChainID, BlockID>,
+        lastVerified: Option<VerifiedResult>)
+        returns (l1Consistent: bool, l2sConsistent: bool)
+      requires Valid()
+      ensures {:axiom} Valid()
+      ensures {:axiom} !l1Consistent ==> lastVerified.Some?
+
+    // Verifies cross-chain interop messages at the given timestamp.
+    // Abstracts verifyFn (i.verifyInteropMessages) from interop.go.
+    method VerifyMessages(ts: nat, blocksAtTS: map<ChainID, BlockID>) returns (result: Result)
+      requires Valid()
+      ensures {:axiom} Valid()
+      ensures {:axiom} result.timestamp == ts
+      ensures {:axiom} result.l2Heads == blocksAtTS
+
+    // Verifies same-timestamp cycle constraints at the given timestamp.
+    // Abstracts cycleVerifyFn (i.verifyCycleMessages) from interop.go.
+    method VerifyCycles(ts: nat, blocksAtTS: map<ChainID, BlockID>) returns (result: Result)
+      requires Valid()
+      ensures {:axiom} Valid()
+
+    // Processes and seals a block's logs in the given chain's log database.
+    // Abstracts processBlockLogs in logdb.go; the stale-data and parent-hash
+    // error returns from persistFrontierLogs are replaced with preconditions.
+    method ProcessBlock(db: LogsDB, info: BlockInfo)
+      modifies db
+      requires Valid()
+      requires db.LatestSealedBlock().None? || (
+        db.LatestSealedBlock().value.number + 1 == info.id.number &&
+        info.parentHash == db.LatestSealedBlock().value.hash)
+      ensures {:axiom} unchanged(verifiedDB)
+      ensures {:axiom} Valid()
+      ensures {:axiom} db.LatestSealedBlock() == Some(info.id)
+      ensures {:axiom} forall n :: n != info.id.number ==> db.FindSealedBlock(n) == old(db.FindSealedBlock(n))
+
+    // Updates currentL1 when no progress is made.
+    // Corresponds to refreshCurrentL1OnWait in interop.go.
+    method RefreshCurrentL1OnWait()
+      modifies this
+      requires Valid()
+      ensures {:axiom} Valid()
+
+    // ========================================================================
+    // Lemmas
+    // ========================================================================
+
+    // AllDBsInSync() implies AllDBsInSyncUpTo(upper) for any upper <= LastTimestamp().
+    // DBsInSync(k) (Some branch) includes DBsInSyncUpTo(k, ts), and since upper <= ts the
+    // quantifier bound [activationTimestamp, upper] is a subset of [activationTimestamp, ts].
+    lemma AllDBsInSyncImpliesAllDBsInSyncUpTo(upper: nat)
+      requires verifiedDB.Valid()
+      requires AllDBsInSync()
+      requires verifiedDB.LastTimestamp().Some?
+      requires upper <= verifiedDB.LastTimestamp().value
+      ensures AllDBsInSyncUpTo(upper)
+    {
+      var ts := verifiedDB.LastTimestamp().value;
+      forall k | k in logsDBs.Keys ensures DBsInSyncUpTo(k, upper) {
+        assert DBsInSync(k);
+        assert DBsInSyncUpTo(k, ts);
+      }
+    }
+
+    // Framing lemma: verifiedDB.Rewind preserves DBsInSyncUpTo for any upper < rewindAtOrAfter.
+    // The LogsDB for chainID is unchanged (not in Rewind's modifies set), so all
+    // FindSealedBlock results are identical; the verifiedDB entries at t <= upper survive
+    // the rewind unchanged; therefore the predicate body holds in the new state too.
+    twostate lemma VerifiedDBRewindPreservesDBsInSyncUpTo(
+        chainID: ChainID, upper: nat, rewindAtOrAfter: nat)
+      requires chainID in logsDBs.Keys
+      requires upper < rewindAtOrAfter
+      requires old(DBsInSyncUpTo(chainID, upper))
+      requires verifiedDB.db ==
+        map k | k in old(verifiedDB.db) && k < rewindAtOrAfter :: old(verifiedDB.db)[k]
+      requires unchanged(logsDBs[chainID])
+      ensures DBsInSyncUpTo(chainID, upper)
+    {
+      forall t | activationTimestamp <= t <= upper
+        ensures verifiedDB.Has(t)
+        ensures chainID in verifiedDB.Get(t).l2Heads
+        ensures logsDBs[chainID].FindSealedBlock(verifiedDB.Get(t).l2Heads[chainID].number).Some?
+        ensures logsDBs[chainID].FindSealedBlock(verifiedDB.Get(t).l2Heads[chainID].number).value.id ==
+          verifiedDB.Get(t).l2Heads[chainID]
+      {
+        assert old(verifiedDB.Has(t));                      // fires trigger on old(DBsInSyncUpTo) at t
+        assert verifiedDB.db[t] == old(verifiedDB.db)[t];  // t survives the rewind (t < rewindAtOrAfter)
+      }
+    }
+
+    // Framing lemma: when verifiedDB.db is unchanged and logsDBs[chainID] is unchanged,
+    // DBsInSyncUpTo is preserved across any state change (e.g. ClearPendingTransition).
+    twostate lemma ClearPendingPreservesDBsInSyncUpTo(chainID: ChainID, upper: nat)
+      requires chainID in logsDBs.Keys
+      requires old(DBsInSyncUpTo(chainID, upper))
+      requires verifiedDB.db == old(verifiedDB.db)
+      requires unchanged(logsDBs[chainID])
+      ensures DBsInSyncUpTo(chainID, upper)
+    {
+      forall t | activationTimestamp <= t <= upper
+        ensures verifiedDB.Has(t)
+        ensures chainID in verifiedDB.Get(t).l2Heads
+        ensures logsDBs[chainID].FindSealedBlock(verifiedDB.Get(t).l2Heads[chainID].number).Some?
+        ensures logsDBs[chainID].FindSealedBlock(verifiedDB.Get(t).l2Heads[chainID].number).value.id ==
+          verifiedDB.Get(t).l2Heads[chainID]
+      {
+        assert old(verifiedDB.Has(t));
+        assert verifiedDB.db[t] == old(verifiedDB.db)[t];
+      }
+    }
+
+    // Framing lemma: ClearPendingTransition preserves DBsInSync.
+    // When only verifiedDB.pendingTransition changes (db and lastTimestamp unchanged)
+    // and logsDBs[chainID] is unchanged, DBsInSync is preserved.
+    // Intended to be called as ClearPendingPreservesDBsInSync@L(k) where L is a label
+    // placed just before the ClearPendingTransition call so that old() resolves to the
+    // pre-clear state where DBsInSync(chainID) is already established.
+    twostate lemma ClearPendingPreservesDBsInSync(chainID: ChainID)
+      requires chainID in logsDBs.Keys
+      requires old(verifiedDB.Valid())
+      requires verifiedDB.Valid()
+      requires verifiedDB.db == old(verifiedDB.db)
+      requires verifiedDB.lastTimestamp == old(verifiedDB.lastTimestamp)
+      requires unchanged(logsDBs[chainID])
+      requires old(DBsInSync(chainID))
+      ensures DBsInSync(chainID)
+    {
+      match old(verifiedDB.LastTimestamp()) {
+        case None => {}
+        case Some(ts) => {
+          assert verifiedDB.db[ts] == old(verifiedDB.db)[ts];
+          ClearPendingPreservesDBsInSyncUpTo(chainID, ts);
+        }
+      }
+    }
+
+    // Framing lemma: Commit establishes DBsInSync at the new timestamp.
+    // Intended to be called as CommitEstablishesDBsInSync@L(k, ts, l2Heads) where L is
+    // placed just before the Commit call (i.e. just after PersistFrontierLogs), so that
+    // old() resolves to the post-PersistFrontierLogs state where:
+    //   - logsDBs[k].LatestSealedBlock() == Some(l2Heads[k])     (PersistFrontierLogs post)
+    //   - DBsInSyncUpTo(k, old LastTimestamp) holds (if non-empty) (PersistFrontierLogs axiom)
+    // Proof splits on t == newTs (new entry, proved from LatestSealedBlock axiom) vs
+    // t < newTs (old entries, preserved via db[t] == old(db)[t] + unchanged logsDBs).
+    twostate lemma CommitEstablishesDBsInSync(
+        chainID: ChainID, newTs: nat, newL2Heads: map<ChainID, BlockID>)
+      requires chainID in logsDBs.Keys
+      requires chainID in newL2Heads
+      requires old(logsDBs[chainID].LatestSealedBlock()) == Some(newL2Heads[chainID])
+      requires old(verifiedDB.LastTimestamp()).None? ==> newTs == activationTimestamp
+      requires old(verifiedDB.LastTimestamp()).Some? ==>
+        newTs == old(verifiedDB.LastTimestamp()).value + 1
+      // newTs - 1 == old(verifiedDB.LastTimestamp()).value (from the require above),
+      // so this encodes old(DBsInSyncUpTo(chainID, old(LastTimestamp()).value)) without nesting old().
+      requires old(verifiedDB.LastTimestamp()).Some? ==>
+        old(DBsInSyncUpTo(chainID, newTs - 1))
+      requires verifiedDB.LastTimestamp() == Some(newTs)
+      requires verifiedDB.Has(newTs)
+      requires verifiedDB.db == old(verifiedDB.db)[newTs := verifiedDB.db[newTs]]
+      requires verifiedDB.Get(newTs).l2Heads == newL2Heads
+      requires unchanged(logsDBs[chainID])
+      requires verifiedDB.Valid()
+      ensures DBsInSync(chainID)
+    {
+      forall t | activationTimestamp <= t <= newTs
+        ensures verifiedDB.Has(t)
+        ensures chainID in verifiedDB.Get(t).l2Heads
+        ensures logsDBs[chainID].FindSealedBlock(verifiedDB.Get(t).l2Heads[chainID].number).Some?
+        ensures logsDBs[chainID].FindSealedBlock(verifiedDB.Get(t).l2Heads[chainID].number).value.id ==
+          verifiedDB.Get(t).l2Heads[chainID]
+      {
+        if t == newTs {
+          // verifiedDB.Has(newTs): from newTs in old(db)[newTs := ...] = verifiedDB.db
+          // chainID in newL2Heads: from requires
+          // LatestSealedBlock() == Some(newL2Heads[chainID]): old() + unchanged(logsDBs)
+          // => FindSealedBlock via LatestSealedBlock axiom
+        } else {
+          // t < newTs. If old(LastTimestamp()).None?, then newTs == activationTimestamp,
+          // so activationTimestamp <= t < activationTimestamp is impossible.
+          // Otherwise old(LastTimestamp()) = Some(oldTs), newTs == oldTs + 1, t <= oldTs.
+          assert old(verifiedDB.Has(t));           // fires trigger on old(DBsInSyncUpTo)
+          assert verifiedDB.db[t] == old(verifiedDB.db)[t];  // t != newTs
+        }
+      }
+    }
+
+    // Framing lemma: ProcessBlock on logsDBs[chainID] (adding block at newBlockNumber,
+    // which must equal oldLatestBlock.number + 1) preserves DBsInSyncUpTo(chainID, upper).
+    // All blocks referenced by DBsInSyncUpTo have numbers <= oldLatestBlock.number, so
+    // the FindSealedBlock results they query are unchanged by ProcessBlock.
+    twostate lemma ProcessBlockPreservesDBsInSyncUpTo(
+        chainID: ChainID, upper: nat, newBlockNumber: nat)
+      requires chainID in logsDBs.Keys
+      requires old(verifiedDB.Valid())
+      requires verifiedDB.db == old(verifiedDB.db)
+      requires old(DBsInSyncUpTo(chainID, upper))
+      requires forall n :: n != newBlockNumber ==>
+        logsDBs[chainID].FindSealedBlock(n) == old(logsDBs[chainID].FindSealedBlock(n))
+      requires old(logsDBs[chainID].LatestSealedBlock()).Some?
+      requires newBlockNumber == old(logsDBs[chainID].LatestSealedBlock()).value.number + 1
+      ensures DBsInSyncUpTo(chainID, upper)
+    {
+      var latestNum := old(logsDBs[chainID].LatestSealedBlock()).value.number;
+
+      forall t | activationTimestamp <= t <= upper
+        ensures verifiedDB.Has(t)
+        ensures chainID in verifiedDB.Get(t).l2Heads
+        ensures logsDBs[chainID].FindSealedBlock(verifiedDB.Get(t).l2Heads[chainID].number).Some?
+        ensures logsDBs[chainID].FindSealedBlock(verifiedDB.Get(t).l2Heads[chainID].number).value.id ==
+          verifiedDB.Get(t).l2Heads[chainID]
+      {
+        assert old(verifiedDB.Has(t));             // fires trigger on old(DBsInSyncUpTo)
+        assert verifiedDB.db[t] == old(verifiedDB.db)[t];
+        var n := verifiedDB.Get(t).l2Heads[chainID].number;
+        // old(FindSealedBlock(n)).Some? from DBsInSyncUpTo, so n <= latestNum by
+        // the LatestSealedBlock axiom contrapositive
+        assert old(logsDBs[chainID].FindSealedBlock(n)).Some?;
+        assert n <= latestNum;
+        assert n != newBlockNumber;
+        assert logsDBs[chainID].FindSealedBlock(n) == old(logsDBs[chainID].FindSealedBlock(n));
+      }
+    }
+
+  }
+}

--- a/op-supernode/dafny-models/Interop.dfy
+++ b/op-supernode/dafny-models/Interop.dfy
@@ -1392,7 +1392,9 @@ module Interop {
           reveal LogsDBsUnchangedUpTo;
           RewindLogsDBsPreservesAllVerifiedCrossValid@BeforeRewindLogsDBs(plan);
         }
-        assert AllDBsInSyncUpTo(plan.resetAllChainsTo.value);
+        assert AllDBsInSyncUpTo(plan.resetAllChainsTo.value) by {
+          AllDBsInSyncImpliesAllDBsInSyncUpTo(plan.resetAllChainsTo.value);
+        }
         assert PlanConsistentWithVerified(plan);
         assert AllLogsDBsConsistentWithChainData();
       }
@@ -2775,7 +2777,8 @@ module Interop {
                                             verifiedDB.Get(ts).l2Heads, map[]))
         {
           assert ts < rewindAt;                     // ts <= lastTS < rewindAt
-          assert ts in old(verifiedDB.db);          // ts in verifiedDB.db = {k in old(db) | k < rewindAt}
+          SequentialContainsRange(old(verifiedDB.db), activationTimestamp);
+          assert ts in old(verifiedDB.db);
           assert old(verifiedDB.Has(ts));           // fires trigger on old(AllVerifiedCrossValid())
           assert verifiedDB.db[ts] == old(verifiedDB.db)[ts];
         }

--- a/op-supernode/dafny-models/Interop.dfy
+++ b/op-supernode/dafny-models/Interop.dfy
@@ -72,6 +72,23 @@ module Interop {
       this.currentL1 := BlockID(0, 0);
       this.chains := chains;
       this.logsDBs := logsDBs;
+      // After all field assignments, 'this' is fully usable.
+      new;
+      // All logsDBs have LatestSealedBlock() == None (empty), so FindSealedBlock(n) == None
+      // for all n (by LatestSealedBlock axiom), making LogsDBConsistentWithChainData vacuously true.
+      assert AllLogsDBsConsistentWithChainData() by {
+        reveal AllLogsDBsConsistentWithChainData;
+        reveal LogsDBConsistentWithChainData;
+        forall chainID | chainID in logsDBs.Keys
+          ensures LogsDBConsistentWithChainData(chainID)
+        {
+          reveal LogsDBConsistentWithChainData;
+          assert logsDBs[chainID].LatestSealedBlock() == None;
+          // LatestSealedBlock axiom: None => forall number :: FindSealedBlock(number) == None
+          assert forall number :: logsDBs[chainID].FindSealedBlock(number) == None;
+          // FindSealedBlock(n) == None for all n means the predicate body is vacuously true.
+        }
+      }
     }
 
     // ========================================================================
@@ -122,7 +139,7 @@ module Interop {
       logsDBs.Keys == CHAIN_IDS &&
       // All logsDBs are distinct.
       (forall k1, k2 :: k1 in logsDBs.Keys && k2 in logsDBs.Keys && k1 != k2 ==> logsDBs[k1] != logsDBs[k2]) &&
-      BlockSealsMatchOnChainTimestamps() &&
+      AllLogsDBsConsistentWithChainData() &&
 
       /* VerifiedDB invariants */
       verifiedDB.Valid() &&
@@ -710,18 +727,6 @@ module Interop {
             ts < logsDBs[chainID].FindSealedBlock(n).value.timestamp
     }
 
-    ghost predicate BlockSealsMatchOnChainTimestamps()
-      reads logsDBs.Values
-      requires logsDBs.Keys == chains.Keys
-    {
-      forall chainID :: chainID in logsDBs.Keys ==>
-        forall n :: logsDBs[chainID].FindSealedBlock(n).Some? ==>
-          var sealedBlock := logsDBs[chainID].FindSealedBlock(n).value;
-          var onChainBlock := chains[chainID].BlockInfo(sealedBlock.id);
-          onChainBlock.Some? &&
-          sealedBlock.timestamp == onChainBlock.value.timestamp
-    }
-
     ghost predicate VerifiedHeadsBoundedByTimestamp(ts: nat)
       reads verifiedDB
       requires verifiedDB.Has(ts)
@@ -809,6 +814,8 @@ module Interop {
       label BeforeSetPending:
       verifiedDB.SetPendingTransition(pendingTx);
 
+      assert VerifiedHeadsAreHighestBlocksUpToTimestamp();
+
       // SetPendingTransition only changes pendingTransition; db and lastTimestamp
       // are unchanged. Re-derive DBsInSync for all chains via the framing lemma.
       forall k | k in logsDBs.Keys ensures DBsInSync(k) {
@@ -827,6 +834,8 @@ module Interop {
         ClearPendingPreservesAllVerifiedHeadsBoundedByTimestamp@BeforeSetPending();
       }
 
+      // These predicates read verifiedDB/logsDBs.Values only; unchanged since BeforeSetPending.
+      assert AllLogsDBsConsistentWithChainData();
       assert AllVerifiedCrossValid() by {
         ClearPendingPreservesAllVerifiedCrossValid@BeforeSetPending();
       }
@@ -1421,7 +1430,13 @@ module Interop {
           var ok := chains[chainIDs[i]].RewindEngine(plan.resetAllChainsTo.value);
           if !ok { failedAny := true; }
         }
+        // Valid() and AllVerifiedCrossValid() read verifiedDB, logsDBs.Values only;
+        // both are unchanged by chain operations — assert explicitly for isolated VCs.
+        assert AllLogsDBsConsistentWithChainData();
         assert VerifiedHeadsAreHighestBlocksUpToTimestamp();
+        assert Valid();
+        assert unchanged(verifiedDB);
+        assert unchanged(logsDBs.Values);
         assert AllVerifiedCrossValid();
       }
       success := !failedAny;
@@ -1443,13 +1458,19 @@ module Interop {
     {
       for i := 0 to |chainIDs|
         invariant Valid()
+        invariant AllLogsDBsConsistentWithChainData()
         invariant |verifiedDB.db| == 0
         invariant forall k :: k in chainIDs[0..i] ==>
           logsDBs[k].LatestSealedBlock() == None
         invariant forall k :: k in chainIDs[0..i] ==>
           RewoundLogsDB(plan, k)
       {
+        label BeforeClear:
         logsDBs[chainIDs[i]].Clear();
+        // Re-establish AllLogsDBsConsistentWithChainData via the framing lemma:
+        // - chainIDs[i]: LatestSealedBlock() == None (Clear postcondition) => vacuous.
+        // - other chains: logsDBs[k] distinct from logsDBs[chainIDs[i]] => unchanged by Clear.
+        ClearPreservesAllLogsDBsConsistentWithChainData@BeforeClear(chainIDs[i]);
       }
     }
 
@@ -1523,9 +1544,6 @@ module Interop {
 
         RewindPreservesVerifiedHeadsHighest@BeforeRewind(chainID, plan.targetHeads[chainID]);
         assert VerifiedHeadsAreHighestBlocksUpToTimestamp();
-        assert BlockSealsMatchOnChainTimestamps() by {
-          RewindPreservesBlockSealsMatch@BeforeRewind(chainID, plan.targetHeads[chainID]);
-        }
         assert AllLogsDBsConsistentWithChainData() by {
           RewindPreservesAllLogsDBsConsistentWithChainData@BeforeRewind(chainID, plan.targetHeads[chainID]);
         }
@@ -2128,46 +2146,6 @@ module Interop {
       }
     }
 
-    // Framing lemma: logsDBs[chainID].Rewind preserves BlockSealsMatchOnChainTimestamps.
-    // Rewind removes seals above targetHead.number; remaining seals have unchanged FindSealedBlock
-    // data (Rewind postcondition), and chains is unchanged, so the timestamp-match property holds
-    // by congruence from the old state. Other chains are untouched.
-    // Intended to be called as RewindPreservesBlockSealsMatch@L(chainID, targetHead)
-    // where L is a label placed just before the Rewind call.
-    twostate lemma {:isolate_assertions} RewindPreservesBlockSealsMatch(
-        chainID: ChainID, targetHead: BlockID)
-      requires chainID in logsDBs.Keys
-      requires logsDBs.Keys == chains.Keys
-      requires forall k1, k2 :: k1 in logsDBs.Keys && k2 in logsDBs.Keys && k1 != k2 ==> logsDBs[k1] != logsDBs[k2]
-      requires logsDBs[chainID].LatestSealedBlock() == Some(targetHead)
-      requires forall n :: 0 <= n <= targetHead.number ==>
-        logsDBs[chainID].FindSealedBlock(n) == old(logsDBs[chainID].FindSealedBlock(n))
-      requires forall k :: k in logsDBs.Keys && k != chainID ==>
-        forall n :: logsDBs[k].FindSealedBlock(n) == old(logsDBs[k].FindSealedBlock(n))
-      requires old(BlockSealsMatchOnChainTimestamps())
-      ensures BlockSealsMatchOnChainTimestamps()
-    {
-      forall cid | cid in logsDBs.Keys
-        ensures forall n :: logsDBs[cid].FindSealedBlock(n).Some? ==>
-          var sealedBlock := logsDBs[cid].FindSealedBlock(n).value;
-          chains[cid].BlockInfo(sealedBlock.id).Some? &&
-          sealedBlock.timestamp == chains[cid].BlockInfo(sealedBlock.id).value.timestamp
-      {
-        forall n: nat | logsDBs[cid].FindSealedBlock(n).Some?
-          ensures var sealedBlock := logsDBs[cid].FindSealedBlock(n).value;
-            chains[cid].BlockInfo(sealedBlock.id).Some? &&
-            sealedBlock.timestamp == chains[cid].BlockInfo(sealedBlock.id).value.timestamp
-        {
-          if cid == chainID {
-            assert n <= targetHead.number;   // from LatestSealedBlock axiom (blocks above are None)
-            assert logsDBs[cid].FindSealedBlock(n) == old(logsDBs[cid].FindSealedBlock(n));
-          } else {
-            assert logsDBs[cid].FindSealedBlock(n) == old(logsDBs[cid].FindSealedBlock(n));
-          }
-        }
-      }
-    }
-
     // Framing lemma: logsDBs[chainID].Rewind preserves AllLogsDBsConsistentWithChainData.
     // Remaining sealed blocks (up to targetHead.number) have unchanged FindSealedBlock and
     // BlockLogs data (from Rewind postconditions + the BlockLogs preservation axiom), so
@@ -2211,6 +2189,49 @@ module Interop {
             assert logsDBs[cid].BlockLogs(blockID.number) == old(logsDBs[cid].BlockLogs(blockID.number));
             assert old(logsDBs[cid].FindSealedBlock(blockID.number)).Some?;
           } else {
+            assert logsDBs[cid].FindSealedBlock(blockID.number) == old(logsDBs[cid].FindSealedBlock(blockID.number));
+            assert logsDBs[cid].BlockLogs(blockID.number) == old(logsDBs[cid].BlockLogs(blockID.number));
+            assert old(logsDBs[cid].FindSealedBlock(blockID.number)).Some?;
+          }
+        }
+      }
+    }
+
+    // Framing lemma: logsDBs[clearedChainID].Clear preserves AllLogsDBsConsistentWithChainData.
+    // The cleared chain has LatestSealedBlock() == None so LogsDBConsistentWithChainData is vacuous.
+    // Other chains have unchanged FindSealedBlock and BlockLogs so LogsDBConsistentWithChainData
+    // holds by congruence from the old state.
+    // Intended to be called as ClearPreservesAllLogsDBsConsistentWithChainData@L(clearedChainID)
+    // where L is a label placed just before the Clear call.
+    twostate lemma {:isolate_assertions} ClearPreservesAllLogsDBsConsistentWithChainData(clearedChainID: ChainID)
+      requires clearedChainID in logsDBs.Keys
+      requires logsDBs.Keys == chains.Keys
+      requires forall k1, k2 :: k1 in logsDBs.Keys && k2 in logsDBs.Keys && k1 != k2 ==> logsDBs[k1] != logsDBs[k2]
+      requires logsDBs[clearedChainID].LatestSealedBlock() == None
+      requires forall k :: k in logsDBs.Keys && k != clearedChainID ==>
+        forall n :: logsDBs[k].FindSealedBlock(n) == old(logsDBs[k].FindSealedBlock(n))
+      requires forall k :: k in logsDBs.Keys && k != clearedChainID ==>
+        forall n :: old(logsDBs[k].FindSealedBlock(n)).Some? ==>
+          logsDBs[k].BlockLogs(n) == old(logsDBs[k].BlockLogs(n))
+      requires old(AllLogsDBsConsistentWithChainData())
+      ensures AllLogsDBsConsistentWithChainData()
+    {
+      reveal AllLogsDBsConsistentWithChainData;
+      reveal LogsDBConsistentWithChainData;
+      forall cid | cid in logsDBs.Keys
+        ensures LogsDBConsistentWithChainData(cid)
+      {
+        reveal LogsDBConsistentWithChainData;
+        if cid == clearedChainID {
+          assert forall number :: logsDBs[cid].FindSealedBlock(number) == None;
+        } else {
+          forall blockID: BlockID | logsDBs[cid].FindSealedBlock(blockID.number).Some?
+            ensures BlockExistedOnChain(cid, blockID) &&
+              var info := chains[cid].BlockInfo(blockID).value;
+              var logs := chains[cid].BlockLogs(blockID).value;
+              logsDBs[cid].FindSealedBlock(info.id.number).value.timestamp == info.timestamp &&
+              logsDBs[cid].BlockLogs(info.id.number) == logs
+          {
             assert logsDBs[cid].FindSealedBlock(blockID.number) == old(logsDBs[cid].FindSealedBlock(blockID.number));
             assert logsDBs[cid].BlockLogs(blockID.number) == old(logsDBs[cid].BlockLogs(blockID.number));
             assert old(logsDBs[cid].FindSealedBlock(blockID.number)).Some?;
@@ -3023,8 +3044,12 @@ module Interop {
               //   AllDBsInSyncUpTo at ts' for chainID: seal at blockID.number exists with id == blockID.
               assert old(logsDBs[chainID].FindSealedBlock(blockID.number)).Some?;
               assert old(logsDBs[chainID].FindSealedBlock(blockID.number)).value.id == blockID;
-              //   BlockSealsMatchOnChainTimestamps: seal timestamp == T_chain.
-              assert old(logsDBs[chainID].FindSealedBlock(blockID.number)).value.timestamp == T_chain;
+              //   AllLogsDBsConsistentWithChainData (opaque): reveal to extract timestamp fact.
+              assert old(logsDBs[chainID].FindSealedBlock(blockID.number)).value.timestamp == T_chain by {
+                reveal AllLogsDBsConsistentWithChainData;
+                reveal LogsDBConsistentWithChainData;
+                assert old(LogsDBConsistentWithChainData(chainID));
+              }
               //   verifiedDB non-decreasing (ts' ≤ ts): blockID.number ≤ plan.targetHeads[chainID].number.
               assert blockID.number <= plan.targetHeads[chainID].number;
               //   AllDBsInSyncUpTo + BlockSealsMatchOnChainTimestamps: seal at targetHead.number has timestamp ts.
@@ -3068,11 +3093,10 @@ module Interop {
       }
     }
 
-    // Proves BlockSealsMatchOnChainTimestamps() after a successful PersistFrontierLogs.
+    // Proves AllLogsDBsConsistentWithChainData() after a successful PersistFrontierLogs.
     // Called as AdvanceEstablishesBlockSealsMatchOnChainTimestamps@L(blocksAtTS) where L is
     // a label placed just before PersistFrontierLogs.
-    // Key: UpdatedAllLogsDBs -> UpdatedLogsDB -> LogsDBConsistentWithChainData instantiated
-    // at blockID := sealedBlock.id, giving seal.timestamp == on-chain timestamp for every block.
+    // Key: UpdatedAllLogsDBs -> UpdatedLogsDB body includes LogsDBConsistentWithChainData directly.
     twostate lemma AdvanceEstablishesBlockSealsMatchOnChainTimestamps(blocksAtTS: map<ChainID, BlockID>)
       requires old(Valid())
       requires logsDBs.Keys == CHAIN_IDS
@@ -3080,37 +3104,11 @@ module Interop {
       requires blocksAtTS.Keys == CHAIN_IDS
       requires BlocksExistedOnChain(blocksAtTS)
       requires UpdatedAllLogsDBs(blocksAtTS)
-      ensures BlockSealsMatchOnChainTimestamps()
+      ensures AllLogsDBsConsistentWithChainData()
     {
       reveal UpdatedAllLogsDBs;
       reveal UpdatedLogsDB;
-      forall chainID | chainID in logsDBs.Keys
-        ensures forall n :: logsDBs[chainID].FindSealedBlock(n).Some? ==>
-          chains[chainID].BlockInfo(logsDBs[chainID].FindSealedBlock(n).value.id).Some? &&
-          logsDBs[chainID].FindSealedBlock(n).value.timestamp ==
-          chains[chainID].BlockInfo(logsDBs[chainID].FindSealedBlock(n).value.id).value.timestamp
-      {
-        reveal LogsDBConsistentWithChainData;
-        forall n | logsDBs[chainID].FindSealedBlock(n).Some?
-          ensures chains[chainID].BlockInfo(logsDBs[chainID].FindSealedBlock(n).value.id).Some? &&
-            logsDBs[chainID].FindSealedBlock(n).value.timestamp ==
-            chains[chainID].BlockInfo(logsDBs[chainID].FindSealedBlock(n).value.id).value.timestamp
-        {
-          var sealedBlock := logsDBs[chainID].FindSealedBlock(n).value;
-          var sealedID := sealedBlock.id;
-          // Trigger LogsDBConsistentWithChainData at blockID := sealedID.
-          // sealedID.number == n, so FindSealedBlock(sealedID.number).Some? holds.
-          assert logsDBs[chainID].FindSealedBlock(sealedID.number).Some?;
-          // Consequent: BlockExistedOnChain(chainID, sealedID) && timestamp match.
-          assert BlockExistedOnChain(chainID, sealedID);
-          assert chains[chainID].BlockInfo(sealedID).Some?;
-          var info := chains[chainID].BlockInfo(sealedID).value;
-          // BlockInfo axiom: info.id == sealedID, so info.id.number == n.
-          assert info.id.number == n;
-          assert logsDBs[chainID].FindSealedBlock(info.id.number).Some?;
-          assert logsDBs[chainID].FindSealedBlock(info.id.number).value.timestamp == info.timestamp;
-        }
-      }
+      reveal AllLogsDBsConsistentWithChainData;
     }
 
     // Proves VerifiedHeadsAreHighestBlocksUpToTimestamp() after PersistFrontierLogs + Commit.

--- a/op-supernode/dafny-models/Interop.dfy
+++ b/op-supernode/dafny-models/Interop.dfy
@@ -1290,13 +1290,6 @@ module Interop {
         PlanConsistentWithAllLogs(plan)
       requires plan.resetAllChainsTo.Some? ==>
         AllDBsInSyncUpTo(plan.resetAllChainsTo.value)
-      // From ProcessBlock sealing blocks with their L2 timestamp (propagated via PersistFrontierLogs).
-      /*
-      requires plan.resetAllChainsTo.Some? ==>
-        forall c :: c in logsDBs.Keys && c in plan.targetHeads ==>
-          logsDBs[c].FindSealedBlock(plan.targetHeads[c].number).Some? &&
-          logsDBs[c].FindSealedBlock(plan.targetHeads[c].number).value.timestamp == plan.resetAllChainsTo.value
-      */
       requires AllVerifiedCrossValid()
       ensures Valid()
       ensures AllLogsDBsConsistentWithChainData()
@@ -1913,7 +1906,6 @@ module Interop {
       requires logsDBs[chainID].LatestSealedBlock().Some? ==>
         logsDBs[chainID].LatestSealedBlock().value.number + 1 == blockID.number &&
         info.parentHash == logsDBs[chainID].LatestSealedBlock().value.hash
-      //ensures {:axiom} unchanged(verifiedDB)
       ensures {:axiom} Valid()
       ensures {:axiom} UpdatedLogsDB(chainID, blockID)
 

--- a/op-supernode/dafny-models/Interop.dfy
+++ b/op-supernode/dafny-models/Interop.dfy
@@ -49,8 +49,13 @@ module Interop {
 
     constructor(chains: map<ChainID, ChainContainer>)
       requires chains.Keys == CHAIN_IDS
-      ensures Valid()
       ensures this.chains == chains
+      ensures Valid()
+      ensures PendingTransitionIsConsistent()
+      ensures AllLogsDBsConsistentWithChainData()
+      ensures AllVerifiedCrossValid()
+      ensures verifiedDB.GetPendingTransition().Some? ==>
+        TransitionIsCrossValid(verifiedDB.GetPendingTransition().value)
     {
       var chainIDs := Enumerate(CHAIN_IDS);
       var logsDBs: map<ChainID, LogsDB> := map[];
@@ -88,6 +93,10 @@ module Interop {
           assert forall number :: logsDBs[chainID].FindSealedBlock(number) == None;
           // FindSealedBlock(n) == None for all n means the predicate body is vacuously true.
         }
+      }
+
+      assert AllVerifiedCrossValid() by {
+        reveal AllVerifiedCrossValid;
       }
     }
 

--- a/op-supernode/dafny-models/LogsDB.dfy
+++ b/op-supernode/dafny-models/LogsDB.dfy
@@ -101,7 +101,6 @@ module LogsDB {
     twostate lemma ContainsMonotone(query: ContainsQuery)
       requires old(Contains(query))
       requires FindSealedBlock(query.blockNum) == old(FindSealedBlock(query.blockNum))
-      ensures Contains(query)
-    { assume false; }  // Admitted: Contains depends only on FindSealedBlock for the queried block.
+      ensures {:axiom} Contains(query)
   }
 }

--- a/op-supernode/dafny-models/LogsDB.dfy
+++ b/op-supernode/dafny-models/LogsDB.dfy
@@ -63,6 +63,34 @@ module LogsDB {
         FindSealedBlock(number).value.id.number == number
       ensures {:axiom} forall number' ::
         0 <= number' < number && FindSealedBlock(number').Some? && FindSealedBlock(number).Some? ==>
-        FindSealedBlock(number').value.timestamp < FindSealedBlock(number).value.timestamp
+          FindSealedBlock(number').value.timestamp < FindSealedBlock(number).value.timestamp
+
+    ghost function BlockLogs(blockNum: nat) : BlockLogs
+      reads this
+      requires FindSealedBlock(blockNum).Some?
+      ensures {:axiom} |BlockLogs(FirstSealedBlock().value.number).execMsgs| == 0
+
+    // Opens a sealed block and returns its block seal plus the map of
+    // logIdx -> ExecutingMessage for all executing messages in that block.
+    // In Go, OpenBlock fails with ErrSkipped for the first block in the DB
+    // because there is no parent to verify against. In Dafny, callers handle
+    // the first block separately using FirstSealedBlock() before calling OpenBlock.
+    // Corresponds to LogsDB.OpenBlock in logdb.go.
+    method OpenBlock(blockNum: nat) returns (ref: BlockSeal, execMsgs: map<nat, ExecutingMessage>)
+      requires FindSealedBlock(blockNum).Some?
+      requires FirstSealedBlock().Some? && FirstSealedBlock().value.number < blockNum
+      ensures {:axiom} ref == FindSealedBlock(blockNum).value
+      ensures {:axiom} execMsgs == BlockLogs(blockNum).execMsgs
+
+    // Checks whether an initiating message matching the query exists in the DB.
+    // Returns true if found. Simplified from Go's Contains, which returns (BlockSeal, error):
+    // both ErrConflict (message absent) and ErrFuture (not yet indexed) map to false here.
+    // Corresponds to LogsDB.Contains in logdb.go.
+    predicate Contains(query: ContainsQuery)
+      reads this
+      ensures {:axiom} Contains(query) ==> FindSealedBlock(query.blockNum).Some?
+      ensures {:axiom} Contains(query) ==> FindSealedBlock(query.blockNum).value.timestamp == query.timestamp
+      ensures {:axiom} Contains(query) ==> query.logIdx in BlockLogs(query.blockNum).execMsgs.Keys
+      ensures {:axiom} Contains(query) ==> BlockLogs(query.blockNum).execMsgs[query.logIdx].checksum == query.checksum
   }
 }

--- a/op-supernode/dafny-models/LogsDB.dfy
+++ b/op-supernode/dafny-models/LogsDB.dfy
@@ -30,6 +30,8 @@ module LogsDB {
       ensures {:axiom} LatestSealedBlock() == Some(newHead)
       ensures {:axiom} forall number :: 0 <= number <= newHead.number ==>
         FindSealedBlock(number) == old(FindSealedBlock(number))
+      ensures {:axiom} forall number :: 0 <= number <= newHead.number && FindSealedBlock(number).Some? ==>
+        BlockLogs(number) == old(BlockLogs(number))
 
     // Returns the first sealed block ID, or None if no blocks are sealed.
     // Corresponds to LogsDB.LatestSealedBlock in logdb.go.
@@ -90,7 +92,16 @@ module LogsDB {
       reads this
       ensures {:axiom} Contains(query) ==> FindSealedBlock(query.blockNum).Some?
       ensures {:axiom} Contains(query) ==> FindSealedBlock(query.blockNum).value.timestamp == query.timestamp
-      ensures {:axiom} Contains(query) ==> query.logIdx in BlockLogs(query.blockNum).execMsgs.Keys
-      ensures {:axiom} Contains(query) ==> BlockLogs(query.blockNum).execMsgs[query.logIdx].checksum == query.checksum
+      ensures {:axiom} Contains(query) ==> query.logIdx < |BlockLogs(query.blockNum).fullLogs|
+      ensures {:axiom} Contains(query) ==> BlockLogs(query.blockNum).fullLogs[query.logIdx].checksum == query.checksum
+
+    // Monotonicity: if Contains held for a query and FindSealedBlock for the queried
+    // block number is unchanged, Contains still holds. This captures that the LogsDB
+    // only grows — adding blocks does not modify or remove existing entries.
+    twostate lemma ContainsMonotone(query: ContainsQuery)
+      requires old(Contains(query))
+      requires FindSealedBlock(query.blockNum) == old(FindSealedBlock(query.blockNum))
+      ensures Contains(query)
+    { assume false; }  // Admitted: Contains depends only on FindSealedBlock for the queried block.
   }
 }

--- a/op-supernode/dafny-models/LogsDB.dfy
+++ b/op-supernode/dafny-models/LogsDB.dfy
@@ -1,0 +1,68 @@
+// Dafny model for the LogsDB interface from logdb.go.
+// Models the subset of the interface used by the Interop activity.
+
+include "VerifiedDB.dfy"
+
+module LogsDB {
+  import opened Types
+  import opened VerifiedDB
+
+  class LogsDB {
+
+    constructor()
+      ensures {:axiom} LatestSealedBlock() == None
+
+    // Removes all data from the database.
+    // Pure I/O with no modeled state changes.
+    // Corresponds to LogsDB.Clear in logdb.go.
+    method Clear()
+      modifies this
+      ensures {:axiom} LatestSealedBlock() == None
+
+    // Removes all blocks after newHead from the database.
+    // Pure I/O with no modeled state changes.
+    // Corresponds to LogsDB.Rewind in logdb.go (the LatestSealedBlock guard is
+    // abstracted into the stub).
+    method Rewind(newHead: BlockID)
+      modifies this
+      requires FindSealedBlock(newHead.number).Some?
+      requires FindSealedBlock(newHead.number).value.id == newHead
+      ensures {:axiom} LatestSealedBlock() == Some(newHead)
+      ensures {:axiom} forall number :: 0 <= number <= newHead.number ==>
+        FindSealedBlock(number) == old(FindSealedBlock(number))
+
+    // Returns the first sealed block ID, or None if no blocks are sealed.
+    // Corresponds to LogsDB.LatestSealedBlock in logdb.go.
+    function FirstSealedBlock(): Option<BlockID>
+      reads this
+      ensures {:axiom} match FirstSealedBlock() {
+        case None => forall number :: FindSealedBlock(number) == None
+        case Some(block) =>
+          FindSealedBlock(block.number).Some? &&
+          FindSealedBlock(block.number).value.id == block &&
+          forall number :: 0 <= number < block.number ==> FindSealedBlock(number) == None
+      }
+
+    // Returns the latest sealed block ID, or None if no blocks are sealed.
+    // Corresponds to LogsDB.LatestSealedBlock in logdb.go.
+    function LatestSealedBlock(): Option<BlockID>
+      reads this
+      ensures {:axiom} match LatestSealedBlock() {
+        case None => forall number :: FindSealedBlock(number) == None
+        case Some(block) =>
+          FindSealedBlock(block.number).Some? &&
+          FindSealedBlock(block.number).value.id == block &&
+          forall number :: block.number < number ==> FindSealedBlock(number) == None
+      }
+
+    // Returns the sealed block at the given block number, or None if not found.
+    // Corresponds to LogsDB.FindSealedBlock in logdb.go.
+    function FindSealedBlock(number: nat): Option<BlockSeal>
+      reads this
+      ensures {:axiom} FindSealedBlock(number).Some? ==>
+        FindSealedBlock(number).value.id.number == number
+      ensures {:axiom} forall number' ::
+        0 <= number' < number && FindSealedBlock(number').Some? && FindSealedBlock(number).Some? ==>
+        FindSealedBlock(number').value.timestamp < FindSealedBlock(number).value.timestamp
+  }
+}

--- a/op-supernode/dafny-models/Types.dfy
+++ b/op-supernode/dafny-models/Types.dfy
@@ -1,0 +1,186 @@
+// Shared type definitions for the Dafny interop model.
+
+module Types {
+
+  // Simplified representation of eth.ChainID
+  type ChainID = nat
+
+  // Simplified representation of eth.BlockID
+  datatype BlockID = BlockID(number: nat, hash: nat)
+
+  // Simplified representation of a block's metadata as returned by FetchReceipts.
+  // Corresponds to eth.BlockInfo in Go; receipts are abstracted away.
+  datatype BlockInfo = BlockInfo(id: BlockID, parentHash: nat, timestamp: nat)
+
+  // Corresponds to interop.VerifiedResult
+  datatype VerifiedResult = VerifiedResult(
+    timestamp: nat,
+    l1Inclusion: BlockID,
+    l2Heads: map<ChainID, BlockID>
+  )
+
+  // Corresponds to interop.Decision
+  datatype Decision = Wait | Advance | Invalidate | Rewind
+
+  // Replaces Go nullable pointers and (value, bool) pairs.
+  datatype Option<T(==)> = None | Some(value: T)
+
+  // Corresponds to interop.Result
+  datatype Result = Result(
+    timestamp: nat,
+    l1Inclusion: BlockID,
+    l2Heads: map<ChainID, BlockID>,
+    invalidHeads: map<ChainID, BlockID>
+  )
+
+  // Corresponds to interop.RewindPlan
+  datatype RewindPlan = RewindPlan(
+    rewindAtOrAfter: nat,
+    resetAllChainsTo: Option<nat>,
+    targetHeads: map<ChainID, BlockID>
+  )
+
+  // Corresponds to interop.PendingTransition.
+  // The WAL operational details are abstracted away; modeled as a plain
+  // optional value held in a field.
+  datatype PendingTransition = PendingTransition(
+    decision: Decision,
+    result: Option<Result>,
+    rewind: Option<RewindPlan>
+  )
+
+  // Sealed block entry stored in a LogsDB.
+  // Corresponds to the block seal used by LogsDB.FindSealedBlock.
+  datatype BlockSeal = BlockSeal(id: BlockID, timestamp: nat)
+
+  // Result of a single OptimisticAt query.
+  // Corresponds to the l2Block and l1Block values returned by c.OptimisticAt in
+  // checkChainsReady in interop.go.
+  datatype OptimisticAtResult = OptimisticAtResult(l2Block: BlockID, l1Head: BlockID)
+
+  // Consistent snapshot of the current round's state, captured upfront so that
+  // the decision function operates on immutable data.
+  // Corresponds to interop.RoundObservation; the test-only Paused field is omitted.
+  datatype RoundObservation = RoundObservation(
+    lastVerifiedTS: Option<nat>,
+    lastVerified: Option<VerifiedResult>,
+    nextTimestamp: nat,
+    chainsReady: bool,
+    blocksAtTS: map<ChainID, BlockID>,
+    l1Heads: map<ChainID, BlockID>,
+    l1Consistent: bool,
+    l2sConsistent: bool
+  )
+
+  // Parallel query results from CheckChainsReady.
+  // Corresponds to chainsReadyResult in interop.go.
+  datatype ChainsReadyResult = ChainsReadyResult(
+    blocks: map<ChainID, BlockID>,
+    l1Heads: map<ChainID, BlockID>
+  )
+
+  // Outcome of a round.
+  // Corresponds to interop.StepOutput, modeled as an algebraic type so that
+  // Advance and Invalidate carry the verification result as a constructor
+  // argument, avoiding an Option<Result> field and associated preconditions.
+  datatype StepOutput =
+    | WaitOutput
+    | AdvanceOutput(result: Result)
+    | InvalidateOutput(result: Result)
+    | RewindOutput
+
+  // ----- System configuration constants -----------------------------------
+
+  // Ghost constants representing the single model instance's configuration.
+  // Named in SCREAMING_SNAKE_CASE to avoid shadowing by class fields.
+  // Linked to the Interop class fields by the Valid() predicate in Interop.dfy:
+  //   activationTimestamp == ACTIVATION_TIMESTAMP
+  //   chains.Keys == CHAIN_IDS
+  const ACTIVATION_TIMESTAMP: nat
+  const CHAIN_IDS: set<ChainID>
+
+  // ----- Structural validity predicates -----------------------------------
+
+  // Structural validity of the rewind plan, independent of the verifiedDB state.
+  // None case: rewindAtOrAfter is at or below the activation timestamp, so
+  // every DB entry (all >= activationTimestamp) will be removed.
+  // Some case: the target timestamp precedes the rewind point and the target
+  // heads cover exactly the current set of chains.
+  ghost predicate ValidRewindPlan(plan: RewindPlan)
+  {
+    match plan.resetAllChainsTo {
+      case None =>
+        plan.rewindAtOrAfter <= ACTIVATION_TIMESTAMP
+      case Some(ts) =>
+        ACTIVATION_TIMESTAMP < plan.rewindAtOrAfter &&
+        ts == plan.rewindAtOrAfter - 1 &&
+        plan.targetHeads.Keys == CHAIN_IDS
+    }
+  }
+
+  // Invariant on a stored pending transition: the decision is not Wait, the
+  // optional fields are present when expected, and the result l2Heads cover
+  // exactly the current set of chains.
+  ghost predicate ValidPendingTransition(pending: PendingTransition)
+  {
+    pending.decision != Wait &&
+    (pending.decision == Rewind ==> pending.rewind.Some?) &&
+    (pending.decision == Rewind ==> ValidRewindPlan(pending.rewind.value)) &&
+    (pending.decision == Advance ==> pending.result.Some?) &&
+    (pending.decision == Invalidate ==> pending.result.Some?) &&
+    (pending.result.Some? ==> pending.result.value.l2Heads.Keys == CHAIN_IDS)
+  }
+
+  // Validity of a step output: the decision is not Wait, the observation
+  // provides a last-verified timestamp when rewinding, and the l2Heads cover
+  // exactly the current set of chains when advancing or invalidating.
+  // Does not depend on either DB.
+  ghost predicate ValidStepOutput(output: StepOutput, obs: RoundObservation)
+  {
+    match output {
+      case WaitOutput => true
+      case RewindOutput => obs.lastVerifiedTS.Some?
+      case AdvanceOutput(result) =>
+        result.timestamp == obs.nextTimestamp &&
+        result.l2Heads == obs.blocksAtTS &&
+        result.l2Heads.Keys == CHAIN_IDS
+      case InvalidateOutput(result) =>
+        result.timestamp == obs.nextTimestamp &&
+        result.l2Heads == obs.blocksAtTS &&
+        result.l2Heads.Keys == CHAIN_IDS
+    }
+  }
+
+  // Structural validity of the round observation, independent of either DB:
+  // the last verified timestamp is present when l1 is inconsistent (i.e., when
+  // a rewind output will be produced), and the observed block map covers exactly
+  // the current chain set when chains are ready.
+  ghost predicate ValidRoundObservation(obs: RoundObservation)
+  {
+    (!obs.l1Consistent ==> obs.lastVerifiedTS.Some?) &&
+    (obs.chainsReady ==> obs.blocksAtTS.Keys == CHAIN_IDS)
+  }
+
+  // Converts a set of ChainIDs to a sequence containing exactly those elements.
+  // Order is non-deterministic; callers that iterate should not depend on it.
+  method Enumerate(s: set<ChainID>) returns (result: seq<ChainID>)
+    ensures forall x :: x in result <==> x in s
+    ensures |result| == |s|
+    ensures forall p, q :: 0 <= p < q < |result| ==> result[p] != result[q]
+  {
+    result := [];
+    var remaining := s;
+    while remaining != {}
+      invariant remaining <= s
+      invariant forall x :: x in result <==> (x in s && x !in remaining)
+      invariant |result| + |remaining| == |s|
+      invariant forall p, q :: 0 <= p < q < |result| ==> result[p] != result[q]
+      decreases |remaining|
+    {
+      var x :| x in remaining;
+      result := result + [x];
+      remaining := remaining - {x};
+    }
+  }
+
+}

--- a/op-supernode/dafny-models/Types.dfy
+++ b/op-supernode/dafny-models/Types.dfy
@@ -53,11 +53,6 @@ module Types {
   // Corresponds to the block seal used by LogsDB.FindSealedBlock.
   datatype BlockSeal = BlockSeal(id: BlockID, timestamp: nat)
 
-  // Result of a single OptimisticAt query.
-  // Corresponds to the l2Block and l1Block values returned by c.OptimisticAt in
-  // checkChainsReady in interop.go.
-  datatype OptimisticAtResult = OptimisticAtResult(l2Block: BlockID, l1Head: BlockID)
-
   // Consistent snapshot of the current round's state, captured upfront so that
   // the decision function operates on immutable data.
   // Corresponds to interop.RoundObservation; the test-only Paused field is omitted.
@@ -89,6 +84,30 @@ module Types {
     | InvalidateOutput(result: Result)
     | RewindOutput
 
+  // Corresponds to types.ExecutingMessage in supervisor/types/types.go.
+  // Models an executing message found in an L2 block's receipts.
+  datatype ExecutingMessage = ExecutingMessage(
+    chainID: ChainID,  // source chain the initiating message was emitted on
+    blockNum: nat,     // block number of the initiating message
+    logIdx: nat,       // log index within the initiating block
+    timestamp: nat,    // timestamp of the initiating block
+    checksum: nat      // simplified from MessageChecksum (hash of payload + identifier)
+  )
+
+  // Corresponds to types.ContainsQuery in supervisor/types/types.go.
+  // Derived from an ExecutingMessage to query for the initiating message in a logsDB.
+  datatype ContainsQuery = ContainsQuery(
+    blockNum: nat,
+    logIdx: nat,
+    timestamp: nat,
+    checksum: nat
+  )
+
+  // The log data for a block: executing messages keyed by log index.
+  // Corresponds to the executing-message subset of types.Receipts returned by
+  // ChainContainer.FetchReceipts. Non-executing logs are omitted from the model.
+  datatype BlockLogs = BlockLogs(execMsgs: map<nat, ExecutingMessage>)
+
   // ----- System configuration constants -----------------------------------
 
   // Ghost constants representing the single model instance's configuration.
@@ -96,8 +115,12 @@ module Types {
   // Linked to the Interop class fields by the Valid() predicate in Interop.dfy:
   //   activationTimestamp == ACTIVATION_TIMESTAMP
   //   chains.Keys == CHAIN_IDS
+  //   messageExpiryWindow == MESSAGE_EXPIRY_WINDOW
   const ACTIVATION_TIMESTAMP: nat
   const CHAIN_IDS: set<ChainID>
+  // Maximum age (in seconds) of an initiating message that can be referenced by
+  // an executing message. Corresponds to defaultMessageExpiryWindow in algo.go.
+  const MESSAGE_EXPIRY_WINDOW: nat
 
   // ----- Structural validity predicates -----------------------------------
 
@@ -127,7 +150,9 @@ module Types {
     (pending.decision == Rewind ==> pending.rewind.Some?) &&
     (pending.decision == Rewind ==> ValidRewindPlan(pending.rewind.value)) &&
     (pending.decision == Advance ==> pending.result.Some?) &&
+    (pending.decision == Advance ==> |pending.result.value.invalidHeads| == 0) &&
     (pending.decision == Invalidate ==> pending.result.Some?) &&
+    (pending.decision == Invalidate ==> 0 < |pending.result.value.invalidHeads|) &&
     (pending.result.Some? ==> pending.result.value.l2Heads.Keys == CHAIN_IDS)
   }
 
@@ -143,11 +168,13 @@ module Types {
       case AdvanceOutput(result) =>
         result.timestamp == obs.nextTimestamp &&
         result.l2Heads == obs.blocksAtTS &&
-        result.l2Heads.Keys == CHAIN_IDS
+        result.l2Heads.Keys == CHAIN_IDS &&
+        |result.invalidHeads| == 0
       case InvalidateOutput(result) =>
         result.timestamp == obs.nextTimestamp &&
         result.l2Heads == obs.blocksAtTS &&
-        result.l2Heads.Keys == CHAIN_IDS
+        result.l2Heads.Keys == CHAIN_IDS &&
+        0 < |result.invalidHeads|
     }
   }
 

--- a/op-supernode/dafny-models/Types.dfy
+++ b/op-supernode/dafny-models/Types.dfy
@@ -134,7 +134,8 @@ module Types {
   {
     match plan.resetAllChainsTo {
       case None =>
-        plan.rewindAtOrAfter <= ACTIVATION_TIMESTAMP
+        plan.rewindAtOrAfter <= ACTIVATION_TIMESTAMP &&
+        |plan.targetHeads| == 0
       case Some(ts) =>
         ACTIVATION_TIMESTAMP < plan.rewindAtOrAfter &&
         ts == plan.rewindAtOrAfter - 1 &&
@@ -148,8 +149,9 @@ module Types {
   ghost predicate ValidPendingTransition(pending: PendingTransition)
   {
     pending.decision != Wait &&
-    (pending.decision == Rewind ==> pending.rewind.Some?) &&
+    (pending.decision == Rewind <==> pending.rewind.Some?) &&
     (pending.decision == Rewind ==> ValidRewindPlan(pending.rewind.value)) &&
+    (pending.decision == Rewind ==> pending.result.None?) &&
     (pending.decision == Advance ==> pending.result.Some?) &&
     (pending.decision == Advance ==> |pending.result.value.invalidHeads| == 0) &&
     (pending.decision == Invalidate ==> pending.result.Some?) &&

--- a/op-supernode/dafny-models/Types.dfy
+++ b/op-supernode/dafny-models/Types.dfy
@@ -103,10 +103,11 @@ module Types {
     checksum: nat
   )
 
-  // The log data for a block: executing messages keyed by log index.
-  // Corresponds to the executing-message subset of types.Receipts returned by
-  // ChainContainer.FetchReceipts. Non-executing logs are omitted from the model.
-  datatype BlockLogs = BlockLogs(execMsgs: map<nat, ExecutingMessage>)
+  datatype Log = Log(data: nat, checksum: nat)
+
+  // The log data for a block: full list plus executing messages keyed by log index.
+  // Corresponds to types.Receipts returned by ChainContainer.FetchReceipts.
+  datatype BlockLogs = BlockLogs(fullLogs: seq<Log>, execMsgs: map<nat, ExecutingMessage>)
 
   // ----- System configuration constants -----------------------------------
 
@@ -185,7 +186,8 @@ module Types {
   ghost predicate ValidRoundObservation(obs: RoundObservation)
   {
     (!obs.l1Consistent ==> obs.lastVerifiedTS.Some?) &&
-    (obs.chainsReady ==> obs.blocksAtTS.Keys == CHAIN_IDS)
+    (obs.chainsReady ==> obs.blocksAtTS.Keys == CHAIN_IDS) &&
+    (0 < |obs.blocksAtTS| ==> obs.chainsReady)
   }
 
   // Converts a set of ChainIDs to a sequence containing exactly those elements.

--- a/op-supernode/dafny-models/Utils.dfy
+++ b/op-supernode/dafny-models/Utils.dfy
@@ -1,0 +1,107 @@
+// Utility lemmas and predicates over nat and generic maps.
+
+module Utils {
+
+  // Maximum element of a non-empty set of naturals.
+  ghost function Max(s: set<nat>): nat
+    requires |s| > 0
+    ensures Max(s) in s
+    ensures forall k :: k in s ==> k <= Max(s)
+  {
+    var x :| x in s;
+    if s == {x} then x
+    else
+      var rest := s - {x};
+      var maxRest := Max(rest);
+      assert forall k :: k in s ==> (k == x || k in rest);
+      if x >= maxRest then x else maxRest
+  }
+
+  // Maximum timestamp key in a non-empty map.
+  // Generic in the value type so it can be shared across any nat-keyed map.
+  ghost function MaxKey<V>(m: map<nat, V>): nat
+    requires |m| > 0
+    ensures MaxKey(m) in m
+    ensures forall k :: k in m ==> k <= MaxKey(m)
+  {
+    Max(m.Keys)
+  }
+
+  // The committed timestamps form a contiguous integer range:
+  // every key strictly below the maximum has an immediate successor in m.
+  // Generic in the value type for the same reason as MaxKey.
+  ghost predicate Sequential<V>(m: map<nat, V>)
+  {
+    |m| == 0 ||
+    forall k :: k in m && k < MaxKey(m) ==> k + 1 in m
+  }
+
+  // Inserting a key greater than all existing keys makes it the new maximum.
+  lemma MaxKeyInsertNewMax<V>(m: map<nat, V>, k: nat, v: V)
+    requires |m| == 0 || k > MaxKey(m)
+    ensures MaxKey(m[k := v]) == k
+  {
+    if |m| == 0 {
+      assert MaxKey(m[k := v]) == k;
+    } else {
+      assert MaxKey(m[k := v]) == k;
+    }
+  }
+
+  // The maximum key of a below-threshold filter is min(MaxKey(m), threshold - 1).
+  // Requires the filtered map to be non-empty (i.e. some key lies below the threshold).
+  lemma MaxKeyFilterBelow<V>(m: map<nat, V>, threshold: nat)
+    requires |m| > 0
+    requires Sequential(m)
+    requires |map k | k in m && k < threshold :: m[k]| > 0
+    ensures MaxKey(map k | k in m && k < threshold :: m[k]) ==
+            if MaxKey(m) < threshold then MaxKey(m) else threshold - 1
+  {
+    var newMap := map k | k in m && k < threshold :: m[k];
+
+    if MaxKey(m) < threshold {
+      assert newMap == m;
+    } else {
+      var keyBelowThreshold :| keyBelowThreshold in m && keyBelowThreshold < threshold;
+      SequentialContainsRange(m, keyBelowThreshold);
+      assert threshold - 1 in newMap;
+      assert MaxKey(newMap) == threshold - 1;
+    }
+  }
+
+  // In a sequential map, every integer in [k0, MaxKey(m)] is a key of m.
+  lemma SequentialContainsRange<V>(m : map<nat, V>, k0 : nat)
+    requires |m| > 0
+    requires Sequential(m)
+    requires k0 in m
+    requires k0 <= MaxKey(m)
+    ensures forall k :: k0 <= k <= MaxKey(m) ==> k in m
+  {
+    var i := k0;
+
+    while i < MaxKey(m)
+      invariant forall k :: k0 <= k < i ==> k in m
+    {
+      if k0 < i {
+        assert (i - 1) in m;
+      }
+
+      i := i + 1;
+    }
+  }
+
+  // Filtering a map to keys below threshold strictly reduces its size iff some key is at or above the threshold.
+  lemma FilterBelowSmallerIffKeyAbove<V>(m: map<nat, V>, threshold: nat)
+    ensures (|map k | k in m && k < threshold :: m[k]| < |m|) <==>
+            (exists k :: k in m && k >= threshold)
+  {
+    var newMap := map k | k in m && k < threshold :: m[k];
+
+    if |newMap| < |m| {
+      assert |m.Keys - newMap.Keys| > 0;
+    } else {
+      assert |m.Keys - newMap.Keys| == 0;
+    }
+  }
+
+}

--- a/op-supernode/dafny-models/VerifiedDB.dfy
+++ b/op-supernode/dafny-models/VerifiedDB.dfy
@@ -150,5 +150,14 @@ module VerifiedDB {
       pendingTransition := None;
     }
 
+    // When the backing map hasn't changed, Get returns the same result in both states.
+    // Used by twostate lemmas to bridge old(Get(ts)) and Get(ts) without triggering
+    // fuel exhaustion from nesting depth.
+    twostate lemma GetStableIfDBUnchanged(ts: nat)
+      requires db == old(db)
+      requires ts in db
+      ensures Get(ts) == old(Get(ts))
+    {}
+
   }
 }

--- a/op-supernode/dafny-models/VerifiedDB.dfy
+++ b/op-supernode/dafny-models/VerifiedDB.dfy
@@ -1,0 +1,154 @@
+// Dafny model for verified_db.go
+
+include "Types.dfy"
+include "Utils.dfy"
+
+module VerifiedDB {
+  import opened Types
+  import opened Utils
+
+  // ----- VerifiedDB class -------------------------------------------------
+
+  class VerifiedDB {
+
+    // Abstract state: map from timestamp to verified result.
+    // Replaces the bbolt on-disk key-value store.
+    var db: map<nat, VerifiedResult>
+
+    // Cached most-recently-committed timestamp. Mirrors the Go field of the
+    // same name; kept consistent with db by the class invariant below.
+    var lastTimestamp: Option<nat>
+
+    // Write-ahead log entry for crash recovery.
+    // Replaces the bbolt pending_transition bucket.
+    var pendingTransition: Option<PendingTransition>
+
+    // Class invariant:
+    //   (1) Committed timestamps form a contiguous range (Sequential).
+    //   (2) Each entry's timestamp field matches its map key.
+    //   (3) lastTimestamp is consistent with the contents of db.
+    ghost predicate Valid()
+      reads this
+    {
+      Sequential(db) &&
+      (forall ts :: ts in db ==> db[ts].timestamp == ts) &&
+      lastTimestamp == (if |db| == 0 then None else Some(MaxKey(db))) &&
+      (forall t1, t2, cid ::
+        t1 in db && t2 in db && t1 <= t2 &&
+        cid in db[t1].l2Heads && cid in db[t2].l2Heads ==>
+        db[t1].l2Heads[cid].number <= db[t2].l2Heads[cid].number)
+    }
+
+    // Initializes an empty VerifiedDB.
+    constructor()
+      ensures Valid()
+      ensures db == map[]
+      ensures pendingTransition == None
+    {
+      db := map[];
+      lastTimestamp := None;
+      pendingTransition := None;
+    }
+
+    // Stores a verified result at the next sequential timestamp.
+    // Precondition replaces the ErrNonSequential / ErrAlreadyCommitted error returns:
+    // the caller is responsible for providing the correct next timestamp.
+    method Commit(result: VerifiedResult)
+      modifies this
+      requires Valid()
+      requires |db| == 0 || result.timestamp == MaxKey(db) + 1
+      requires LastTimestamp().Some? ==>
+        result.l2Heads.Keys == db[LastTimestamp().value].l2Heads.Keys
+      requires LastTimestamp().Some? ==>
+        forall cid :: cid in result.l2Heads ==>
+          db[LastTimestamp().value].l2Heads[cid].number <= result.l2Heads[cid].number
+      ensures Valid()
+      ensures db == old(db)[result.timestamp := result]
+      ensures lastTimestamp == Some(result.timestamp)
+      ensures pendingTransition == old(pendingTransition)
+    {
+      MaxKeyInsertNewMax(db, result.timestamp, result);
+      db := db[result.timestamp := result];
+      lastTimestamp := Some(result.timestamp);
+    }
+
+    // Returns the verified result at the given timestamp.
+    // Precondition replaces the ErrNotFound error return.
+    function Get(ts: nat): VerifiedResult
+      reads this
+      requires ts in db
+    {
+      db[ts]
+    }
+
+    // Returns whether a timestamp has a committed verified result.
+    // Can equivalently be expressed inline as `ts in db`.
+    function Has(ts: nat): bool
+      reads this
+    {
+      ts in db
+    }
+
+    // Returns the most recently committed timestamp, or None if empty.
+    function LastTimestamp(): Option<nat>
+      reads this
+    {
+      lastTimestamp
+    }
+
+    // Removes all verified results at or after the given timestamp.
+    // Returns true if any entries were deleted.
+    method Rewind(timestamp: nat) returns (deleted: bool)
+      modifies this
+      requires Valid()
+      ensures Valid()
+      ensures db == map k | k in old(db) && k < timestamp :: old(db)[k]
+      ensures deleted <==> exists k :: k in old(db) && k >= timestamp
+      ensures pendingTransition == old(pendingTransition)
+    {
+      var newDb := map k | k in db && k < timestamp :: db[k];
+      FilterBelowSmallerIffKeyAbove(db, timestamp);
+      deleted := |newDb| < |db|;
+      if |newDb| == 0 {
+        lastTimestamp := None;
+      } else {
+        MaxKeyFilterBelow(db, timestamp);
+        var oldMax := lastTimestamp.value;
+        lastTimestamp := Some(if oldMax < timestamp then oldMax else timestamp - 1);
+      }
+      db := newDb;
+    }
+
+    // Persists a pending transition as the write-ahead log entry.
+    method SetPendingTransition(pending: PendingTransition)
+      modifies this
+      requires Valid()
+      ensures Valid()
+      ensures pendingTransition == Some(pending)
+      ensures db == old(db)
+      ensures lastTimestamp == old(lastTimestamp)
+    {
+      pendingTransition := Some(pending);
+    }
+
+    // Returns the current pending transition, or None if none exists.
+    function GetPendingTransition(): Option<PendingTransition>
+      reads this
+    {
+      pendingTransition
+    }
+
+    // Clears the pending transition after it has been fully applied.
+    method ClearPendingTransition()
+      modifies this
+      requires Valid()
+      ensures Valid()
+      ensures pendingTransition == None
+      ensures db == old(db)
+      ensures lastTimestamp == old(lastTimestamp)
+    {
+      pendingTransition := None;
+    }
+
+  }
+}

--- a/op-supernode/dafny-models/dafny-spec-check.md
+++ b/op-supernode/dafny-models/dafny-spec-check.md
@@ -1,0 +1,703 @@
+# Dafny Spec Check Report
+
+> **Project**: `op-supernode`  
+> **Dafny model**: `dafny-models`  
+> **Generated**: 2026-07-01
+
+---
+
+## Summary
+
+| # | Go Function | Dafny Method | Pre ✓ | Pre ? | Pre ✗ | Post ✓ | Post ? | Post ✗ |
+|---|---|---|---|---|---|---|---|---|
+| 1 | `persistFrontierLogs` | `Interop.PersistFrontierLogs` | 5 | 0 | 0 | 1 | 4 | 0 |
+| 2 | `processBlockLogs` | `Interop.ProcessBlock` | 1 | 5 | 0 | 0 | 1 | 1 |
+| 3 | `refreshCurrentL1OnWait` | `Interop.RefreshCurrentL1OnWait` | 1 | 0 | 0 | 1 | 0 | 0 |
+| 4 | `verifyExecutingMessage` | `Interop.VerifyExecutingMessage` | 2 | 0 | 0 | 2 | 1 | 0 |
+| 5 | `l1Inclusion` | `Interop.ComputeL1Inclusion` | 1 | 0 | 0 | 1 | 0 | 0 |
+| 6 | `resetChainEnginesIfNeeded` | `Interop.RewindChainEngines` | 7 | 0 | 0 | 6 | 0 | 0 |
+| 7 | `resolveFrontierVerificationView` | `Interop.ResolveFrontierVerificationView` | 3 | 0 | 0 | 2 | 1 | 0 |
+| 8 | `checkChainsReady` | `Interop.CheckChainsReady` | 0 | 3 | 0 | 4 | 1 | 0 |
+| 9 | `buildPendingTransition` | `Interop.BuildPendingTransition` | 6 | 0 | 0 | 3 | 0 | 3 |
+| 10 | `verifyInteropMessages` | `Interop.VerifyMessages` | 0 | 4 | 0 | 2 | 1 | 1 |
+| 11 | `applyRewindPlan` | `Interop.ApplyRewindPlan` | 10 | 0 | 0 | 8 | 2 | 0 |
+| 12 | `verify` | `Interop.Verify` | 2 | 2 | 0 | 4 | 0 | 0 |
+| 13 | `observeRound` | `Interop.ObserveRound` | 2 | 0 | 0 | 3 | 0 | 3 |
+| 14 | `applyPendingTransition` | `Interop.ApplyPendingTransition` | 6 | 0 | 0 | 1 | 8 | 0 |
+| 15 | `progressInterop` | `Interop.ProgressInterop` | 3 | 0 | 0 | 6 | 2 | 0 |
+| 16 | `progressAndRecord` | `Interop.ProgressAndRecord` | 0 | 4 | 0 | 4 | 0 | 0 |
+
+---
+
+## 1. `persistFrontierLogs` → `Interop.PersistFrontierLogs`
+
+**Go file**: `supernode/activity/interop/logdb.go:82`  
+**Dafny**: `dafny-models/Interop.dfy` — class `Interop`, method `PersistFrontierLogs`  
+**Notes**: Go validates timestamp monotonicity and enforces a maximum gap size (no more than one block time between consecutive timestamps) inside sealBlockDataIntoLogsDB; the Dafny model uses assume for these parent-hash and monotonicity conditions. Go also iterates over a map (nondeterministic order), while the Dafny model sequences log persistence deterministically.  
+
+### Preconditions
+
+- [x] `Valid()` — **Satisfied**
+- [x] `blocksAtTS.Keys == chains.Keys` — **Satisfied**
+- [x] `AdvancesAllLogsDBs(ts, blocksAtTS)` — **Satisfied**
+- [x] `BlocksExistedOnChain(blocksAtTS)` — **Satisfied**
+- [x] `AllLogsDBsConsistentWithChainData()` — **Satisfied**
+
+### Postconditions
+
+- [?] `Valid()` — **Uncertain** — Go's processBlockLogs can return an I/O error with no analog in the Dafny model — ProcessBlock is axiomatically assumed to always succeed (ensures {:axiom} Valid()). If processBlockLogs for chain C fails after partially writing to logsDBs[C] (e.g., block data written but seal not committed), the sub-predicates AllLogsDBsConsistentWithChainData() and VerifiedHeadsAreHighestBlocksUpToTimestamp() that compose Valid() may no longer hold for chain C. The ProcessBlock axiom only covers the success path and therefore does not bound this Go-specific failure mode.
+- [?] `AdvancesAllLogsDBs(ts, blocksAtTS)` — **Uncertain** — If processBlockLogs fails in Go for chain C after partially updating logsDBs[C], logsDBs[C].LatestSealedBlock() may be left in an intermediate state — neither the old value (which satisfied AdvancesLogsDB by precondition 3) nor Some(blocksAtTS[C]) (which would satisfy it trivially). In that case AdvancesLogsDB(ts, C, blocksAtTS[C]) can fail the check latestBlock.number <= newBlock.number <= latestBlock.number + 1 evaluated in the post-state, violating AdvancesAllLogsDBs.
+- [?] `AllLogsDBsConsistentWithChainData()` — **Uncertain** — Same root cause as post-conditions 1 and 2: if processBlockLogs fails in Go after writing a partial seal entry for chain C, FindSealedBlock may return a record whose on-chain block data (BlockInfo / BlockLogs) does not match what was committed to the logsDB, directly violating LogsDBConsistentWithChainData(C) and therefore AllLogsDBsConsistentWithChainData(). This failure path has no representation in the Dafny spec.
+- [x] `success ==> UpdatedAllLogsDBs(blocksAtTS)` — **Satisfied**
+- [?] `!success ==> forall chainID :: chainID in logsDBs.Keys ==> UpdatedLogsDB(chainID, blocksAtTS[chainID]) || unchanged(logsDBs[chainID])` — **Uncertain** — If processBlockLogs for chain C returns a Go I/O error after partially modifying logsDBs[C] (a failure mode absent from the Dafny spec), neither disjunct holds: UpdatedLogsDB(C, blocksAtTS[C]) requires LatestSealedBlock() == Some(blocksAtTS[C]) and a specific framing on all other block numbers, which a half-written logsDB does not satisfy; unchanged(logsDBs[C]) requires every FindSealedBlock entry to equal its old value, which the partial write violates. Go's nondeterministic map iteration order also means the identity of chain C is non-deterministic, so this scenario can affect any element of logsDBs.Keys.
+
+### Callsite Analysis
+
+| Caller | Precondition Verdicts |
+|---|---|
+| `applyPendingTransition` (supernode/activity/interop/interop.go:757) | `Valid()` ✓ — applyPendingTransition is the Go body of ApplyPendingTransition, whose Dafny spec carries Valid() as a precondition. The DecisionAdvance branch performs no state-mutating operations before line 757 (only a nil-guard on pending.Result); Valid() is therefore intact at the call site.; `blocksAtTS.Keys == chains.Keys` ✓ — ValidPendingTransition(pending) — implied by Valid() (a precondition of ApplyPendingTransition) — requires pending.result.value.l2Heads.Keys == CHAIN_IDS for an Advance decision. Valid() also requires chains.Keys == CHAIN_IDS. Together they give pending.Result.L2Heads.Keys == i.chains.Keys, which is exactly blocksAtTS.Keys == chains.Keys at the call site.; `AdvancesAllLogsDBs(ts, blocksAtTS)` ✓ — PendingTransitionIsConsistent() is a precondition of ApplyPendingTransition. For a stored Advance pending transition, TransitionConsistentWithLogs(pending) holds, which directly asserts AdvancesAllLogsDBs(pending.result.value.timestamp, pending.result.value.l2Heads). These are the exact ts and blocksAtTS values passed to persistFrontierLogs. No logsDB mutations intervene between ApplyPendingTransition entry and line 757.; `BlocksExistedOnChain(blocksAtTS)` ✓ — PendingTransitionIsConsistent() is a precondition of ApplyPendingTransition. For a stored Advance transition, TransitionConsistentWithChainState(pending) holds, which asserts BlocksExistedOnChain(pending.result.value.l2Heads). That map is identical to blocksAtTS at the call site. No chain-state mutations occur before line 757.; `AllLogsDBsConsistentWithChainData()` ✓ — AllLogsDBsConsistentWithChainData() is a direct precondition of ApplyPendingTransition. The DecisionAdvance branch writes to no logsDB before reaching line 757 (only a nil-guard and the pending.Result nil-check execute), so the invariant is preserved intact at the call site. |
+
+### Violation Scenarios
+
+**Postcondition `Valid()`** (uncertain):
+
+Go's processBlockLogs can return an I/O error with no analog in the Dafny model — ProcessBlock is axiomatically assumed to always succeed (ensures {:axiom} Valid()). If processBlockLogs for chain C fails after partially writing to logsDBs[C] (e.g., block data written but seal not committed), the sub-predicates AllLogsDBsConsistentWithChainData() and VerifiedHeadsAreHighestBlocksUpToTimestamp() that compose Valid() may no longer hold for chain C. The ProcessBlock axiom only covers the success path and therefore does not bound this Go-specific failure mode.
+
+**Postcondition `AdvancesAllLogsDBs(ts, blocksAtTS)`** (uncertain):
+
+If processBlockLogs fails in Go for chain C after partially updating logsDBs[C], logsDBs[C].LatestSealedBlock() may be left in an intermediate state — neither the old value (which satisfied AdvancesLogsDB by precondition 3) nor Some(blocksAtTS[C]) (which would satisfy it trivially). In that case AdvancesLogsDB(ts, C, blocksAtTS[C]) can fail the check latestBlock.number <= newBlock.number <= latestBlock.number + 1 evaluated in the post-state, violating AdvancesAllLogsDBs.
+
+**Postcondition `AllLogsDBsConsistentWithChainData()`** (uncertain):
+
+Same root cause as post-conditions 1 and 2: if processBlockLogs fails in Go after writing a partial seal entry for chain C, FindSealedBlock may return a record whose on-chain block data (BlockInfo / BlockLogs) does not match what was committed to the logsDB, directly violating LogsDBConsistentWithChainData(C) and therefore AllLogsDBsConsistentWithChainData(). This failure path has no representation in the Dafny spec.
+
+**Postcondition `!success ==> forall chainID :: chainID in logsDBs.Keys ==> UpdatedLogsDB(chainID, blocksAtTS[chainID]) || unchanged(logsDBs[chainID])`** (uncertain):
+
+If processBlockLogs for chain C returns a Go I/O error after partially modifying logsDBs[C] (a failure mode absent from the Dafny spec), neither disjunct holds: UpdatedLogsDB(C, blocksAtTS[C]) requires LatestSealedBlock() == Some(blocksAtTS[C]) and a specific framing on all other block numbers, which a half-written logsDB does not satisfy; unchanged(logsDBs[C]) requires every FindSealedBlock entry to equal its old value, which the partial write violates. Go's nondeterministic map iteration order also means the identity of chain C is non-deterministic, so this scenario can affect any element of logsDBs.Keys.
+
+---
+
+## 2. `processBlockLogs` → `Interop.ProcessBlock`
+
+**Go file**: `supernode/activity/interop/logdb.go:222`  
+**Dafny**: `dafny-models/Interop.dfy` — class `Interop`, method `ProcessBlock`  
+**Notes**: The Dafny method is an axiom stub (ensures {:axiom} Valid(), ensures {:axiom} UpdatedLogsDB). In Go, `processBlockLogs` handles a special first-block case by sealing a virtual parent block when the logsDB is empty; it then iterates over all receipt logs, decodes executing messages when present, calls AddLog for each, and seals the block at the end. The parent-hash and block-number preconditions from the Dafny spec are enforced by the outer caller (`sealBlockDataIntoLogsDB`) rather than by `processBlockLogs` itself.  
+
+### Preconditions
+
+- [x] `chainID in CHAIN_IDS` — **Satisfied**
+- [?] `Valid()` — **Uncertain** — If sealBlockDataIntoLogsDB is invoked from a context where Valid() does not hold (e.g., mid-mutation by a concurrent or incompletely applied operation), Valid() would be absent at the processBlockLogs call site.
+- [?] `BlockExistedOnChain(chainID, blockID)` — **Uncertain** — If sealBlockDataIntoLogsDB is called with a blockID that does not correspond to any block on chainID in the chain container (e.g., a speculative or incorrect block), BlockExistedOnChain(chainID, blockID) fails.
+- [?] `info == chains[chainID].BlockInfo(blockID).value` — **Uncertain** — If the blockInfo supplied to sealBlockDataIntoLogsDB is stale, belongs to a different fork, or is otherwise non-canonical for blockID on chainID, the precondition fails.
+- [?] `logs == chains[chainID].BlockLogs(blockID).value` — **Uncertain** — If the receipts parameter does not match the canonical BlockLogs for blockID on chainID (e.g., receipts from a reorged fork), the precondition fails.
+- [?] `logsDBs[chainID].LatestSealedBlock().Some? ==> logsDBs[chainID].LatestSealedBlock().value.number + 1 == blockID.number && info.parentHash == logsDBs[chainID].LatestSealedBlock().value.hash` — **Uncertain** — Under non-canonical block data (preconditions 3/4 not guaranteed), blockID.Number could exceed latestBlock.Number by more than 1 while blockInfo.ParentHash() still equals latestBlock.Hash if blockInfo is malformed. The Go code lacks an explicit numeric check that blockID.Number == latestBlock.Number + 1.
+
+### Postconditions
+
+- [?] `{:axiom} Valid()` — **Uncertain** — processBlockLogs calls db.AddLog for each receipt log and db.SealBlock twice in the first-block case (virtual parent plus blockID). These operations modify one chain's logsDB. Whether all Valid() invariants are preserved — in particular AllLogsDBsConsistentWithChainData (requiring block seals to reflect canonical chain data), VerifiedHeadsAreHighestBlocksUpToTimestamp, and logsDBs distinctness — depends on the correctness of the LogsDB implementation and the canonicality of the supplied blockInfo and receipts. This cannot be verified from the shown code.
+- [ ] `{:axiom} UpdatedLogsDB(chainID, blockID)` — **Violated** — UpdatedLogsDB requires `forall n :: n != blockID.number ==> db.FindSealedBlock(n) == old(db.FindSealedBlock(n))`. In the first-block case (isFirstBlock == true && blockNum > 0), processBlockLogs calls db.SealBlock(common.Hash{}, parentBlock, blockInfo.Time()) at approximately line 242 before iterating logs. This seals the virtual parent at blockNum-1. Because the logsDB is empty before the call, old(db.FindSealedBlock(blockNum-1)) == None, but after the call FindSealedBlock(blockNum-1) == Some(parentBlock seal). Since blockNum-1 != blockID.number (= blockNum), this change violates the forall constraint, falsifying UpdatedLogsDB.
+
+### Callsite Analysis
+
+| Caller | Precondition Verdicts |
+|---|---|
+| `sealBlockDataIntoLogsDB` (supernode/activity/interop/logdb.go:143) | `chainID in CHAIN_IDS` ✓ — sealBlockDataIntoLogsDB guards with `chain, ok := i.chains[chainID]; if !ok { return nil }` before reaching the processBlockLogs call site. processBlockLogs is therefore only called when chainID ∈ i.chains. Valid() guarantees chains.Keys == CHAIN_IDS, so chainID ∈ CHAIN_IDS holds at that point.; `Valid()` ? — sealBlockDataIntoLogsDB neither asserts nor re-establishes Valid() before calling processBlockLogs. The code between function entry and the call modifies no Interop state, so Valid() is preserved if it held at entry. However, the callers of sealBlockDataIntoLogsDB are not shown; whether Valid() holds at entry cannot be determined from the shown code.; `BlockExistedOnChain(chainID, blockID)` ? — sealBlockDataIntoLogsDB receives blockInfo and blockID as caller-supplied parameters. No call to chains[chainID].BlockInfo(blockID) is made to verify the block exists on the canonical chain. Satisfaction depends entirely on callers of sealBlockDataIntoLogsDB (not shown) guaranteeing canonical block data.; `info == chains[chainID].BlockInfo(blockID).value` ? — sealBlockDataIntoLogsDB passes the blockInfo parameter directly to processBlockLogs without verifying it equals i.chains[chainID].BlockInfo(blockID). The mapping between the Go blockInfo argument and the canonical chain block info is not checked inside the shown caller.; `logs == chains[chainID].BlockLogs(blockID).value` ? — sealBlockDataIntoLogsDB passes the receipts parameter directly to processBlockLogs without comparing it to i.chains[chainID].BlockLogs(blockID). Correctness depends on callers of sealBlockDataIntoLogsDB (not shown) supplying canonical receipt data.; `logsDBs[chainID].LatestSealedBlock().Some? ==> logsDBs[chainID].LatestSealedBlock().value.number + 1 == blockID.number && info.parentHash == logsDBs[chainID].LatestSealedBlock().value.hash` ? — When hasBlocks is true, sealBlockDataIntoLogsDB explicitly checks `blockInfo.ParentHash() != latestBlock.Hash` and returns an error if mismatched, enforcing the info.parentHash == hash part. The number+1 relationship is not checked directly: the code only establishes latestBlock.Number < blockID.Number (by eliminating the > and == cases). The exact +1 is implied only under canonical block data (blockInfo.ParentHash() being the hash of block blockID.Number-1), which depends on uncertain preconditions 3 and 4 holding. |
+
+### Violation Scenarios
+
+**Precondition `Valid()`** (uncertain):
+
+If sealBlockDataIntoLogsDB is invoked from a context where Valid() does not hold (e.g., mid-mutation by a concurrent or incompletely applied operation), Valid() would be absent at the processBlockLogs call site.
+
+**Precondition `BlockExistedOnChain(chainID, blockID)`** (uncertain):
+
+If sealBlockDataIntoLogsDB is called with a blockID that does not correspond to any block on chainID in the chain container (e.g., a speculative or incorrect block), BlockExistedOnChain(chainID, blockID) fails.
+
+**Precondition `info == chains[chainID].BlockInfo(blockID).value`** (uncertain):
+
+If the blockInfo supplied to sealBlockDataIntoLogsDB is stale, belongs to a different fork, or is otherwise non-canonical for blockID on chainID, the precondition fails.
+
+**Precondition `logs == chains[chainID].BlockLogs(blockID).value`** (uncertain):
+
+If the receipts parameter does not match the canonical BlockLogs for blockID on chainID (e.g., receipts from a reorged fork), the precondition fails.
+
+**Precondition `logsDBs[chainID].LatestSealedBlock().Some? ==> logsDBs[chainID].LatestSealedBlock().value.number + 1 == blockID.number && info.parentHash == logsDBs[chainID].LatestSealedBlock().value.hash`** (uncertain):
+
+Under non-canonical block data (preconditions 3/4 not guaranteed), blockID.Number could exceed latestBlock.Number by more than 1 while blockInfo.ParentHash() still equals latestBlock.Hash if blockInfo is malformed. The Go code lacks an explicit numeric check that blockID.Number == latestBlock.Number + 1.
+
+**Postcondition `{:axiom} Valid()`** (uncertain):
+
+processBlockLogs calls db.AddLog for each receipt log and db.SealBlock twice in the first-block case (virtual parent plus blockID). These operations modify one chain's logsDB. Whether all Valid() invariants are preserved — in particular AllLogsDBsConsistentWithChainData (requiring block seals to reflect canonical chain data), VerifiedHeadsAreHighestBlocksUpToTimestamp, and logsDBs distinctness — depends on the correctness of the LogsDB implementation and the canonicality of the supplied blockInfo and receipts. This cannot be verified from the shown code.
+
+**Postcondition `{:axiom} UpdatedLogsDB(chainID, blockID)`** (violated):
+
+UpdatedLogsDB requires `forall n :: n != blockID.number ==> db.FindSealedBlock(n) == old(db.FindSealedBlock(n))`. In the first-block case (isFirstBlock == true && blockNum > 0), processBlockLogs calls db.SealBlock(common.Hash{}, parentBlock, blockInfo.Time()) at approximately line 242 before iterating logs. This seals the virtual parent at blockNum-1. Because the logsDB is empty before the call, old(db.FindSealedBlock(blockNum-1)) == None, but after the call FindSealedBlock(blockNum-1) == Some(parentBlock seal). Since blockNum-1 != blockID.number (= blockNum), this change violates the forall constraint, falsifying UpdatedLogsDB.
+
+---
+
+## 3. `refreshCurrentL1OnWait` → `Interop.RefreshCurrentL1OnWait`
+
+**Go file**: `supernode/activity/interop/interop.go:496`  
+**Dafny**: `dafny-models/Interop.dfy` — class `Interop`, method `RefreshCurrentL1OnWait`  
+**Notes**: The Dafny method is an axiom stub (ensures {:axiom} Valid()). In Go, `refreshCurrentL1OnWait` calls `collectCurrentL1` and updates `currentL1` under a mutex lock. If collection fails, the error is logged and the function returns gracefully with (false, nil); this silent-failure path is absent from the Dafny model.  
+
+### Preconditions
+
+- [x] `Valid()` — **Satisfied**
+
+### Postconditions
+
+- [x] `{:axiom} Valid()` — **Satisfied**
+
+### Callsite Analysis
+
+| Caller | Precondition Verdicts |
+|---|---|
+| `progressAndRecord` (supernode/activity/interop/interop.go:477) | `Valid()` ✓ — progressAndRecord has Valid() as its own precondition. The only call that modifies state before reaching line 477 is progressInterop(), whose postcondition ensures Valid() (modifies only chains.Values). The metrics increment between progressInterop's return and the refreshCurrentL1OnWait call is not in Valid()'s reads clause (reads verifiedDB, logsDBs.Values), so Valid() remains unaffected. The pending != nil early-return path bypasses refreshCurrentL1OnWait entirely. The err != nil early-return after progressInterop also bypasses it. Therefore, at line 477, Valid() is guaranteed by progressInterop's postcondition. |
+
+---
+
+## 4. `verifyExecutingMessage` → `Interop.VerifyExecutingMessage`
+
+**Go file**: `supernode/activity/interop/algo.go:184`  
+**Dafny**: `dafny-models/Interop.dfy` — class `Interop`, method `VerifyExecutingMessage`  
+**Notes**: This function is also a co_function of the VerifyMessages mapping entry; here it is checked directly against its own Dafny spec. In Go, the function returns error (nil = valid, non-nil = invalid) rather than bool. Go performs two separate ErrUnknownChain checks (for the source logsDB and for both chains map entries) before the activation checks; the Dafny model uses a single combined guard. Same-timestamp messages are checked against the frontier view first in both models.  
+
+### Preconditions
+
+- [x] `Valid()` — **Satisfied**
+- [x] `executingChain in CHAIN_IDS` — **Satisfied**
+
+### Postconditions
+
+- [x] `Valid()` — **Satisfied**
+- [x] `valid ==> ValidExecutingMessage(executingTimestamp, executingChain, execMsg)` — **Satisfied**
+- [?] `valid ==> if execMsg.timestamp == executingTimestamp then InitMsgInFrontierView(execMsg, view) else assert execMsg.timestamp < executingTimestamp; InitMsgInLogsDB(execMsg)` — **Uncertain** — execMsg.Timestamp == executingTimestamp (line 233), view.contains(execMsg.ChainID, query) returns ok=false (e.g., the frontier block for execMsg.ChainID has a different block number), but i.logsDBs[execMsg.ChainID] contains a sealed block at execMsg.BlockNum with timestamp executingTimestamp and matching checksum. sourceDB.Contains(query) at line 240 returns nil, so the function returns nil (valid), yet InitMsgInFrontierView(execMsg, view) is false. Under Valid() alone, VerifiedHeadsAreHighestBlocksUpToTimestamp() only requires logsDB blocks above the verified head to have timestamps strictly greater than the verified timestamp, which permits a block with timestamp == executingTimestamp. The scenario is excluded in practice by the caller's AdvancesAllLogsDBs(ts, blocksAtTS) + AllDBsInSync() invariants (ensuring all logsDB blocks carry timestamps < executingTimestamp), but those are preconditions of VerifyMessages, not of VerifyExecutingMessage itself.
+
+### Callsite Analysis
+
+| Caller | Precondition Verdicts |
+|---|---|
+| `verifyInteropMessages` (supernode/activity/interop/algo.go:151) | `Valid()` ✓ — VerifyMessages requires Valid() and has no modifies clause (frame-safe), so Valid() holds throughout the caller's execution up to and including the call at line 151. No mutations of Interop state occur before this call site.; `executingChain in CHAIN_IDS` ✓ — The argument is chainID, drawn from iterating blocksAtTimestamp. VerifyMessages requires blocksAtTS.Keys == CHAIN_IDS, so every chainID in the iteration is guaranteed to be in CHAIN_IDS. |
+
+### Violation Scenarios
+
+**Postcondition `valid ==> if execMsg.timestamp == executingTimestamp then InitMsgInFrontierView(execMsg, view) else assert execMsg.timestamp < executingTimestamp; InitMsgInLogsDB(execMsg)`** (uncertain):
+
+execMsg.Timestamp == executingTimestamp (line 233), view.contains(execMsg.ChainID, query) returns ok=false (e.g., the frontier block for execMsg.ChainID has a different block number), but i.logsDBs[execMsg.ChainID] contains a sealed block at execMsg.BlockNum with timestamp executingTimestamp and matching checksum. sourceDB.Contains(query) at line 240 returns nil, so the function returns nil (valid), yet InitMsgInFrontierView(execMsg, view) is false. Under Valid() alone, VerifiedHeadsAreHighestBlocksUpToTimestamp() only requires logsDB blocks above the verified head to have timestamps strictly greater than the verified timestamp, which permits a block with timestamp == executingTimestamp. The scenario is excluded in practice by the caller's AdvancesAllLogsDBs(ts, blocksAtTS) + AllDBsInSync() invariants (ensuring all logsDB blocks carry timestamps < executingTimestamp), but those are preconditions of VerifyMessages, not of VerifyExecutingMessage itself.
+
+---
+
+## 5. `l1Inclusion` → `Interop.ComputeL1Inclusion`
+
+**Go file**: `supernode/activity/interop/algo.go:43`  
+**Dafny**: `dafny-models/Interop.dfy` — class `Interop`, method `ComputeL1Inclusion`  
+**Notes**: The Dafny method is an axiom stub (ensures {:axiom} Valid()). In Go, `l1Inclusion` iterates over `blocksAtTimestamp`, skips chains absent from `i.chains`, and selects the L1 block with the highest block number from `l1Heads`. If a chain is present in `blocksAtTimestamp` but absent from `l1Heads`, Go returns an error; the Dafny axiom stub does not model this failure path.  
+
+### Preconditions
+
+- [x] `Valid()` — **Satisfied**
+
+### Postconditions
+
+- [x] `{:axiom} Valid()` — **Satisfied**
+
+### Callsite Analysis
+
+| Caller | Precondition Verdicts |
+|---|---|
+| `verifyInteropMessages` (supernode/activity/interop/algo.go:76) | `Valid()` ✓ — verifyInteropMessages maps to Interop.VerifyMessages, which has Valid() as its own precondition. The call to i.l1Inclusion is the first substantive operation in the body (line 76), executed before any state-mutating calls. VerifyMessages has no modifies clause, so no receiver state can have changed before this call site. |
+
+---
+
+## 6. `resetChainEnginesIfNeeded` → `Interop.RewindChainEngines`
+
+**Go file**: `supernode/activity/interop/interop.go:905`  
+**Dafny**: `dafny-models/Interop.dfy` — class `Interop`, method `RewindChainEngines`  
+**Notes**: This function is also a co_function of the ApplyRewindPlan mapping entry; here it is checked directly against its own Dafny spec. In Go, `resetChainEnginesIfNeeded` returns early if `plan.ResetAllChainsTo == nil`, which corresponds to the `plan.resetAllChainsTo.None?` guard inside the Dafny loop body. Errors are accumulated via a `recordErr` callback in Go rather than a boolean `failedAny` flag as in Dafny.  
+
+### Preconditions
+
+- [x] `Valid()` — **Satisfied**
+- [x] `ValidRewindPlan(plan)` — **Satisfied**
+- [x] `PlanConsistentWithVerified(plan)` — **Satisfied**
+- [x] `RewoundVerifiedDB(plan)` — **Satisfied**
+- [x] `AllVerifiedCrossValid()` — **Satisfied**
+- [x] `forall k :: k in chainIDs <==> k in chains.Keys` — **Satisfied**
+- [x] `forall k :: k in chainIDs ==> PlanConsistentWithLogs(plan, k)` — **Satisfied**
+
+### Postconditions
+
+- [x] `Valid()` — **Satisfied**
+- [x] `ValidRewindPlan(plan)` — **Satisfied**
+- [x] `RewoundVerifiedDB(plan)` — **Satisfied**
+- [x] `AllVerifiedCrossValid()` — **Satisfied**
+- [x] `forall k :: k in chainIDs ==> PlanConsistentWithLogs(plan, k)` — **Satisfied**
+- [x] `unchanged(logsDBs.Values)` — **Satisfied**
+
+### Callsite Analysis
+
+| Caller | Precondition Verdicts |
+|---|---|
+| `applyRewindPlan` (supernode/activity/interop/interop.go:876) | `Valid()` ✓ — applyRewindPlan's Dafny spec requires Valid() on entry. Before line 876, three operations occur: (1) verifiedDB.Rewind — VerifiedDB.Rewind spec maintains VerifiedDB.Valid() and preserves pendingTransition; under ValidRewindPlan the None case means rewindAtOrAfter <= ACTIVATION_TIMESTAMP, so all entries (each ts >= activationTimestamp >= rewindAtOrAfter) are removed, leaving an empty DB. (2) PruneDeniedAtOrAfterTimestamp — modifies chain containers; its spec has no Interop-level postcondition. (3) db.Clear() on all logsDBs — LogsDB.Clear ensures LatestSealedBlock()==None, making AllLogsDBsConsistentWithChainData() and VerifiedHeadsAreHighestBlocksUpToTimestamp() vacuously true over the now-empty verifiedDB. Valid() is maintained.; `ValidRewindPlan(plan)` ✓ — applyRewindPlan's Dafny spec lists ValidRewindPlan(plan) as a precondition. The plan is a Go value type passed through unchanged; no intermediate operation modifies it or the constants (ACTIVATION_TIMESTAMP, CHAIN_IDS) on which ValidRewindPlan depends.; `PlanConsistentWithVerified(plan)` ✓ — applyRewindPlan requires PlanConsistentWithVerified(plan). For the None case (the only valid case when TargetHeads is nil under ValidRewindPlan), the predicate's antecedent plan.resetAllChainsTo.Some? is false, so the predicate holds trivially after the verifiedDB.Rewind. No logsDB modifications affect verifiedDB state.; `RewoundVerifiedDB(plan)` ✓ — applyRewindPlan's preconditions establish verifiedDB.pendingTransition.Some? with decision==Rewind and rewind==Some(plan). VerifiedDB.Rewind spec guarantees pendingTransition == old(pendingTransition), so the decision/rewind fields are preserved. For the None case, rewindAtOrAfter <= ACTIVATION_TIMESTAMP, so VerifiedDB.Rewind removes all entries (all ts >= activationTimestamp >= rewindAtOrAfter), giving |verifiedDB.db|==0. db.Clear() and PruneDenied do not modify verifiedDB.; `AllVerifiedCrossValid()` ✓ — applyRewindPlan requires AllVerifiedCrossValid(). Under the None case, verifiedDB.db is empty after the rewind, so AllVerifiedCrossValid() is vacuously true (the outer implication on LastTimestamp().Some? is false). db.Clear() on all logsDBs does not affect this vacuously empty verifiedDB condition.; `forall k :: k in chainIDs <==> k in chains.Keys` ✓ — sortedChainIDs is constructed by ranging over i.chains (lines immediately before the call in applyRewindPlan), so it contains exactly the keys of i.chains. The Dafny quantifier forall k :: k in chainIDs <==> k in chains.Keys is therefore satisfied by construction; no subsequent operation adds or removes chains from i.chains.; `forall k :: k in chainIDs ==> PlanConsistentWithLogs(plan, k)` ✓ — Under ValidRewindPlan, plan.TargetHeads==nil (empty map) implies resetAllChainsTo.None, making PlanConsistentWithLogs(plan, k) vacuously true for every k (the antecedent plan.resetAllChainsTo.Some? is false). The db.Clear() calls that precede this line are irrelevant because the predicate body is never evaluated in the None case. |
+| `applyRewindPlan` (supernode/activity/interop/interop.go:900) | `Valid()` ✓ — applyRewindPlan's Dafny spec requires Valid() on entry. Before line 900, verifiedDB.Rewind retains entries k < rewindAtOrAfter and preserves VerifiedDB.Valid(). PruneDeniedAtOrAfterTimestamp has no Interop.Valid() side-effects per its spec. db.Rewind(expectedHead) for selective chains — LogsDB.Rewind spec preserves FindSealedBlock(n) for all n <= expectedHead.number = plan.targetHeads[chainID].number, so AllLogsDBsConsistentWithChainData() is maintained for retained blocks; removed blocks can no longer trigger the forall. VerifiedHeadsAreHighestBlocksUpToTimestamp() is preserved because retained logsDB blocks had timestamps satisfying the predicate before the rewind (part of Valid() pre-call) and no new blocks are added.; `ValidRewindPlan(plan)` ✓ — Same reasoning as line 876; sortedChainIDs is a derived slice and does not alter plan or the constants ValidRewindPlan reads.; `PlanConsistentWithVerified(plan)` ✓ — For the Some(ts) case with ts = rewindAtOrAfter-1, VerifiedDB.Rewind(rewindAtOrAfter) postcondition retains all k < rewindAtOrAfter, so ts is still in the DB. PlanConsistentWithVerified requires ts to be the max key below rewindAtOrAfter (established by the precondition), which holds after the rewind since no new entries are introduced. plan.targetHeads == verifiedDB.Get(ts).l2Heads is unchanged. The subsequent logsDB operations do not modify verifiedDB.; `RewoundVerifiedDB(plan)` ✓ — pendingTransition is preserved by VerifiedDB.Rewind. For the Some(ts) case with ts = rewindAtOrAfter-1, after verifiedDB.Rewind(rewindAtOrAfter) the DB contains exactly {k : k < rewindAtOrAfter}; its MaxKey is ts (because PlanConsistentWithVerified guaranteed ts was the max key below rewindAtOrAfter), so verifiedDB.LastTimestamp()==Some(ts). plan.targetHeads == verifiedDB.Get(ts).l2Heads is unchanged. logsDB operations do not touch verifiedDB.; `AllVerifiedCrossValid()` ✓ — AllVerifiedCrossValid() was established as a precondition of applyRewindPlan. After verifiedDB.Rewind, only entries with ts < rewindAtOrAfter remain; each was already cross-valid by the precondition. db.Rewind(expectedHead) preserves all blocks with number <= plan.targetHeads[chainID].number per LogsDB.Rewind spec. Since verified l2Heads at each remaining timestamp have block numbers <= plan.targetHeads[chainID].number (l2Heads are non-decreasing in the verifiedDB by Valid()), all InitMsgInLogsDB witnesses for those timestamps are preserved. Cross-validity therefore holds for all retained timestamps.; `forall k :: k in chainIDs <==> k in chains.Keys` ✓ — The same sortedChainIDs slice is reused; the construction guarantee is identical and no intermediate step modifies i.chains keys.; `forall k :: k in chainIDs ==> PlanConsistentWithLogs(plan, k)` ✓ — applyRewindPlan's precondition plan.resetAllChainsTo.Some? ==> PlanConsistentWithAllLogs(plan) establishes FindSealedBlock(plan.targetHeads[chainID].number).Some? for every chain at the start. For chains where db.Rewind(expectedHead) is called (expectedHead == plan.TargetHeads[chainID]), LogsDB.Rewind spec preserves FindSealedBlock(n) for all n <= expectedHead.number, so PlanConsistentWithLogs is maintained. For chains skipped because latestBlock==expectedHead, the logsDB is unchanged and the condition trivially holds. The case latestBlock.Number < expectedHead.Number cannot occur under valid preconditions: it would require FindSealedBlock(expectedHead.number)==None, contradicting PlanConsistentWithAllLogs. |
+
+---
+
+## 7. `resolveFrontierVerificationView` → `Interop.ResolveFrontierVerificationView`
+
+**Go file**: `supernode/activity/interop/verification_view.go:29`  
+**Dafny**: `dafny-models/Interop.dfy` — class `Interop`, method `ResolveFrontierVerificationView`  
+**Notes**: The Dafny method is an axiom stub (ensures {:axiom} IsCorrectFrontierView). In Go, `resolveFrontierVerificationView` fetches block receipts for each chain in `blocksAtTS` via `chain.FetchReceipts`, extracts executing messages using `buildFrontierBlockView`, and builds a lookup map keyed by `frontierQueryKey`. Chains absent from `i.chains` are silently skipped in Go, while the Dafny precondition requires `blocksAtTS.Keys == CHAIN_IDS`.  
+
+### Preconditions
+
+- [x] `Valid()` — **Satisfied**
+- [x] `blocksAtTS.Keys == CHAIN_IDS` — **Satisfied**
+- [x] `BlocksExistedOnChain(blocksAtTS)` — **Satisfied**
+
+### Postconditions
+
+- [x] `{:axiom} Valid()` — **Satisfied**
+- [x] `{:axiom} fresh(view)` — **Satisfied**
+- [?] `{:axiom} IsCorrectFrontierView(view, blocksAtTS)` — **Uncertain** — Two gaps prevent confirmation. (1) FetchReceipts failure: the Dafny FetchReceipts spec guarantees only result.Some? ==> BlockInfo(blockID).Some?, not the converse; FetchReceipts can return None even when BlocksExistedOnChain(blocksAtTS) holds. In that case the Go function returns (nil, error) and produces no view, while the Dafny spec has no error return and unconditionally ensures a correctly-populated FrontierView — the postcondition cannot be discharged for that execution path. (2) buildFrontierBlockView opacity: in the success path, buildFrontierBlockView(chainID, blockInfo, receipts) at line ~42 must populate view.blocks[chainID] so that the abstract view.BlockInfo(chainID) and view.BlockLogs(chainID) ghost functions equal chains[chainID].BlockInfo(blocksAtTS[chainID]).value and chains[chainID].BlockLogs(blocksAtTS[chainID]).value respectively; the implementation of buildFrontierBlockView is not in scope, so this mapping cannot be confirmed. Note: the silent-skip branch (if !ok { continue }) is unreachable when preconditions hold because Valid() guarantees chains.Keys == CHAIN_IDS == blocksAtTS.Keys, so that branch is not a source of violation.
+
+### Callsite Analysis
+
+| Caller | Precondition Verdicts |
+|---|---|
+| `verify` (supernode/activity/interop/interop.go:601) | `Valid()` ✓ — Interop.Verify lists Valid() as its first requires clause. verify is the Go implementation of Verify; it passes blocksAtTS unchanged to resolveFrontierVerificationView without any intervening mutations, so Valid() holds at the call site.; `blocksAtTS.Keys == CHAIN_IDS` ✓ — Interop.Verify requires blocksAtTS.Keys == CHAIN_IDS. verify at line 601 forwards the same blocksAtTS map directly to resolveFrontierVerificationView without modification, so the key-set equality holds at the call site.; `BlocksExistedOnChain(blocksAtTS)` ✓ — Interop.Verify requires BlocksExistedOnChain(blocksAtTS). verify passes the same blocksAtTS to resolveFrontierVerificationView at line 601 without any modification, so BlocksExistedOnChain holds for every chainID in the map. |
+
+### Violation Scenarios
+
+**Postcondition `{:axiom} IsCorrectFrontierView(view, blocksAtTS)`** (uncertain):
+
+Two gaps prevent confirmation. (1) FetchReceipts failure: the Dafny FetchReceipts spec guarantees only result.Some? ==> BlockInfo(blockID).Some?, not the converse; FetchReceipts can return None even when BlocksExistedOnChain(blocksAtTS) holds. In that case the Go function returns (nil, error) and produces no view, while the Dafny spec has no error return and unconditionally ensures a correctly-populated FrontierView — the postcondition cannot be discharged for that execution path. (2) buildFrontierBlockView opacity: in the success path, buildFrontierBlockView(chainID, blockInfo, receipts) at line ~42 must populate view.blocks[chainID] so that the abstract view.BlockInfo(chainID) and view.BlockLogs(chainID) ghost functions equal chains[chainID].BlockInfo(blocksAtTS[chainID]).value and chains[chainID].BlockLogs(blocksAtTS[chainID]).value respectively; the implementation of buildFrontierBlockView is not in scope, so this mapping cannot be confirmed. Note: the silent-skip branch (if !ok { continue }) is unreachable when preconditions hold because Valid() guarantees chains.Keys == CHAIN_IDS == blocksAtTS.Keys, so that branch is not a source of violation.
+
+---
+
+## 8. `checkChainsReady` → `Interop.CheckChainsReady`
+
+**Go file**: `supernode/activity/interop/interop.go:941`  
+**Dafny**: `dafny-models/Interop.dfy` — class `Interop`, method `CheckChainsReady`  
+**Notes**: In Go, all chains are queried concurrently via goroutines, with results collected through a buffered channel before returning; the Dafny model uses a sequential for loop over chainIDs. Go returns an error (wrapping ethereum.NotFound) when any chain is not ready, while the Dafny model returns None for the optional result type.  
+
+### Preconditions
+
+- [?] `Valid()` — **Uncertain** — In the uninitialized branch of observeRound, firstVerifiableTimestamp() is called before checkChainsReady. Because firstVerifiableTimestamp is not in scope (no Dafny spec provided), any modification it makes to the Interop struct could break Valid() before line 558 is reached.
+- [?] `AllDBsInSync()` — **Uncertain** — Same as Valid(): firstVerifiableTimestamp() is not covered by any in-scope Dafny spec, so its effect on AllDBsInSync() cannot be confirmed. A modification to verifiedDB or any logsDB inside that function would break AllDBsInSync() before line 558.
+- [?] `forall k :: k in logsDBs && logsDBs[k].LatestSealedBlock().None? ==> ts == activationTimestamp` — **Uncertain** — When the verifiedDB is empty (initialized=false), all logsDBs have LatestSealedBlock()==None. obs.NextTimestamp is assigned from firstVerifiableTimestamp(), which is not mapped to any in-scope Dafny spec. If firstVerifiableTimestamp() returns a value other than activationTimestamp (e.g. due to some offset or configuration), the precondition forall k :: LatestSealedBlock(k)==None ==> ts==activationTimestamp is violated.
+
+### Postconditions
+
+- [x] `Valid()` — **Satisfied**
+- [x] `result.Some? ==> result.value.blocks.Keys == chains.Keys` — **Satisfied**
+- [?] `result.Some? ==> AdvancesAllLogsDBs(ts, result.value.blocks)` — **Uncertain** — AdvancesLogsDB requires logsDBs[chainID].LatestSealedBlock().value.number <= newBlock.number <= logsDBs[chainID].LatestSealedBlock().value.number + 1 for the Some case. The Dafny spec for OptimisticAt only guarantees BlockInfo(l2Block).Some? and BlockInfo(l2Block).value.timestamp <= ts; it provides no bound on l2Block.number relative to the logsDB's latest sealed block number. If OptimisticAt returns a block whose number is more than one step ahead of or behind the logsDB tip, AdvancesLogsDB is violated and the postcondition fails.
+- [x] `result.Some? ==> BlocksExistedOnChain(result.value.blocks)` — **Satisfied**
+- [x] `result.Some? ==> FrontierBlocksConsistentWithTimestamp(ts, result.value.blocks)` — **Satisfied**
+
+### Callsite Analysis
+
+| Caller | Precondition Verdicts |
+|---|---|
+| `observeRound` (supernode/activity/interop/interop.go:558) | `Valid()` ? — ObserveRound's spec requires Valid() at entry. Before line 558, the function calls verifiedDB.LastTimestamp() and verifiedDB.Get(lastTS), both frame-safe (no modifies clause), so they cannot break Valid(). However, in the uninitialized branch (verifiedDB empty), firstVerifiableTimestamp() is called and is not an in-scope mapped function; its modifies footprint and effect on Interop state are unknown. If it mutates verifiedDB, logsDBs, or Interop fields, Valid() may no longer hold at line 558.; `AllDBsInSync()` ? — ObserveRound's spec requires AllDBsInSync() at entry. Frame-safe verifiedDB calls before line 558 cannot break AllDBsInSync(). But firstVerifiableTimestamp() in the uninitialized branch is not in scope; if it advances or alters the verifiedDB or logsDBs independently, AllDBsInSync() may be violated before the call to checkChainsReady at line 558.; `forall k :: k in logsDBs && logsDBs[k].LatestSealedBlock().None? ==> ts == activationTimestamp` ? — When initialized=true: verifiedDB.LastTimestamp().Some? and AllDBsInSync() together imply logsDBs[k].LatestSealedBlock() == Some(...) for all k, so the antecedent is universally false and the condition holds vacuously. When initialized=false: AllDBsInSync() with verifiedDB.LastTimestamp()==None implies all logsDBs have LatestSealedBlock()==None, making the antecedent true for every k. ts is then set to the return value of firstVerifiableTimestamp(), which must equal activationTimestamp for the condition to hold. firstVerifiableTimestamp() is not in scope; it is not confirmed to return activationTimestamp. |
+
+### Violation Scenarios
+
+**Precondition `Valid()`** (uncertain):
+
+In the uninitialized branch of observeRound, firstVerifiableTimestamp() is called before checkChainsReady. Because firstVerifiableTimestamp is not in scope (no Dafny spec provided), any modification it makes to the Interop struct could break Valid() before line 558 is reached.
+
+**Precondition `AllDBsInSync()`** (uncertain):
+
+Same as Valid(): firstVerifiableTimestamp() is not covered by any in-scope Dafny spec, so its effect on AllDBsInSync() cannot be confirmed. A modification to verifiedDB or any logsDB inside that function would break AllDBsInSync() before line 558.
+
+**Precondition `forall k :: k in logsDBs && logsDBs[k].LatestSealedBlock().None? ==> ts == activationTimestamp`** (uncertain):
+
+When the verifiedDB is empty (initialized=false), all logsDBs have LatestSealedBlock()==None. obs.NextTimestamp is assigned from firstVerifiableTimestamp(), which is not mapped to any in-scope Dafny spec. If firstVerifiableTimestamp() returns a value other than activationTimestamp (e.g. due to some offset or configuration), the precondition forall k :: LatestSealedBlock(k)==None ==> ts==activationTimestamp is violated.
+
+**Postcondition `result.Some? ==> AdvancesAllLogsDBs(ts, result.value.blocks)`** (uncertain):
+
+AdvancesLogsDB requires logsDBs[chainID].LatestSealedBlock().value.number <= newBlock.number <= logsDBs[chainID].LatestSealedBlock().value.number + 1 for the Some case. The Dafny spec for OptimisticAt only guarantees BlockInfo(l2Block).Some? and BlockInfo(l2Block).value.timestamp <= ts; it provides no bound on l2Block.number relative to the logsDB's latest sealed block number. If OptimisticAt returns a block whose number is more than one step ahead of or behind the logsDB tip, AdvancesLogsDB is violated and the postcondition fails.
+
+---
+
+## 9. `buildPendingTransition` → `Interop.BuildPendingTransition`
+
+**Go file**: `supernode/activity/interop/interop.go:651`  
+**Dafny**: `dafny-models/Interop.dfy` — class `Interop`, method `BuildPendingTransition`  
+**Notes**: Go uses firstVerifiableTimestamp (which may exceed activationTimestamp after a cold start with late-joining chains) as the lower bound in buildRewindPlan, while the Dafny model always uses activationTimestamp. Go also sets resetAllChainsTo based on a per-chain deny-list check (HasDeniedAtOrAfterTimestamp); the Dafny model treats this field as an opaque decision with no link to a deny-list predicate.  
+
+### Preconditions
+
+- [x] `Valid()` — **Satisfied**
+- [x] `!output.WaitOutput?` — **Satisfied**
+- [x] `ValidStepOutput(output, obs)` — **Satisfied**
+- [x] `OutputConsistentWithVerified(output, obs)` — **Satisfied**
+- [x] `OutputConsistentWithLogs(output, obs)` — **Satisfied**
+- [x] `OutputConsistentWithChainState(output, obs)` — **Satisfied**
+
+### Postconditions
+
+- [ ] `ValidPendingTransition(pendingTx)` — **Violated** — In the DecisionRewind branch, buildRewindPlan can produce plans that fail ValidRewindPlan, which is a conjunct of ValidPendingTransition. Two concrete paths: (1) shouldResetEnginesOnRewind returns false and *obs.LastVerifiedTS > activationTimestamp — plan.ResetAllChainsTo is nil (Dafny None), but ValidRewindPlan's None branch requires rewindAtOrAfter <= ACTIVATION_TIMESTAMP; since rewindAtOrAfter = lastTS > activationTimestamp, the condition fails. (2) shouldResetEnginesOnRewind returns true and lastTS <= firstVerifiableTimestamp — buildRewindPlan sets plan.ResetAllChainsTo = Some(lastTS−1) but returns before setting plan.TargetHeads (empty map); ValidRewindPlan's Some branch requires targetHeads.Keys == CHAIN_IDS, which an empty map cannot satisfy. The Advance and Invalidate branches are unaffected: ValidStepOutput (precondition 3) directly supplies |invalidHeads|==0 for Advance, 0<|invalidHeads| for Invalidate, and l2Heads.Keys==CHAIN_IDS for both.
+- [ ] `TransitionConsistentWithVerified(pendingTx)` — **Violated** — Advance maps to AdvancesVerifiedDB, which is guaranteed by precondition OutputConsistentWithVerified (AdvanceOutput case). Invalidate is trivially true. For Rewind, the obligation is PlanConsistentWithVerified, which fires only when resetAllChainsTo.Some?. When shouldResetEnginesOnRewind=true and lastTS <= firstVerifiableTimestamp: plan.ResetAllChainsTo = Some(lastTS−1) but plan.TargetHeads is empty; PlanConsistentWithVerified requires plan.targetHeads == verifiedDB.Get(lastTS−1).l2Heads, but verifiedDB.Get returns a map with Keys==CHAIN_IDS (from Valid()) while plan.TargetHeads is empty. Additionally, if lastTS == activationTimestamp, verifiedDB.Has(lastTS−1) = verifiedDB.Has(activationTimestamp−1) is false because Valid() guarantees all db entries >= activationTimestamp, again violating PlanConsistentWithVerified.
+- [ ] `TransitionConsistentWithLogs(pendingTx)` — **Violated** — Advance requires AdvancesAllLogsDBs, which is established by precondition OutputConsistentWithLogs (AdvanceOutput case), and newL2Heads.Keys==logsDBs.Keys follows from ValidStepOutput and Valid(). Invalidate is trivially true. For Rewind, TransitionConsistentWithLogs requires: for every k in logsDBs.Keys, if resetAllChainsTo.Some? then k in pending.rewind.value.targetHeads and PlanConsistentWithLogs holds. When shouldResetEnginesOnRewind=true and lastTS <= firstVerifiableTimestamp, buildRewindPlan returns with plan.TargetHeads empty; the antecedent resetAllChainsTo.Some? is true (plan.ResetAllChainsTo = Some(lastTS−1)), so k in targetHeads is required for every chain k in CHAIN_IDS, but an empty map satisfies this for no chain — violated for all CHAIN_IDS elements. When shouldResetEnginesOnRewind=true and lastTS > firstVerifiableTimestamp, plan.TargetHeads = prevResult.L2Heads whose keys are CHAIN_IDS (from Valid()), and PlanConsistentWithLogs follows from OutputConsistentWithLogs (RewindOutput with activationTimestamp < lastTS).
+- [x] `output.AdvanceOutput? <==> pendingTx.decision.Advance?` — **Satisfied**
+- [x] `output.InvalidateOutput? <==> pendingTx.decision.Invalidate?` — **Satisfied**
+- [x] `(pendingTx.decision.Advance? || pendingTx.decision.Invalidate?) ==> pendingTx.result.value == output.result` — **Satisfied**
+
+### Callsite Analysis
+
+| Caller | Precondition Verdicts |
+|---|---|
+| `progressAndRecord` (supernode/activity/interop/interop.go:483) | `Valid()` ✓ — ProgressAndRecord's own Dafny spec requires Valid() as a precondition. ProgressInterop (called immediately before buildPendingTransition) ensures Valid() in its postcondition, so Valid() is re-established at the callsite.; `!output.WaitOutput?` ✓ — Before reaching the buildPendingTransition call, progressAndRecord returns early when output.Decision == DecisionWait (the Go guard 'if output.Decision == DecisionWait { return i.refreshCurrentL1OnWait() }'). DecisionWait is therefore excluded from any call to buildPendingTransition.; `ValidStepOutput(output, obs)` ✓ — ProgressInterop's Dafny spec ensures ValidStepOutput(output, obs). This postcondition is established by the call to progressInterop immediately before buildPendingTransition is invoked in progressAndRecord.; `OutputConsistentWithVerified(output, obs)` ✓ — ProgressInterop's Dafny spec ensures OutputConsistentWithVerified(output, obs). This postcondition is established by the call to progressInterop immediately before buildPendingTransition is invoked.; `OutputConsistentWithLogs(output, obs)` ✓ — ProgressInterop's Dafny spec ensures OutputConsistentWithLogs(output, obs). This postcondition is established by the call to progressInterop immediately before buildPendingTransition is invoked.; `OutputConsistentWithChainState(output, obs)` ✓ — ProgressInterop's Dafny spec ensures OutputConsistentWithChainState(output, obs). This postcondition is established by the call to progressInterop immediately before buildPendingTransition is invoked. |
+
+### Violation Scenarios
+
+**Postcondition `ValidPendingTransition(pendingTx)`** (violated):
+
+In the DecisionRewind branch, buildRewindPlan can produce plans that fail ValidRewindPlan, which is a conjunct of ValidPendingTransition. Two concrete paths: (1) shouldResetEnginesOnRewind returns false and *obs.LastVerifiedTS > activationTimestamp — plan.ResetAllChainsTo is nil (Dafny None), but ValidRewindPlan's None branch requires rewindAtOrAfter <= ACTIVATION_TIMESTAMP; since rewindAtOrAfter = lastTS > activationTimestamp, the condition fails. (2) shouldResetEnginesOnRewind returns true and lastTS <= firstVerifiableTimestamp — buildRewindPlan sets plan.ResetAllChainsTo = Some(lastTS−1) but returns before setting plan.TargetHeads (empty map); ValidRewindPlan's Some branch requires targetHeads.Keys == CHAIN_IDS, which an empty map cannot satisfy. The Advance and Invalidate branches are unaffected: ValidStepOutput (precondition 3) directly supplies |invalidHeads|==0 for Advance, 0<|invalidHeads| for Invalidate, and l2Heads.Keys==CHAIN_IDS for both.
+
+**Postcondition `TransitionConsistentWithVerified(pendingTx)`** (violated):
+
+Advance maps to AdvancesVerifiedDB, which is guaranteed by precondition OutputConsistentWithVerified (AdvanceOutput case). Invalidate is trivially true. For Rewind, the obligation is PlanConsistentWithVerified, which fires only when resetAllChainsTo.Some?. When shouldResetEnginesOnRewind=true and lastTS <= firstVerifiableTimestamp: plan.ResetAllChainsTo = Some(lastTS−1) but plan.TargetHeads is empty; PlanConsistentWithVerified requires plan.targetHeads == verifiedDB.Get(lastTS−1).l2Heads, but verifiedDB.Get returns a map with Keys==CHAIN_IDS (from Valid()) while plan.TargetHeads is empty. Additionally, if lastTS == activationTimestamp, verifiedDB.Has(lastTS−1) = verifiedDB.Has(activationTimestamp−1) is false because Valid() guarantees all db entries >= activationTimestamp, again violating PlanConsistentWithVerified.
+
+**Postcondition `TransitionConsistentWithLogs(pendingTx)`** (violated):
+
+Advance requires AdvancesAllLogsDBs, which is established by precondition OutputConsistentWithLogs (AdvanceOutput case), and newL2Heads.Keys==logsDBs.Keys follows from ValidStepOutput and Valid(). Invalidate is trivially true. For Rewind, TransitionConsistentWithLogs requires: for every k in logsDBs.Keys, if resetAllChainsTo.Some? then k in pending.rewind.value.targetHeads and PlanConsistentWithLogs holds. When shouldResetEnginesOnRewind=true and lastTS <= firstVerifiableTimestamp, buildRewindPlan returns with plan.TargetHeads empty; the antecedent resetAllChainsTo.Some? is true (plan.ResetAllChainsTo = Some(lastTS−1)), so k in targetHeads is required for every chain k in CHAIN_IDS, but an empty map satisfies this for no chain — violated for all CHAIN_IDS elements. When shouldResetEnginesOnRewind=true and lastTS > firstVerifiableTimestamp, plan.TargetHeads = prevResult.L2Heads whose keys are CHAIN_IDS (from Valid()), and PlanConsistentWithLogs follows from OutputConsistentWithLogs (RewindOutput with activationTimestamp < lastTS).
+
+---
+
+## 10. `verifyInteropMessages` → `Interop.VerifyMessages`
+
+**Go file**: `supernode/activity/interop/algo.go:69`  
+**Dafny**: `dafny-models/Interop.dfy` — class `Interop`, method `VerifyMessages`  
+**Notes**: In Go, executing messages in the first sealed block are silently skipped because no predecessor frontier entry exists for that block. A chain is also silently skipped if it is absent from i.logsDBs. Additionally, Go breaks on the first invalid executing message per block rather than checking all messages before returning a verdict.  
+
+### Preconditions
+
+- [?] `Valid()` — **Uncertain** — No in-scope callers are available; it cannot be determined from the code whether the Interop struct invariants (logsDBs.Keys == CHAIN_IDS, verifiedDB.Valid(), AllLogsDBsConsistentWithChainData, chains.Keys == CHAIN_IDS, etc.) always hold at every call site.
+- [?] `blocksAtTS.Keys == CHAIN_IDS` — **Uncertain** — No in-scope callers are available; it cannot be determined whether the blocksAtTimestamp argument always covers exactly CHAIN_IDS at every call site.
+- [?] `AdvancesAllLogsDBs(ts, blocksAtTS)` — **Uncertain** — No in-scope callers are available; it cannot be determined whether each chain's logsDB is at the correct tip (LatestSealedBlock().number <= blocksAtTS[chainID].number <= LatestSealedBlock().number + 1, or None and ts == activationTimestamp) before every call.
+- [?] `IsCorrectFrontierView(view, blocksAtTS)` — **Uncertain** — No in-scope callers are available; it cannot be determined whether the frontier view always carries view.BlockInfo(chainID) == chains[chainID].BlockInfo(blocksAtTS[chainID]).value and matching BlockLogs for every chain in CHAIN_IDS at call time.
+
+### Postconditions
+
+- [?] `Valid()` — **Uncertain** — i.newInvalidHead is invoked in three branches (first-block hash-mismatch, block hash-mismatch, and invalid-exec-msgs) but has no Dafny spec; its frame safety is not established. All other called functions (l1Inclusion, db.OpenBlock, db.FirstSealedBlock, verifyExecutingMessage) carry 'modifies nothing' in their specs and cannot disturb Valid(). If newInvalidHead writes to verifiedDB, logsDBs, or chains, the invariants constituting Valid() could be broken.
+- [x] `result.timestamp == ts` — **Satisfied**
+- [x] `result.l2Heads == blocksAtTS` — **Satisfied**
+- [ ] `|result.invalidHeads| == 0 ==> forall chainID in CHAIN_IDS :: BlockIsCrossValid(view.BlockInfo(chainID).timestamp, chainID, view.BlockInfo(chainID).id) && AllInitMsgsPresent(chainID, view.BlockInfo(chainID).id, blocksAtTS)` — **Violated** — When view.block(chainID) returns false for some chain C and db.OpenBlock(expectedBlock.Number) returns ErrSkipped because C's block is the first sealed entry in its logsDB, the code calls db.FirstSealedBlock(), confirms the block number matches expectedBlock.Number, and executes 'continue' without iterating over execMsgs at all. If the hash also matches, no entry is added to result.InvalidHeads, so |result.invalidHeads| == 0. But any executing messages that exist in that first block are never passed to verifyExecutingMessage, so neither ValidExecutingMessage nor InitMsgPresent is established for them. BlockIsCrossValid (which quantifies over all execMsgs in chains[C].BlockLogs(blocksAtTS[C]).value) and AllInitMsgsPresent may therefore be false, violating the postcondition's consequent. The Dafny LogsDB axiom |BlockLogs(FirstSealedBlock().value.number).execMsgs| == 0 is a model assumption not enforced on the concrete Go logsDB, so the violation is reachable.
+
+### Violation Scenarios
+
+**Precondition `Valid()`** (uncertain):
+
+No in-scope callers are available; it cannot be determined from the code whether the Interop struct invariants (logsDBs.Keys == CHAIN_IDS, verifiedDB.Valid(), AllLogsDBsConsistentWithChainData, chains.Keys == CHAIN_IDS, etc.) always hold at every call site.
+
+**Precondition `blocksAtTS.Keys == CHAIN_IDS`** (uncertain):
+
+No in-scope callers are available; it cannot be determined whether the blocksAtTimestamp argument always covers exactly CHAIN_IDS at every call site.
+
+**Precondition `AdvancesAllLogsDBs(ts, blocksAtTS)`** (uncertain):
+
+No in-scope callers are available; it cannot be determined whether each chain's logsDB is at the correct tip (LatestSealedBlock().number <= blocksAtTS[chainID].number <= LatestSealedBlock().number + 1, or None and ts == activationTimestamp) before every call.
+
+**Precondition `IsCorrectFrontierView(view, blocksAtTS)`** (uncertain):
+
+No in-scope callers are available; it cannot be determined whether the frontier view always carries view.BlockInfo(chainID) == chains[chainID].BlockInfo(blocksAtTS[chainID]).value and matching BlockLogs for every chain in CHAIN_IDS at call time.
+
+**Postcondition `Valid()`** (uncertain):
+
+i.newInvalidHead is invoked in three branches (first-block hash-mismatch, block hash-mismatch, and invalid-exec-msgs) but has no Dafny spec; its frame safety is not established. All other called functions (l1Inclusion, db.OpenBlock, db.FirstSealedBlock, verifyExecutingMessage) carry 'modifies nothing' in their specs and cannot disturb Valid(). If newInvalidHead writes to verifiedDB, logsDBs, or chains, the invariants constituting Valid() could be broken.
+
+**Postcondition `|result.invalidHeads| == 0 ==> forall chainID in CHAIN_IDS :: BlockIsCrossValid(view.BlockInfo(chainID).timestamp, chainID, view.BlockInfo(chainID).id) && AllInitMsgsPresent(chainID, view.BlockInfo(chainID).id, blocksAtTS)`** (violated):
+
+When view.block(chainID) returns false for some chain C and db.OpenBlock(expectedBlock.Number) returns ErrSkipped because C's block is the first sealed entry in its logsDB, the code calls db.FirstSealedBlock(), confirms the block number matches expectedBlock.Number, and executes 'continue' without iterating over execMsgs at all. If the hash also matches, no entry is added to result.InvalidHeads, so |result.invalidHeads| == 0. But any executing messages that exist in that first block are never passed to verifyExecutingMessage, so neither ValidExecutingMessage nor InitMsgPresent is established for them. BlockIsCrossValid (which quantifies over all execMsgs in chains[C].BlockLogs(blocksAtTS[C]).value) and AllInitMsgsPresent may therefore be false, violating the postcondition's consequent. The Dafny LogsDB axiom |BlockLogs(FirstSealedBlock().value.number).execMsgs| == 0 is a model assumption not enforced on the concrete Go logsDB, so the violation is reachable.
+
+---
+
+## 11. `applyRewindPlan` → `Interop.ApplyRewindPlan`
+
+**Go file**: `supernode/activity/interop/interop.go:838`  
+**Dafny**: `dafny-models/Interop.dfy` — class `Interop`, method `ApplyRewindPlan`  
+**Notes**: In Go, resetChainEnginesIfNeeded is called only after all logsDB rewinds succeed; the Dafny model calls RewindChainEngines before the logsDB steps and treats engine-rewind success as independent of logsDB outcomes. If any logsDB operation fails in Go, the engine reset is skipped entirely, making the rewind sequence non-idempotent under partial failure.  
+
+### Preconditions
+
+- [x] `Valid()` — **Satisfied**
+- [x] `AllLogsDBsConsistentWithChainData()` — **Satisfied**
+- [x] `verifiedDB.pendingTransition.Some?` — **Satisfied**
+- [x] `verifiedDB.pendingTransition.value.decision == Rewind` — **Satisfied**
+- [x] `verifiedDB.pendingTransition.value.rewind == Some(plan)` — **Satisfied**
+- [x] `ValidRewindPlan(plan)` — **Satisfied**
+- [x] `PlanConsistentWithVerified(plan)` — **Satisfied**
+- [x] `plan.resetAllChainsTo.Some? ==> PlanConsistentWithAllLogs(plan)` — **Satisfied**
+- [x] `plan.resetAllChainsTo.Some? ==> AllDBsInSyncUpTo(plan.resetAllChainsTo.value)` — **Satisfied**
+- [x] `AllVerifiedCrossValid()` — **Satisfied**
+
+### Postconditions
+
+- [?] `Valid()` — **Uncertain** — If LogsDB.Clear() or LogsDB.Rewind() fails in Go and leaves the logsDB in a partially-modified state, AllLogsDBsConsistentWithChainData() — a component of Valid() — may not hold. The Dafny LogsDB model never fails; the Go implementation can. All other components of Valid() (verifiedDB.Valid() via VerifiedDB.Rewind's ensures, VerifiedHeadsAreHighestBlocksUpToTimestamp() because remaining logsDB blocks at n > old verifiedHead for any remaining ts have timestamps >= rewindAtOrAfter > ts, AllVerifiedHeadsBoundedByTimestamp() because l2Heads and BlockInfo are unchanged) are maintained even under partial failure.
+- [?] `AllLogsDBsConsistentWithChainData()` — **Uncertain** — LogsDB.Clear() and LogsDB.Rewind() are modeled in Dafny as always-succeeding; their ensures clauses then guarantee consistency. In Go both can return errors. If a failed Clear() or Rewind() atomically leaves the logsDB unchanged, the precondition guarantees AllLogsDBsConsistentWithChainData() still holds. If a failed operation partially modifies the logsDB's internal index in a way that makes FindSealedBlock return data inconsistent with chain data, the predicate can be violated. This cannot be determined from the Go source alone.
+- [x] `ValidRewindPlan(plan)` — **Satisfied**
+- [x] `verifiedDB.pendingTransition == old(verifiedDB.pendingTransition)` — **Satisfied**
+- [x] `PlanConsistentWithVerified(plan)` — **Satisfied**
+- [x] `plan.resetAllChainsTo.Some? ==> PlanConsistentWithAllLogs(plan)` — **Satisfied**
+- [x] `plan.resetAllChainsTo.Some? && success ==> RewoundAllLogsDB(plan)` — **Satisfied**
+- [x] `plan.resetAllChainsTo.Some? ==> AllDBsInSyncUpTo(plan.resetAllChainsTo.value)` — **Satisfied**
+- [x] `success ==> AllDBsInSync()` — **Satisfied**
+- [x] `AllVerifiedCrossValid()` — **Satisfied**
+
+### Callsite Analysis
+
+| Caller | Precondition Verdicts |
+|---|---|
+| `applyPendingTransition` (supernode/activity/interop/interop.go:682) | `Valid()` ✓ — applyPendingTransition's Dafny spec lists Valid() as a requires clause, so Valid() is established before applyRewindPlan is called.; `AllLogsDBsConsistentWithChainData()` ✓ — applyPendingTransition's Dafny spec explicitly requires AllLogsDBsConsistentWithChainData(), so it holds at the call site.; `verifiedDB.pendingTransition.Some?` ✓ — applyPendingTransition's spec requires verifiedDB.GetPendingTransition() == Some(pending), guaranteeing pendingTransition.Some? before the call.; `verifiedDB.pendingTransition.value.decision == Rewind` ✓ — applyRewindPlan is only reached inside case DecisionRewind at line 682, so the decision is Rewind at every call site.; `verifiedDB.pendingTransition.value.rewind == Some(plan)` ✓ — ValidPendingTransition (implied by Valid()) guarantees rewind.Some? when decision == Rewind. The call passes *pending.Rewind, so plan equals pending.rewind.value. The nil guard at line ~671 ensures pending.Rewind != nil before the dereference.; `ValidRewindPlan(plan)` ✓ — ValidPendingTransition (implied by Valid() + verifiedDB.pendingTransition.Some?) requires ValidRewindPlan(pending.rewind.value). plan == pending.rewind.value, so this holds.; `PlanConsistentWithVerified(plan)` ✓ — applyPendingTransition's spec requires PendingTransitionIsConsistent(). For the Rewind decision, PendingTransitionIsConsistent() unfolds to TransitionConsistentWithVerified(pending), which for Rewind equals PlanConsistentWithVerified(pending.rewind.value) == PlanConsistentWithVerified(plan).; `plan.resetAllChainsTo.Some? ==> PlanConsistentWithAllLogs(plan)` ✓ — PendingTransitionIsConsistent() for the Rewind case also expands to TransitionConsistentWithLogs(pending), which for Rewind reads: forall k in logsDBs.Keys && resetAllChainsTo.Some? ==> k in targetHeads && PlanConsistentWithLogs(plan, k). This is exactly PlanConsistentWithAllLogs(plan) under the Some? antecedent.; `plan.resetAllChainsTo.Some? ==> AllDBsInSyncUpTo(plan.resetAllChainsTo.value)` ✓ — PendingTransitionIsConsistent() for the Rewind case explicitly includes: p.rewind.value.resetAllChainsTo.Some? ==> AllDBsInSyncUpTo(p.rewind.value.resetAllChainsTo.value). This is exactly the precondition.; `AllVerifiedCrossValid()` ✓ — applyPendingTransition's Dafny spec requires AllVerifiedCrossValid() before the call. |
+
+### Violation Scenarios
+
+**Postcondition `Valid()`** (uncertain):
+
+If LogsDB.Clear() or LogsDB.Rewind() fails in Go and leaves the logsDB in a partially-modified state, AllLogsDBsConsistentWithChainData() — a component of Valid() — may not hold. The Dafny LogsDB model never fails; the Go implementation can. All other components of Valid() (verifiedDB.Valid() via VerifiedDB.Rewind's ensures, VerifiedHeadsAreHighestBlocksUpToTimestamp() because remaining logsDB blocks at n > old verifiedHead for any remaining ts have timestamps >= rewindAtOrAfter > ts, AllVerifiedHeadsBoundedByTimestamp() because l2Heads and BlockInfo are unchanged) are maintained even under partial failure.
+
+**Postcondition `AllLogsDBsConsistentWithChainData()`** (uncertain):
+
+LogsDB.Clear() and LogsDB.Rewind() are modeled in Dafny as always-succeeding; their ensures clauses then guarantee consistency. In Go both can return errors. If a failed Clear() or Rewind() atomically leaves the logsDB unchanged, the precondition guarantees AllLogsDBsConsistentWithChainData() still holds. If a failed operation partially modifies the logsDB's internal index in a way that makes FindSealedBlock return data inconsistent with chain data, the predicate can be violated. This cannot be determined from the Go source alone.
+
+---
+
+## 12. `verify` → `Interop.Verify`
+
+**Go file**: `supernode/activity/interop/interop.go:600`  
+**Dafny**: `dafny-models/Interop.dfy` — class `Interop`, method `Verify`  
+**Notes**: In Go, `verify` delegates to injected closures (`verifyFn` defaulting to `verifyInteropMessages`, and `cycleVerifyFn`) rather than calling those functions directly; this indirection supports test overrides. The Dafny model inlines the three sub-operations (ResolveFrontierVerificationView, VerifyMessages, VerifyCycles) directly. Invalid heads from the cycle check are merged into the message-verification result in both models.  
+
+### Preconditions
+
+- [x] `Valid()` — **Satisfied**
+- [?] `blocksAtTS.Keys == CHAIN_IDS` — **Uncertain** — If checkPreconditions returns nil while obs.chainsReady is false (e.g., a code path that bypasses the chainsReady check), obs.BlocksAtTS.Keys would not equal CHAIN_IDS, violating this precondition. Not provable safe from the listed Dafny specs alone.
+- [x] `BlocksExistedOnChain(blocksAtTS)` — **Satisfied**
+- [?] `AdvancesAllLogsDBs(ts, blocksAtTS)` — **Uncertain** — If checkPreconditions returns nil when obs.l2sConsistent or obs.l1Consistent is false (while obs.chainsReady is true), AdvancesAllLogsDBs(obs.nextTimestamp, obs.blocksAtTS) is not guaranteed by any listed spec, violating this precondition.
+
+### Postconditions
+
+- [x] `Valid()` — **Satisfied**
+- [x] `result.timestamp == ts` — **Satisfied**
+- [x] `result.l2Heads == blocksAtTS` — **Satisfied**
+- [x] `|result.invalidHeads| == 0 ==> ResultIsCrossValid(result)` — **Satisfied**
+
+### Callsite Analysis
+
+| Caller | Precondition Verdicts |
+|---|---|
+| `progressInterop` (supernode/activity/interop/interop.go:522) | `Valid()` ✓ — ProgressInterop (Dafny) carries Valid() as a precondition. observeRound has `requires Valid()` and `ensures Valid()` (modifies only chains.Values). checkPreconditions is not in the Dafny spec list, but from the Go code it accepts obs by value and returns a *StepOutput without touching Interop fields. Therefore Valid() is unaffected between the observeRound return and the verify call at line 522.; `blocksAtTS.Keys == CHAIN_IDS` ? — obs.BlocksAtTS is passed as blocksAtTS. observeRound ensures ValidRoundObservation(obs) (`obs.chainsReady ==> obs.blocksAtTS.Keys == CHAIN_IDS`) and ObservationConsistentWithChainState(obs) (`0 < |obs.blocksAtTS| ==> obs.blocksAtTS.Keys == CHAIN_IDS`). Neither guarantee unconditionally holds: if obs.chainsReady is false and obs.blocksAtTS is empty, both conditionals are vacuously satisfied but blocksAtTS.Keys != CHAIN_IDS (when CHAIN_IDS is non-empty). checkPreconditions presumably guards on obs.chainsReady, but it has no Dafny spec in the listed functions, so its postcondition cannot be treated as an established fact.; `BlocksExistedOnChain(blocksAtTS)` ✓ — observeRound ensures ObservationConsistentWithChainState(obs): `0 < |obs.blocksAtTS| ==> obs.blocksAtTS.Keys == CHAIN_IDS && BlocksExistedOnChain(obs.blocksAtTS)`. When obs.blocksAtTS is empty the predicate `BlocksExistedOnChain(blocksAtTS)` is vacuously true (universal quantification over an empty domain). So in every case established by observeRound's postconditions, BlocksExistedOnChain(obs.BlocksAtTS) holds. checkPreconditions does not modify obs, so the property is preserved at the verify call site.; `AdvancesAllLogsDBs(ts, blocksAtTS)` ? — observeRound ensures ObservationConsistentWithLogs(obs): `obs.chainsReady && obs.l2sConsistent && obs.l1Consistent ==> AdvancesAllLogsDBs(obs.nextTimestamp, obs.blocksAtTS)`. All three flags must be true for the guarantee to apply. checkPreconditions presumably enforces these flags before allowing the verify call to proceed, but checkPreconditions has no Dafny spec in the listed functions, so this conditional cannot be discharged from specs alone. |
+
+### Violation Scenarios
+
+**Precondition `blocksAtTS.Keys == CHAIN_IDS`** (uncertain):
+
+If checkPreconditions returns nil while obs.chainsReady is false (e.g., a code path that bypasses the chainsReady check), obs.BlocksAtTS.Keys would not equal CHAIN_IDS, violating this precondition. Not provable safe from the listed Dafny specs alone.
+
+**Precondition `AdvancesAllLogsDBs(ts, blocksAtTS)`** (uncertain):
+
+If checkPreconditions returns nil when obs.l2sConsistent or obs.l1Consistent is false (while obs.chainsReady is true), AdvancesAllLogsDBs(obs.nextTimestamp, obs.blocksAtTS) is not guaranteed by any listed spec, violating this precondition.
+
+---
+
+## 13. `observeRound` → `Interop.ObserveRound`
+
+**Go file**: `supernode/activity/interop/interop.go:532`  
+**Dafny**: `dafny-models/Interop.dfy` — class `Interop`, method `ObserveRound`  
+**Notes**: Go uses a two-phase L1 consistency check: it tracks both L1NeedsRewind (which triggers a rewind from the last-verified L1) and l1Consistent (whether all chains agree on L1). The Dafny model uses a single l1Consistent flag and does not model L1NeedsRewind as a distinct concept.  
+
+### Preconditions
+
+- [x] `Valid()` — **Satisfied**
+- [x] `AllDBsInSync()` — **Satisfied**
+
+### Postconditions
+
+- [x] `Valid()` — **Satisfied**
+- [x] `AllDBsInSync()` — **Satisfied**
+- [ ] `ValidRoundObservation(obs)` — **Violated** — ValidRoundObservation requires (!obs.l1Consistent ==> obs.lastVerifiedTS.Some?). When verifiedDB is empty (initialized=false on the LastTimestamp call), obs.LastVerifiedTS stays nil and obs.LastVerified stays nil. If checkChainsReady then returns successfully (obs.ChainsReady=true, obs.BlocksAtTS and obs.L1Heads set), the guard 'if obs.LastVerified != nil' is false, so the L1NeedsRewind branch is skipped entirely. Execution falls through to the frontier-heads SameL1Chain call and sets obs.L1Consistent = same. If same=false, obs.L1Consistent=false while obs.LastVerifiedTS=nil, violating the implication. The same violation occurs on the NotFound early-return path: obs.L1Consistent defaults to false (Go zero value) while obs.LastVerifiedTS may be nil when the verifiedDB is uninitialized.
+- [ ] `ObservationConsistentWithVerified(obs)` — **Violated** — ObservationConsistentWithVerified has ValidRoundObservation(obs) as a predicate precondition. The same scenario that violates POST3 (empty verifiedDB + frontier L1 check returns false) makes ValidRoundObservation(obs) false, so calling ObservationConsistentWithVerified(obs) is ill-typed and the ensures clause is violated. Additionally, the sub-condition obs.nextTimestamp == NextTimestamp() in the uninitialized branch (initialized=false) depends on firstVerifiableTimestamp() returning exactly activationTimestamp; this function carries no Dafny spec, so conformance cannot be confirmed from specs alone. In the initialized branch and under a valid ValidRoundObservation, the remaining sub-conditions hold: obs.LastVerifiedTS matches verifiedDB.lastTimestamp by direct assignment; the rewind sub-condition holds because Valid()/Sequential and AllDBsInSync() guarantee lastTS-1 is in verifiedDB.db when activationTimestamp < lastTS; and the AdvancesVerifiedDB sub-condition is vacuously true because obs.L2sConsistent is never set to true in observeRound (Go zero value is false).
+- [ ] `ObservationConsistentWithLogs(obs)` — **Violated** — ObservationConsistentWithLogs has both ValidRoundObservation(obs) and ObservationConsistentWithVerified(obs) as predicate preconditions. The POST3-violation scenario (empty verifiedDB + frontier L1 check returns false) makes ValidRoundObservation(obs) false, so the ensures clause is violated. In scenarios where ValidRoundObservation does hold: the rewind sub-condition (!obs.l1Consistent && lastVerifiedTS.value > activationTimestamp ==> sealed blocks for lastTS-1 exist) is satisfied because AllDBsInSync() guarantees DBsInSyncUpTo through lastTS, which covers lastTS-1; the advance sub-condition (chainsReady && l2sConsistent && l1Consistent ==> AdvancesAllLogsDBs) is vacuously true because observeRound never sets obs.L2sConsistent=true (Go zero value is false, a structural divergence from the Dafny model).
+- [x] `ObservationConsistentWithChainState(obs)` — **Satisfied**
+
+### Callsite Analysis
+
+| Caller | Precondition Verdicts |
+|---|---|
+| `progressInterop` (supernode/activity/interop/interop.go:513) | `Valid()` ✓ — The Dafny spec for progressInterop lists Valid() as a requires clause. observeRound is the first call in progressInterop (line 513), so Valid() is established at the call site with no intervening mutations.; `AllDBsInSync()` ✓ — The Dafny spec for progressInterop lists AllDBsInSync() as a requires clause. observeRound is the first call in progressInterop (line 513), so AllDBsInSync() is established at the call site with no intervening mutations. |
+
+### Violation Scenarios
+
+**Postcondition `ValidRoundObservation(obs)`** (violated):
+
+ValidRoundObservation requires (!obs.l1Consistent ==> obs.lastVerifiedTS.Some?). When verifiedDB is empty (initialized=false on the LastTimestamp call), obs.LastVerifiedTS stays nil and obs.LastVerified stays nil. If checkChainsReady then returns successfully (obs.ChainsReady=true, obs.BlocksAtTS and obs.L1Heads set), the guard 'if obs.LastVerified != nil' is false, so the L1NeedsRewind branch is skipped entirely. Execution falls through to the frontier-heads SameL1Chain call and sets obs.L1Consistent = same. If same=false, obs.L1Consistent=false while obs.LastVerifiedTS=nil, violating the implication. The same violation occurs on the NotFound early-return path: obs.L1Consistent defaults to false (Go zero value) while obs.LastVerifiedTS may be nil when the verifiedDB is uninitialized.
+
+**Postcondition `ObservationConsistentWithVerified(obs)`** (violated):
+
+ObservationConsistentWithVerified has ValidRoundObservation(obs) as a predicate precondition. The same scenario that violates POST3 (empty verifiedDB + frontier L1 check returns false) makes ValidRoundObservation(obs) false, so calling ObservationConsistentWithVerified(obs) is ill-typed and the ensures clause is violated. Additionally, the sub-condition obs.nextTimestamp == NextTimestamp() in the uninitialized branch (initialized=false) depends on firstVerifiableTimestamp() returning exactly activationTimestamp; this function carries no Dafny spec, so conformance cannot be confirmed from specs alone. In the initialized branch and under a valid ValidRoundObservation, the remaining sub-conditions hold: obs.LastVerifiedTS matches verifiedDB.lastTimestamp by direct assignment; the rewind sub-condition holds because Valid()/Sequential and AllDBsInSync() guarantee lastTS-1 is in verifiedDB.db when activationTimestamp < lastTS; and the AdvancesVerifiedDB sub-condition is vacuously true because obs.L2sConsistent is never set to true in observeRound (Go zero value is false).
+
+**Postcondition `ObservationConsistentWithLogs(obs)`** (violated):
+
+ObservationConsistentWithLogs has both ValidRoundObservation(obs) and ObservationConsistentWithVerified(obs) as predicate preconditions. The POST3-violation scenario (empty verifiedDB + frontier L1 check returns false) makes ValidRoundObservation(obs) false, so the ensures clause is violated. In scenarios where ValidRoundObservation does hold: the rewind sub-condition (!obs.l1Consistent && lastVerifiedTS.value > activationTimestamp ==> sealed blocks for lastTS-1 exist) is satisfied because AllDBsInSync() guarantees DBsInSyncUpTo through lastTS, which covers lastTS-1; the advance sub-condition (chainsReady && l2sConsistent && l1Consistent ==> AdvancesAllLogsDBs) is vacuously true because observeRound never sets obs.L2sConsistent=true (Go zero value is false, a structural divergence from the Dafny model).
+
+---
+
+## 14. `applyPendingTransition` → `Interop.ApplyPendingTransition`
+
+**Go file**: `supernode/activity/interop/interop.go:673`  
+**Dafny**: `dafny-models/Interop.dfy` — class `Interop`, method `ApplyPendingTransition`  
+**Notes**: Before any invalidateBlock call, Go pauses all chains' validation nodes via PauseAndStopVN and resumes non-invalidated chains afterwards; this VN lifecycle management has no counterpart in the Dafny model. Go also has a nil-result guard that calls ClearPendingTransition and returns gracefully when pending.Result == nil; the Dafny model treats this scenario as a precondition violation rather than a recoverable runtime condition.  
+
+### Preconditions
+
+- [x] `Valid()` — **Satisfied**
+- [x] `verifiedDB.GetPendingTransition() == Some(pending)` — **Satisfied**
+- [x] `PendingTransitionIsConsistent()` — **Satisfied**
+- [x] `TransitionIsCrossValid(pending)` — **Satisfied**
+- [x] `AllVerifiedCrossValid()` — **Satisfied**
+- [x] `AllLogsDBsConsistentWithChainData()` — **Satisfied**
+
+### Postconditions
+
+- [?] `Valid()` — **Uncertain** — DecisionInvalidate path: invalidateBlock has no Dafny spec, so it is unknown whether it preserves the Valid() invariants on verifiedDB and logsDBs. ClearPendingTransition only modifies verifiedDB.pendingTransition and cannot repair deeper invariant violations. DecisionAdvance path: commitVerifiedResult has no Dafny spec; if it leaves verifiedDB.db or logsDBs in a state that violates Valid() (e.g. non-sequential timestamps or mismatched l2Heads.Keys), Valid() would not hold despite the subsequent ClearPendingTransition call.
+- [?] `PendingTransitionIsConsistent()` — **Uncertain** — DecisionInvalidate success path: after ClearPendingTransition sets pendingTransition == None, PendingTransitionIsConsistent() requires AllDBsInSync(). invalidateBlock has no Dafny spec guaranteeing AllDBsInSync() is preserved. DecisionAdvance success path: after commitVerifiedResult and ClearPendingTransition, AllDBsInSync() is required; commitVerifiedResult has no spec confirming it performs the VerifiedDB.Commit step that would bring verifiedDB.db in line with the already-updated logsDBs. DecisionInvalidate error path with failedAny: pendingTransition == Some(pending) remains but the Invalidate extra condition AllDBsInSync() may be broken by partial invalidateBlock calls.
+- [?] `AllVerifiedCrossValid()` — **Uncertain** — DecisionInvalidate path: invalidateBlock has no Dafny spec; if it modifies verifiedDB.db in a way that adds or alters entries, previously cross-valid results might no longer satisfy ResultIsCrossValid under the new chain state. DecisionAdvance path: commitVerifiedResult has no Dafny spec; if it does not perform the VerifiedDB.Commit that establishes AllVerifiedCrossValid() for the new timestamp, the postcondition is unverified.
+- [?] `AllLogsDBsConsistentWithChainData()` — **Uncertain** — AllLogsDBsConsistentWithChainData() is a conjunct of Valid(). Same uncertainty applies: invalidateBlock (DecisionInvalidate) and commitVerifiedResult (DecisionAdvance) have no Dafny specs confirming they preserve the LogsDB-to-chain-data consistency invariant. ClearPendingTransition does not repair logsDB state.
+- [?] `madeProgress.None? ==> verifiedDB.pendingTransition == Some(pending)` — **Uncertain** — DecisionAdvance error from commitVerifiedResult: commitVerifiedResult has no Dafny spec. It is unknown whether it modifies verifiedDB.pendingTransition before returning an error. If it does (e.g. if it internally calls ClearPendingTransition or sets pendingTransition to None as part of a partial commit), the error return would have pendingTransition != Some(pending), violating this postcondition. All other error paths (applyRewindPlan failure, persistFrontierLogs failure, failedAny in Invalidate) do not call ClearPendingTransition first and the relevant modifies clauses (applyRewindPlan: verifiedDB.pendingTransition == old(verifiedDB.pendingTransition); ChainContainer.InvalidateBlock: modifies this only; persistFrontierLogs: modifies logsDBs.Values and chains.Values only) confirm pendingTransition is unchanged in those cases.
+- [?] `madeProgress.Some? ==> verifiedDB.pendingTransition == None` — **Uncertain** — All successful Go return paths call ClearPendingTransition last, which ensures pendingTransition == None — but ClearPendingTransition requires Valid() as a precondition. For DecisionInvalidate: Valid() after invalidateBlock calls is not guaranteed (no spec for invalidateBlock), so the precondition of ClearPendingTransition may be violated and its postcondition (pendingTransition == None) cannot be relied upon. For DecisionAdvance: Valid() after commitVerifiedResult is not guaranteed (no spec), same issue.
+- [x] `madeProgress.Some? ==> (madeProgress.value <==> pending.decision == Advance)` — **Satisfied**
+- [?] `madeProgress.Some? ==> AllDBsInSync()` — **Uncertain** — DecisionInvalidate success: after invalidateBlock calls, AllDBsInSync() requires each chain's logsDB LatestSealedBlock to match the verifiedDB's latest verified l2Head. invalidateBlock has no Dafny spec guaranteeing this; it may rewind some logsDBs but leave verifiedDB.db unchanged, or vice versa. DecisionAdvance success: persistFrontierLogs postcondition ensures UpdatedAllLogsDBs (logsDBs advanced), but commitVerifiedResult has no Dafny spec to confirm it performs the VerifiedDB.Commit step that would make verifiedDB.db consistent with those logsDB updates, so AllDBsInSync() is unverified.
+- [?] `madeProgress.None? ==> TransitionIsCrossValid(pending)` — **Uncertain** — TransitionIsCrossValid is trivially true for Rewind and Invalidate decisions, so error paths in those branches satisfy this postcondition trivially. For DecisionAdvance errors from commitVerifiedResult: commitVerifiedResult has no Dafny spec; if it modifies logsDBs (which AllInitMsgsPresent/InitMsgInLogsDB depends on) in a way that removes entries needed by ResultIsCrossValid(pending.result.value), the postcondition could be violated. persistFrontierLogs errors are safe because its partial-update postcondition only adds blocks to logsDBs (Contains is monotone), which can only maintain or strengthen InitMsgInLogsDB queries.
+
+### Callsite Analysis
+
+| Caller | Precondition Verdicts |
+|---|---|
+| `progressAndRecord` (supernode/activity/interop/interop.go:467) | `Valid()` ✓ — Valid() is a direct precondition of progressAndRecord. GetPendingTransition() is frame-safe (no modifies clause), so Valid() is unmodified between progressAndRecord entry and the call.; `verifiedDB.GetPendingTransition() == Some(pending)` ✓ — pending is the non-nil result of GetPendingTransition(); applyPendingTransition receives *pending. Nothing between the GetPendingTransition call and the applyPendingTransition call modifies verifiedDB.pendingTransition, so GetPendingTransition() == Some(*pending) at the call.; `PendingTransitionIsConsistent()` ✓ — PendingTransitionIsConsistent() is a direct precondition of progressAndRecord; GetPendingTransition() is frame-safe, so it holds unchanged at the call.; `TransitionIsCrossValid(pending)` ✓ — progressAndRecord precondition: GetPendingTransition().Some? ==> TransitionIsCrossValid(...). Since pending != nil the Some? branch fires, yielding TransitionIsCrossValid(*pending).; `AllVerifiedCrossValid()` ✓ — AllVerifiedCrossValid() is a direct precondition of progressAndRecord; frame-safe GetPendingTransition() does not change verifiedDB.db.; `AllLogsDBsConsistentWithChainData()` ✓ — AllLogsDBsConsistentWithChainData() is a conjunct of Valid(). Valid() is a direct precondition of progressAndRecord; frame-safe GetPendingTransition() does not disturb it. |
+| `progressAndRecord` (supernode/activity/interop/interop.go:490) | `Valid()` ✓ — progressInterop postcondition ensures Valid(). buildPendingTransition is frame-safe. SetPendingTransition postcondition ensures Valid(). All three preserve Valid() up to the call.; `verifiedDB.GetPendingTransition() == Some(pending)` ✓ — SetPendingTransition postcondition ensures pendingTransition == Some(pendingTx). applyPendingTransition(pendingTx) is called immediately after with no intervening state changes, so GetPendingTransition() == Some(pendingTx) == Some(pending).; `PendingTransitionIsConsistent()` ✓ — progressInterop postcondition yields AllDBsInSync(). buildPendingTransition postcondition yields TransitionConsistentWithVerified, TransitionConsistentWithLogs, and TransitionConsistentWithChainState (via OutputConsistentWithChainState from progressInterop). SetPendingTransition does not change verifiedDB.db or logsDBs. For each decision: Invalidate/Advance require AllDBsInSync() (preserved through frame-safe operations); Rewind extra condition AllDBsInSyncUpTo(resetAllChainsTo.value) follows because that timestamp <= LastTimestamp() and AllDBsInSync() implies AllDBsInSyncUpTo for any timestamp at or below LastTimestamp().; `TransitionIsCrossValid(pending)` ✓ — progressInterop postcondition: output.AdvanceOutput? ==> ResultIsCrossValid(output.result). buildPendingTransition postcondition: output.AdvanceOutput? <==> pendingTx.decision.Advance? and pendingTx.result.value == output.result for Advance. TransitionIsCrossValid is trivially true for Rewind and Invalidate decisions.; `AllVerifiedCrossValid()` ✓ — progressInterop postcondition ensures AllVerifiedCrossValid(). buildPendingTransition is frame-safe. SetPendingTransition does not modify verifiedDB.db (postcondition: db == old(db)), so AllVerifiedCrossValid() is preserved.; `AllLogsDBsConsistentWithChainData()` ✓ — progressInterop postcondition ensures Valid() which includes AllLogsDBsConsistentWithChainData(). buildPendingTransition is frame-safe; SetPendingTransition only modifies verifiedDB.pendingTransition. Condition preserved at the call. |
+
+### Violation Scenarios
+
+**Postcondition `Valid()`** (uncertain):
+
+DecisionInvalidate path: invalidateBlock has no Dafny spec, so it is unknown whether it preserves the Valid() invariants on verifiedDB and logsDBs. ClearPendingTransition only modifies verifiedDB.pendingTransition and cannot repair deeper invariant violations. DecisionAdvance path: commitVerifiedResult has no Dafny spec; if it leaves verifiedDB.db or logsDBs in a state that violates Valid() (e.g. non-sequential timestamps or mismatched l2Heads.Keys), Valid() would not hold despite the subsequent ClearPendingTransition call.
+
+**Postcondition `PendingTransitionIsConsistent()`** (uncertain):
+
+DecisionInvalidate success path: after ClearPendingTransition sets pendingTransition == None, PendingTransitionIsConsistent() requires AllDBsInSync(). invalidateBlock has no Dafny spec guaranteeing AllDBsInSync() is preserved. DecisionAdvance success path: after commitVerifiedResult and ClearPendingTransition, AllDBsInSync() is required; commitVerifiedResult has no spec confirming it performs the VerifiedDB.Commit step that would bring verifiedDB.db in line with the already-updated logsDBs. DecisionInvalidate error path with failedAny: pendingTransition == Some(pending) remains but the Invalidate extra condition AllDBsInSync() may be broken by partial invalidateBlock calls.
+
+**Postcondition `AllVerifiedCrossValid()`** (uncertain):
+
+DecisionInvalidate path: invalidateBlock has no Dafny spec; if it modifies verifiedDB.db in a way that adds or alters entries, previously cross-valid results might no longer satisfy ResultIsCrossValid under the new chain state. DecisionAdvance path: commitVerifiedResult has no Dafny spec; if it does not perform the VerifiedDB.Commit that establishes AllVerifiedCrossValid() for the new timestamp, the postcondition is unverified.
+
+**Postcondition `AllLogsDBsConsistentWithChainData()`** (uncertain):
+
+AllLogsDBsConsistentWithChainData() is a conjunct of Valid(). Same uncertainty applies: invalidateBlock (DecisionInvalidate) and commitVerifiedResult (DecisionAdvance) have no Dafny specs confirming they preserve the LogsDB-to-chain-data consistency invariant. ClearPendingTransition does not repair logsDB state.
+
+**Postcondition `madeProgress.None? ==> verifiedDB.pendingTransition == Some(pending)`** (uncertain):
+
+DecisionAdvance error from commitVerifiedResult: commitVerifiedResult has no Dafny spec. It is unknown whether it modifies verifiedDB.pendingTransition before returning an error. If it does (e.g. if it internally calls ClearPendingTransition or sets pendingTransition to None as part of a partial commit), the error return would have pendingTransition != Some(pending), violating this postcondition. All other error paths (applyRewindPlan failure, persistFrontierLogs failure, failedAny in Invalidate) do not call ClearPendingTransition first and the relevant modifies clauses (applyRewindPlan: verifiedDB.pendingTransition == old(verifiedDB.pendingTransition); ChainContainer.InvalidateBlock: modifies this only; persistFrontierLogs: modifies logsDBs.Values and chains.Values only) confirm pendingTransition is unchanged in those cases.
+
+**Postcondition `madeProgress.Some? ==> verifiedDB.pendingTransition == None`** (uncertain):
+
+All successful Go return paths call ClearPendingTransition last, which ensures pendingTransition == None — but ClearPendingTransition requires Valid() as a precondition. For DecisionInvalidate: Valid() after invalidateBlock calls is not guaranteed (no spec for invalidateBlock), so the precondition of ClearPendingTransition may be violated and its postcondition (pendingTransition == None) cannot be relied upon. For DecisionAdvance: Valid() after commitVerifiedResult is not guaranteed (no spec), same issue.
+
+**Postcondition `madeProgress.Some? ==> AllDBsInSync()`** (uncertain):
+
+DecisionInvalidate success: after invalidateBlock calls, AllDBsInSync() requires each chain's logsDB LatestSealedBlock to match the verifiedDB's latest verified l2Head. invalidateBlock has no Dafny spec guaranteeing this; it may rewind some logsDBs but leave verifiedDB.db unchanged, or vice versa. DecisionAdvance success: persistFrontierLogs postcondition ensures UpdatedAllLogsDBs (logsDBs advanced), but commitVerifiedResult has no Dafny spec to confirm it performs the VerifiedDB.Commit step that would make verifiedDB.db consistent with those logsDB updates, so AllDBsInSync() is unverified.
+
+**Postcondition `madeProgress.None? ==> TransitionIsCrossValid(pending)`** (uncertain):
+
+TransitionIsCrossValid is trivially true for Rewind and Invalidate decisions, so error paths in those branches satisfy this postcondition trivially. For DecisionAdvance errors from commitVerifiedResult: commitVerifiedResult has no Dafny spec; if it modifies logsDBs (which AllInitMsgsPresent/InitMsgInLogsDB depends on) in a way that removes entries needed by ResultIsCrossValid(pending.result.value), the postcondition could be violated. persistFrontierLogs errors are safe because its partial-update postcondition only adds blocks to logsDBs (Contains is monotone), which can only maintain or strengthen InitMsgInLogsDB queries.
+
+---
+
+## 15. `progressInterop` → `Interop.ProgressInterop`
+
+**Go file**: `supernode/activity/interop/interop.go:512`  
+**Dafny**: `dafny-models/Interop.dfy` — class `Interop`, method `ProgressInterop`  
+**Notes**: The precondition-check logic is extracted into a separate standalone function checkPreconditions in Go; the Dafny model inlines this logic directly inside ProgressInterop. Go also supports a Paused state (controlled by pauseAtTimestamp) that silently halts verification progress; this concept is absent from the Dafny model.  
+
+### Preconditions
+
+- [x] `Valid()` — **Satisfied**
+- [x] `AllDBsInSync()` — **Satisfied**
+- [x] `AllVerifiedCrossValid()` — **Satisfied**
+
+### Postconditions
+
+- [x] `Valid()` — **Satisfied**
+- [x] `AllDBsInSync()` — **Satisfied**
+- [x] `AllVerifiedCrossValid()` — **Satisfied**
+- [x] `ValidStepOutput(output, obs)` — **Satisfied**
+- [?] `OutputConsistentWithVerified(output, obs)` — **Uncertain** — For the AdvanceOutput case, OutputConsistentWithVerified requires AdvancesVerifiedDB(result.timestamp, result.l2Heads). ObservationConsistentWithVerified (ensured by observeRound) only guarantees AdvancesVerifiedDB when obs.chainsReady && obs.l2sConsistent && obs.l1Consistent. However, observeRound in Go never sets obs.L2sConsistent — it retains its zero value (false) — so the antecedent of that implication is never satisfied and AdvancesVerifiedDB is not established through any listed Dafny postcondition. An informal argument (AllDBsInSync() precondition + checkChainsReady postcondition AdvancesAllLogsDBs implies AdvancesVerifiedDB) would establish it, but this equivalence is not captured by any Dafny lemma or spec in scope.
+- [?] `OutputConsistentWithLogs(output, obs)` — **Uncertain** — OutputConsistentWithLogs carries a requires of OutputConsistentWithVerified(output, obs). For the AdvanceOutput case that requires clause is uncertain (see post 5). For WaitOutput and RewindOutput the requires is satisfied and ObservationConsistentWithLogs (ensured by observeRound) supplies the needed sealed-block property for the RewindOutput path; for AdvanceOutput, checkChainsReady ensures AdvancesAllLogsDBs independently, but since the requires (post 5) is uncertain the overall status of post 6 is uncertain.
+- [x] `OutputConsistentWithChainState(output, obs)` — **Satisfied**
+- [x] `output.AdvanceOutput? ==> ResultIsCrossValid(output.result)` — **Satisfied**
+
+### Callsite Analysis
+
+| Caller | Precondition Verdicts |
+|---|---|
+| `progressAndRecord` (supernode/activity/interop/interop.go:471) | `Valid()` ✓ — progressAndRecord's Dafny spec requires Valid(). Before the call to progressInterop at line 471, only verifiedDB.GetPendingTransition() (frame-safe, no modifies) executes. When pending != nil the function returns early via applyPendingTransition without reaching progressInterop. No state is modified between the entry of progressAndRecord and the call to progressInterop, so Valid() holds at the call site.; `AllDBsInSync()` ✓ — progressAndRecord requires PendingTransitionIsConsistent(). When verifiedDB.GetPendingTransition() returns None (pending == nil in Go), PendingTransitionIsConsistent() reduces to AllDBsInSync(). progressInterop is only reachable when pending == nil (the non-nil branch returns early at line 467). GetPendingTransition() is frame-safe, so AllDBsInSync() is unmodified at the call site.; `AllVerifiedCrossValid()` ✓ — progressAndRecord requires AllVerifiedCrossValid(). Only the frame-safe GetPendingTransition() executes before progressInterop is called, leaving AllVerifiedCrossValid() unmodified at the call site. |
+
+### Violation Scenarios
+
+**Postcondition `OutputConsistentWithVerified(output, obs)`** (uncertain):
+
+For the AdvanceOutput case, OutputConsistentWithVerified requires AdvancesVerifiedDB(result.timestamp, result.l2Heads). ObservationConsistentWithVerified (ensured by observeRound) only guarantees AdvancesVerifiedDB when obs.chainsReady && obs.l2sConsistent && obs.l1Consistent. However, observeRound in Go never sets obs.L2sConsistent — it retains its zero value (false) — so the antecedent of that implication is never satisfied and AdvancesVerifiedDB is not established through any listed Dafny postcondition. An informal argument (AllDBsInSync() precondition + checkChainsReady postcondition AdvancesAllLogsDBs implies AdvancesVerifiedDB) would establish it, but this equivalence is not captured by any Dafny lemma or spec in scope.
+
+**Postcondition `OutputConsistentWithLogs(output, obs)`** (uncertain):
+
+OutputConsistentWithLogs carries a requires of OutputConsistentWithVerified(output, obs). For the AdvanceOutput case that requires clause is uncertain (see post 5). For WaitOutput and RewindOutput the requires is satisfied and ObservationConsistentWithLogs (ensured by observeRound) supplies the needed sealed-block property for the RewindOutput path; for AdvanceOutput, checkChainsReady ensures AdvancesAllLogsDBs independently, but since the requires (post 5) is uncertain the overall status of post 6 is uncertain.
+
+---
+
+## 16. `progressAndRecord` → `Interop.ProgressAndRecord`
+
+**Go file**: `supernode/activity/interop/interop.go:460`  
+**Dafny**: `dafny-models/Interop.dfy` — class `Interop`, method `ProgressAndRecord`  
+
+### Preconditions
+
+- [?] `Valid()` — **Uncertain** — If a prior invocation of `applyPendingTransition` returned a Go error after partially mutating `verifiedDB` or `logsDBs`, `Valid()` (which requires `verifiedDB.Valid()`, `AllLogsDBsConsistentWithChainData()`, sequential commits, etc.) could be broken before the next call to `progressAndRecord`. Dafny models errors as `None` returns and does not cover partial mutations on Go error paths, so this scenario is outside the formal model but observable in the implementation.
+- [?] `PendingTransitionIsConsistent()` — **Uncertain** — Same error-path scenario as `Valid()`: if `applyPendingTransition` partially rewinds or advances `verifiedDB`/`logsDBs` before returning a Go error, `logsDBs` and `verifiedDB` could be out of sync, violating `AllDBsInSync()` and therefore `PendingTransitionIsConsistent()` at the next call site.
+- [?] `AllVerifiedCrossValid()` — **Uncertain** — If `applyPendingTransition` commits a new timestamp to `verifiedDB` but then fails before updating the logsDBs to match, the new entry in `verifiedDB` would not satisfy `ResultIsCrossValid` (because `AllInitMsgsInLogsDB` could fail), violating `AllVerifiedCrossValid()` at the next entry to `progressAndRecord`.
+- [?] `verifiedDB.GetPendingTransition().Some? ==> TransitionIsCrossValid(verifiedDB.GetPendingTransition().value)` — **Uncertain** — If a future version of the code stores a pending transition in `verifiedDB` before the cross-validity of its result is confirmed (e.g., calling `SetPendingTransition` before `progressInterop` validates the blocks), then a crash-and-restart picking up that pending transition would find `TransitionIsCrossValid` not holding. This is not the current code flow, but the condition cannot be proven satisfied purely from the Go code without formal verification.
+
+### Postconditions
+
+- [x] `Valid()` — **Satisfied**
+- [x] `PendingTransitionIsConsistent()` — **Satisfied**
+- [x] `AllVerifiedCrossValid()` — **Satisfied**
+- [x] `verifiedDB.GetPendingTransition().Some? ==> TransitionIsCrossValid(verifiedDB.GetPendingTransition().value)` — **Satisfied**
+
+### Callsite Analysis
+
+| Caller | Precondition Verdicts |
+|---|---|
+| `progress` (supernode/activity/interop/interop.go:386) | `Valid()` ? — `progress` calls `progressAndRecord` as its first statement with no prior action that establishes or checks `Valid()`. `Valid()` must therefore hold on entry to `progress` itself, which requires tracing the full call chain back to the constructor. The constructor ensures `Valid()`, and every in-scope mapped function (including `applyPendingTransition`, `progressInterop`, `refreshCurrentL1OnWait`, `SetPendingTransition`) lists `Valid()` in its postconditions, so the invariant is designed to be maintained across calls. However, Go provides no static enforcement of this; an I/O-error early-exit from `applyPendingTransition` (modifies `this, verifiedDB, chains.Values, logsDBs.Values`) could leave the object in a state where `Valid()` no longer holds before the next invocation of `progress`.; `PendingTransitionIsConsistent()` ? — `progress` performs no action before calling `progressAndRecord`, so `PendingTransitionIsConsistent()` must hold on entry to `progress`. When `verifiedDB.GetPendingTransition() == None`, this collapses to `AllDBsInSync()`; when `Some(p)`, it additionally requires `TransitionConsistentWithVerified(p)`, `TransitionConsistentWithLogs(p)`, and `TransitionConsistentWithChainState(p)`. `applyPendingTransition` ensures `PendingTransitionIsConsistent()` post-call, and `progressInterop` ensures `AllDBsInSync()`, so the invariant is designed to be propagated. The same caveat applies as for `Valid()`: a Go-error path out of `applyPendingTransition` after partial DB mutation could leave `AllDBsInSync()` violated for the next round.; `AllVerifiedCrossValid()` ? — `progress` does not check or establish `AllVerifiedCrossValid()`. The constructor ensures it; `applyPendingTransition` and `progressInterop` both list it in their postconditions; and functions that do not modify `verifiedDB` or `logsDBs.Values` (e.g., `buildPendingTransition`, `refreshCurrentL1OnWait`) preserve it by framing. The same caveat applies: a Go error mid-way through `applyPendingTransition` (which commits to `verifiedDB` before potentially failing) could invalidate a just-committed result, breaking `AllVerifiedCrossValid()` before the next call.; `verifiedDB.GetPendingTransition().Some? ==> TransitionIsCrossValid(verifiedDB.GetPendingTransition().value)` ? — `progress` does not check this condition. The invariant is maintained by: (a) the constructor ensuring it, (b) `applyPendingTransition` postcondition ensuring it when `madeProgress.None?` (pending kept), and clearing the pending when `madeProgress.Some?` (vacuously satisfied). In path 2c of `progressAndRecord`, `TransitionIsCrossValid(pendingTx)` is established from `progressInterop`'s `output.AdvanceOutput? ==> ResultIsCrossValid(output.result)` combined with `buildPendingTransition`'s `pendingTx.decision.Advance? <==> output.AdvanceOutput?` and `pendingTx.decision.Advance? ==> pendingTx.result.value == output.result`. However, if a prior Go error left a pending transition in `verifiedDB` whose cross-validity was not confirmed (e.g., stored before `ResultIsCrossValid` was established), this precondition could be violated. |
+
+### Violation Scenarios
+
+**Precondition `Valid()`** (uncertain):
+
+If a prior invocation of `applyPendingTransition` returned a Go error after partially mutating `verifiedDB` or `logsDBs`, `Valid()` (which requires `verifiedDB.Valid()`, `AllLogsDBsConsistentWithChainData()`, sequential commits, etc.) could be broken before the next call to `progressAndRecord`. Dafny models errors as `None` returns and does not cover partial mutations on Go error paths, so this scenario is outside the formal model but observable in the implementation.
+
+**Precondition `PendingTransitionIsConsistent()`** (uncertain):
+
+Same error-path scenario as `Valid()`: if `applyPendingTransition` partially rewinds or advances `verifiedDB`/`logsDBs` before returning a Go error, `logsDBs` and `verifiedDB` could be out of sync, violating `AllDBsInSync()` and therefore `PendingTransitionIsConsistent()` at the next call site.
+
+**Precondition `AllVerifiedCrossValid()`** (uncertain):
+
+If `applyPendingTransition` commits a new timestamp to `verifiedDB` but then fails before updating the logsDBs to match, the new entry in `verifiedDB` would not satisfy `ResultIsCrossValid` (because `AllInitMsgsInLogsDB` could fail), violating `AllVerifiedCrossValid()` at the next entry to `progressAndRecord`.
+
+**Precondition `verifiedDB.GetPendingTransition().Some? ==> TransitionIsCrossValid(verifiedDB.GetPendingTransition().value)`** (uncertain):
+
+If a future version of the code stores a pending transition in `verifiedDB` before the cross-validity of its result is confirmed (e.g., calling `SetPendingTransition` before `progressInterop` validates the blocks), then a crash-and-restart picking up that pending transition would find `TransitionIsCrossValid` not holding. This is not the current code flow, but the condition cannot be proven satisfied purely from the Go code without formal verification.
+
+---


### PR DESCRIPTION
## Description

This republishes #21820 from a repository-owned branch, rebased onto the latest `develop`, so maintainers can update the branch and CI can run against the current tree.

The original change adds an abstract OP Supernode model implemented in Dafny. It formally verifies critical design properties, including core invariants, cross-validity of `VerifiedDB` entries, and recovery of database consistency after successful pending-transition application. It also includes an AI-assisted analysis report comparing the model specifications with the Go implementation.

## Commit preservation

All 10 commits from #21820 were replayed in their original order with the original author attribution. `git range-diff` reports an exact patch match for every commit.

## Why

The source branch for #21820 is 836 upstream commits behind and has maintainer edits disabled, so it cannot be updated by repository maintainers. Rebasing the same commits onto current `develop` also incorporates the CI workflow changes made since its last run.

## Validation

- Rebase onto current `develop` completed without conflicts.
- `git range-diff` matched all 10 original commits one-for-one.
- The final diff contains only the original seven files under `op-supernode/dafny-models/`.
- No Go code changed.
- The Dafny CLI is not installed in the local environment, so the model was not re-verified locally.

Original PR and authorship: #21820 by @lucasmt.