### PR TITLE
kona-engine: skip unsafe-head staleness check for seals atomic with their build

### DIFF
--- a/rust/kona/crates/node/engine/src/lib.rs
+++ b/rust/kona/crates/node/engine/src/lib.rs
@@ -40,10 +40,11 @@ extern crate tracing;
 
 mod task_queue;
 pub use task_queue::{
-    BuildTask, BuildTaskError, ConsolidateInput, ConsolidateTask, ConsolidateTaskError, Engine,
-    EngineBuildError, EngineResetError, EngineTask, EngineTaskError, EngineTaskErrorSeverity,
-    EngineTaskErrors, EngineTaskExt, FinalizeBlockId, FinalizeTask, FinalizeTaskError, InsertTask,
-    InsertTaskError, SealTask, SealTaskError, SynchronizeTask, SynchronizeTaskError,
+    BuildSealCoupling, BuildTask, BuildTaskError, ConsolidateInput, ConsolidateTask,
+    ConsolidateTaskError, Engine, EngineBuildError, EngineResetError, EngineTask, EngineTaskError,
+    EngineTaskErrorSeverity, EngineTaskErrors, EngineTaskExt, FinalizeBlockId, FinalizeTask,
+    FinalizeTaskError, InsertTask, InsertTaskError, SealTask, SealTaskError, SynchronizeTask,
+    SynchronizeTaskError,
 };
 
 mod attributes;

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/build/task_test.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/build/task_test.rs
@@ -1,5 +1,3 @@
-//! Tests for `BuildTask::execute`
-
 use crate::{
     BuildTask, BuildTaskError, EngineBuildError, EngineClient, EngineForkchoiceVersion,
     EngineState, EngineTaskExt,

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/finalize/task_test.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/finalize/task_test.rs
@@ -1,5 +1,3 @@
-//! Tests for [`FinalizeTask::execute`].
-
 use crate::{
     EngineTaskExt, FinalizeBlockId, FinalizeTask, FinalizeTaskError,
     test_utils::{TestEngineStateBuilder, test_engine_client_builder},

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/mod.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/mod.rs
@@ -15,7 +15,7 @@ mod build;
 pub use build::{BuildTask, BuildTaskError, EngineBuildError};
 
 mod seal;
-pub use seal::{SealTask, SealTaskError};
+pub use seal::{BuildSealCoupling, SealTask, SealTaskError};
 
 mod consolidate;
 pub use consolidate::{ConsolidateInput, ConsolidateTask, ConsolidateTaskError};

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/seal/mod.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/seal/mod.rs
@@ -5,3 +5,6 @@ pub use task::SealTask;
 
 mod error;
 pub use error::SealTaskError;
+
+#[cfg(test)]
+mod task_test;

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/seal/mod.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/seal/mod.rs
@@ -1,7 +1,7 @@
 //! Task and its associated types for importing a block that has been started.
 
 mod task;
-pub use task::SealTask;
+pub use task::{BuildSealCoupling, SealTask};
 
 mod error;
 pub use error::SealTaskError;

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/seal/task.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/seal/task.rs
@@ -39,6 +39,12 @@ pub struct SealTask<EngineClient_: EngineClient> {
     pub attributes: OpAttributesWithParent,
     /// Whether or not the payload was derived, or created by the sequencer.
     pub is_attributes_derived: bool,
+    /// Whether this seal runs in the same engine task as the build that produced `payload_id`.
+    ///
+    /// When true, no other task can have advanced the unsafe head since the build started, so
+    /// the unsafe-head staleness check is skipped: a derivation-driven reorg legitimately seals
+    /// a payload whose parent differs from the current unsafe head.
+    pub is_atomic_with_build: bool,
     /// An optional sender to convey success/failure result of the built
     /// [`OpExecutionPayloadEnvelope`] after the block has been built, imported, and canonicalized
     /// or the [`SealTaskError`] that occurred during processing.
@@ -266,9 +272,14 @@ impl<EngineClient_: EngineClient> EngineTaskExt for SealTask<EngineClient_> {
         let unsafe_block_info = state.sync_state.unsafe_head().block_info;
         let parent_block_info = self.attributes.parent.block_info;
 
-        let res = if unsafe_block_info.hash != parent_block_info.hash ||
-            unsafe_block_info.number != parent_block_info.number
-        {
+        // A seal detached from its build (enqueued as a separate task) may observe an unsafe
+        // head that moved past the build parent, invalidating the built payload. A seal atomic
+        // with its build cannot race, so the mismatch there is an expected reorg, not staleness.
+        let build_is_stale = !self.is_atomic_with_build &&
+            (unsafe_block_info.hash != parent_block_info.hash ||
+                unsafe_block_info.number != parent_block_info.number);
+
+        let res = if build_is_stale {
             info!(
                 target: "engine",
                 unsafe_block_info = ?unsafe_block_info,

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/seal/task.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/seal/task.rs
@@ -14,6 +14,18 @@ use op_alloy_rpc_types_engine::OpExecutionPayloadEnvelope;
 use std::{sync::Arc, time::Instant};
 use tokio::sync::mpsc;
 
+/// How a [`SealTask`] is coupled to the build that produced its payload.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum BuildSealCoupling {
+    /// Build and seal run inside the same engine task, so no other task can advance the unsafe
+    /// head between them. The unsafe-head staleness check is skipped: a derivation-driven reorg
+    /// legitimately seals a payload whose parent differs from the current unsafe head.
+    Atomic,
+    /// The seal is enqueued as a task separate from its build, so another task may advance the
+    /// unsafe head in between, invalidating the built payload as stale.
+    Detached,
+}
+
 /// Task for block sealing and canonicalization.
 ///
 /// The [`SealTask`] handles the following parts of the block building workflow:
@@ -39,12 +51,8 @@ pub struct SealTask<EngineClient_: EngineClient> {
     pub attributes: OpAttributesWithParent,
     /// Whether or not the payload was derived, or created by the sequencer.
     pub is_attributes_derived: bool,
-    /// Whether this seal runs in the same engine task as the build that produced `payload_id`.
-    ///
-    /// When true, no other task can have advanced the unsafe head since the build started, so
-    /// the unsafe-head staleness check is skipped: a derivation-driven reorg legitimately seals
-    /// a payload whose parent differs from the current unsafe head.
-    pub is_atomic_with_build: bool,
+    /// How this seal is coupled to the build that produced `payload_id`.
+    pub coupling: BuildSealCoupling,
     /// An optional sender to convey success/failure result of the built
     /// [`OpExecutionPayloadEnvelope`] after the block has been built, imported, and canonicalized
     /// or the [`SealTaskError`] that occurred during processing.
@@ -272,10 +280,7 @@ impl<EngineClient_: EngineClient> EngineTaskExt for SealTask<EngineClient_> {
         let unsafe_block_info = state.sync_state.unsafe_head().block_info;
         let parent_block_info = self.attributes.parent.block_info;
 
-        // A seal detached from its build (enqueued as a separate task) may observe an unsafe
-        // head that moved past the build parent, invalidating the built payload. A seal atomic
-        // with its build cannot race, so the mismatch there is an expected reorg, not staleness.
-        let build_is_stale = !self.is_atomic_with_build &&
+        let build_is_stale = self.coupling == BuildSealCoupling::Detached &&
             (unsafe_block_info.hash != parent_block_info.hash ||
                 unsafe_block_info.number != parent_block_info.number);
 

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/seal/task_test.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/seal/task_test.rs
@@ -1,0 +1,71 @@
+//! Tests for `SealTask::execute`
+
+use crate::{
+    EngineTaskExt, SealTask, SealTaskError,
+    test_utils::{
+        TestAttributesBuilder, TestEngineStateBuilder, test_block_info, test_engine_client_builder,
+    },
+};
+use alloy_rpc_types_engine::PayloadId;
+use kona_genesis::RollupConfig;
+use rstest::rstest;
+use std::sync::Arc;
+use tokio::sync::mpsc;
+
+/// The two paths the unsafe-head check can steer `execute` into: aborting the seal as stale, or
+/// proceeding to the payload fetch — which the unconfigured mock client fails, surfacing as
+/// [`SealTaskError::GetPayloadFailed`].
+#[derive(Debug, PartialEq, Eq)]
+enum SealOutcome {
+    AbortedAsStale,
+    ProceededToSeal,
+}
+
+fn classify(err: &SealTaskError) -> SealOutcome {
+    match err {
+        SealTaskError::UnsafeHeadChangedSinceBuild => SealOutcome::AbortedAsStale,
+        SealTaskError::GetPayloadFailed(_) => SealOutcome::ProceededToSeal,
+        other => panic!("unexpected seal error: {other:?}"),
+    }
+}
+
+#[rstest]
+#[case::detached_with_moved_unsafe_head(false, false, SealOutcome::AbortedAsStale)]
+#[case::detached_with_current_unsafe_head(false, true, SealOutcome::ProceededToSeal)]
+#[case::atomic_with_reorged_unsafe_head(true, false, SealOutcome::ProceededToSeal)]
+#[case::atomic_with_current_unsafe_head(true, true, SealOutcome::ProceededToSeal)]
+#[tokio::test]
+async fn unsafe_head_check_variants(
+    #[case] is_atomic_with_build: bool,
+    #[case] unsafe_head_at_parent: bool,
+    #[case] expected: SealOutcome,
+    #[values(true, false)] with_channel: bool,
+) {
+    let parent_block = test_block_info(10);
+    let unsafe_head = if unsafe_head_at_parent { parent_block } else { test_block_info(15) };
+
+    let attributes = TestAttributesBuilder::new().with_parent(parent_block).build();
+    let mut state = TestEngineStateBuilder::new().with_unsafe_head(unsafe_head).build();
+
+    let (tx, mut rx) = mpsc::channel(1);
+    let task = SealTask::new(
+        Arc::new(test_engine_client_builder().build()),
+        Arc::new(RollupConfig::default()),
+        PayloadId::new([1u8; 8]),
+        attributes,
+        false,
+        is_atomic_with_build,
+        with_channel.then_some(tx),
+    );
+
+    let result = task.execute(&mut state).await;
+
+    if with_channel {
+        // With a result channel, the task itself succeeds and the error is relayed to the caller.
+        result.expect("task with a result channel should succeed");
+        let relayed = rx.recv().await.expect("channel should receive the seal result");
+        assert_eq!(classify(&relayed.expect_err("seal should fail against the mock")), expected);
+    } else {
+        assert_eq!(classify(&result.expect_err("seal should fail against the mock")), expected);
+    }
+}

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/seal/task_test.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/seal/task_test.rs
@@ -1,6 +1,5 @@
-//! Tests for `SealTask::execute`
-
 use crate::{
+    BuildSealCoupling::{self, Atomic, Detached},
     EngineTaskExt, SealTask, SealTaskError,
     test_utils::{
         TestAttributesBuilder, TestEngineStateBuilder, test_block_info, test_engine_client_builder,
@@ -30,13 +29,13 @@ fn classify(err: &SealTaskError) -> SealOutcome {
 }
 
 #[rstest]
-#[case::detached_with_moved_unsafe_head(false, false, SealOutcome::AbortedAsStale)]
-#[case::detached_with_current_unsafe_head(false, true, SealOutcome::ProceededToSeal)]
-#[case::atomic_with_reorged_unsafe_head(true, false, SealOutcome::ProceededToSeal)]
-#[case::atomic_with_current_unsafe_head(true, true, SealOutcome::ProceededToSeal)]
+#[case::detached_with_moved_unsafe_head(Detached, false, SealOutcome::AbortedAsStale)]
+#[case::detached_with_current_unsafe_head(Detached, true, SealOutcome::ProceededToSeal)]
+#[case::atomic_with_reorged_unsafe_head(Atomic, false, SealOutcome::ProceededToSeal)]
+#[case::atomic_with_current_unsafe_head(Atomic, true, SealOutcome::ProceededToSeal)]
 #[tokio::test]
 async fn unsafe_head_check_variants(
-    #[case] is_atomic_with_build: bool,
+    #[case] coupling: BuildSealCoupling,
     #[case] unsafe_head_at_parent: bool,
     #[case] expected: SealOutcome,
     #[values(true, false)] with_channel: bool,
@@ -54,7 +53,7 @@ async fn unsafe_head_check_variants(
         PayloadId::new([1u8; 8]),
         attributes,
         false,
-        is_atomic_with_build,
+        coupling,
         with_channel.then_some(tx),
     );
 

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/util.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/util.rs
@@ -1,6 +1,6 @@
 //! Utility functions for task execution.
 
-use super::{BuildTask, BuildTaskError, EngineTaskExt, SealTask, SealTaskError};
+use super::{BuildSealCoupling, BuildTask, BuildTaskError, EngineTaskExt, SealTask, SealTaskError};
 use crate::{EngineClient, EngineState};
 use kona_genesis::RollupConfig;
 use kona_protocol::OpAttributesWithParent;
@@ -50,16 +50,14 @@ pub(in crate::task_queue) async fn build_and_seal<EngineClient_: EngineClient>(
     .execute(state)
     .await?;
 
-    // Execute the seal task with the payload ID from the build. The seal is atomic with the
-    // build above: both run inside the same engine task, so the unsafe head cannot move in
-    // between.
+    // Execute the seal task with the payload ID from the build.
     SealTask::new(
         engine,
         cfg,
         payload_id,
         attributes,
         is_attributes_derived,
-        /* is_atomic_with_build */ true,
+        BuildSealCoupling::Atomic,
         None,
     )
     .execute(state)

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/util.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/util.rs
@@ -50,10 +50,20 @@ pub(in crate::task_queue) async fn build_and_seal<EngineClient_: EngineClient>(
     .execute(state)
     .await?;
 
-    // Execute the seal task with the payload ID from the build
-    SealTask::new(engine, cfg, payload_id, attributes, is_attributes_derived, None)
-        .execute(state)
-        .await?;
+    // Execute the seal task with the payload ID from the build. The seal is atomic with the
+    // build above: both run inside the same engine task, so the unsafe head cannot move in
+    // between.
+    SealTask::new(
+        engine,
+        cfg,
+        payload_id,
+        attributes,
+        is_attributes_derived,
+        /* is_atomic_with_build */ true,
+        None,
+    )
+    .execute(state)
+    .await?;
 
     Ok(())
 }

--- a/rust/kona/crates/node/service/src/actors/engine/actor.rs
+++ b/rust/kona/crates/node/service/src/actors/engine/actor.rs
@@ -5,8 +5,9 @@ use crate::{
 use async_trait::async_trait;
 use kona_derive::{ResetSignal, Signal};
 use kona_engine::{
-    BuildTask, ConsolidateInput, ConsolidateTask, Engine, EngineClient, EngineTask,
-    EngineTaskError, EngineTaskErrorSeverity, FinalizeBlockId, FinalizeTask, InsertTask, SealTask,
+    BuildSealCoupling, BuildTask, ConsolidateInput, ConsolidateTask, Engine, EngineClient,
+    EngineTask, EngineTaskError, EngineTaskErrorSeverity, FinalizeBlockId, FinalizeTask,
+    InsertTask, SealTask,
 };
 use kona_genesis::RollupConfig;
 use kona_protocol::L2BlockInfo;
@@ -293,9 +294,7 @@ where
                     attributes,
                     // The payload is not derived in this case.
                     false,
-                    // The build ran as a separate task, so the unsafe head may have moved
-                    // since it started.
-                    false,
+                    BuildSealCoupling::Detached,
                     Some(result_tx),
                 )));
                 self.engine.enqueue(task);

--- a/rust/kona/crates/node/service/src/actors/engine/actor.rs
+++ b/rust/kona/crates/node/service/src/actors/engine/actor.rs
@@ -293,6 +293,9 @@ where
                     attributes,
                     // The payload is not derived in this case.
                     false,
+                    // The build ran as a separate task, so the unsafe head may have moved
+                    // since it started.
+                    false,
                     Some(result_tx),
                 )));
                 self.engine.enqueue(task);


### PR DESCRIPTION
## Description

Fixes the kona-node crash loop from #22342: `Critical error in sub-routine: EngineTask(Consolidate(SealTaskFailed(UnsafeHeadChangedSinceBuild)))` while re-deriving a deep backlog behind a fast-moving unsafe tip.

### Root cause

`SealTask::execute` errors with `UnsafeHeadChangedSinceBuild` whenever the engine state's unsafe head differs from the build's parent block. That check targets a real race in the sequencer flow, where Build and Seal are enqueued as *separate* engine tasks and a gossip `Insert` task can advance the unsafe head in between — and there the error is relayed over the seal's result channel and handled gracefully (rebuild).

`build_and_seal` — the path `ConsolidateTask` takes when derived attributes mismatch the local unsafe chain, and the Holocene deposits-only fallback — runs Build and Seal **atomically inside one engine task**, so nothing can interleave and the unsafe head cannot move between them. In that path the unsafe head never equaled the build parent to begin with: during catch-up the unsafe head is the gossip tip while the build parent is the safe head being re-derived. The check is a guaranteed false positive there, and since the path has no result channel, it surfaces with `Critical` severity and exits the node. It self-resolves once derivation catches up because then unsafe head == safe head == build parent — matching the observed behavior. Sealing in this path is safe: it is an intentional derivation-driven reorg, and `InsertTask` moves the unsafe/safe heads to the newly built block afterward.

### Fix

Add a `BuildSealCoupling { Atomic, Detached }` enum to `SealTask` and gate the staleness check on it:

- `build_and_seal` passes `BuildSealCoupling::Atomic` — the check is skipped and the derivation-driven reorg completes in one pass instead of crashing the node.
- The engine actor's detached `Seal` request (sequencer flow) passes `BuildSealCoupling::Detached` — the race detection and its existing graceful handling are unchanged.

Downgrading the error's severity instead (retry / reset) was considered but rejected: a `Temporary` retry spins on identical state, and a `Reset` would thrash the derivation pipeline on every unsafe reorg during catch-up. Skipping the meaningless check at its source is simpler and strictly better.

## Tests

New `rstest` table test `seal/task_test.rs` covering the check matrix — a detached seal with a moved unsafe head still aborts with `UnsafeHeadChangedSinceBuild`; a detached seal with a current head, and an atomic seal with either head state, proceed into sealing — each crossed with the result-channel and direct-error delivery paths (8 cases).

Also drops the `//!` headers from the `task_test.rs` files in the crate (review nit, applied to `build`/`finalize`/`seal` alike for consistency).

Verified: `cargo nextest run -p kona-engine` (69 passed) and `-p kona-node-service` (117 passed), `cargo clippy --all-features --all-targets -D warnings` clean on both crates, pinned-nightly `just fmt-check` clean.

Fixes #22342

🤖 Generated with [Claude Code](https://claude.com/claude-code)
