### PR TITLE
kona-node: instrument Tokio worker stack overflow

### DIFF
--- a/rust/kona/bin/node/src/cli.rs
+++ b/rust/kona/bin/node/src/cli.rs
@@ -102,11 +102,27 @@ impl Cli {
     /// Creates a new tokio multi-thread [Runtime](tokio::runtime::Runtime) with all features
     /// enabled.
     pub fn tokio_runtime() -> Result<tokio::runtime::Runtime, std::io::Error> {
-        // The deeply nested derivation pipeline can exhaust Tokio's default 2 MiB worker stack.
-        // Use the size validated against initial historical derivation, with enough headroom for
-        // native library calls made from the pipeline.
+        // Diagnostic-only override that lets the same binary reproduce with 2 MiB and serve as an
+        // 8 MiB control. This branch is not intended to merge.
+        let thread_stack_size = std::env::var("RUST_MIN_STACK")
+            .ok()
+            .map(|value| {
+                value.parse::<usize>().map_err(|err| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::InvalidInput,
+                        format!("invalid RUST_MIN_STACK value {value:?}: {err}"),
+                    )
+                })
+            })
+            .transpose()?
+            .unwrap_or(2 * 1024 * 1024);
+
+        tracing::info!(target: "cli", thread_stack_size, "Configuring Tokio worker stack");
+
         tokio::runtime::Builder::new_multi_thread()
-            .thread_stack_size(8 * 1024 * 1024)
+            .thread_stack_size(thread_stack_size)
+            // Signal alternate stacks are thread-local and are not inherited from the main thread.
+            .on_thread_start(kona_cli::sigsegv_handler::install)
             .enable_all()
             .build()
     }

--- a/rust/kona/bin/node/src/cli.rs
+++ b/rust/kona/bin/node/src/cli.rs
@@ -99,10 +99,16 @@ impl Cli {
         })
     }
 
-    /// Creates a new default tokio multi-thread [Runtime](tokio::runtime::Runtime) with all
-    /// features enabled
+    /// Creates a new tokio multi-thread [Runtime](tokio::runtime::Runtime) with all features
+    /// enabled.
     pub fn tokio_runtime() -> Result<tokio::runtime::Runtime, std::io::Error> {
-        tokio::runtime::Builder::new_multi_thread().enable_all().build()
+        // The deeply nested derivation pipeline can exhaust Tokio's default 2 MiB worker stack.
+        // Use the size validated against initial historical derivation, with enough headroom for
+        // native library calls made from the pipeline.
+        tokio::runtime::Builder::new_multi_thread()
+            .thread_stack_size(8 * 1024 * 1024)
+            .enable_all()
+            .build()
     }
 }
 

--- a/rust/kona/crates/providers/providers-alloy/src/beacon_client.rs
+++ b/rust/kona/crates/providers/providers-alloy/src/beacon_client.rs
@@ -3,13 +3,14 @@
 #[cfg(feature = "metrics")]
 use crate::Metrics;
 use crate::blobs::BoxedBlob;
-use alloy_eips::eip4844::{env_settings::EnvKzgSettings, kzg_to_versioned_hash};
+use alloy_eips::eip4844::{
+    Blob as AlloyBlob, deserialize_blob, env_settings::EnvKzgSettings, kzg_to_versioned_hash,
+};
 use alloy_primitives::{B256, FixedBytes};
-use alloy_rpc_types_beacon::sidecar::GetBlobsResponse;
 use async_trait::async_trait;
 use c_kzg::Blob;
 use reqwest::{self, Client};
-use std::{boxed::Box, collections::HashMap, format, string::String, vec::Vec};
+use std::{boxed::Box, format, string::String, vec::Vec};
 use thiserror::Error;
 
 /// The config spec engine api method.
@@ -96,6 +97,19 @@ pub trait BeaconClient {
 }
 
 const BLOB_SIZE: usize = 131072;
+
+/// A beacon API blob decoded directly into its final heap allocation.
+///
+/// [`alloy_rpc_types_beacon::sidecar::GetBlobsResponse`] stores blobs inline in a `Vec<Blob>`.
+/// Deserializing the 128 KiB fixed-size values through serde can exhaust a Tokio worker's stack.
+#[derive(Debug, serde::Deserialize)]
+struct BoxedBeaconBlob(#[serde(deserialize_with = "deserialize_blob")] Box<AlloyBlob>);
+
+/// The subset of the beacon API blob response used by the online provider.
+#[derive(Debug, serde::Deserialize)]
+struct BoxedGetBlobsResponse {
+    data: Vec<BoxedBeaconBlob>,
+}
 
 /// [`blob_versioned_hash`] computes the versioned hash of a blob.
 fn blob_versioned_hash(blob: &FixedBytes<BLOB_SIZE>) -> Result<B256, BeaconClientError> {
@@ -184,27 +198,28 @@ impl OnlineBeaconClient {
         }
 
         let response = response.error_for_status()?;
-        let bundle = response.json::<GetBlobsResponse>().await?;
+        let bundle = response.json::<BoxedGetBlobsResponse>().await?;
 
-        let returned_blobs_mapped_by_hash = bundle
+        let mut returned_blobs = bundle
             .data
-            .iter()
+            .into_iter()
             .map(|data| -> Result<_, BeaconClientError> {
-                let recomputed_hash = blob_versioned_hash(data)?;
-                Ok((recomputed_hash, data))
+                let recomputed_hash = blob_versioned_hash(&data.0)?;
+                Ok((recomputed_hash, data.0))
             })
-            .collect::<Result<HashMap<_, _>, BeaconClientError>>()?;
+            .collect::<Result<Vec<_>, BeaconClientError>>()?;
 
-        // Map the input (blob_hashes) into the output,
-        // finding the blob from the response
-        // whose hash matches the input:
+        // Map the input blob hashes into the output while moving each blob's existing allocation.
+        // Using a vector also preserves duplicate blobs in a response.
         blob_hashes
             .iter()
             .map(|blob_hash| -> Result<BoxedBlob, BeaconClientError> {
-                let matching_data = returned_blobs_mapped_by_hash
-                    .get(blob_hash)
+                let position = returned_blobs
+                    .iter()
+                    .position(|(recomputed_hash, _)| recomputed_hash == blob_hash)
                     .ok_or(BeaconClientError::BlobNotFound(blob_hash.to_string()))?;
-                Ok(BoxedBlob { blob: Box::new(**matching_data) })
+                let (_, blob) = returned_blobs.swap_remove(position);
+                Ok(BoxedBlob { blob })
             })
             .collect::<Result<Vec<_>, BeaconClientError>>()
     }


### PR DESCRIPTION
## Description

Diagnostic-only follow-up to #22513. This makes the Tokio worker stack size selectable through `RUST_MIN_STACK` and installs Kona's existing alternate SIGSEGV stack on every Tokio runtime thread, where stack overflows have been observed.

The image will be used for a controlled 2 MiB/8 MiB A/B reproduction on an isolated alpha Kona node. This PR is intentionally a draft and is not intended to merge.

## Tests

- `cargo +nightly-2026-08-18 fmt --all --check`
- `cargo test -p kona-node --locked` (79 passed)
- `cargo clippy -p kona-node --all-targets --all-features --locked -- -D warnings`
- `git diff --check`

## Root-cause candidate

The captured trace is acyclic and exhausts the worker stack in `serde_json` while deserializing `GetBlobsResponse.data` as `Vec<FixedBytes<131072>>`. The second commit replaces this with a response type that deserializes each blob directly into `Box<Blob>` and moves the allocation into the provider result. This will be tested with the same node and a 2 MiB worker stack.
