### PR TITLE
kona-node: increase Tokio worker stack size

### DIFF
--- a/rust/kona/bin/node/src/cli.rs
+++ b/rust/kona/bin/node/src/cli.rs
@@ -99,10 +99,16 @@ impl Cli {
         })
     }
 
-    /// Creates a new default tokio multi-thread [Runtime](tokio::runtime::Runtime) with all
-    /// features enabled
+    /// Creates a new tokio multi-thread [Runtime](tokio::runtime::Runtime) with all features
+    /// enabled.
     pub fn tokio_runtime() -> Result<tokio::runtime::Runtime, std::io::Error> {
-        tokio::runtime::Builder::new_multi_thread().enable_all().build()
+        // The deeply nested derivation pipeline can exhaust Tokio's default 2 MiB worker stack.
+        // Use the size validated against initial historical derivation, with enough headroom for
+        // native library calls made from the pipeline.
+        tokio::runtime::Builder::new_multi_thread()
+            .thread_stack_size(8 * 1024 * 1024)
+            .enable_all()
+            .build()
     }
 }
 


### PR DESCRIPTION
## Summary

Increase kona-node's Tokio worker stack from the 2 MiB default to 8 MiB.

During initial historical derivation, the deeply nested pipeline exhausted the default worker stack and terminated with SIGSEGV before Rust could report a stack overflow. All six observed crashes faulted from `tokio-rt-worker` at the same instruction in `_dl_catch_exception`, immediately after its stack-frame allocation crossed into the guard page.

Running the same image and workload with `RUST_MIN_STACK=8388608` completed historical derivation and caught up without restarts. Configuring the validated size in Kona makes that runtime requirement independent of deployment configuration.

## Testing

- `cargo nextest run --package kona-node` (79 passed)
- `just lint`
- Live historical-derivation validation with an 8 MiB worker stack
