### PR TITLE
ci,rust: rebalance rust-cargo-hack with weighted package partitioning

### DIFF
--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -508,7 +508,7 @@ jobs:
             if [ "$CIRCLE_NODE_TOTAL" -gt 1 ]; then
               PARTITION_FLAG="$((CIRCLE_NODE_INDEX + 1))/$CIRCLE_NODE_TOTAL"
             fi
-            just hack "$PARTITION_FLAG" "true" "$CIRCLE_WORKFLOW_ID"
+            just hack "$PARTITION_FLAG"
       # Check each crate's test targets in isolation with default features. The
       # lib-only `hack` step above never compiles test code, so a crate whose
       # tests rely on a feature only enabled via workspace feature unification
@@ -524,7 +524,7 @@ jobs:
             if [ "$CIRCLE_NODE_TOTAL" -gt 1 ]; then
               PARTITION_FLAG="$((CIRCLE_NODE_INDEX + 1))/$CIRCLE_NODE_TOTAL"
             fi
-            just hack-tests-default "$PARTITION_FLAG" "true" "$CIRCLE_WORKFLOW_ID"
+            just hack-tests-default "$PARTITION_FLAG"
       - rust-save-build-cache: *hack-cache-args
 
   # --------------------------------------------------------------------------
@@ -927,7 +927,8 @@ workflows:
 
       - rust-ci-cargo-hack:
           name: rust-cargo-hack
-          # cargo-hack shards its --each-feature checks via --partition i/N.
+          # Nodes split the workspace by weighted bin-packing; see
+          # rust/scripts/hack-partition.sh and hack-weights.txt.
           parallelism: 10
           context: *rust-ci-context
 

--- a/rust/justfile
+++ b/rust/justfile
@@ -445,53 +445,60 @@ check-udeps:
 
 # Run cargo hack feature checking, enabling each feature one at a time.
 # Cheaper than the full powerset (~n checks per crate vs ~2^n).
-# shuffle: "true" to shuffle package order before partitioning (spreads heavy/light crates more evenly)
-# seed: deterministic seed for shuffle (all partition nodes must use the same seed)
-hack partition="" shuffle="false" seed="default":
+# partition: "<index>/<total>" to run only this node's share of a weighted
+#   package split (see scripts/hack-partition.sh); empty checks the whole
+#   workspace
+hack partition="":
   #!/usr/bin/env bash
   set -euo pipefail
-  if [ "{{partition}}" != "" ]; then
-    echo "Running cargo hack with partition {{partition}}"
-  else
-    echo "Running cargo hack without partition"
+  if [ "{{partition}}" = "" ]; then
+    echo "Running cargo hack on the full workspace"
+    cargo hack check --each-feature --no-dev-deps
+    exit 0
   fi
 
-  PKG_FLAGS=""
-  if [ "{{shuffle}}" = "true" ]; then
-    PKGS=$(cargo metadata --no-deps --format-version 1 \
-      | jq -r '.packages[].name' \
-      | shuf --random-source=<(openssl enc -aes-256-ctr -pass "pass:{{seed}}" -nosalt </dev/zero 2>/dev/null))
-    PKG_FLAGS=$(echo "$PKGS" | sed 's/^/-p /' | tr '\n' ' ')
-    echo "Shuffled package order (seed={{seed}}): $PKGS"
+  ASSIGNMENT=$(scripts/hack-partition.sh "{{partition}}")
+  echo "Assignment for partition {{partition}}:"
+  echo "$ASSIGNMENT"
+
+  WHOLE_PKGS=$(awk 'NF == 1' <<<"$ASSIGNMENT")
+  if [ -n "$WHOLE_PKGS" ]; then
+    cargo hack check --each-feature --no-dev-deps $(sed 's/^/-p /' <<<"$WHOLE_PKGS" | tr '\n' ' ')
   fi
 
-  cargo hack check --each-feature --no-dev-deps $PKG_FLAGS {{ if partition != "" { "--partition " + partition } else { "" } }}
+  while read -r PKG SHARD; do
+    [ -n "$PKG" ] || continue
+    cargo hack check --each-feature --no-dev-deps -p "$PKG" --partition "$SHARD"
+  done < <(awk 'NF == 2' <<<"$ASSIGNMENT")
 
 # Check each crate's test targets in isolation with default features only.
 # Catches tests that only compile via workspace feature unification: a crate
 # whose tests use a dependency's feature they never declare, or a non-default
 # feature of the crate itself (enable it for the test build via a self
 # dev-dependency).
