### PR TITLE
kona-node: always reset the engine on a pipeline reset

### DIFF
--- a/rust/kona/crates/node/service/src/actors/derivation/actor.rs
+++ b/rust/kona/crates/node/service/src/actors/derivation/actor.rs
@@ -261,12 +261,32 @@ where
     }
 }
 
+/// An error from the [`DerivationActor`].
+#[derive(Error, Debug)]
+pub enum DerivationError {
+    /// An error originating from the derivation pipeline.
+    #[error(transparent)]
+    Pipeline(#[from] PipelineErrorKind),
+    /// Waiting for more data to be available.
+    #[error("Waiting for more data to be available")]
+    Yield,
+    /// An error originating from the broadcast sender.
+    #[error("Failed to send event to broadcast sender: {0}")]
+    Sender(Box<dyn std::error::Error>),
+    /// Failed to receive inbound request
+    #[error("Failed to receive inbound request")]
+    RequestReceiveFailed,
+    /// An invalid state transition occurred.
+    #[error(transparent)]
+    StateTransitionError(#[from] DerivationStateTransitionError),
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{DerivationState, actors::derivation::engine_client::MockDerivationEngineClient};
+    use crate::actors::derivation::engine_client::MockDerivationEngineClient;
     use alloy_primitives::B256;
-    use kona_derive::{PipelineResult, StepResult};
+    use kona_derive::PipelineResult;
     use kona_genesis::{HardForkConfig, RollupConfig, SystemConfig};
     use kona_protocol::{BlockInfo, L2BlockInfo};
     use rstest::rstest;
@@ -357,24 +377,4 @@ mod tests {
 
         assert_eq!(actor.derivation_state_machine.current_state(), DerivationState::AwaitingSignal);
     }
-}
-
-/// An error from the [`DerivationActor`].
-#[derive(Error, Debug)]
-pub enum DerivationError {
-    /// An error originating from the derivation pipeline.
-    #[error(transparent)]
-    Pipeline(#[from] PipelineErrorKind),
-    /// Waiting for more data to be available.
-    #[error("Waiting for more data to be available")]
-    Yield,
-    /// An error originating from the broadcast sender.
-    #[error("Failed to send event to broadcast sender: {0}")]
-    Sender(Box<dyn std::error::Error>),
-    /// Failed to receive inbound request
-    #[error("Failed to receive inbound request")]
-    RequestReceiveFailed,
-    /// An invalid state transition occurred.
-    #[error(transparent)]
-    StateTransitionError(#[from] DerivationStateTransitionError),
 }

--- a/rust/kona/crates/node/service/src/actors/derivation/actor.rs
+++ b/rust/kona/crates/node/service/src/actors/derivation/actor.rs
@@ -127,19 +127,10 @@ where
 
                                     kona_macros::inc!(counter, Metrics::L1_REORG_COUNT);
                                 }
-                                // send the `reset` signal to the engine actor only when interop is
-                                // not active.
-                                if !self.pipeline.rollup_config().is_interop_active(
-                                    self.derivation_state_machine
-                                        .last_confirmed_safe_head()
-                                        .block_info
-                                        .timestamp,
-                                ) {
-                                    self.engine_client.reset_engine_forkchoice().await.map_err(|e| {
-                                        error!(target: "derivation", ?e, "Failed to send reset request");
-                                        DerivationError::Sender(Box::new(e))
-                                    })?;
-                                }
+                                self.engine_client.reset_engine_forkchoice().await.map_err(|e| {
+                                    error!(target: "derivation", ?e, "Failed to send reset request");
+                                    DerivationError::Sender(Box::new(e))
+                                })?;
                                 self.derivation_state_machine
                                     .update(&DerivationStateUpdate::SignalNeeded)?;
                                 return Err(DerivationError::Yield);
@@ -267,6 +258,104 @@ where
             DerivationError::RequestReceiveFailed
         })?;
         self.handle_derivation_actor_request(request).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{DerivationState, actors::derivation::engine_client::MockDerivationEngineClient};
+    use alloy_primitives::B256;
+    use kona_derive::{PipelineResult, StepResult};
+    use kona_genesis::{HardForkConfig, RollupConfig, SystemConfig};
+    use kona_protocol::{BlockInfo, L2BlockInfo};
+    use rstest::rstest;
+    use std::sync::Arc;
+
+    /// A pipeline stub whose every step reports an L1 reorg, forcing the reset branch of
+    /// [`DerivationActor::produce_next_attributes`].
+    #[derive(Debug)]
+    struct ReorgingPipeline {
+        rollup_config: Arc<RollupConfig>,
+    }
+
+    impl Iterator for ReorgingPipeline {
+        type Item = OpAttributesWithParent;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            None
+        }
+    }
+
+    impl kona_derive::OriginProvider for ReorgingPipeline {
+        fn origin(&self) -> Option<BlockInfo> {
+            Some(BlockInfo::default())
+        }
+    }
+
+    #[async_trait]
+    impl SignalReceiver for ReorgingPipeline {
+        async fn signal(&mut self, _: Signal) -> PipelineResult<()> {
+            Ok(())
+        }
+    }
+
+    #[async_trait]
+    impl Pipeline for ReorgingPipeline {
+        fn peek(&self) -> Option<&OpAttributesWithParent> {
+            None
+        }
+
+        async fn step(&mut self, _: L2BlockInfo) -> StepResult {
+            StepResult::StepFailed(PipelineErrorKind::Reset(ResetError::ReorgDetected(
+                B256::ZERO,
+                B256::repeat_byte(1),
+            )))
+        }
+
+        fn rollup_config(&self) -> &RollupConfig {
+            &self.rollup_config
+        }
+
+        async fn system_config_by_l2_hash(
+            &mut self,
+            _: B256,
+        ) -> Result<SystemConfig, PipelineErrorKind> {
+            Ok(SystemConfig::default())
+        }
+    }
+
+    /// A pipeline-driven reset must always reach the engine actor. The engine's reset is what
+    /// sends the pipeline its [`Signal`] back; without it the actor parks in
+    /// [`DerivationState::AwaitingSignal`] forever.
+    #[rstest]
+    #[case::interop_inactive(None)]
+    #[case::interop_active(Some(0))]
+    #[tokio::test]
+    async fn test_pipeline_reset_always_resets_engine(#[case] lagoon_time: Option<u64>) {
+        let rollup_config = Arc::new(RollupConfig {
+            hardforks: HardForkConfig { lagoon_time, ..Default::default() },
+            ..Default::default()
+        });
+
+        let mut engine_client = MockDerivationEngineClient::new();
+        engine_client.expect_reset_engine_forkchoice().times(1).returning(|| Ok(()));
+
+        let (request_tx, request_rx) = mpsc::channel(1);
+        let mut actor = DerivationActor::new(
+            engine_client,
+            request_rx,
+            ReorgingPipeline { rollup_config: rollup_config.clone() },
+        );
+
+        // Complete EL sync so the actor starts deriving, then let it hit the reorg.
+        request_tx
+            .send(DerivationActorRequest::ProcessEngineSyncCompletionRequest(Box::default()))
+            .await
+            .unwrap();
+        actor.step().await.unwrap();
+
+        assert_eq!(actor.derivation_state_machine.current_state(), DerivationState::AwaitingSignal);
     }
 }
 


### PR DESCRIPTION
Removes the derivation actor's `is_interop_active` suppression: on `PipelineErrorKind::Reset` (e.g. an L1 reorg) the actor skipped the engine reset when the chain's fork schedule said interop was active, then parked in `AwaitingSignal` forever — a live park-forever bug on interop-activated chains, left over from the removed op-supervisor design that assumed an external supervisor would drive the reset. Resets now route to the engine actor unconditionally.

Red/green: new `test_pipeline_reset_always_resets_engine` (rstest over interop inactive/active) failed on the interop-active case before the fix, passes after.

Part of #22519.

🤖 *Co-created with Claude (Fable 5)*