### PR TITLE
docs: require agents to watch CI after pushing to a PR

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,19 @@ This list is a floor, not a ceiling: also run the review agents and review skill
 
 For the remaining pre-PR steps (broad tests, rebase on `develop`, PR guidelines) see [docs/ai/dev-workflow.md](docs/ai/dev-workflow.md#before-every-pr).
 
+## After Pushing to a PR
+
+Pushing is not the end of the task. Watch CI to a terminal state after **every** push — the PR's first one and each follow-up — and fix what your change broke. A red check on your own PR is your work, not the reviewer's.
+
+```bash
+gh pr checks <pr> --watch --fail-fast   # both CircleCI and the GitHub Actions checks
+gh pr checks <pr> --required            # only the checks that gate merge
+```
+
+Merge is gated by the checks the `develop` branch ruleset requires, so individual green jobs do not mean the PR is mergeable — `gh pr checks <pr> --required` enumerates them. `gh pr view <pr> --json mergeable,mergeStateStatus` answers mergeability, not check state: a `BLOCKED` PR with every required check green is usually waiting on the review requirement. If the harness provides a CI-watching skill or agent, use it instead of a bare polling loop.
+
+Before debugging a failure, rule out one your branch inherited from `develop` and check whether the test is a known flake — see [docs/ai/ci-ops.md](docs/ai/ci-ops.md#watching-ci-after-a-push). Never report a PR as green while checks are pending, and never present a flake as a pass: state which checks failed and why.
+
 ## Subdirectory Instructions
 
 Some subdirectories have their own CLAUDE.md with domain-specific conventions. Read the relevant file before working in that area — do not read them all upfront.

--- a/docs/ai/ci-ops.md
+++ b/docs/ai/ci-ops.md
@@ -4,6 +4,46 @@ This document provides guidance for AI agents working with CI/CD operational tas
 
 For Docker image build failures — especially flaky `apt`/`apk`/`curl` downloads from package registries and CDNs — see [docker.md](docker.md).
 
+## Watching CI after a push
+
+Watch every push to a terminal state — `AGENTS.md` requires it. Most jobs run on
+CircleCI and report as commit statuses, so `gh` sees them alongside the GitHub Actions
+and Wiz checks:
+
+```bash
+gh pr checks <pr> --watch --fail-fast   # blocks until done, exits on the first failure
+gh pr checks <pr> --required            # only the merge-gating checks
+gh pr checks <pr> --json name,bucket,link --jq '.[]|select(.bucket=="fail")'
+```
+
+`--watch` blocks until every reported check settles — the `main` workflow alone runs
+~25 minutes, past most agent command timeouts — so background it or re-invoke it
+instead of running it as a blocking call.
+
+Notes that matter in practice:
+
+- **Wait for the gates the ruleset requires,** not the individual jobs: the four
+  CircleCI fan-in gates (`ci-gate`, `required-contracts-ci`, `required-rust-ci`,
+  `required-rust-e2e`) plus the `dependency-review` GitHub Actions check. A gate reports
+  last, so it can still be pending while every job you were watching is green. On skip
+  paths the gate is produced by an `always-succeed` companion, so a gate that never
+  reports at all is a config bug (see [ci-config-review.md](ci-config-review.md) item 2),
+  not something to wait out.
+- **A first push is not the only push to watch.** Rebases, review fixups, and
+  merge-queue rebases each start a new pipeline against a different merge base.
+- **Triage before rerunning.** Rule out an inherited failure (next section), then check
+  whether the test is a known flake. The `generate-flaky-tests-report` job publishes a
+  `flaky-test-reports` artifact, but it covers `op-acceptance-tests` only, is scoped to
+  the pipeline's own branch (use a `develop` pipeline's copy, not your PR's) and does not
+  run on fast paths; for every other suite, look for an open flake issue instead. A rerun
+  that hides a real regression costs more than the minutes it saved, and a confirmed
+  flake needs an issue, not a silent retry. Reruns through the CircleCI v2 API need a
+  personal API token in `CIRCLE_TOKEN` — the same variable
+  [ci-config-review.md](ci-config-review.md) uses for `circleci config validate --org`;
+  the `CIRCLE_API_TOKEN` in `.circleci/` is the in-job context token, not this one. For
+  flakes in `op-acceptance-tests/`/`op-devstack/`,
+  [flake-prevention.md](flake-prevention.md) catalogues the recurring causes.
+
 ## Diagnosing a CI failure on a feature branch
 
 Before assuming a red check is caused by your change, rule out a failure the branch


### PR DESCRIPTION
Pushing is not the end of the task. `AGENTS.md` gains `## After Pushing to a PR`: watch CI to a terminal state on every push, and fix what your change broke instead of leaving a red PR for a human to notice.

The mechanics live in `docs/ai/ci-ops.md` (`## Watching CI after a push`), next to the existing inherited-failure triage: the `gh pr checks` invocations, which checks actually gate merge, why a rebase or merge-queue push needs watching again, and triage-before-rerun. `--watch` blocks for ~25 minutes, so it says to background it rather than run it as a blocking call.

Facts verified against the live repo rather than assumed, several of them corrections from the review pass:
- Merge needs **five** required contexts, not the four CircleCI fan-in gates — `gh api repos/…/rules/branches/develop` also requires `dependency-review`.
- A gate that never reports is a config bug ([ci-config-review.md](docs/ai/ci-config-review.md) item 2), not something to wait out: skip paths emit it via an `always-succeed` companion.
- `mergeStateStatus` answers mergeability, not check state — this PR sat at `BLOCKED` with all five required checks green, waiting on review.
- The JSON filter uses `bucket=="fail"`; `state!="SUCCESS"` reports `SKIPPED` checks as failures on a fully green PR.
- The `flaky-test-reports` artifact covers `op-acceptance-tests` only, is branch-scoped, and does not run on fast paths.

Review watching is deliberately **not** here — it needs a trust boundary (only `ethereum-optimism` org members) to avoid prompt injection from public commenters, so it ships as an opt-in skill in a follow-up PR.

🤖 *Co-created with claude-opus-5*