### PR TITLE
docs: add node101 to OP Stack RPC directory

### DIFF
--- a/docs/public-docs/app-developers/reference/rpc-providers.mdx
+++ b/docs/public-docs/app-developers/reference/rpc-providers.mdx
@@ -169,6 +169,14 @@ The following providers offer production-grade RPC access to OP Stack networks. 
 
 **Supported Mainnets**: OP Mainnet, Base, Lisk
 
+### node101
+
+**Description**: [node101](https://node101.io/en/rpc/optimism) offers managed RPC access for the following [networks](https://node101.io/en/rpc):
+
+**Supported Testnets**: n/a
+
+**Supported Mainnets**: OP Mainnet, Base, Unichain, World
+
 ### Nodies DLB
 
 **Description**: [Nodies DLB](https://www.nodies.app/) offers [free and paid plans](https://www.nodies.app/pricing) for the following [networks](https://docs.nodies.app/overview/supported-blockchains):


### PR DESCRIPTION
**Description**

Adds node101 to the OP Stack production RPC provider directory in alphabetical placement.

The listing includes the OP Stack mainnets currently supported by node101:

- OP Mainnet
- Base
- Unichain
- World

No testnets are listed because network-specific testnet support is not currently documented.

**Tests**

Documentation-only change.

- Verified the listed networks against the current node101 RPC catalog
- Ran `git diff --check`
- Ran the documentation nav validator
- Ran the documentation redirect and internal-link validator

**Additional context**

- Optimism RPC: https://node101.io/en/rpc/optimism
- Supported networks: https://node101.io/en/rpc

**Metadata**

No related issue; this provider-submitted PR follows the RPC directory governance section.