-# seed: deterministic seed for shuffle (all partition nodes must use the same seed)
-hack-tests-default partition="" shuffle="false" seed="default":
+# partition: "<index>/<total>" to run only this node's share of a weighted
+#   package split (see scripts/hack-partition.sh); empty checks the whole
+#   workspace
+hack-tests-default partition="":
   #!/usr/bin/env bash
   set -euo pipefail
-  if [ "{{partition}}" != "" ]; then
-    echo "Running cargo hack (tests, default-features) with partition {{partition}}"
-  else
-    echo "Running cargo hack (tests, default-features) without partition"
+  if [ "{{partition}}" = "" ]; then
+    echo "Running cargo hack (tests, default-features) on the full workspace"
+    cargo hack check --tests
+    exit 0
   fi
 
-  PKG_FLAGS=""
-  if [ "{{shuffle}}" = "true" ]; then
-    PKGS=$(cargo metadata --no-deps --format-version 1 \
-      | jq -r '.packages[].name' \
-      | shuf --random-source=<(openssl enc -aes-256-ctr -pass "pass:{{seed}}" -nosalt </dev/zero 2>/dev/null))
-    PKG_FLAGS=$(echo "$PKGS" | sed 's/^/-p /' | tr '\n' ' ')
-    echo "Shuffled package order (seed={{seed}}): $PKGS"
+  # A package sharded across nodes in the lib step has a single test-targets
+  # run, so the node holding shard 1 checks its tests.
+  PKGS=$(scripts/hack-partition.sh "{{partition}}" | awk 'NF == 1 || $2 ~ /^1\// { print $1 }')
+  echo "Packages for partition {{partition}}:"
+  echo "$PKGS"
+  if [ -z "$PKGS" ]; then
+    echo "No packages assigned to this partition"
+    exit 0
   fi
 
-  cargo hack check --tests $PKG_FLAGS {{ if partition != "" { "--partition " + partition } else { "" } }}
+  cargo hack check --tests $(sed 's/^/-p /' <<<"$PKGS" | tr '\n' ' ')
 
 ########################### Release #################################
 

