### PR TITLE
op-node: tolerate pruned L1 history in genesis check (including reth --minimal)

### DIFF
--- a/op-node/rollup/types.go
+++ b/op-node/rollup/types.go
@@ -258,9 +258,10 @@ func (cfg *Config) CheckL1ChainID(ctx context.Context, client L1Client) error {
 func (cfg *Config) CheckL1GenesisBlockHash(ctx context.Context, logger log.Logger, client L1Client) error {
 	l1GenesisBlockRef, err := client.L1BlockRefByNumber(ctx, cfg.Genesis.L1.Number)
 	if err != nil {
-		if errors.Is(eth.MaybeAsNotFoundErr(err), ethereum.NotFound) {
-			// Genesis block isn't available to check, so just accept it and hope for the best
-			logger.Warn("L1 genesis block not found, skipping validity check")
+		if errors.Is(eth.MaybeAsNotFoundErr(err), ethereum.NotFound) || isHistoryPrunedErr(err) {
+			// Genesis block isn't available to check, either because it was never found or
+			// because history expiry has pruned it, so just accept it and hope for the best
+			logger.Warn("L1 genesis block not available, skipping validity check", "err", err)
 			return nil
 		}
 		return fmt.Errorf("failed to get L1 genesis blockhash: %w", err)

--- a/op-node/rollup/types_test.go
+++ b/op-node/rollup/types_test.go
@@ -191,6 +191,17 @@ func TestCheckL1BlockRefByNumber(t *testing.T) {
 	mockClient.err = errors.New("block not found")
 	err = config.CheckL1GenesisBlockHash(context.Background(), logger, &mockClient)
 	assert.NoError(t, err)
+
+	// A history-pruned execution engine can no longer serve the genesis block; the configured
+	// genesis hash is authoritative, so the check is skipped rather than failing.
+	mockClient.err = historyPrunedRPCError{}
+	err = config.CheckL1GenesisBlockHash(context.Background(), logger, &mockClient)
+	assert.NoError(t, err)
+
+	// Any other fetch error still fails the check.
+	mockClient.err = errors.New("connection refused")
+	err = config.CheckL1GenesisBlockHash(context.Background(), logger, &mockClient)
+	assert.Error(t, err)
 }
 
 // TestRandomConfigDescription tests that the description works for different variations of a random rollup config.


### PR DESCRIPTION
## Description

`CheckL1GenesisBlockHash` fails op-node startup when the L1 execution engine no
longer retains the genesis header. Engines with history expiry enabled (e.g.
`reth --minimal`) do not answer with a "not found" error for pruned blocks — they
return JSON-RPC error code `4444` — so the existing `ethereum.NotFound` condition
does not catch it and startup aborts with `failed to get L1 genesis blockhash`.

This mirrors what `CheckL2GenesisBlockHash` already does: it accepts the
`historyPrunedErrCode` (4444) case in addition to `NotFound`, logs a warning, and
skips the check. The helper `isHistoryPrunedErr` already exists in the same file
and is reused as-is.

The warning is also extended to include the underlying error, so operators can
tell a pruned-history skip apart from a genuinely missing block.

## Tests

`TestCheckL1BlockRefByNumber` extended with two cases: history-pruned (`4444`) →
accept, other fetch error → fail. 

Also verified end to end against a live `reth --minimal` L1 (v2.5.0-dev) driving the
real `sources.L1Client`: `ValidateL1Config` fails on `develop` with
`failed to get L1 genesis blockhash: pruned history unavailable` and succeeds on this
branch, logging the skip warning. 

## Additional context

* `CheckL1GenesisBlockHash` learned to skip on `ethereum.NotFound` in #17407
 * #21587 later added the `4444` history-expiry code, but only wired it into the L2 check,
its description assumed the L1 sibling "already tolerates an unavailable L1 genesis block",
which holds only for engines that answer `NotFound`. reth-family L1s return
JSON-RPC `4444` instead (paradigmxyz/reth#24760), so L1 startup still fails
against `reth --minimal`. This closes that gap and brings the two checks to
parity.

Related: #13570 (EIP-4444 L1 compatibility, whose community fix #13828 went
stale), #21584 / #21587 (the L2 half).

## Metadata

N/A