### PR TITLE
op-reth: use the engine's sparse trie pipeline on the payload build path

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -13598,6 +13598,7 @@ dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth 2.1.1",
  "derive_more 2.1.1",
+ "metrics-util",
  "op-alloy-consensus",
  "op-alloy-rpc-types-engine",
  "op-revm",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -13547,6 +13547,7 @@ dependencies = [
  "reth-node-api",
  "reth-node-builder",
  "reth-node-core",
+ "reth-node-metrics",
  "reth-optimism-chainspec",
  "reth-optimism-consensus",
  "reth-optimism-evm",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -13618,6 +13618,7 @@ dependencies = [
  "reth-revm",
  "reth-storage-api",
  "reth-transaction-pool",
+ "reth-trie-parallel",
  "revm",
  "serde",
  "sha2 0.10.9",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -428,6 +428,7 @@ reth-transaction-pool = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef
 reth-trie = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1" }
 reth-trie-common = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1", default-features = false }
 reth-trie-db = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1" }
+reth-trie-parallel = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1" }
 
 # ==================== REVM (latest: op-reth versions) ====================
 revm = { version = "41.0.0", default-features = false }

--- a/rust/op-reth/crates/node/Cargo.toml
+++ b/rust/op-reth/crates/node/Cargo.toml
@@ -90,6 +90,8 @@ reth-optimism-node = { workspace = true, features = ["test-utils"] }
 reth-db = { workspace = true, features = ["test-utils"] }
 reth-db-common.workspace = true
 reth-node-builder = { workspace = true, features = ["test-utils"] }
+# Reads the payload builder's counters in tests/e2e-testsuite/sparse_trie.rs.
+reth-node-metrics.workspace = true
 reth-provider = { workspace = true, features = ["test-utils"] }
 reth-tasks.workspace = true
 reth-payload-util.workspace = true

--- a/rust/op-reth/crates/node/src/node.rs
+++ b/rust/op-reth/crates/node/src/node.rs
@@ -40,7 +40,9 @@ use reth_optimism_forks::OpHardforks;
 use reth_optimism_payload_builder::{
     OpBuiltPayload, OpExecData, OpPayloadBuilderAttributes, OpPayloadPrimitives,
     builder::OpPayloadTransactions,
-    config::{OpBuilderConfig, OpDAConfig, OpGasLimitConfig, OperatorSdmOptIn},
+    config::{
+        DEFAULT_STATE_ROOT_WAIT, OpBuilderConfig, OpDAConfig, OpGasLimitConfig, OperatorSdmOptIn,
+    },
 };
 use reth_optimism_primitives::{DepositReceipt, OpPrimitives};
 use reth_optimism_rpc::{
@@ -267,6 +269,7 @@ impl OpNode {
             operator_sdm_opt_in: self.operator_sdm_opt_in.clone(),
             interop_failsafe: self.interop_failsafe.clone(),
             max_uncompressed_block_size: self.args.max_uncompressed_block_size,
+            state_root_wait: Some(DEFAULT_STATE_ROOT_WAIT),
         }
     }
 

--- a/rust/op-reth/crates/node/tests/e2e-testsuite/main.rs
+++ b/rust/op-reth/crates/node/tests/e2e-testsuite/main.rs
@@ -1,6 +1,7 @@
 #![allow(missing_docs)]
 
 mod p2p;
+mod sparse_trie;
 mod testsuite;
 
 const fn main() {}

--- a/rust/op-reth/crates/node/tests/e2e-testsuite/sparse_trie.rs
+++ b/rust/op-reth/crates/node/tests/e2e-testsuite/sparse_trie.rs
@@ -1,0 +1,86 @@
+use alloy_genesis::Genesis;
+use reth_e2e_test_utils::setup_engine;
+use reth_node_api::TreeConfig;
+use reth_node_metrics::recorder::install_prometheus_recorder;
+use reth_optimism_chainspec::OpChainSpecBuilder;
+use reth_optimism_node::{
+    OpNode,
+    utils::{advance_chain, optimism_payload_attributes},
+};
+use reth_provider::BlockNumReader;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+/// Tests that the sparse trie pipeline can be shared with the payload builder.
+///
+/// Mirrors reth's `test_share_sparse_trie_with_payload_builder`
+/// (`crates/ethereum/node/tests/e2e/eth.rs`): enables both
+/// `share_execution_cache_with_payload_builder` and `share_sparse_trie_with_payload_builder`, then
+/// advances multiple blocks. Each FCU spawns a state root task that the payload builder uses for
+/// incremental state root computation instead of the blocking trie walk in `BlockBuilder::finish`.
+///
+/// The test validates that all blocks are successfully built and their state roots are accepted by
+/// the engine (`newPayload` returns VALID): a root that disagreed with the engine's own computation
+/// would fail the payload submission inside `advance_chain`.
+///
+/// It also asserts that the shared trie produced the root, rather than only that the chain
+/// advanced. Upstream's test stops at the block count, which a builder that silently ignores the
+/// handle satisfies just as well.
+///
+/// Calls `setup_engine` directly rather than op-reth's `setup()`, which hardcodes
+/// `Default::default()` in the `TreeConfig` slot and so cannot reach the flags.
+#[tokio::test]
+async fn test_share_sparse_trie_with_payload_builder() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let tree_config = TreeConfig::default()
+        .with_share_execution_cache_with_payload_builder(true)
+        .with_share_sparse_trie_with_payload_builder(true);
+
+    let genesis: Genesis = serde_json::from_str(include_str!("../assets/genesis.json")).unwrap();
+    let (mut nodes, wallet) = setup_engine::<OpNode>(
+        1,
+        Arc::new(
+            OpChainSpecBuilder::optimism_sepolia().genesis(genesis).ecotone_activated().build(),
+        ),
+        false,
+        tree_config,
+        optimism_payload_attributes,
+    )
+    .await?;
+
+    let mut node = nodes.pop().unwrap();
+    let wallet = Arc::new(Mutex::new(wallet));
+
+    let num_blocks = 5;
+    advance_chain(num_blocks, &mut node, wallet).await?;
+
+    let best_block = node.inner.provider.best_block_number()?;
+    assert_eq!(best_block, num_blocks as u64, "Expected {num_blocks} blocks, got {best_block}");
+
+    let from_shared_trie = counter("state_root_from_shared_trie_total");
+    let fallbacks = counter("state_root_fallback_total");
+    assert!(
+        from_shared_trie >= num_blocks as u64,
+        "expected at least {num_blocks} roots from the shared trie, got {from_shared_trie} \
+         ({fallbacks} fallbacks)"
+    );
+
+    Ok(())
+}
+
+/// Reads an `optimism_payload_builder` counter out of the process-wide Prometheus recorder, which
+/// the node installs while launching (`with_prometheus_server`). Absent counters read as zero: a
+/// metric only appears once it has been touched.
+///
+/// The recorder is global to the test binary, so this is a running total across every node the
+/// binary has launched. Assert lower bounds against it, never equality.
+fn counter(name: &str) -> u64 {
+    let rendered = install_prometheus_recorder().handle().render();
+    let key = format!("reth_optimism_payload_builder_{name} ");
+    rendered
+        .lines()
+        .find_map(|line| line.strip_prefix(&key))
+        .and_then(|value| value.trim().parse().ok())
+        .unwrap_or(0)
+}

--- a/rust/op-reth/crates/node/tests/e2e-testsuite/sparse_trie.rs
+++ b/rust/op-reth/crates/node/tests/e2e-testsuite/sparse_trie.rs
@@ -1,3 +1,4 @@
+use alloy_consensus::BlockHeader;
 use alloy_genesis::Genesis;
 use reth_e2e_test_utils::setup_engine;
 use reth_node_api::TreeConfig;
@@ -7,7 +8,7 @@ use reth_optimism_node::{
     OpNode,
     utils::{advance_chain, optimism_payload_attributes},
 };
-use reth_provider::BlockNumReader;
+use reth_provider::{BlockNumReader, HeaderProvider, StateProviderFactory};
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
@@ -65,6 +66,13 @@ async fn test_share_sparse_trie_with_payload_builder() -> eyre::Result<()> {
         "expected at least {num_blocks} roots from the shared trie, got {from_shared_trie} \
          ({fallbacks} fallbacks)"
     );
+
+    // Independently walk the canonical database trie and compare its root with the payload header.
+    // This catches a shared-trie wiring bug even if the engine accepts the same incorrect result.
+    let header =
+        node.inner.provider.header_by_number(best_block)?.expect("best block header should exist");
+    let synchronous_root = node.inner.provider.latest()?.state_root(Default::default())?;
+    assert_eq!(synchronous_root, header.state_root());
 
     Ok(())
 }

