### PR TITLE
op-deployer: set the default genesis time offset to 3H

### DIFF
--- a/op-deployer/pkg/deployer/flags.go
+++ b/op-deployer/pkg/deployer/flags.go
@@ -148,7 +148,8 @@ var (
 		Name: GenesisTimeOffsetFlagName,
 		Usage: "Offset in seconds added to the L1 anchor block's timestamp to produce the committed L2 genesis " +
 			"timestamp. Must cover the runtime of the off-chain pipeline between anchor selection and OPCM.deploy " +
-			"landing on L1, including the prestate build.",
+			"landing on L1, including the prestate build. " +
+			fmt.Sprintf("Must be at least %d seconds.", standard.MinGenesisTimeOffsetSeconds),
 		EnvVars: PrefixEnvVar("GENESIS_TIME_OFFSET"),
 		Value:   standard.DefaultGenesisTimeOffsetSeconds,
 	}

--- a/op-deployer/pkg/deployer/integration_test/cli/continue_test.go
+++ b/op-deployer/pkg/deployer/integration_test/cli/continue_test.go
@@ -172,7 +172,7 @@ func newContinueCLIFixture(t *testing.T) *continueCLIFixture {
 		PrivateKey:        privateKey,
 		L1RPCUrl:          l1RPC,
 		CacheDir:          setupCacheDir,
-		GenesisTimeOffset: 600,
+		GenesisTimeOffset: standard.MinGenesisTimeOffsetSeconds,
 	}))
 
 	prepared, err := pipeline.ReadState(preparedWorkdir)

--- a/op-deployer/pkg/deployer/integration_test/cli/pcd_boot_test.go
+++ b/op-deployer/pkg/deployer/integration_test/cli/pcd_boot_test.go
@@ -20,7 +20,8 @@ func TestCLIPCDBoot(t *testing.T) {
 
 	// Backdate L1 so the L2 genesis time is in the past when the node starts.
 	// The sequencer cannot create block 1 before that time.
-	requestedL1Timestamp := uint64(time.Now().Add(-time.Hour).Unix())
+	backdate := time.Duration(pcdGenesisTimeOffset)*time.Second + time.Hour
+	requestedL1Timestamp := uint64(time.Now().Add(-backdate).Unix())
 	chainIDs := []common.Hash{uint256.NewInt(1).Bytes32()}
 	journey := newPCDJourneyFixtureWithAnvilOptions(
 		t,

--- a/op-deployer/pkg/deployer/integration_test/cli/pcd_fixture.go
+++ b/op-deployer/pkg/deployer/integration_test/cli/pcd_fixture.go
@@ -32,7 +32,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const pcdGenesisTimeOffset = 600
+const pcdGenesisTimeOffset = standard.MinGenesisTimeOffsetSeconds
 
 type pcdChainArtifacts struct {
 	chainID     common.Hash

--- a/op-deployer/pkg/deployer/integration_test/continue_test.go
+++ b/op-deployer/pkg/deployer/integration_test/continue_test.go
@@ -601,7 +601,7 @@ func newContinuationEnvWithIntentMutator(
 		PrivateKey:        privateKey,
 		L1RPCUrl:          l1RPC,
 		CacheDir:          cacheDir,
-		GenesisTimeOffset: 600,
+		GenesisTimeOffset: standard.MinGenesisTimeOffsetSeconds,
 	}))
 
 	prepared, err := pipeline.ReadState(workdir)

--- a/op-deployer/pkg/deployer/prepare.go
+++ b/op-deployer/pkg/deployer/prepare.go
@@ -64,6 +64,10 @@ func (c *PrepareConfig) Check() error {
 		return fmt.Errorf("l1 RPC URL must be specified")
 	}
 
+	if c.GenesisTimeOffset < standard.MinGenesisTimeOffsetSeconds {
+		return fmt.Errorf("genesis time offset must be at least %d seconds", standard.MinGenesisTimeOffsetSeconds)
+	}
+
 	return nil
 }
 
@@ -393,7 +397,6 @@ func predictChains(
 				return fmt.Errorf("failed to select anchor block for chain %s: %w", chain.ID.Hex(), err)
 			}
 
-			// TODO(#20916): A reasonable minimum will be enforced in the future, once the L2 deployment is benchmarked.
 			// Commit the anchor and the genesis time.
 			genesisTime = hexutil.Uint64(uint64(anchorBlock.Time) + genesisTimeOffset)
 			st.PinChainAnchor(chain.ID, anchorBlock, genesisTime)

