### PR TITLE
op-challenger: support ZK challenges in move command

### DIFF
--- a/op-challenger/cmd/move.go
+++ b/op-challenger/cmd/move.go
@@ -1,12 +1,15 @@
 package main
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/flags"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts"
+	contractMetrics "github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts/metrics"
 	opservice "github.com/ethereum-optimism/optimism/op-service"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/urfave/cli/v2"
@@ -15,7 +18,7 @@ import (
 var (
 	AttackFlag = &cli.BoolFlag{
 		Name:    "attack",
-		Usage:   "An attack move. If true, the defend flag must not be set.",
+		Usage:   "An attack move or ZK game challenge. If true, the defend flag must not be set.",
 		EnvVars: opservice.PrefixEnvVar(flags.EnvVarPrefix, "ATTACK"),
 	}
 	DefendFlag = &cli.BoolFlag{
@@ -25,12 +28,12 @@ var (
 	}
 	ParentIndexFlag = &cli.StringFlag{
 		Name:    "parent-index",
-		Usage:   "The index of the claim to move on.",
+		Usage:   "The index of the claim to move on (fault dispute games only).",
 		EnvVars: opservice.PrefixEnvVar(flags.EnvVarPrefix, "PARENT_INDEX"),
 	}
 	ClaimFlag = &cli.StringFlag{
 		Name:    "claim",
-		Usage:   "The claim hash.",
+		Usage:   "The claim hash (fault dispute games only).",
 		EnvVars: opservice.PrefixEnvVar(flags.EnvVarPrefix, "CLAIM"),
 	}
 )
@@ -38,35 +41,33 @@ var (
 func Move(ctx *cli.Context) error {
 	attack := ctx.Bool(AttackFlag.Name)
 	defend := ctx.Bool(DefendFlag.Name)
-	parentIndex := ctx.Uint64(ParentIndexFlag.Name)
-	claim := common.HexToHash(ctx.String(ClaimFlag.Name))
 
 	if attack && defend {
 		return fmt.Errorf("both attack and defense flags cannot be set")
 	}
-
-	contract, txMgr, err := NewContractWithTxMgr[contracts.FaultDisputeGameContract](ctx, AddrFromFlag(GameAddressFlag.Name), contracts.NewFaultDisputeGameContract)
-	if err != nil {
-		return fmt.Errorf("failed to create dispute game bindings: %w", err)
-	}
-
-	parentClaim, err := contract.GetClaim(ctx.Context, parentIndex)
-	if err != nil {
-		return fmt.Errorf("failed to get parent claim: %w", err)
-	}
-	var tx txmgr.TxCandidate
-	if attack {
-		tx, err = contract.AttackTx(ctx.Context, parentClaim, claim)
-		if err != nil {
-			return fmt.Errorf("failed to create attack tx: %w", err)
-		}
-	} else if defend {
-		tx, err = contract.DefendTx(ctx.Context, parentClaim, claim)
-		if err != nil {
-			return fmt.Errorf("failed to create defense tx: %w", err)
-		}
-	} else {
+	if !attack && !defend {
 		return fmt.Errorf("either attack or defense flag must be set")
+	}
+
+	caller, txMgr, err := newClientsFromCLI(ctx)
+	if err != nil {
+		return err
+	}
+	gameAddr, err := AddrFromFlag(GameAddressFlag.Name)(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to parse game address: %w", err)
+	}
+
+	tx, err := createMoveTx(
+		ctx.Context,
+		caller,
+		gameAddr,
+		attack,
+		ctx.Uint64(ParentIndexFlag.Name),
+		common.HexToHash(ctx.String(ClaimFlag.Name)),
+	)
+	if err != nil {
+		return err
 	}
 
 	rct, err := txMgr.Send(ctx.Context, tx)
@@ -76,6 +77,61 @@ func Move(ctx *cli.Context) error {
 	fmt.Printf("Sent tx with status: %v, hash: %s\n", rct.Status, rct.TxHash.String())
 
 	return nil
+}
+
+func createMoveTx(
+	ctx context.Context,
+	caller *batching.MultiCaller,
+	gameAddr common.Address,
+	attack bool,
+	parentIndex uint64,
+	claim common.Hash,
+) (txmgr.TxCandidate, error) {
+	gameType, err := contracts.DetectGameType(ctx, gameAddr, caller)
+	if err != nil {
+		return txmgr.TxCandidate{}, fmt.Errorf("failed to detect dispute game type: %w", err)
+	}
+	contract, err := contracts.NewDisputeGameContract(
+		ctx,
+		contractMetrics.NoopContractMetrics,
+		caller,
+		gameType,
+		gameAddr,
+	)
+	if err != nil {
+		return txmgr.TxCandidate{}, fmt.Errorf("failed to create dispute game bindings: %w", err)
+	}
+
+	switch contract := contract.(type) {
+	case contracts.ZKDisputeGameContract:
+		if !attack {
+			return txmgr.TxCandidate{}, fmt.Errorf("zk dispute games do not support defense moves")
+		}
+		tx, err := contract.ChallengeTx(ctx)
+		if err != nil {
+			return txmgr.TxCandidate{}, fmt.Errorf("failed to create challenge tx: %w", err)
+		}
+		return tx, nil
+	case contracts.FaultDisputeGameContract:
+		parentClaim, err := contract.GetClaim(ctx, parentIndex)
+		if err != nil {
+			return txmgr.TxCandidate{}, fmt.Errorf("failed to get parent claim: %w", err)
+		}
+		if attack {
+			tx, err := contract.AttackTx(ctx, parentClaim, claim)
+			if err != nil {
+				return txmgr.TxCandidate{}, fmt.Errorf("failed to create attack tx: %w", err)
+			}
+			return tx, nil
+		}
+		tx, err := contract.DefendTx(ctx, parentClaim, claim)
+		if err != nil {
+			return txmgr.TxCandidate{}, fmt.Errorf("failed to create defense tx: %w", err)
+		}
+		return tx, nil
+	default:
+		return txmgr.TxCandidate{}, fmt.Errorf("game type %v does not support moves", gameType)
+	}
 }
 
 func moveFlags() []cli.Flag {
@@ -94,8 +150,8 @@ func moveFlags() []cli.Flag {
 
 var MoveCommand = &cli.Command{
 	Name:        "move",
-	Usage:       "Creates and sends a move transaction to the dispute game",
-	Description: "Creates and sends a move transaction to the dispute game",
+	Usage:       "Creates and sends an attack, defense, or ZK challenge transaction",
+	Description: "Creates and sends an attack, defense, or ZK challenge transaction",
 	Action:      Interruptible(Move),
 	Flags:       moveFlags(),
 }

--- a/op-challenger/cmd/move_test.go
+++ b/op-challenger/cmd/move_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
+	batchingTest "github.com/ethereum-optimism/optimism/op-service/sources/batching/test"
+	"github.com/ethereum-optimism/optimism/packages/contracts-bedrock/snapshots"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateMoveTxZKChallenge(t *testing.T) {
+	gameAddr := common.Address{0xaa}
+	bond := big.NewInt(1234)
+	stubRPC := batchingTest.NewAbiBasedRpc(t, gameAddr, snapshots.LoadZKDisputeGameABI())
+	stubRPC.SetResponse(gameAddr, "gameType", rpcblock.Latest, nil, []interface{}{uint32(gameTypes.ZKDisputeGameType)})
+	stubRPC.SetResponse(gameAddr, "challengerBond", rpcblock.Latest, nil, []interface{}{bond})
+	stubRPC.SetResponse(gameAddr, "challenge", rpcblock.Latest, nil, nil)
+	caller := batching.NewMultiCaller(stubRPC, batching.DefaultBatchSize)
+
+	tx, err := createMoveTx(context.Background(), caller, gameAddr, true, 0, common.Hash{})
+	require.NoError(t, err)
+	require.Equal(t, bond, tx.Value)
+	stubRPC.VerifyTxCandidate(tx)
+}
+
+func TestCreateMoveTxRejectsZKDefense(t *testing.T) {
+	gameAddr := common.Address{0xaa}
+	stubRPC := batchingTest.NewAbiBasedRpc(t, gameAddr, snapshots.LoadZKDisputeGameABI())
+	stubRPC.SetResponse(gameAddr, "gameType", rpcblock.Latest, nil, []interface{}{uint32(gameTypes.ZKDisputeGameType)})
+	caller := batching.NewMultiCaller(stubRPC, batching.DefaultBatchSize)
+
+	_, err := createMoveTx(context.Background(), caller, gameAddr, false, 0, common.Hash{})
+	require.EqualError(t, err, "zk dispute games do not support defense moves")
+}
+
+func TestCreateMoveTxFaultGameAttack(t *testing.T) {
+	gameAddr := common.Address{0xbb}
+	parentClaim := common.Hash{0x11}
+	attackClaim := common.Hash{0x22}
+	bond := big.NewInt(5678)
+	stubRPC := batchingTest.NewAbiBasedRpc(t, gameAddr, snapshots.LoadFaultDisputeGameABI())
+	stubRPC.SetResponse(gameAddr, "gameType", rpcblock.Latest, nil, []interface{}{uint32(gameTypes.CannonGameType)})
+	stubRPC.SetResponse(gameAddr, "version", rpcblock.Latest, nil, []interface{}{"1.4.0"})
+	stubRPC.SetResponse(gameAddr, "claimData", rpcblock.Latest, []interface{}{big.NewInt(3)}, []interface{}{
+		uint32(0), common.Address{}, common.Address{}, big.NewInt(0), parentClaim, big.NewInt(1), big.NewInt(0),
+	})
+	stubRPC.SetResponse(gameAddr, "getRequiredBond", rpcblock.Latest, []interface{}{big.NewInt(2)}, []interface{}{bond})
+	stubRPC.SetResponse(gameAddr, "attack", rpcblock.Latest, []interface{}{parentClaim, big.NewInt(3), attackClaim}, nil)
+	caller := batching.NewMultiCaller(stubRPC, batching.DefaultBatchSize)
+
+	tx, err := createMoveTx(context.Background(), caller, gameAddr, true, 3, attackClaim)
+	require.NoError(t, err)
+	require.Equal(t, bond, tx.Value)
+	stubRPC.VerifyTxCandidate(tx)
+}

--- a/op-challenger/game/fault/contracts/detect.go
+++ b/op-challenger/game/fault/contracts/detect.go
@@ -35,7 +35,8 @@ func DetectGameType(ctx context.Context, addr common.Address, caller *batching.M
 		gameTypes.AlphabetGameType,
 		gameTypes.FastGameType,
 		gameTypes.SuperPermissionedGameType,
-		gameTypes.SuperCannonKonaGameType:
+		gameTypes.SuperCannonKonaGameType,
+		gameTypes.ZKDisputeGameType:
 		return gameType, nil
 	default:
 		return gameTypes.UnknownGameType, fmt.Errorf("unsupported game type: %d", gameType)

--- a/op-challenger/game/fault/contracts/faultdisputegame.go
+++ b/op-challenger/game/fault/contracts/faultdisputegame.go
@@ -89,8 +89,14 @@ func NewFaultDisputeGameContract(ctx context.Context, metrics metrics.ContractMe
 	switch gameType {
 	case gameTypes.SuperCannonKonaGameType, gameTypes.SuperPermissionedGameType:
 		return NewSuperFaultDisputeGameContract(ctx, metrics, addr, caller)
-	default:
+	case gameTypes.CannonGameType,
+		gameTypes.PermissionedGameType,
+		gameTypes.CannonKonaGameType,
+		gameTypes.AlphabetGameType,
+		gameTypes.FastGameType:
 		return NewPreInteropFaultDisputeGameContract(ctx, metrics, addr, caller)
+	default:
+		return nil, fmt.Errorf("%w: %v", ErrUnsupportedGameType, gameType)
 	}
 }
 


### PR DESCRIPTION
The `op-challenger move --attack` command only supported fault dispute games, even though op-challenger already has ZK game bindings.

Detect the onchain game type before constructing the transaction. For ZK games, `--attack` now calls the payable `challenge()` function with the required challenger bond. `--parent-index` and `--claim` remain specific to fault games, while `--defend` is rejected for ZK games.

The fault-only constructor now explicitly rejects ZK games to prevent binding them as legacy fault games.