--- a/rust/op-reth/crates/payload/Cargo.toml
+++ b/rust/op-reth/crates/payload/Cargo.toml
@@ -25,6 +25,7 @@ reth-payload-util.workspace = true
 reth-payload-primitives.workspace = true
 reth-basic-payload-builder.workspace = true
 reth-payload-validator.workspace = true
+reth-trie-parallel.workspace = true
 reth-metrics.workspace = true
 
 # op-reth

--- a/rust/op-reth/crates/payload/Cargo.toml
+++ b/rust/op-reth/crates/payload/Cargo.toml
@@ -58,3 +58,4 @@ serde.workspace = true
 reth-optimism-chainspec = { workspace = true, features = ["superchain-configs"] }
 reth-revm = { workspace = true, features = ["test-utils"] }
 alloy-rpc-types-eth.workspace = true
+metrics-util = { workspace = true, features = ["debugging"] }

--- a/rust/op-reth/crates/payload/src/builder.rs
+++ b/rust/op-reth/crates/payload/src/builder.rs
@@ -49,6 +49,7 @@ use reth_revm::{
 };
 use reth_storage_api::{StateProvider, StateProviderFactory, errors::ProviderError};
 use reth_transaction_pool::{BestTransactionsAttributes, PoolTransaction, TransactionPool};
+use reth_trie_parallel::state_root_task::PayloadStateRootHandle;
 use revm::context::{Block, BlockEnv};
 use std::{marker::PhantomData, sync::Arc};
 use tracing::{debug, trace, warn};
