### PR TITLE
op-e2e: mark TestSequencerFailover_ConductorRPC as flaky

### DIFF
--- a/op-e2e/system/conductor/sequencer_failover_test.go
+++ b/op-e2e/system/conductor/sequencer_failover_test.go
@@ -30,6 +30,8 @@ func TestSequencerFailover_SetupCluster(t *testing.T) {
 // [Category: conductor rpc]
 // In this test, we test all rpcs exposed by conductor.
 func TestSequencerFailover_ConductorRPC(t *testing.T) {
+	t.Skip("Flaky test tracked in ethereum-optimism/optimism#22094")
+
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 	sys, conductors, cleanup := setupSequencerFailoverTest(t)


### PR DESCRIPTION
## Summary

- skip `TestSequencerFailover_ConductorRPC` while its leadership-transfer flake is unresolved
- link the skip to tracking issue #22094

## Test plan

- `go test ./op-e2e/system/conductor -run '^TestSequencerFailover_ConductorRPC$' -count=1`