--- a/rust/scripts/hack-partition.sh
+++ b/rust/scripts/hack-partition.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Usage: hack-partition.sh <index>/<total>
+#
+# Assigns every workspace package to one of <total> CI nodes by weighted LPT
+# (longest-processing-time) bin-packing over scripts/hack-weights.txt, then
+# prints node <index>'s (1-based) share, one entry per line:
+#
+#   <package>             run all of the package's checks on this node
+#   <package> <i>/<k>     run shard i of the package's checks on this node
+#                         (pass to `cargo hack -p <package> --partition i/k`)
+#
+# The assignment is a pure function of the workspace member list, the weights
+# file, and <total>, so every node computes the identical split and each
+# package (or shard) lands on exactly one node.
+set -euo pipefail
+
+partition=$1
+node_index=${partition%/*}
+node_total=${partition#*/}
+
+if ! [[ "$node_index" =~ ^[0-9]+$ && "$node_total" =~ ^[0-9]+$ ]] \
+  || [ "$node_index" -lt 1 ] || [ "$node_index" -gt "$node_total" ]; then
+  echo "invalid partition '$partition': expected <index>/<total> with 1 <= index <= total" >&2
+  exit 1
+fi
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+weights_file="$script_dir/hack-weights.txt"
+
+# One line per bin-packing item: "<weight> <package> <shard> <shards>". A
+# package with a splits column becomes <splits> items of weight/splits each.
+cargo metadata --no-deps --format-version 1 \
+  | jq -r '.packages[].name' \
+  | sort -u \
+  | awk -v weights_file="$weights_file" '
+      BEGIN {
+        default_weight = 30
+        while ((getline line < weights_file) > 0) {
+          sub(/#.*/, "", line)
+          n = split(line, field, /[ \t]+/)
+          if (n < 2) continue
+          weight[field[1]] = field[2]
+          splits[field[1]] = (n >= 3 && field[3] > 1) ? field[3] : 1
+        }
+      }
+      {
+        pkg_weight = ($0 in weight) ? weight[$0] : default_weight
+        pkg_splits = ($0 in splits) ? splits[$0] : 1
+        for (shard = 1; shard <= pkg_splits; shard++)
+          printf "%.3f %s %d %d\n", pkg_weight / pkg_splits, $0, shard, pkg_splits
+      }' \
+  | sort -k1,1nr -k2,2 -k3,3n \
+  | awk -v node_index="$node_index" -v node_total="$node_total" '
+      {
+        item_weight = $1; pkg = $2; shard = $3; shards = $4
+
+        # Lightest bin wins, lowest index breaks ties; bins already holding a
+        # shard of this package are skipped so shards spread across nodes.
+        best = 0
+        for (bin = 1; bin <= node_total; bin++) {
+          if (occupied[bin, pkg]) continue
+          if (best == 0 || load[bin] < load[best]) best = bin
+        }
+        if (best == 0) {
+          best = 1
+          for (bin = 2; bin <= node_total; bin++) if (load[bin] < load[best]) best = bin
+        }
+
+        load[best] += item_weight
+        occupied[best, pkg] = 1
+        if (best != node_index) next
+        if (shards > 1) { print pkg, shard "/" shards } else { print pkg }
+      }'

--- a/rust/scripts/hack-weights.txt
+++ b/rust/scripts/hack-weights.txt
@@ -1,0 +1,94 @@
+# Per-package cost weights for partitioning the CI cargo-hack job.
+# Read by scripts/hack-partition.sh.
+#
+# Columns: <package> <weight> [<splits>]
+#
+# weight: approximate seconds the package's checks take in CI, summed across
+#   the lib step (--each-feature --no-dev-deps) and the test-targets step
+#   (--tests). Only relative magnitude matters. Derived from the per-run
+#   `Finished ... in Ns` lines in CI logs of the rust-cargo-hack job (build
+#   5489984, 2026-08-19), scaled per node to the step's wall time. Packages
+#   missing here get a default weight of 30; refresh stale entries the same
+#   way when the balance drifts.
+#
+# splits: shard the package's --each-feature runs across this many nodes via
+#   `cargo hack -p <package> --partition <i>/<splits>`. Only worth it for a
+#   package whose weight alone exceeds the mean per-node load: every extra
+#   shard re-checks the package's dependency tree once.
+
+alloy-op-evm 53
+alloy-op-hardforks 5
+example-discovery 4
+example-engine-api-access 64
+example-exex-hello-world 72
+example-gossip 5
+example-op-db-access 14
+execution-fixture 24
+kona-cli 10
+kona-client 12
+kona-derive 17
+kona-disc 10
+kona-driver 7
+kona-engine 20
+kona-executor 66
+kona-genesis 15
+kona-gossip 50
+kona-hardforks 20
+kona-host 62
+kona-interop 19
+kona-macros 1
+kona-mpt 9
+kona-node 70
+kona-node-service 39
+kona-peers 14
+kona-preimage 13
+kona-proof 14
+kona-proof-interop 9
+kona-protocol 17
+kona-providers-alloy 14
+kona-providers-local 11
+kona-registry 11
+kona-rpc 14
+kona-serde 5
+kona-sources 7
+kona-sp1-client-utils 7
+kona-sp1-elfs 1
+kona-sp1-ethereum-client-utils 1
+kona-sp1-ethereum-host-utils 48
+kona-sp1-host-utils 6
+kona-sp1-proposer 16
+kona-sp1-range-executor 3
+kona-sp1-super-range-executor 9
+kona-std-fpvm 2
+kona-std-fpvm-proc 3
+lokahi 3
+op-alloy 25
+op-alloy-consensus 24
+op-alloy-network 11
+op-alloy-provider 5
+op-alloy-rpc-jsonrpsee 6
+op-alloy-rpc-types 21
+op-alloy-rpc-types-engine 11
+op-reth 680 2
+op-reth-proof-bench 4
+op-reth-sdm-fixture 58
+op-reth-test-engine 33
+op-revm 33
+op-version 1
+reth-op 233
+reth-optimism-chainspec 84
+reth-optimism-cli 424 2
+reth-optimism-consensus 41
+reth-optimism-evm 62
+reth-optimism-exex 103
+reth-optimism-flashblocks 18
+reth-optimism-forks 14
+reth-optimism-node 263
+reth-optimism-payload-builder 16
+reth-optimism-post-exec-replay 15
+reth-optimism-primitives 37
+reth-optimism-rpc 69
+reth-optimism-storage 19
+reth-optimism-trie 72
+reth-optimism-txpool 36
+revm-ee-tests 11


### PR DESCRIPTION
Closes #22103.

### Root cause

The `hack*` recipes shuffled the package list with a seeded `shuf` and passed it as `-p` flags, but cargo-hack uses `-p` only as a membership filter and iterates workspace members in cargo-metadata order — the shuffle never changed the run order. `--partition` then sliced that fixed order into contiguous chunks, concentrating the adjacent heavy op-reth/kona blocks on the same nodes: 0.9–13.1 min per-node spread at parallelism 10 (measured from [build 5489984](https://app.circleci.com/pipelines/gh/ethereum-optimism/optimism/jobs/5489984)).

### Fix

- **`rust/scripts/hack-partition.sh`** deterministically assigns packages to nodes by LPT (longest-processing-time) bin-packing over a checked-in weight table, and each node passes only its own `-p` subset. The assignment is a pure function of the member list, the table, and the node count, so every node computes the identical split.
- **`rust/scripts/hack-weights.txt`** holds per-package weights in seconds, measured from build 5489984's logs (per-run `Finished ... in Ns` lines attributed to their package, scaled per node to the step's true wall time). Packages missing from the table default to 30s; the header documents how to refresh.
- **Heavy packages are sharded below package granularity.** Package-level packing alone floors the tail at op-reth (~11.3 min): every other node would idle at ~4.6. An optional `splits` column shards a package's `--each-feature` runs across nodes via `cargo hack -p <pkg> --partition i/k` (op-reth ×2, reth-optimism-cli ×2). This is nearly free: with the restored cache, op-reth's first run costs only ~25s more than its steady ~28s/run. A sharded package's single test-targets run goes to its shard-1 node.
- **Both hack steps share one assignment**, so the per-node **sum** of both steps is what gets balanced.
- The placebo `shuffle`/`seed` parameters (and the `shuf`/`openssl` dependency) are removed from the recipes and CI call sites.

### Predicted effect

Per-node hack compute goes from 0.9–13.1 min to **5.5–5.7 min** on all 10 nodes; the job wall drops **~13.8 → ~7 min** (incl. ~1 min of fixed steps).

Two considerations worth stating explicitly:

1. **This does not shorten the `rust-ci` workflow end-to-end today.** Across the four most recent develop runs, `required-rust-ci` is gated by `rust-build-release` (~22 min) with `op-rbuilder-checks` next (~20 min); `rust-cargo-hack` already finishes at +12.4–13.8. The issue's premise (hack as the wall-clock driver) dated from parallelism 6 (27-min tail); the bump to 10 bought it off the critical path at the cost of the skew this PR fixes. Speeding up the workflow itself means attacking those two jobs.
2. **Credits are nearly flat in the node count**, since each node bills its own runtime and the balanced split conserves total compute — only the ~1 min/node fixed overhead scales. Simulated with the checked-in weights:

   | parallelism | job wall | credits (node-min) |
   |---|---|---|
   | 6 | ~10.2 min | ~61 |
   | 8 | ~8.0 min | ~63 |
   | **10 (kept)** | **~6.7 min** | **~65** |
   | 12 | ~6.7 min | ~67 |

   Parallelism stays at 10: it's the fastest option and the extra nodes cost ~2 node-min per run. The packing is near-perfect (tail ≈ mean) up to N=8; at N=10 the op-reth half-shards become the floor, so scaling beyond 10 first needs op-reth's `splits` bumped to 3 in the weight table.

### Verification

- Simulated assignment for N=10 covers every package/shard exactly once, with unique test-step owners per package.
- Script is deterministic, rejects malformed partitions, and is shellcheck-clean.
- Both recipes exercised end-to-end through a `cargo` shim: partitioned nodes, shard-only nodes, empty test-step nodes, and the no-partition (full workspace) path all produce the expected invocations.
- `-p <pkg> --partition i/k` slicing confirmed against real cargo-hack (each shard runs its slice and skips the rest).
- CI fragments merge cleanly via `merge-configs.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