@@ -254,7 +255,14 @@ where
         Txs:
             PayloadTransactions<Transaction: PoolTransaction<Consensus = N::SignedTx> + OpPooledTx>,
     {
-        let BuildArguments { mut cached_reads, config, cancel, best_payload, .. } = args;
+        let BuildArguments {
+            mut cached_reads,
+            config,
+            cancel,
+            best_payload,
+            state_root_handle,
+            ..
+        } = args;
 
         let ctx = OpPayloadBuilderCtx {
             evm_config: self.evm_config.clone(),
@@ -265,7 +273,7 @@ where
             best_payload,
         };
 
-        let builder = OpBuilder::new(best);
+        let builder = OpBuilder::new(best).with_state_root_handle(state_root_handle);
 
         let state_provider = self.client.state_by_block_hash(ctx.parent().hash())?;
         let state = StateProviderDatabase::new(&state_provider);
@@ -433,12 +441,27 @@ pub struct OpBuilder<'a, Txs> {
     /// Yields the best transaction to include if transactions from the mempool are allowed.
     #[debug(skip)]
     best: Box<dyn FnOnce(BestTransactionsAttributes) -> Txs + 'a>,
+    /// Handle to the engine's sparse trie pipeline, if it shares one for this payload.
+    state_root_handle: Option<PayloadStateRootHandle>,
 }
 
 impl<'a, Txs> OpBuilder<'a, Txs> {
     /// Creates a new [`OpBuilder`].
     pub fn new(best: impl FnOnce(BestTransactionsAttributes) -> Txs + Send + Sync + 'a) -> Self {
-        Self { best: Box::new(best) }
+        Self { best: Box::new(best), state_root_handle: None }
+    }
+
+    /// Shares the engine's sparse trie pipeline with this build.
+    ///
+    /// When set, state diffs stream to the trie task as they commit during execution and the
+    /// final root is taken from it, instead of the blocking trie walk in
+    /// [`BlockBuilder::finish`].
+    pub fn with_state_root_handle(
+        mut self,
+        state_root_handle: Option<PayloadStateRootHandle>,
+    ) -> Self {
+        self.state_root_handle = state_root_handle;
+        self
     }
 }
 
@@ -462,7 +485,7 @@ impl<Txs> OpBuilder<'_, Txs> {
             PayloadTransactions<Transaction: PoolTransaction<Consensus = N::SignedTx> + OpPooledTx>,
         Attrs: OpAttributes<Transaction = N::SignedTx>,
     {
-        let Self { best } = self;
+        let Self { best, mut state_root_handle } = self;
         debug!(target: "payload_builder", id=%ctx.payload_id(), parent_header = ?ctx.parent().hash(), parent_number = ctx.parent().number(), "building new payload");
 
         let mut db = State::builder().with_database(db).with_bundle_update().build();
@@ -481,6 +504,12 @@ impl<Txs> OpBuilder<'_, Txs> {
         let produce_post_exec = matches!(post_exec_mode, PostExecMode::Produce);
 
         let mut builder = ctx.block_builder_with_mode(&mut db, post_exec_mode)?;
+
+        // If the engine shares its sparse trie for this payload, stream state diffs to it as they
+        // commit so the final root is already computed when execution ends.
+        if let Some(task) = state_root_handle.as_mut() {
+            builder.evm_mut().db_mut().set_state_hook(Some(Box::new(task.take_state_hook())));
+        }
 
         // 1. apply pre-execution changes
         builder.apply_pre_execution_changes().map_err(|err| {
@@ -535,7 +564,30 @@ impl<Txs> OpBuilder<'_, Txs> {
             trie_updates,
             block,
             block_access_list: _,
-        } = builder.finish(state_provider, None)?;
+        } = if let Some(mut task) = state_root_handle {
+            // Drop the state hook, which finishes the update stream and signals the trie task to
+            // finalize.
+            builder.evm_mut().db_mut().set_state_hook(None);
+
+            // The sparse trie has been computing incrementally alongside tx execution.
+            // This waits for the final root hash — most work is already done.
+            // Fall back to sync state root if the trie pipeline fails.
+            match task.state_root() {
+                Ok(outcome) => {
+                    debug!(target: "payload_builder", id=%ctx.payload_id(), state_root=?outcome.state_root, job=task.name(), "received state root from sparse trie");
+                    builder.finish(
+                        state_provider,
+                        Some((outcome.state_root, Arc::unwrap_or_clone(outcome.trie_updates))),
+                    )?
+                }
+                Err(err) => {
+                    warn!(target: "payload_builder", id=%ctx.payload_id(), %err, "sparse trie failed, falling back to sync state root");
+                    builder.finish(state_provider, None)?
+                }
+            }
+        } else {
+            builder.finish(state_provider, None)?
+        };
 
         OpPayloadBuilderMetrics::default().record_sdm_refund_gas(sdm_refund_gas);
 
@@ -959,7 +1011,14 @@ where
     ) -> Result<
         impl BlockBuilder<
             Primitives = Evm::Primitives,