--- a/op-deployer/pkg/deployer/prepare_test.go
+++ b/op-deployer/pkg/deployer/prepare_test.go
@@ -77,9 +77,9 @@ func TestNewPrepareConfig_FlagsPassed(t *testing.T) {
 
 func TestNewPrepareConfig_GenesisTimeOffsetOverride(t *testing.T) {
 	cliCtx := newPrepareCtx(t, testPrivKey)
-	require.NoError(t, cliCtx.Set(GenesisTimeOffsetFlagName, "900"))
+	require.NoError(t, cliCtx.Set(GenesisTimeOffsetFlagName, "7200"))
 	cfg := newPrepareConfig(cliCtx, log.NewLogger(log.DiscardHandler()))
-	require.EqualValues(t, 900, cfg.GenesisTimeOffset)
+	require.EqualValues(t, 7200, cfg.GenesisTimeOffset)
 }
 
 func TestMakePredictionInput(t *testing.T) {
@@ -399,12 +399,21 @@ func TestResolveSuperchainConfigProxy(t *testing.T) {
 
 func TestPrepareConfigCheck(t *testing.T) {
 	valid := PrepareConfig{
-		Workdir:    "/tmp",
-		Logger:     log.NewLogger(log.DiscardHandler()),
-		PrivateKey: testPrivKey,
-		L1RPCUrl:   testL1RPCUrl,
+		Workdir:           "/tmp",
+		Logger:            log.NewLogger(log.DiscardHandler()),
+		PrivateKey:        testPrivKey,
+		L1RPCUrl:          testL1RPCUrl,
+		GenesisTimeOffset: standard.DefaultGenesisTimeOffsetSeconds,
 	}
 	require.NoError(t, valid.Check())
+
+	atMinimumOffset := valid
+	atMinimumOffset.GenesisTimeOffset = standard.MinGenesisTimeOffsetSeconds
+	require.NoError(t, atMinimumOffset.Check())
+
+	belowMinimumOffset := valid
+	belowMinimumOffset.GenesisTimeOffset = standard.MinGenesisTimeOffsetSeconds - 1
+	require.ErrorContains(t, belowMinimumOffset.Check(), "genesis time offset must be at least")
 
 	missingKey := valid
 	missingKey.PrivateKey = ""
@@ -1298,10 +1307,11 @@ func TestPrepare_RejectsAppliedWorkdir(t *testing.T) {
 	require.NoError(t, st.WriteToFile(filepath.Join(workdir, "state.json")))
 
 	err := Prepare(context.Background(), PrepareConfig{
-		Workdir:    workdir,
-		Logger:     testlog.Logger(t, slog.LevelWarn),
-		PrivateKey: testPrivKey,
-		L1RPCUrl:   testL1RPCUrl,
+		Workdir:           workdir,
+		Logger:            testlog.Logger(t, slog.LevelWarn),
+		PrivateKey:        testPrivKey,
+		L1RPCUrl:          testL1RPCUrl,
+		GenesisTimeOffset: standard.DefaultGenesisTimeOffsetSeconds,
 	})
 	require.ErrorContains(t, err, "cannot be prepared")
 }

--- a/op-deployer/pkg/deployer/standard/standard.go
+++ b/op-deployer/pkg/deployer/standard/standard.go
@@ -40,11 +40,11 @@ const (
 	Eip1559Denominator       uint64 = 50
 	Eip1559Elasticity        uint64 = 6
 
-	// TODO(#20916): This value should be replaced with a benchmark based on the time it takes to perform a full
-	// L2 genesis deployment.
 	// DefaultGenesisTimeOffsetSeconds is the default offset added to the L1 anchor block's
 	// timestamp to produce the committed L2 genesis timestamp.
-	DefaultGenesisTimeOffsetSeconds uint64 = 21600 // 6 hours
+	DefaultGenesisTimeOffsetSeconds uint64 = 10800 // 3 hours
+	// MinGenesisTimeOffsetSeconds is the smallest offset prepare accepts.
+	MinGenesisTimeOffsetSeconds uint64 = 3600 // 1 hour
 
 	ContractsV160Tag        = "op-contracts/v1.6.0"
 	ContractsV180Tag        = "op-contracts/v1.8.0-rc.4"


### PR DESCRIPTION
## Context
`DefaultGenesisTimeOffsetSeconds` drops from 6h to 3h. A new `MinGenesisTimeOffsetSeconds` of 1h is enforced in `PrepareConfig.Check`. Resolves the `TODO(#20916)` that deferred a minimum until the L2 deployment was benchmarked.

## Tests

- `TestPrepareConfigCheck` covers both edges of the floor.
- Updates tests to use `MinGenesisTimeOffsetSeconds`.

Closes #20916