-            Executor: PostExecExecutorExt + BlockExecutor<Result: PreRefundGasUsed>,
+            // The database bound is re-stated from `post_exec_builder_for_next_block` so callers
+            // can reach the underlying `State`, which owns the state hook the sparse trie
+            // pipeline streams through.
+            Executor: PostExecExecutorExt
+                          + BlockExecutor<
+                Evm: AlloyEvm<DB: core::ops::DerefMut<Target = State<DB>>>,
+                Result: PreRefundGasUsed,
+            >,
         > + 'a,
         PayloadBuilderError,
     > {

--- a/rust/op-reth/crates/payload/src/builder.rs
+++ b/rust/op-reth/crates/payload/src/builder.rs
@@ -25,7 +25,7 @@ use reth_evm::{
 use reth_execution_types::BlockExecutionOutput;
 use reth_metrics::{
     Metrics,
-    metrics::{self, Counter, Gauge},
+    metrics::{self, Counter, Gauge, Histogram},
 };
 use reth_optimism_evm::{
     ConfigurePostExecEvm, PostExecExecutorExt, PostExecMode, PreRefundGasUsed,
@@ -57,7 +57,7 @@ use revm::context::{Block, BlockEnv};
 use std::{
     marker::PhantomData,
     sync::{Arc, mpsc::RecvTimeoutError},
-    time::Duration,
+    time::{Duration, Instant},
 };
 use tracing::{debug, trace, warn};
 
@@ -83,6 +83,28 @@ impl OpPayloadBuilderMetrics {
     }
 }
 
+/// Metrics for waiting on the engine's shared sparse trie.
+#[derive(Metrics, Clone)]
+#[metrics(scope = "optimism_payload_builder")]
+struct StateRootWaitMetrics {
+    /// Time spent waiting for the shared sparse trie's state root, in seconds.
+    state_root_wait_duration_seconds: Histogram,
+}
+
+impl StateRootWaitMetrics {
+    fn record(outcome: &'static str, elapsed: Duration) {
+        Self::new_with_labels(&[("outcome", outcome)])
+            .state_root_wait_duration_seconds
+            .record(elapsed);
+    }
+}
+
+enum StateRootWaitResult {
+    Task(Result<StateRootComputeOutcome, StateRootTaskError>),
+    Timeout(Duration),
+    Disconnected(&'static str),
+}
+
 /// Waits for the engine's shared sparse trie to produce a state root, bounded by `wait`.
 ///
 /// `None` waits indefinitely, which is what reth's `newPayload` path does when
@@ -96,15 +118,43 @@ fn await_sparse_trie_state_root(
     handle: &mut PayloadStateRootHandle,
     wait: Option<Duration>,
 ) -> Result<StateRootComputeOutcome, StateRootTaskError> {
-    let Some(wait) = wait else { return handle.state_root() };
+    let receiver = handle.take_state_root_rx();
+    let started = Instant::now();
+    let result = wait.map_or_else(
+        || {
+            receiver.recv().map_or_else(
+                |_| StateRootWaitResult::Disconnected("state root task dropped"),
+                StateRootWaitResult::Task,
+            )
+        },
+        |wait| match receiver.recv_timeout(wait) {
+            Ok(result) => StateRootWaitResult::Task(result),
+            Err(RecvTimeoutError::Timeout) => StateRootWaitResult::Timeout(wait),
+            Err(RecvTimeoutError::Disconnected) => {
+                StateRootWaitResult::Disconnected("sparse trie task dropped")
+            }
+        },
+    );
+    let elapsed = started.elapsed();
 
-    match handle.take_state_root_rx().recv_timeout(wait) {
-        Ok(result) => result,
-        Err(RecvTimeoutError::Timeout) => Err(StateRootTaskError::Other(format!(
-            "sparse trie task did not produce a state root within {wait:?}"
-        ))),
-        Err(RecvTimeoutError::Disconnected) => {
-            Err(StateRootTaskError::Other("sparse trie task dropped".to_string()))
+    match result {
+        StateRootWaitResult::Task(Ok(outcome)) => {
+            StateRootWaitMetrics::record("success", elapsed);
+            Ok(outcome)
+        }
+        StateRootWaitResult::Task(Err(err)) => {
+            StateRootWaitMetrics::record("task_error", elapsed);
+            Err(err)
+        }
+        StateRootWaitResult::Timeout(wait) => {
+            StateRootWaitMetrics::record("timeout", elapsed);
+            Err(StateRootTaskError::Other(format!(
+                "sparse trie task did not produce a state root within {wait:?}"
+            )))
+        }
+        StateRootWaitResult::Disconnected(message) => {
+            StateRootWaitMetrics::record("disconnected", elapsed);
+            Err(StateRootTaskError::Other(message.to_string()))
         }
     }
 }

--- a/rust/op-reth/crates/payload/src/builder.rs
+++ b/rust/op-reth/crates/payload/src/builder.rs
@@ -49,12 +49,19 @@ use reth_revm::{
 };
 use reth_storage_api::{StateProvider, StateProviderFactory, errors::ProviderError};
 use reth_transaction_pool::{BestTransactionsAttributes, PoolTransaction, TransactionPool};
-use reth_trie_parallel::state_root_task::PayloadStateRootHandle;
+use reth_trie_parallel::{
+    error::StateRootTaskError,
+    state_root_task::{PayloadStateRootHandle, StateRootComputeOutcome},
+};
 use revm::context::{Block, BlockEnv};
-use std::{marker::PhantomData, sync::Arc};
+use std::{
+    marker::PhantomData,
+    sync::{Arc, mpsc::RecvTimeoutError},
+    time::Duration,
+};
 use tracing::{debug, trace, warn};
 
-/// SDM/PostExec payload-builder metrics.
+/// Payload-builder metrics.
 #[derive(Metrics, Clone)]
 #[metrics(scope = "optimism_payload_builder")]
 struct OpPayloadBuilderMetrics {
@@ -62,12 +69,43 @@ struct OpPayloadBuilderMetrics {
     sdm_refund_gas_total: Counter,
     /// SDM gas refunded by the latest produced block.
     sdm_refund_gas_per_block: Gauge,
+    /// Builds whose state root came from the engine's shared sparse trie.
+    state_root_from_shared_trie_total: Counter,
+    /// Builds that fell back to the synchronous trie walk after the shared sparse trie failed to
+    /// produce a state root.
+    state_root_fallback_total: Counter,
 }
 
 impl OpPayloadBuilderMetrics {
     fn record_sdm_refund_gas(&self, gas_refund: u64) {
         self.sdm_refund_gas_total.increment(gas_refund);
         self.sdm_refund_gas_per_block.set(gas_refund as f64);
+    }
+}
+
+/// Waits for the engine's shared sparse trie to produce a state root, bounded by `wait`.
+///
+/// `None` waits indefinitely, which is what reth's `newPayload` path does when
+/// `--engine.state-root-task-timeout` is disabled. A timeout is reported as an error so the caller
+/// takes the same fallback it already takes when the pipeline fails.
+///
+/// Unlike the engine, the builder cannot race the fallback against the trie task:
+/// `BlockBuilder::finish` consumes the builder, so the synchronous walk can only start once we
+/// have given up on the task. A build that times out therefore pays both.
+fn await_sparse_trie_state_root(
+    handle: &mut PayloadStateRootHandle,
+    wait: Option<Duration>,
+) -> Result<StateRootComputeOutcome, StateRootTaskError> {
+    let Some(wait) = wait else { return handle.state_root() };
+
+    match handle.take_state_root_rx().recv_timeout(wait) {
+        Ok(result) => result,
+        Err(RecvTimeoutError::Timeout) => Err(StateRootTaskError::Other(format!(
+            "sparse trie task did not produce a state root within {wait:?}"
+        ))),
+        Err(RecvTimeoutError::Disconnected) => {
+            Err(StateRootTaskError::Other("sparse trie task dropped".to_string()))
+        }
     }
 }
 
@@ -558,6 +596,8 @@ impl<Txs> OpBuilder<'_, Txs> {
             0
         };
 
+        let metrics = OpPayloadBuilderMetrics::default();
+
         let BlockBuilderOutcome {
             execution_result,
             hashed_state,
@@ -569,11 +609,13 @@ impl<Txs> OpBuilder<'_, Txs> {
             // finalize.
             builder.evm_mut().db_mut().set_state_hook(None);
 
-            // The sparse trie has been computing incrementally alongside tx execution.
-            // This waits for the final root hash — most work is already done.
-            // Fall back to sync state root if the trie pipeline fails.
-            match task.state_root() {
+            // The sparse trie has been computing incrementally alongside tx execution, so the
+            // final root is usually immediate. Bound the wait anyway: a trie task that never
+            // answers would otherwise park this build forever, and with it the payload job, which
+            // never spawns another attempt and never resolves `getPayload`.
+            match await_sparse_trie_state_root(&mut task, ctx.builder_config.state_root_wait) {
                 Ok(outcome) => {
+                    metrics.state_root_from_shared_trie_total.increment(1);
                     debug!(target: "payload_builder", id=%ctx.payload_id(), state_root=?outcome.state_root, job=task.name(), "received state root from sparse trie");
                     builder.finish(
                         state_provider,
@@ -581,7 +623,11 @@ impl<Txs> OpBuilder<'_, Txs> {
                     )?
                 }
                 Err(err) => {
+                    metrics.state_root_fallback_total.increment(1);
                     warn!(target: "payload_builder", id=%ctx.payload_id(), %err, "sparse trie failed, falling back to sync state root");
+                    // Cancel the abandoned task rather than let it compete with the walk we are
+                    // about to pay for.
+                    drop(task);
                     builder.finish(state_provider, None)?
                 }
             }
@@ -589,7 +635,7 @@ impl<Txs> OpBuilder<'_, Txs> {
             builder.finish(state_provider, None)?
         };
 
-        OpPayloadBuilderMetrics::default().record_sdm_refund_gas(sdm_refund_gas);
+        metrics.record_sdm_refund_gas(sdm_refund_gas);
 
         let sealed_block = Arc::new(block.sealed_block().clone());
         debug!(target: "payload_builder", id=%ctx.attributes().payload_id(), sealed_block_header = ?sealed_block.header(), "sealed built block");

--- a/rust/op-reth/crates/payload/src/builder/tests.rs
+++ b/rust/op-reth/crates/payload/src/builder/tests.rs
@@ -16,12 +16,14 @@ use alloy_eips::{
 use alloy_evm::RecoveredTx;
 use alloy_primitives::{Address, B64, B256, Bytes, Signature, TxHash, TxKind, U256};
 use alloy_rpc_types_eth::erc4337::TransactionConditional;
+use metrics_util::debugging::{DebugValue, DebuggingRecorder, Snapshot};
 use op_alloy_consensus::{
     POST_EXEC_PAYLOAD_VERSION, PostExecPayload, SDMGasEntry, build_post_exec_tx,
 };
 use reth_basic_payload_builder::PayloadConfig;
 use reth_chainspec::MIN_TRANSACTION_GAS;
 use reth_evm::execute::{BlockBuilder, BlockExecutionError};
+use reth_metrics::metrics;
 use reth_optimism_chainspec::{OpChainSpec, OpChainSpecBuilder};
 use reth_optimism_evm::{OpEvmConfig, PostExecMode, PreRefundGasUsed};
 use reth_optimism_primitives::{OpPrimitives, OpTransactionSigned};
@@ -44,6 +46,7 @@ use reth_trie_parallel::{
 use std::{
     borrow::Cow,
     cell::Cell,
+    collections::HashMap,
     sync::{Arc, mpsc},
     thread,
     time::Duration,
@@ -1004,6 +1007,59 @@ fn root_outcome(state_root: B256) -> StateRootComputeOutcome {
         trie_updates: Arc::new(Default::default()),
         hashed_state: Arc::new(Default::default()),
         changed_paths: None,
+    }
+}
+
+fn state_root_wait_samples(snapshot: Snapshot) -> HashMap<String, usize> {
+    snapshot
+        .into_vec()
+        .into_iter()
+        .filter_map(|(key, _, _, value)| {
+            let is_wait_metric =
+                key.key().name() == "optimism_payload_builder.state_root_wait_duration_seconds";
+            let outcome = key
+                .key()
+                .labels()
+                .find(|label| label.key() == "outcome")
+                .map(|label| label.value().to_string());
+            match (is_wait_metric, outcome, value) {
+                (true, Some(outcome), DebugValue::Histogram(samples)) => {
+                    Some((outcome, samples.len()))
+                }
+                _ => None,
+            }
+        })
+        .collect()
+}
+
+#[test]
+fn state_root_wait_records_each_outcome() {
+    let recorder = DebuggingRecorder::new();
+    let snapshotter = recorder.snapshotter();
+
+    metrics::with_local_recorder(&recorder, || {
+        let (mut success_handle, success_tx) = fake_trie_task();
+        success_tx.send(Ok(root_outcome(B256::repeat_byte(0x42)))).unwrap();
+        await_sparse_trie_state_root(&mut success_handle, Some(Duration::from_secs(1))).unwrap();
+
+        let (mut task_error_handle, task_error_tx) = fake_trie_task();
+        task_error_tx.send(Err(StateRootTaskError::Other("failed".to_string()))).unwrap();
+        await_sparse_trie_state_root(&mut task_error_handle, Some(Duration::from_secs(1)))
+            .unwrap_err();
+
+        let (mut timeout_handle, _timeout_tx) = fake_trie_task();
+        await_sparse_trie_state_root(&mut timeout_handle, Some(Duration::from_millis(1)))
+            .unwrap_err();
+
+        let (mut disconnected_handle, disconnected_tx) = fake_trie_task();
+        drop(disconnected_tx);
+        let error = await_sparse_trie_state_root(&mut disconnected_handle, None).unwrap_err();
+        assert_eq!(error.to_string(), "state root task dropped");
+    });
+
+    let samples = state_root_wait_samples(snapshotter.snapshot());
+    for outcome in ["success", "task_error", "timeout", "disconnected"] {
+        assert_eq!(samples.get(outcome), Some(&1), "missing outcome {outcome}");
     }
 }
 

--- a/rust/op-reth/crates/payload/src/builder/tests.rs
+++ b/rust/op-reth/crates/payload/src/builder/tests.rs
@@ -1,6 +1,7 @@
 use super::{
     CommittedTxGas, ExecutionInfo, OpPayloadBuilderCtx, PayloadTransactionsWithCommitHook,
-    RethPayloadTransactions, build_post_exec_recovered_tx, try_include_post_exec_tx,
+    RethPayloadTransactions, await_sparse_trie_state_root, build_post_exec_recovered_tx,
+    try_include_post_exec_tx,
 };
 use crate::{OpPayloadBuilderAttributes, config::OpBuilderConfig};
 use alloy_consensus::{
@@ -36,7 +37,17 @@ use reth_payload_util::PayloadTransactionsFixed;
 use reth_primitives_traits::{Account, InMemorySize, SealedHeader};
 use reth_revm::{database::StateProviderDatabase, db::State, test_utils::StateProviderTest};
 use reth_transaction_pool::PoolTransaction;
-use std::{borrow::Cow, cell::Cell, sync::Arc};
+use reth_trie_parallel::{
+    error::StateRootTaskError,
+    state_root_task::{PayloadStateRootHandle, StateRootComputeOutcome},
+};
+use std::{
+    borrow::Cow,
+    cell::Cell,
+    sync::{Arc, mpsc},
+    thread,
+    time::Duration,
+};
 
 fn entries(specs: &[(u64, u64)]) -> Vec<SDMGasEntry> {
     specs.iter().map(|&(index, gas_refund)| SDMGasEntry { index, gas_refund }).collect()
@@ -977,4 +988,72 @@ fn execute_best_transactions_excludes_interop_txs_when_failsafe_active() {
     // build's `mark_invalid` did not permanently exclude it.
     failsafe.set(false);
     assert_eq!(build(&failsafe), vec![normal_hash, interop_hash]);
+}
+
+/// Builds a [`PayloadStateRootHandle`] backed by a live channel, plus the sender the trie task
+/// would answer on. Dropping that sender is how a task that died reports itself.
+fn fake_trie_task()
+-> (PayloadStateRootHandle, mpsc::Sender<Result<StateRootComputeOutcome, StateRootTaskError>>) {
+    let (root_tx, root_rx) = mpsc::channel();
+    (PayloadStateRootHandle::new("test", None, root_rx, None), root_tx)
+}
+
+fn root_outcome(state_root: B256) -> StateRootComputeOutcome {
+    StateRootComputeOutcome {
+        state_root,
+        trie_updates: Arc::new(Default::default()),
+        hashed_state: Arc::new(Default::default()),
+        changed_paths: None,
+    }
+}
+
+#[test]
+fn bounded_wait_takes_the_root_the_trie_task_produced() {
+    let (mut handle, root_tx) = fake_trie_task();
+    let root = B256::repeat_byte(0x42);
+    root_tx.send(Ok(root_outcome(root))).unwrap();
+
+    let result = await_sparse_trie_state_root(&mut handle, Some(Duration::from_secs(10)));
+
+    assert_eq!(result.unwrap().state_root, root);
+}
+
+#[test]
+fn bounded_wait_gives_up_instead_of_parking_the_build() {
+    // The failure this guards against: a trie task that never answers used to park the payload
+    // job forever, so it never spawned another attempt and `getPayload` never resolved.
+    let (mut handle, _root_tx) = fake_trie_task();
+
+    let started = std::time::Instant::now();
+    let result = await_sparse_trie_state_root(&mut handle, Some(Duration::from_millis(50)));
+
+    assert!(started.elapsed() < Duration::from_secs(5), "wait was not bounded");
+    let err = result.expect_err("a silent trie task must not produce a root");
+    assert!(err.to_string().contains("did not produce a state root"), "unexpected error: {err}");
+}
+
+#[test]
+fn bounded_wait_reports_a_dropped_trie_task() {
+    let (mut handle, root_tx) = fake_trie_task();
+    drop(root_tx);
+
+    let err = await_sparse_trie_state_root(&mut handle, Some(Duration::from_secs(10)))
+        .expect_err("a dropped trie task must not produce a root");
+
+    assert!(err.to_string().contains("dropped"), "unexpected error: {err}");
+}
+
+#[test]
+fn unbounded_wait_still_waits_for_a_late_root() {
+    // `None` is the opt-out, and must keep the pre-existing behaviour of waiting indefinitely.
+    let (mut handle, root_tx) = fake_trie_task();
+    let root = B256::repeat_byte(0x7);
+    thread::spawn(move || {
+        thread::sleep(Duration::from_millis(100));
+        let _ = root_tx.send(Ok(root_outcome(root)));
+    });
+
+    let result = await_sparse_trie_state_root(&mut handle, None);
+
+    assert_eq!(result.unwrap().state_root, root);
 }

--- a/rust/op-reth/crates/payload/src/config.rs
+++ b/rust/op-reth/crates/payload/src/config.rs
@@ -1,13 +1,24 @@
 //! Additional configuration for the OP builder
 
 use reth_optimism_txpool::interop::InteropFailsafe;
-use std::sync::{
-    Arc,
-    atomic::{AtomicBool, AtomicU64, Ordering},
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicBool, AtomicU64, Ordering},
+    },
+    time::Duration,
 };
 
+/// Default bound on waiting for the engine's shared sparse trie to produce a state root.
+///
+/// Matches `TreeConfig`'s own `DEFAULT_STATE_ROOT_TASK_TIMEOUT`, which bounds the same computation
+/// on the `newPayload` path. Kept short deliberately: unlike the engine, the builder cannot race
+/// the fallback against the trie task, so a build that times out pays the wait *and* the
+/// synchronous trie walk, and on a one-second chain a longer bound costs whole slots.
+pub const DEFAULT_STATE_ROOT_WAIT: Duration = Duration::from_secs(1);
+
 /// Settings for the OP builder.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct OpBuilderConfig {
     /// Data availability configuration for the OP builder.
     pub da_config: OpDAConfig,
@@ -27,6 +38,25 @@ pub struct OpBuilderConfig {
     /// clients (e.g. the common 10 MiB JSON payload cap). op-geth enforces an equivalent but
     /// non-configurable cap via `params.MaxBlockSize`.
     pub max_uncompressed_block_size: Option<u64>,
+    /// How long to wait for the engine's shared sparse trie to return a state root before
+    /// falling back to the synchronous trie walk.
+    ///
+    /// `None` waits indefinitely. Only consulted when the engine shares a trie handle with the
+    /// builder, which it does under `--engine.share-sparse-trie-with-payload-builder`.
+    pub state_root_wait: Option<Duration>,
+}
+
+impl Default for OpBuilderConfig {
+    fn default() -> Self {
+        Self {
+            da_config: OpDAConfig::default(),
+            gas_limit_config: OpGasLimitConfig::default(),
+            operator_sdm_opt_in: OperatorSdmOptIn::default(),
+            interop_failsafe: InteropFailsafe::default(),
+            max_uncompressed_block_size: None,
+            state_root_wait: Some(DEFAULT_STATE_ROOT_WAIT),
+        }
+    }
 }
 
 impl OpBuilderConfig {
@@ -38,6 +68,7 @@ impl OpBuilderConfig {
             operator_sdm_opt_in: OperatorSdmOptIn::default(),
             interop_failsafe: InteropFailsafe::default(),
             max_uncompressed_block_size: None,
+            state_root_wait: Some(DEFAULT_STATE_ROOT_WAIT),
         }
     }
 


### PR DESCRIPTION
op-reth's payload builder threw away the sparse-trie handle the engine gives it, so
`--engine.share-sparse-trie-with-payload-builder` did nothing: every build walked the trie
synchronously anyway. This wires it through, same as reth's Ethereum builder, keeping the sync walk
as the fallback.

## What was wrong

`OpPayloadBuilder::build_payload` discarded `state_root_handle` through the `..` pattern, so
`--engine.share-sparse-trie-with-payload-builder` was inert: every build walked the trie
synchronously in `BlockBuilder::finish`, and the sparse trie the engine had preserved for the
payload went unused.

Wiring it up brings a second problem along. `PayloadStateRootHandle::state_root()` is a blocking
`recv()` with no deadline (`crates/trie/parallel/src/state_root_task.rs:271`), so a trie task that
never answers parks the build forever. That costs the slot, not just the block. The handle reaches
only build attempt #1 (`crates/payload/basic/src/lib.rs:418`, `.take()`), so the parked attempt is
the only one, `best_payload` stays `None`, and `getPayload` gets
`MissingPayloadBehaviour::AwaitInProgress` and pends forever. A payload-task permit and a
blocking-pool thread go with it: the job's deadline ends the job, but does not unblock a thread
sitting in `recv()`. Every other consumer of the handle bounds its wait. The payload builders are
the only ones that do not.

## Is the hang actually reachable?

Yes, by two routes at this pin. A task that panics or dies drops its sender, so `recv()` returns
`Err` and the fallback works — the hang needs a task that is alive but stuck.

A dispatched proof batch that is never answered is one. The sparse-trie task keeps its own clone of
the proof-result sender (`state_root_strategy/sparse_trie.rs:38,152,877`), so that channel can never
disconnect, `in_flight_proof_batches` stays above zero, and the stall detector is blind to it:
`ensure_not_stalled` requires `in_flight_proof_batches == 0` (`:918`), the case it excludes. Batches
get lost to a proof-worker startup failure (`fix(trie): propagate proof worker startup failures
(#26545)`, merged upstream but not in our pin), a worker panic, or a worker parked in an MDBX read.

Queue-head blocking is the other. `spawn_blocking_named` is a `WorkerMap`: one OS thread per name,
strictly sequential (`crates/tasks/src/worker_map.rs:36-53`). Engine validation and payload building
share the single `"sparse-trie"` name (`state_root_strategy/mod.rs:596`), so a closure queued behind
a stuck predecessor holds its result sender with nobody watching its cancel channel.

Nothing in tree recovers from either. `#26759` makes cancellation cooperative, which a parked
`recv()` never polls, and the cancel guard is held by the blocked consumer itself, so cancellation
is unreachable exactly when it is needed. Bounding the wait is what makes that mechanism usable.

## What this does

Waits at most `OpBuilderConfig::state_root_wait` (default 1s, `None` keeps the unbounded wait) and
reports a timeout as an error, so it takes the fallback the pipeline already had. Treat the bound as
a hang-breaker rather than a latency knob: the builder cannot race the fallback against the task the
way the engine does, because `BlockBuilder::finish` consumes the builder, so a timed-out build pays
for both.

On the fallback path the handle is dropped before the walk starts, cancelling the abandoned task
through its `cancel_guard` rather than leaving it competing for CPU with the walk replacing it. That
costs a cold trie for the next `newPayload` (`PreservedSparseTrie::cleared` rather than `anchored`).

Both outcomes are counted, in `state_root_from_shared_trie_total` and `state_root_fallback_total`:
is the pipeline being used at all, and is it working. Previously the failure side was a lone
`warn!` and the success side was invisible.

The hook now goes on the database (`builder.evm_mut().db_mut().set_state_hook(..)`), because
`BlockExecutor::set_state_hook` no longer exists, so updates arrive at commit granularity rather
than per transaction. Worth a look in review. It also forced `block_builder_with_mode` to re-state
the database bound its `ConfigurePostExecEvm` counterpart already carries; without it the `State`
owning the hook is unreachable.

## Two questions for reviewers

### Is 1s the right default?

It matches `TreeConfig::default()`, but reth's CLI default for the same quantity is 4s. Argument for
the larger number: this is a hang-breaker, so pick it generously rather than tuning for latency,
since a false positive costs the wait *plus* the full walk. Argument for the smaller one: a bound
that only fires after several block times is not much of a liveness guarantee on a one-second chain,
and 1s is what the engine itself uses when no CLI flag is set. I took 1s, and I am happy to be
argued out of it.

### Where should the knob live?

`state_root_wait` is a fork-local field, reachable only through `OpNode::builder_config()`. Upstream
is the better home: put the deadline inside `PayloadStateRootHandle`, sourced from the
`state_root_task_timeout` the engine already holds in `prepare_payload_builder`. One knob for both
builders, no new CLI flag, and every custom builder inherits it instead of re-implementing the wait.

That has to land in reth and reach us through a pin bump, so this PR takes the local route for now.
The field should then be deleted rather than left to drift from the engine's default. Adding
`--builder.state-root-wait` is the third option, and I would rather not, if the upstream fix is
coming.

## Verified

- `cargo test -p reth-optimism-payload-builder`: 29 passed, including 4 new tests covering the happy
  path, the timeout, a dropped task, and that `None` still waits for a late root. They drive a real
  `PayloadStateRootHandle` over a real channel, not a mock.
- `cargo test -p reth-optimism-node --all-features --test e2e_testsuite`: 3 passed, 1 pre-existing
  ignore. Mutating `with_state_root_handle(state_root_handle)` to `…(None)` fails the new test with
  "expected at least 5 roots from the shared trie, got 0" — upstream's version of the same test
  passes under that mutation, which is why this one asserts the counter and not just the block
  count.

## Follow-ups

`build_payload` still drops `execution_cache` through the `..`, and the builder still hardcodes
`changed_paths: None` even though the trie task now hands one back. Both can be picked up in a
follow-up.
