### PR TITLE
op-node: publish gossiped blocks off the sequencer's hot path

### DIFF
--- a/op-node/metrics/metrics.go
+++ b/op-node/metrics/metrics.go
@@ -39,6 +39,8 @@ type Metricer interface {
 	RecordSuperAuthorityReorgSignal(reason string)
 	RecordSequencingError()
 	RecordPublishingError()
+	RecordPublishQueueLen(length int)
+	RecordDroppedPublish()
 	RecordDerivationError()
 	RecordEmittedEvent(eventName string, emitter string)
 	RecordProcessedEvent(eventName string, deriver string, duration time.Duration)
@@ -98,6 +100,8 @@ type Metrics struct {
 	DerivationErrors *metrics.Event
 	SequencingErrors *metrics.Event
 	PublishingErrors *metrics.Event
+	DroppedPublishes *metrics.Event
+	PublishQueueLen  prometheus.Gauge
 	SequencerActive  prometheus.Gauge
 
 	*event.EventMetricsTracker
@@ -216,6 +220,12 @@ func NewMetrics(procName string, labels prometheus.Labels) *Metrics {
 		DerivationErrors: metrics.NewEvent(factory, ns, "", "derivation_errors", "derivation errors"),
 		SequencingErrors: metrics.NewEvent(factory, ns, "", "sequencing_errors", "sequencing errors"),
 		PublishingErrors: metrics.NewEvent(factory, ns, "", "publishing_errors", "p2p publishing errors"),
+		DroppedPublishes: metrics.NewEvent(factory, ns, "", "dropped_publishes", "sealed blocks dropped without being published to p2p"),
+		PublishQueueLen: factory.NewGauge(prometheus.GaugeOpts{
+			Namespace: ns,
+			Name:      "publish_queue_len",
+			Help:      "Number of sealed blocks awaiting publication to p2p",
+		}),
 		SequencerActive: factory.NewGauge(prometheus.GaugeOpts{
 			Namespace: ns,
 			Name:      "sequencer_active",
@@ -483,6 +493,14 @@ func (m *Metrics) RecordPublishingError() {
 	m.PublishingErrors.Record()
 }
 
+func (m *Metrics) RecordPublishQueueLen(length int) {
+	m.PublishQueueLen.Set(float64(length))
+}
+
+func (m *Metrics) RecordDroppedPublish() {
+	m.DroppedPublishes.Record()
+}
+
 func (m *Metrics) RecordDerivationError() {
 	m.DerivationErrors.Record()
 }
@@ -694,6 +712,12 @@ func (n *noopMetricer) RecordSequencingError() {
 }
 
 func (n *noopMetricer) RecordPublishingError() {
+}
+
+func (n *noopMetricer) RecordPublishQueueLen(length int) {
+}
+
+func (n *noopMetricer) RecordDroppedPublish() {
 }
 
 func (n *noopMetricer) RecordDerivationError() {

--- a/op-node/metrics/metrics.go
+++ b/op-node/metrics/metrics.go
@@ -220,7 +220,7 @@ func NewMetrics(procName string, labels prometheus.Labels) *Metrics {
 		DerivationErrors: metrics.NewEvent(factory, ns, "", "derivation_errors", "derivation errors"),
 		SequencingErrors: metrics.NewEvent(factory, ns, "", "sequencing_errors", "sequencing errors"),
 		PublishingErrors: metrics.NewEvent(factory, ns, "", "publishing_errors", "p2p publishing errors"),
-		DroppedPublishes: metrics.NewEvent(factory, ns, "", "dropped_publishes", "sealed blocks dropped without being published to p2p"),
+		DroppedPublishes: metrics.NewEvent(factory, ns, "", "dropped_publishes", "sealed blocks dropped because the p2p publish queue overflowed"),
 		PublishQueueLen: factory.NewGauge(prometheus.GaugeOpts{
 			Namespace: ns,
 			Name:      "publish_queue_len",

--- a/op-node/metrics/metrics.go
+++ b/op-node/metrics/metrics.go
@@ -220,7 +220,7 @@ func NewMetrics(procName string, labels prometheus.Labels) *Metrics {
 		DerivationErrors: metrics.NewEvent(factory, ns, "", "derivation_errors", "derivation errors"),
 		SequencingErrors: metrics.NewEvent(factory, ns, "", "sequencing_errors", "sequencing errors"),
 		PublishingErrors: metrics.NewEvent(factory, ns, "", "publishing_errors", "p2p publishing errors"),
-		DroppedPublishes: metrics.NewEvent(factory, ns, "", "dropped_publishes", "sealed blocks dropped because the p2p publish queue overflowed"),
+		DroppedPublishes: metrics.NewEvent(factory, ns, "", "dropped_publishes", "sealed blocks that were never published to p2p, through queue overflow or giving up"),
 		PublishQueueLen: factory.NewGauge(prometheus.GaugeOpts{
 			Namespace: ns,
 			Name:      "publish_queue_len",

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -813,19 +813,6 @@ func (n *OpNode) Stop(ctx context.Context) error {
 		}
 	}
 
-	// The driver closes before p2p and the block signer, because it owns the async
-	// gossiper whose publisher goroutine uses both, and that goroutine only stops
-	// as part of Driver.Close. Closing them first let a publish still in flight -
-	// or one of up to maxPublishQueue queued behind it - run against a closed topic
-	// and a closed signer.
-	if n.l2Driver != nil {
-		if err := n.l2Driver.Close(); err != nil {
-			result = errors.Join(result, fmt.Errorf("failed to close L2 engine driver cleanly: %w", err))
-		}
-	}
-
-	// Still ahead of resourcesClose, which cancels the context the pubsub instance
-	// was built on: closing a topic after that fails with the cancellation.
 	n.p2pMu.Lock()
 	if n.p2pNode != nil {
 		if err := n.p2pNode.Close(); err != nil {
@@ -857,6 +844,24 @@ func (n *OpNode) Stop(ctx context.Context) error {
 	// stop polling for L1 finalized-head changes
 	if n.l1FinalizedSub != nil {
 		n.l1FinalizedSub.Unsubscribe()
+	}
+
+	// close L2 driver
+	//
+	// This is deliberately last, and in particular after p2p and the block signer,
+	// even though the driver owns the async gossiper whose publisher goroutine uses
+	// both - so a publish in flight, or one of up to maxPublishQueue queued behind
+	// it, can still run against a closed topic and a closed signer and log an error
+	// on the way out. Both alternatives are worse: closing p2p after the driver puts
+	// it after resourcesClose, which cancels the context the pubsub instance was
+	// built on, so the topic close itself then fails; and closing the driver early
+	// leaves the rest of the node running against a cancelled driver context, which
+	// spins the derivation system resetting. Stopping only the publisher, before
+	// either, needs a hook that does not exist yet - see the review thread on #22585.
+	if n.l2Driver != nil {
+		if err := n.l2Driver.Close(); err != nil {
+			result = errors.Join(result, fmt.Errorf("failed to close L2 engine driver cleanly: %w", err))
+		}
 	}
 
 	if n.eventSys != nil {

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -813,6 +813,35 @@ func (n *OpNode) Stop(ctx context.Context) error {
 		}
 	}
 
+	// The driver closes before p2p and the block signer, because it owns the async
+	// gossiper whose publisher goroutine uses both, and that goroutine only stops
+	// as part of Driver.Close. Closing them first let a publish still in flight -
+	// or one of up to maxPublishQueue queued behind it - run against a closed topic
+	// and a closed signer.
+	if n.l2Driver != nil {
+		if err := n.l2Driver.Close(); err != nil {
+			result = errors.Join(result, fmt.Errorf("failed to close L2 engine driver cleanly: %w", err))
+		}
+	}
+
+	// Still ahead of resourcesClose, which cancels the context the pubsub instance
+	// was built on: closing a topic after that fails with the cancellation.
+	n.p2pMu.Lock()
+	if n.p2pNode != nil {
+		if err := n.p2pNode.Close(); err != nil {
+			result = errors.Join(result, fmt.Errorf("failed to close p2p node: %w", err))
+		}
+		// Prevent further use of p2p.
+		n.p2pNode = nil
+	}
+	n.p2pMu.Unlock()
+
+	if n.p2pSigner != nil {
+		if err := n.p2pSigner.Close(); err != nil {
+			result = errors.Join(result, fmt.Errorf("failed to close p2p signer: %w", err))
+		}
+	}
+
 	if n.resourcesClose != nil {
 		n.resourcesClose()
 	}
@@ -828,33 +857,6 @@ func (n *OpNode) Stop(ctx context.Context) error {
 	// stop polling for L1 finalized-head changes
 	if n.l1FinalizedSub != nil {
 		n.l1FinalizedSub.Unsubscribe()
-	}
-
-	// close L2 driver
-	if n.l2Driver != nil {
-		if err := n.l2Driver.Close(); err != nil {
-			result = errors.Join(result, fmt.Errorf("failed to close L2 engine driver cleanly: %w", err))
-		}
-	}
-
-	// p2p and the block signer are closed only now, after the driver. The driver
-	// owns the async gossiper, whose publisher goroutine uses both, and it only
-	// stops as part of Driver.Close. Closing them earlier let a publish still in
-	// flight - or a queued one - run against a closed topic and a closed signer.
-	n.p2pMu.Lock()
-	if n.p2pNode != nil {
-		if err := n.p2pNode.Close(); err != nil {
-			result = errors.Join(result, fmt.Errorf("failed to close p2p node: %w", err))
-		}
-		// Prevent further use of p2p.
-		n.p2pNode = nil
-	}
-	n.p2pMu.Unlock()
-
-	if n.p2pSigner != nil {
-		if err := n.p2pSigner.Close(); err != nil {
-			result = errors.Join(result, fmt.Errorf("failed to close p2p signer: %w", err))
-		}
 	}
 
 	if n.eventSys != nil {

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/node/tracer"
 	"github.com/ethereum-optimism/optimism/op-node/p2p"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/async"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/conductor"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/driver"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/sequencing"
@@ -764,7 +765,9 @@ func (n *OpNode) SignAndPublishL2Payload(ctx context.Context, envelope *eth.Exec
 	// publish to p2p, if we are running p2p at all
 	if p2pNode := n.getP2PNodeIfEnabled(); p2pNode != nil {
 		if n.p2pSigner == nil {
-			return fmt.Errorf("node has no p2p signer, payload %s cannot be published", envelope.ID())
+			// Fixed at startup: no retry can make a signer appear.
+			return fmt.Errorf("%w: node has no p2p signer, payload %s cannot be published",
+				async.ErrPermanentPublish, envelope.ID())
 		}
 		n.log.Info("Publishing signed execution payload on p2p", "id", envelope.ID())
 		return p2pNode.GossipOut().SignAndPublishL2Payload(ctx, envelope, n.p2pSigner)
@@ -810,22 +813,6 @@ func (n *OpNode) Stop(ctx context.Context) error {
 		}
 	}
 
-	n.p2pMu.Lock()
-	if n.p2pNode != nil {
-		if err := n.p2pNode.Close(); err != nil {
-			result = errors.Join(result, fmt.Errorf("failed to close p2p node: %w", err))
-		}
-		// Prevent further use of p2p.
-		n.p2pNode = nil
-	}
-	n.p2pMu.Unlock()
-
-	if n.p2pSigner != nil {
-		if err := n.p2pSigner.Close(); err != nil {
-			result = errors.Join(result, fmt.Errorf("failed to close p2p signer: %w", err))
-		}
-	}
-
 	if n.resourcesClose != nil {
 		n.resourcesClose()
 	}
@@ -847,6 +834,26 @@ func (n *OpNode) Stop(ctx context.Context) error {
 	if n.l2Driver != nil {
 		if err := n.l2Driver.Close(); err != nil {
 			result = errors.Join(result, fmt.Errorf("failed to close L2 engine driver cleanly: %w", err))
+		}
+	}
+
+	// p2p and the block signer are closed only now, after the driver. The driver
+	// owns the async gossiper, whose publisher goroutine uses both, and it only
+	// stops as part of Driver.Close. Closing them earlier let a publish still in
+	// flight - or a queued one - run against a closed topic and a closed signer.
+	n.p2pMu.Lock()
+	if n.p2pNode != nil {
+		if err := n.p2pNode.Close(); err != nil {
+			result = errors.Join(result, fmt.Errorf("failed to close p2p node: %w", err))
+		}
+		// Prevent further use of p2p.
+		n.p2pNode = nil
+	}
+	n.p2pMu.Unlock()
+
+	if n.p2pSigner != nil {
+		if err := n.p2pSigner.Close(); err != nil {
+			result = errors.Join(result, fmt.Errorf("failed to close p2p signer: %w", err))
 		}
 	}
 

--- a/op-node/p2p/gossip.go
+++ b/op-node/p2p/gossip.go
@@ -29,6 +29,11 @@ import (
 )
 
 const (
+	// maxFutureGossipDrift is how far into the future, in seconds, a payload's
+	// timestamp may be before the block is rejected. Unlike the staleness
+	// threshold it is not configurable.
+	maxFutureGossipDrift = 5
+
 	// maxGossipSize limits the total size of gossip RPC containers as well as decompressed individual messages.
 	maxGossipSize = 10 * (1 << 20)
 	// minGossipSize is used to make sure that there is at least some data to validate the signature against.
@@ -347,11 +352,7 @@ func BuildBlocksValidator(log log.Logger, cfg *rollup.Config, runCfg GossipRunti
 
 		payload := envelope.ExecutionPayload
 
-		// rounding down to seconds is fine here.
-		now := uint64(time.Now().Unix())
-		if clk != nil {
-			now = uint64(clk.Now().Unix())
-		}
+		now := gossipNow(clk)
 
 		// [REJECT] if the `payload.timestamp` is older than the configured threshold
 		threshold := uint64(gossipConf.GetGossipTimestampThreshold().Seconds())
@@ -360,8 +361,8 @@ func BuildBlocksValidator(log log.Logger, cfg *rollup.Config, runCfg GossipRunti
 			return pubsub.ValidationReject
 		}
 
-		// [REJECT] if the `payload.timestamp` is more than 5 seconds into the future
-		if uint64(payload.Timestamp) > now+5 {
+		// [REJECT] if the `payload.timestamp` is too far into the future
+		if uint64(payload.Timestamp) > now+maxFutureGossipDrift {
 			log.Warn("payload is too new", "timestamp", uint64(payload.Timestamp))
 			return pubsub.ValidationReject
 		}
@@ -547,9 +548,22 @@ type publisher struct {
 	blocksV4 *blockTopic
 
 	runCfg GossipRuntimeConfig
+
+	// clk is the clock the validator judges timestamps against, so that
+	// classifyPublishError reasons about the same "now" it did. Nil outside tests.
+	clk clock.Clock
 }
 
 var _ GossipOut = (*publisher)(nil)
+
+// gossipNow is the clock the block validator judges payload timestamps against.
+// clk is nil outside tests. Rounding down to seconds is fine here.
+func gossipNow(clk clock.Clock) uint64 {
+	if clk != nil {
+		return uint64(clk.Now().Unix())
+	}
+	return uint64(time.Now().Unix())
+}
 
 func combinePeers(allPeers ...[]peer.ID) []peer.ID {
 	seen := make(map[peer.ID]bool)
@@ -657,13 +671,13 @@ func (p *publisher) publishRawSignedPayload(ctx context.Context, timestamp uint6
 	out := snappy.Encode(nil, data)
 
 	if p.cfg.IsIsthmus(timestamp) {
-		return classifyPublishError(p.blocksV4.topic.Publish(ctx, out))
+		return p.classifyPublishError(p.blocksV4.topic.Publish(ctx, out), timestamp)
 	} else if p.cfg.IsEcotone(timestamp) {
-		return classifyPublishError(p.blocksV3.topic.Publish(ctx, out))
+		return p.classifyPublishError(p.blocksV3.topic.Publish(ctx, out), timestamp)
 	} else if p.cfg.IsCanyon(timestamp) {
-		return classifyPublishError(p.blocksV2.topic.Publish(ctx, out))
+		return p.classifyPublishError(p.blocksV2.topic.Publish(ctx, out), timestamp)
 	} else {
-		return classifyPublishError(p.blocksV1.topic.Publish(ctx, out))
+		return p.classifyPublishError(p.blocksV1.topic.Publish(ctx, out), timestamp)
 	}
 }
 
@@ -672,20 +686,29 @@ func (p *publisher) publishRawSignedPayload(ctx context.Context, timestamp uint6
 // queue. Publishing runs our own topic validator inline on this node - see
 // ValidateLocal - so a rejection here is this node judging its own block against
 // the envelope, the fork config and the clock, and it will judge it the same way
-// next time. That includes the timestamp threshold, which only moves further out
-// of reach: a retry can make a block older, never younger.
+// next time. The staleness threshold in particular only moves further out of
+// reach, because a retry makes a block older, never younger.
 //
-// Deliberately an allowlist. Topic.Publish also surfaces the caller's context
-// error, from its eval loop and from sendMsgBlocking, so a publish that merely
-// ran out of time arrives here looking like any other failure - and it must stay
-// retryable.
-func classifyPublishError(err error) error {
+// The exception is a block that is still ahead of the local clock, which
+// validates once the clock catches up. That needs the clock to have stepped
+// backwards to reach at all - block timestamps are chain-derived, and the
+// sequencer waits rather than sealing early - but treating it as permanent would
+// turn a clock step into sustained gossip loss rather than a few seconds of it.
+//
+// Deliberately an allowlist otherwise. Topic.Publish also surfaces the caller's
+// context error, from its eval loop and from sendMsgBlocking, so a publish that
+// merely ran out of time arrives here looking like any other failure - and it
+// must stay retryable.
+func (p *publisher) classifyPublishError(err error, timestamp uint64) error {
 	if err == nil {
 		return nil
 	}
 	// ValidationError is returned by value, so the target must be too.
 	var invalid pubsub.ValidationError
 	if errors.As(err, &invalid) || errors.Is(err, pubsub.ErrTopicClosed) {
+		if timestamp > gossipNow(p.clk)+maxFutureGossipDrift {
+			return err
+		}
 		return fmt.Errorf("%w: %w", async.ErrPermanentPublish, err)
 	}
 	return err
@@ -742,6 +765,7 @@ func JoinGossip(self peer.ID, ps *pubsub.PubSub, log log.Logger, cfg *rollup.Con
 		blocksV3:  blocksV3,
 		blocksV4:  blocksV4,
 		runCfg:    runCfg,
+		clk:       clk,
 	}, nil
 }
 

--- a/op-node/p2p/gossip.go
+++ b/op-node/p2p/gossip.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/async"
 	"github.com/ethereum-optimism/optimism/op-service/clock"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/ptr"
@@ -627,11 +628,15 @@ func (p *publisher) SignAndPublishL2Payload(ctx context.Context, envelope *eth.E
 
 	if envelope.ParentBeaconBlockRoot != nil {
 		if _, err := envelope.MarshalSSZ(buf); err != nil {
-			return fmt.Errorf("failed to encoded execution payload envelope to publish: %w", err)
+			// A pure function of the envelope: encoding it again cannot succeed.
+			return fmt.Errorf("%w: failed to encoded execution payload envelope to publish: %w",
+				async.ErrPermanentPublish, err)
 		}
 	} else {
 		if _, err := envelope.ExecutionPayload.MarshalSSZ(buf); err != nil {
-			return fmt.Errorf("failed to encoded execution payload to publish: %w", err)
+			// A pure function of the envelope: encoding it again cannot succeed.
+			return fmt.Errorf("%w: failed to encoded execution payload to publish: %w",
+				async.ErrPermanentPublish, err)
 		}
 	}
 	data := buf.Bytes()
@@ -652,14 +657,38 @@ func (p *publisher) publishRawSignedPayload(ctx context.Context, timestamp uint6
 	out := snappy.Encode(nil, data)
 
 	if p.cfg.IsIsthmus(timestamp) {
-		return p.blocksV4.topic.Publish(ctx, out)
+		return classifyPublishError(p.blocksV4.topic.Publish(ctx, out))
 	} else if p.cfg.IsEcotone(timestamp) {
-		return p.blocksV3.topic.Publish(ctx, out)
+		return classifyPublishError(p.blocksV3.topic.Publish(ctx, out))
 	} else if p.cfg.IsCanyon(timestamp) {
-		return p.blocksV2.topic.Publish(ctx, out)
+		return classifyPublishError(p.blocksV2.topic.Publish(ctx, out))
 	} else {
-		return p.blocksV1.topic.Publish(ctx, out)
+		return classifyPublishError(p.blocksV1.topic.Publish(ctx, out))
 	}
+}
+
+// classifyPublishError marks the publish failures that cannot succeed on a
+// retry, so the caller drops the block instead of holding it at the head of a
+// queue. Publishing runs our own topic validator inline on this node - see
+// ValidateLocal - so a rejection here is this node judging its own block against
+// the envelope, the fork config and the clock, and it will judge it the same way
+// next time. That includes the timestamp threshold, which only moves further out
+// of reach: a retry can make a block older, never younger.
+//
+// Deliberately an allowlist. Topic.Publish also surfaces the caller's context
+// error, from its eval loop and from sendMsgBlocking, so a publish that merely
+// ran out of time arrives here looking like any other failure - and it must stay
+// retryable.
+func classifyPublishError(err error) error {
+	if err == nil {
+		return nil
+	}
+	// ValidationError is returned by value, so the target must be too.
+	var invalid pubsub.ValidationError
+	if errors.As(err, &invalid) || errors.Is(err, pubsub.ErrTopicClosed) {
+		return fmt.Errorf("%w: %w", async.ErrPermanentPublish, err)
+	}
+	return err
 }
 
 func (p *publisher) Close() error {

--- a/op-node/p2p/gossip_test.go
+++ b/op-node/p2p/gossip_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/ecdsa"
+	"errors"
 	"fmt"
 	"io"
 	"math/big"
@@ -13,6 +14,7 @@ import (
 	"github.com/golang/snappy"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/rollup/async"
 	"github.com/ethereum-optimism/optimism/op-service/clock"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/ptr"
@@ -342,4 +344,75 @@ func (m *mockGossipSetupConfigurablesWithThreshold) ConfigureGossip(rollupCfg *r
 
 func (m *mockGossipSetupConfigurablesWithThreshold) GetGossipTimestampThreshold() time.Duration {
 	return m.threshold
+}
+
+// TestClassifyPublishError pins which publish failures the async gossiper is
+// allowed to give up on. Getting this wrong is silent in both directions: too
+// broad and a timed-out publish is never retried, too narrow and a block that
+// can never be published holds up every block behind it.
+func TestClassifyPublishError(t *testing.T) {
+	clk := clock.NewDeterministicClock(time.Unix(1_700_000_000, 0))
+	p := &publisher{clk: clk}
+	now := uint64(clk.Now().Unix())
+
+	for _, tc := range []struct {
+		name      string
+		err       error
+		timestamp uint64
+		permanent bool
+	}{
+		{
+			name: "nil is not an error at all",
+			err:  nil,
+		},
+		{
+			name:      "the local validator rejected the block",
+			err:       pubsub.ValidationError{Reason: pubsub.RejectValidationFailed},
+			timestamp: now,
+			permanent: true,
+		},
+		{
+			name:      "the local validator has already seen the block",
+			err:       pubsub.ValidationError{Reason: pubsub.RejectValidationIgnored},
+			timestamp: now,
+			permanent: true,
+		},
+		{
+			name:      "the topic is closed",
+			err:       pubsub.ErrTopicClosed,
+			timestamp: now,
+			permanent: true,
+		},
+		{
+			// The one rejection a retry fixes: the clock catches up to the block.
+			name:      "the block is still ahead of the local clock",
+			err:       pubsub.ValidationError{Reason: pubsub.RejectValidationFailed},
+			timestamp: now + maxFutureGossipDrift + 1,
+			permanent: false,
+		},
+		{
+			// Topic.Publish surfaces the caller's context error from its own
+			// internals, so this arrives looking like any other failure.
+			name:      "the publish ran out of time",
+			err:       context.DeadlineExceeded,
+			timestamp: now,
+			permanent: false,
+		},
+		{
+			name:      "the signer failed",
+			err:       errors.New("failed to sign execution payload with signer: connection refused"),
+			timestamp: now,
+			permanent: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := p.classifyPublishError(tc.err, tc.timestamp)
+			if tc.err == nil {
+				require.NoError(t, got)
+				return
+			}
+			require.ErrorIs(t, got, tc.err, "the cause must survive classification")
+			require.Equal(t, tc.permanent, errors.Is(got, async.ErrPermanentPublish))
+		})
+	}
 }

--- a/op-node/rollup/async/asyncgossiper.go
+++ b/op-node/rollup/async/asyncgossiper.go
@@ -19,16 +19,6 @@ const (
 	// from wedging publishing until TCP gives up.
 	publishTimeout = 10 * time.Second
 
-	// maxPublishAge is how long a sealed block may wait for its turn to be
-	// published before it is dropped. It mirrors the default of
-	// --p2p.gossip.timestamp.threshold: peers REJECT a payload older than that,
-	// and an invalid delivery is scored against the sender, so publishing a block
-	// that has aged out spends a signing round-trip and peer score to have the
-	// block refused. A node configured with a lower threshold publishes a few
-	// blocks its peers refuse; the horizon is deliberately not plumbed through
-	// from the p2p config for that one case.
-	maxPublishAge = 60 * time.Second
-
 	// maxPublishQueue caps the queue, so that a signer the sequencer cannot reach
 	// costs gossip rather than block production: once the queue is full the
 	// oldest entries are dropped instead of held, and the sequencer is never
@@ -36,9 +26,8 @@ const (
 	// nodes by other means - L1 and derivation, other sync mechanisms - whereas
 	// a sequencer that stops building produces nothing for anyone.
 	//
-	// It doubles as a memory bound: an envelope can be megabytes, and
-	// maxPublishAge alone bounds the queue only in time. 32 spans the whole
-	// publishable window at a 2s block time.
+	// It doubles as a memory bound: an envelope can be megabytes. 32 is ~1 minute
+	// of blocks at a 2s block time.
 	maxPublishQueue = 32
 )
 
@@ -84,16 +73,13 @@ type SimpleAsyncGossiper struct {
 	net     Network
 	log     log.Logger
 	metrics Metrics
-	// timeNow is overridden in tests to age queue entries
-	timeNow func() time.Time
 }
 
 // queuedPayload is a payload awaiting publication, tagged with the epoch it was
-// handed over in and when it joined the queue.
+// handed over in.
 type queuedPayload struct {
-	payload    *eth.ExecutionPayloadEnvelope
-	epoch      uint64
-	enqueuedAt time.Time
+	payload *eth.ExecutionPayloadEnvelope
+	epoch   uint64
 }
 
 // To avoid import cycles, we define a new Network interface here
@@ -119,7 +105,6 @@ func NewAsyncGossiper(ctx context.Context, net Network, log log.Logger, metrics 
 		ctx:     ctx,
 		log:     log,
 		metrics: metrics,
-		timeNow: time.Now,
 	}
 }
 
@@ -128,17 +113,13 @@ func NewAsyncGossiper(ctx context.Context, net Network, log log.Logger, metrics 
 //
 // Blocks are published in the order they were sealed rather than skipping to the
 // tip: a verifier that never receives a block cannot follow the chain past it
-// over gossip alone. Blocks are dropped only when the queue overflows or an
-// entry ages out - see maxPublishQueue and maxPublishAge - at which point
-// keeping the sequencer building is worth more than the gossip.
+// over gossip alone. Blocks are dropped only when the queue overflows - see
+// maxPublishQueue - at which point keeping the sequencer building is worth more
+// than the gossip.
 func (p *SimpleAsyncGossiper) Gossip(payload *eth.ExecutionPayloadEnvelope) {
 	p.mu.Lock()
 	p.epoch++
-	p.queue = append(p.queue, &queuedPayload{
-		payload:    payload,
-		epoch:      p.epoch,
-		enqueuedAt: p.timeNow(),
-	})
+	p.queue = append(p.queue, &queuedPayload{payload: payload, epoch: p.epoch})
 	for len(p.queue) > maxPublishQueue {
 		dropped := p.queue[0]
 		p.queue[0] = nil // do not keep the envelope alive through the backing array
@@ -217,27 +198,18 @@ func (p *SimpleAsyncGossiper) Start() {
 	}()
 }
 
-// dequeue takes the oldest payload that a peer would still accept, dropping any
-// that aged out while they waited. It returns nil when the queue holds nothing
-// publishable, along with the number of entries left behind.
+// dequeue takes the oldest queued payload, along with the number of entries left
+// behind. It returns nil when the queue is empty.
 func (p *SimpleAsyncGossiper) dequeue() (*queuedPayload, int) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	for len(p.queue) > 0 {
-		next := p.queue[0]
-		p.queue[0] = nil // do not keep the envelope alive through the backing array
-		p.queue = p.queue[1:]
-
-		if age := p.timeNow().Sub(next.enqueuedAt); age > maxPublishAge {
-			p.log.Warn("dropping unpublished block, aged out of the gossip window",
-				"id", next.payload.ExecutionPayload.ID(),
-				"age", age, "len", len(p.queue))
-			p.metrics.RecordDroppedPublish()
-			continue
-		}
-		return next, len(p.queue)
+	if len(p.queue) == 0 {
+		return nil, 0
 	}
-	return nil, 0
+	next := p.queue[0]
+	p.queue[0] = nil // do not keep the envelope alive through the backing array
+	p.queue = p.queue[1:]
+	return next, len(p.queue)
 }
 
 // publish publishes the next queued payload and stores it for reuse if the

--- a/op-node/rollup/async/asyncgossiper.go
+++ b/op-node/rollup/async/asyncgossiper.go
@@ -11,12 +11,36 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
-// publishTimeout bounds a single publish attempt: signing the block (a network
-// round-trip when a remote signer is configured) plus the p2p publish. It is
-// generous compared with any block time, so it never cuts a working signer
-// short. Its job is to stop a signer connection that hangs rather than errors
-// from wedging publishing until TCP gives up.
-const publishTimeout = 10 * time.Second
+const (
+	// publishTimeout bounds a single publish attempt: signing the block (a network
+	// round-trip when a remote signer is configured) plus the p2p publish. It is
+	// generous compared with any block time, so it never cuts a working signer
+	// short. Its job is to stop a signer connection that hangs rather than errors
+	// from wedging publishing until TCP gives up.
+	publishTimeout = 10 * time.Second
+
+	// maxPublishAge is how long a sealed block may wait for its turn to be
+	// published before it is dropped. It mirrors the default of
+	// --p2p.gossip.timestamp.threshold: peers REJECT a payload older than that,
+	// and an invalid delivery is scored against the sender, so publishing a block
+	// that has aged out spends a signing round-trip and peer score to have the
+	// block refused. A node configured with a lower threshold publishes a few
+	// blocks its peers refuse; the horizon is deliberately not plumbed through
+	// from the p2p config for that one case.
+	maxPublishAge = 60 * time.Second
+
+	// maxPublishQueue caps the queue, so that a signer the sequencer cannot reach
+	// costs gossip rather than block production: once the queue is full the
+	// oldest entries are dropped instead of held, and the sequencer is never
+	// asked to wait for room. A block that goes ungossiped still reaches other
+	// nodes by other means - L1 and derivation, other sync mechanisms - whereas
+	// a sequencer that stops building produces nothing for anyone.
+	//
+	// It doubles as a memory bound: an envelope can be megabytes, and
+	// maxPublishAge alone bounds the queue only in time. 32 spans the whole
+	// publishable window at a 2s block time.
+	maxPublishQueue = 32
+)
 
 type AsyncGossiper interface {
 	Gossip(payload *eth.ExecutionPayloadEnvelope)
@@ -44,8 +68,10 @@ type SimpleAsyncGossiper struct {
 	stop chan struct{}
 
 	mu sync.Mutex
-	// pending is the payload waiting to be picked up by the publisher goroutine
-	pending *pendingPayload
+	// queue holds the payloads waiting to be published, oldest first. Blocks are
+	// published in the order they were sealed, so a peer is not asked to accept a
+	// block before its parent.
+	queue []*queuedPayload
 	// currentPayload is the last successfully published payload that has not
 	// been cleared since: the payload the sequencer may reuse
 	currentPayload *eth.ExecutionPayloadEnvelope
@@ -58,13 +84,16 @@ type SimpleAsyncGossiper struct {
 	net     Network
 	log     log.Logger
 	metrics Metrics
+	// timeNow is overridden in tests to age queue entries
+	timeNow func() time.Time
 }
 
-// pendingPayload is a payload handed to the publisher goroutine, tagged with the
-// epoch it was handed over in.
-type pendingPayload struct {
-	payload *eth.ExecutionPayloadEnvelope
-	epoch   uint64
+// queuedPayload is a payload awaiting publication, tagged with the epoch it was
+// handed over in and when it joined the queue.
+type queuedPayload struct {
+	payload    *eth.ExecutionPayloadEnvelope
+	epoch      uint64
+	enqueuedAt time.Time
 }
 
 // To avoid import cycles, we define a new Network interface here
@@ -77,6 +106,8 @@ type Network interface {
 // this interface is compatible with driver.Metrics
 type Metrics interface {
 	RecordPublishingError()
+	RecordPublishQueueLen(length int)
+	RecordDroppedPublish()
 }
 
 func NewAsyncGossiper(ctx context.Context, net Network, log log.Logger, metrics Metrics) *SimpleAsyncGossiper {
@@ -88,25 +119,46 @@ func NewAsyncGossiper(ctx context.Context, net Network, log log.Logger, metrics 
 		ctx:     ctx,
 		log:     log,
 		metrics: metrics,
+		timeNow: time.Now,
 	}
 }
 
-// Gossip hands a payload to the publisher goroutine. It does not wait for the
-// payload to be published.
+// Gossip queues a payload for publication. It does not wait for the payload to
+// be published, and never waits for room in the queue.
 //
-// A payload that has not started publishing yet is replaced: the newer block is
-// the one peers need, and they reach the older one through sync.
+// Blocks are published in the order they were sealed rather than skipping to the
+// tip: a verifier that never receives a block cannot follow the chain past it
+// over gossip alone. Blocks are dropped only when the queue overflows or an
+// entry ages out - see maxPublishQueue and maxPublishAge - at which point
+// keeping the sequencer building is worth more than the gossip.
 func (p *SimpleAsyncGossiper) Gossip(payload *eth.ExecutionPayloadEnvelope) {
 	p.mu.Lock()
-	if p.pending != nil {
-		p.log.Warn("dropping unpublished block, superseded before it was published",
-			"dropped", p.pending.payload.ExecutionPayload.ID(),
-			"id", payload.ExecutionPayload.ID())
-	}
 	p.epoch++
-	p.pending = &pendingPayload{payload: payload, epoch: p.epoch}
+	p.queue = append(p.queue, &queuedPayload{
+		payload:    payload,
+		epoch:      p.epoch,
+		enqueuedAt: p.timeNow(),
+	})
+	for len(p.queue) > maxPublishQueue {
+		dropped := p.queue[0]
+		p.queue[0] = nil // do not keep the envelope alive through the backing array
+		p.queue = p.queue[1:]
+		p.log.Warn("dropping unpublished block, publish queue is full",
+			"dropped", dropped.payload.ExecutionPayload.ID(),
+			"queued", payload.ExecutionPayload.ID(),
+			"len", len(p.queue))
+		p.metrics.RecordDroppedPublish()
+	}
+	length := len(p.queue)
 	p.mu.Unlock()
 
+	p.metrics.RecordPublishQueueLen(length)
+	p.signal()
+}
+
+// signal wakes the publisher goroutine. A queued signal is enough, because the
+// publisher reads the queue after receiving one.
+func (p *SimpleAsyncGossiper) signal() {
 	select {
 	case p.wake <- struct{}{}:
 	default: // the publisher is awake already, or has a signal queued
@@ -165,25 +217,50 @@ func (p *SimpleAsyncGossiper) Start() {
 	}()
 }
 
-// publish publishes the pending payload, if there is one, and stores it for
-// reuse if the publish succeeded and the payload is still the one the sequencer
-// cares about. It runs on the publisher goroutine and holds no lock across the
-// network call.
-func (p *SimpleAsyncGossiper) publish() {
+// dequeue takes the oldest payload that a peer would still accept, dropping any
+// that aged out while they waited. It returns nil when the queue holds nothing
+// publishable, along with the number of entries left behind.
+func (p *SimpleAsyncGossiper) dequeue() (*queuedPayload, int) {
 	p.mu.Lock()
-	pending := p.pending
-	p.pending = nil
-	p.mu.Unlock()
-	if pending == nil {
-		return // an earlier signal already took it
+	defer p.mu.Unlock()
+	for len(p.queue) > 0 {
+		next := p.queue[0]
+		p.queue[0] = nil // do not keep the envelope alive through the backing array
+		p.queue = p.queue[1:]
+
+		if age := p.timeNow().Sub(next.enqueuedAt); age > maxPublishAge {
+			p.log.Warn("dropping unpublished block, aged out of the gossip window",
+				"id", next.payload.ExecutionPayload.ID(),
+				"age", age, "len", len(p.queue))
+			p.metrics.RecordDroppedPublish()
+			continue
+		}
+		return next, len(p.queue)
+	}
+	return nil, 0
+}
+
+// publish publishes the next queued payload and stores it for reuse if the
+// publish succeeded and the payload is still the one the sequencer cares about.
+// It runs on the publisher goroutine and holds no lock across the network call.
+func (p *SimpleAsyncGossiper) publish() {
+	next, remaining := p.dequeue()
+	p.metrics.RecordPublishQueueLen(remaining)
+	if next == nil {
+		return // an earlier signal already drained the queue
+	}
+	if remaining > 0 {
+		// Come back for the rest, via the select, so a stop is still honored
+		// between publishes.
+		p.signal()
 	}
 
 	ctx, cancel := context.WithTimeout(p.ctx, publishTimeout)
 	defer cancel()
-	if err := p.net.SignAndPublishL2Payload(ctx, pending.payload); err != nil {
+	if err := p.net.SignAndPublishL2Payload(ctx, next.payload); err != nil {
 		p.log.Warn("failed to publish newly created block",
-			"id", pending.payload.ExecutionPayload.ID(),
-			"hash", pending.payload.ExecutionPayload.BlockHash,
+			"id", next.payload.ExecutionPayload.ID(),
+			"hash", next.payload.ExecutionPayload.BlockHash,
 			"err", err)
 		p.metrics.RecordPublishingError()
 		return
@@ -194,8 +271,8 @@ func (p *SimpleAsyncGossiper) publish() {
 	// A Clear (the block was inserted) or a newer Gossip while we were
 	// publishing makes this payload unfit for reuse: the sequencer would rebuild
 	// a block it has already moved past.
-	if p.epoch == pending.epoch {
-		p.currentPayload = pending.payload
+	if p.epoch == next.epoch {
+		p.currentPayload = next.payload
 	}
 }
 

--- a/op-node/rollup/async/asyncgossiper.go
+++ b/op-node/rollup/async/asyncgossiper.go
@@ -2,12 +2,21 @@ package async
 
 import (
 	"context"
+	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
+
+// publishTimeout bounds a single publish attempt: signing the block (a network
+// round-trip when a remote signer is configured) plus the p2p publish. It is
+// generous compared with any block time, so it never cuts a working signer
+// short. Its job is to stop a signer connection that hangs rather than errors
+// from wedging publishing until TCP gives up.
+const publishTimeout = 10 * time.Second
 
 type AsyncGossiper interface {
 	Gossip(payload *eth.ExecutionPayloadEnvelope)
@@ -18,25 +27,44 @@ type AsyncGossiper interface {
 }
 
 // SimpleAsyncGossiper is a component that stores and gossips a single payload at a time
-// it uses a separate goroutine to handle gossiping the payload asynchronously
 // the payload can be accessed by the Get function to be reused when the payload was gossiped but not inserted
-// exposed functions are synchronous, and block until the async routine is able to start handling the request
+//
+// Publishing runs on a dedicated goroutine, and the exposed functions only take
+// a mutex: none of them waits for the network. The sequencer calls Gossip, Get
+// and Clear on the hot path between sealing block N and opening the build window
+// for block N+1, and that window is computed as a residual - so any wait here is
+// subtracted 1:1 from the next block's building time.
 type SimpleAsyncGossiper struct {
 	running atomic.Bool
-	// channel to add new payloads to gossip
-	set chan *eth.ExecutionPayloadEnvelope
-	// channel to request getting the currently gossiping payload
-	get chan chan *eth.ExecutionPayloadEnvelope
-	// channel to request clearing the currently gossiping payload
-	clear chan struct{}
-	// channel to request stopping the handling loop
+	// wake signals the publisher goroutine that there is a payload to publish.
+	// Capacity 1, and sent to without blocking: a single queued signal suffices,
+	// because the publisher reads the pending payload after receiving one.
+	wake chan struct{}
+	// channel to request stopping the publisher goroutine
 	stop chan struct{}
 
+	mu sync.Mutex
+	// pending is the payload waiting to be picked up by the publisher goroutine
+	pending *pendingPayload
+	// currentPayload is the last successfully published payload that has not
+	// been cleared since: the payload the sequencer may reuse
 	currentPayload *eth.ExecutionPayloadEnvelope
-	ctx            context.Context
-	net            Network
-	log            log.Logger
-	metrics        Metrics
+	// epoch identifies the payload the sequencer currently cares about. Both
+	// Gossip and Clear advance it, so a publish that was already in flight can
+	// tell that its result has since become stale.
+	epoch uint64
+
+	ctx     context.Context
+	net     Network
+	log     log.Logger
+	metrics Metrics
+}
+
+// pendingPayload is a payload handed to the publisher goroutine, tagged with the
+// epoch it was handed over in.
+type pendingPayload struct {
+	payload *eth.ExecutionPayloadEnvelope
+	epoch   uint64
 }
 
 // To avoid import cycles, we define a new Network interface here
@@ -53,38 +81,57 @@ type Metrics interface {
 
 func NewAsyncGossiper(ctx context.Context, net Network, log log.Logger, metrics Metrics) *SimpleAsyncGossiper {
 	return &SimpleAsyncGossiper{
-		running: atomic.Bool{},
-		set:     make(chan *eth.ExecutionPayloadEnvelope),
-		get:     make(chan chan *eth.ExecutionPayloadEnvelope),
-		clear:   make(chan struct{}),
-		stop:    make(chan struct{}),
+		wake: make(chan struct{}, 1),
+		stop: make(chan struct{}),
 
-		currentPayload: nil,
-		net:            net,
-		ctx:            ctx,
-		log:            log,
-		metrics:        metrics,
+		net:     net,
+		ctx:     ctx,
+		log:     log,
+		metrics: metrics,
 	}
 }
 
-// Gossip is a synchronous function to store and gossip a payload
-// it blocks until the payload can be taken by the async routine
+// Gossip hands a payload to the publisher goroutine. It does not wait for the
+// payload to be published.
+//
+// A payload that has not started publishing yet is replaced: the newer block is
+// the one peers need, and they reach the older one through sync.
 func (p *SimpleAsyncGossiper) Gossip(payload *eth.ExecutionPayloadEnvelope) {
-	p.set <- payload
+	p.mu.Lock()
+	if p.pending != nil {
+		p.log.Warn("dropping unpublished block, superseded before it was published",
+			"dropped", p.pending.payload.ExecutionPayload.ID(),
+			"id", payload.ExecutionPayload.ID())
+	}
+	p.epoch++
+	p.pending = &pendingPayload{payload: payload, epoch: p.epoch}
+	p.mu.Unlock()
+
+	select {
+	case p.wake <- struct{}{}:
+	default: // the publisher is awake already, or has a signal queued
+	}
 }
 
-// Get is a synchronous function to get the currently held payload
-// it blocks until the async routine is able to return the payload
+// Get returns the payload that was published and not cleared since, if any.
+//
+// It does not wait for a publish that is still in flight: a nil result means
+// there is nothing to reuse, and the sequencer seals (or re-seals) its building
+// job instead of paying for the wait out of the block's build window.
 func (p *SimpleAsyncGossiper) Get() *eth.ExecutionPayloadEnvelope {
-	c := make(chan *eth.ExecutionPayloadEnvelope)
-	p.get <- c
-	return <-c
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.currentPayload
 }
 
-// Clear is a synchronous function to clear the currently gossiping payload
-// it blocks until the signal to clear is picked up by the async routine
+// Clear drops the payload held for reuse. A publish that is in flight still
+// completes - peers need the block either way - but its result no longer
+// repopulates the buffer.
 func (p *SimpleAsyncGossiper) Clear() {
-	p.clear <- struct{}{}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.currentPayload = nil
+	p.epoch++
 }
 
 // Stop is a synchronous function to stop the async routine
@@ -98,28 +145,19 @@ func (p *SimpleAsyncGossiper) Stop() {
 	p.stop <- struct{}{}
 }
 
-// Start starts the AsyncGossiper's gossiping loop on a separate goroutine
-// each behavior of the loop is handled by a select case on a channel, plus an internal handler function call
+// Start starts the AsyncGossiper's publisher goroutine
 func (p *SimpleAsyncGossiper) Start() {
 	// if the gossiping is already running, return
 	if !p.running.CompareAndSwap(false, true) {
 		return
 	}
-	// else, start the handling loop
+	// else, start the publishing loop
 	go func() {
 		defer p.running.Store(false)
 		for {
 			select {
-			// new payloads to be gossiped are found in the `set` channel
-			case payload := <-p.set:
-				p.gossip(p.ctx, payload)
-			// requests to get the current payload are found in the `get` channel
-			case c := <-p.get:
-				p.getPayload(c)
-			// requests to clear the current payload are found in the `clear` channel
-			case <-p.clear:
-				p.clearPayload()
-			// if the context is done, return
+			case <-p.wake:
+				p.publish()
 			case <-p.stop:
 				return
 			}
@@ -127,31 +165,38 @@ func (p *SimpleAsyncGossiper) Start() {
 	}()
 }
 
-// gossip is the internal handler function for gossiping the current payload
-// and storing the payload in the async AsyncGossiper's state
-// it is called by the Start loop when a new payload is set
-// the payload is only stored if the publish is successful
-func (p *SimpleAsyncGossiper) gossip(ctx context.Context, payload *eth.ExecutionPayloadEnvelope) {
-	if err := p.net.SignAndPublishL2Payload(ctx, payload); err == nil {
-		p.currentPayload = payload
-	} else {
+// publish publishes the pending payload, if there is one, and stores it for
+// reuse if the publish succeeded and the payload is still the one the sequencer
+// cares about. It runs on the publisher goroutine and holds no lock across the
+// network call.
+func (p *SimpleAsyncGossiper) publish() {
+	p.mu.Lock()
+	pending := p.pending
+	p.pending = nil
+	p.mu.Unlock()
+	if pending == nil {
+		return // an earlier signal already took it
+	}
+
+	ctx, cancel := context.WithTimeout(p.ctx, publishTimeout)
+	defer cancel()
+	if err := p.net.SignAndPublishL2Payload(ctx, pending.payload); err != nil {
 		p.log.Warn("failed to publish newly created block",
-			"id", payload.ExecutionPayload.ID(),
-			"hash", payload.ExecutionPayload.BlockHash,
+			"id", pending.payload.ExecutionPayload.ID(),
+			"hash", pending.payload.ExecutionPayload.BlockHash,
 			"err", err)
 		p.metrics.RecordPublishingError()
+		return
 	}
-}
 
-// getPayload is the internal handler function for getting the current payload
-// c is the channel the caller expects to receive the payload on
-func (p *SimpleAsyncGossiper) getPayload(c chan *eth.ExecutionPayloadEnvelope) {
-	c <- p.currentPayload
-}
-
-// clearPayload is the internal handler function for clearing the current payload
-func (p *SimpleAsyncGossiper) clearPayload() {
-	p.currentPayload = nil
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	// A Clear (the block was inserted) or a newer Gossip while we were
+	// publishing makes this payload unfit for reuse: the sequencer would rebuild
+	// a block it has already moved past.
+	if p.epoch == pending.epoch {
+		p.currentPayload = pending.payload
+	}
 }
 
 // NoOpGossiper is a no-op implementation of AsyncGossiper

--- a/op-node/rollup/async/asyncgossiper.go
+++ b/op-node/rollup/async/asyncgossiper.go
@@ -31,13 +31,14 @@ const (
 	// of blocks at a 2s block time.
 	maxPublishQueue = 32
 
-	// maxPublishAttempts bounds how often a single block is offered to the
-	// network before it is given up on. A block that fails to publish is retried
-	// ahead of the blocks behind it, because a peer cannot follow the chain past
-	// a block it never received - the same reason blocks go out in seal order
-	// rather than skipping to the tip. The bound keeps a signer that is simply
-	// down from holding the head, and every block behind it, forever.
-	maxPublishAttempts = 2
+	// retryInterval paces retries of a failed publish. It is a spin guard, not a
+	// policy: how long a block is worth retrying is decided by queue pressure,
+	// above. A publish can fail in about a millisecond without touching the
+	// network, because op-node runs its own block validator inline on the
+	// publishing node - and a block retried past the gossip timestamp threshold
+	// fails exactly that way, every time, forever. Unpaced, those retries would
+	// spin this goroutine rather than wait for anything.
+	retryInterval = time.Second
 )
 
 type AsyncGossiper interface {
@@ -92,6 +93,10 @@ type SimpleAsyncGossiper struct {
 	// was being published, so the attempt is not retried or reused on return.
 	publishDiscarded bool
 
+	// retryInterval is the pacing between retries of a failed publish, defaulted
+	// from the constant of the same name. It is a field so tests can shorten it.
+	retryInterval time.Duration
+
 	ctx     context.Context
 	net     Network
 	log     log.Logger
@@ -103,7 +108,9 @@ type queuedPayload struct {
 	payload *eth.ExecutionPayloadEnvelope
 	hash    common.Hash
 	// attempts counts how often this block has been handed to the network,
-	// including the attempt in flight. See maxPublishAttempts.
+	// including the attempt in flight. Queue pressure is what normally bounds the
+	// retry; this is the backstop for when production has stopped and no eviction
+	// is coming. See finishPublish.
 	attempts int
 }
 
@@ -125,6 +132,8 @@ func NewAsyncGossiper(ctx context.Context, net Network, log log.Logger, metrics 
 	return &SimpleAsyncGossiper{
 		wake: make(chan struct{}, 1),
 		stop: make(chan struct{}),
+
+		retryInterval: retryInterval,
 
 		net:     net,
 		ctx:     ctx,
@@ -295,6 +304,11 @@ func (p *SimpleAsyncGossiper) DiscardAll() {
 
 // Stop is a synchronous function to stop the async routine
 // it blocks until the async routine accepts the signal
+//
+// That means it waits for a publish in flight, and for up to retryInterval if a
+// retry is being paced. In practice neither bites at shutdown: Driver.Close
+// cancels the context this gossiper was built with before calling Stop, which
+// both aborts the publish and skips the pacing.
 func (p *SimpleAsyncGossiper) Stop() {
 	// if the gossiping isn't running, nothing to do
 	if !p.running.Load() {
@@ -324,15 +338,15 @@ func (p *SimpleAsyncGossiper) Start() {
 	}()
 }
 
-// dequeue takes the oldest queued payload and marks it in flight, along with the
-// number of entries left behind. It returns nil when the queue is empty. Like
-// enqueue, it updates the gauge under the same lock as the queue mutation.
-func (p *SimpleAsyncGossiper) dequeue() (*queuedPayload, int) {
+// dequeue takes the oldest queued payload and marks it in flight. It returns nil
+// when the queue is empty. Like enqueue, it updates the gauge under the same lock
+// as the queue mutation.
+func (p *SimpleAsyncGossiper) dequeue() *queuedPayload {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if len(p.queue) == 0 {
 		p.publishInFlight = false
-		return nil, 0
+		return nil
 	}
 	next := p.queue[0]
 	p.queue[0] = nil // do not keep the envelope alive through the backing array
@@ -342,32 +356,53 @@ func (p *SimpleAsyncGossiper) dequeue() (*queuedPayload, int) {
 	p.publishInFlight = true
 	p.publishDiscarded = false
 	p.metrics.RecordPublishQueueLen(len(p.queue))
-	return next, len(p.queue)
+	return next
 }
 
 // publish publishes the next queued payload. It runs on the publisher goroutine
 // and holds no lock across the network call.
+//
+// The wake-up for the rest of the queue happens at the end rather than up front,
+// so that a retry cannot be picked up by a signal queued before the attempt that
+// failed - which would skip the pacing exactly when it is needed.
 func (p *SimpleAsyncGossiper) publish() {
-	next, remaining := p.dequeue()
+	next := p.dequeue()
 	if next == nil {
 		return // an earlier signal already drained the queue
-	}
-	if remaining > 0 {
-		// Come back for the rest, via the select, so a stop is still honored
-		// between publishes.
-		p.signal()
 	}
 
 	ctx, cancel := context.WithTimeout(p.ctx, publishTimeout)
 	defer cancel()
 	err := p.net.SignAndPublishL2Payload(ctx, next.payload)
-	p.finishPublish(next, err)
+
+	if p.finishPublish(next, err) {
+		// The block went back to the front of the queue. Wait before offering it
+		// again - see retryInterval.
+		select {
+		case <-time.After(p.retryInterval):
+		case <-p.ctx.Done():
+			return
+		}
+	}
+	p.signalIfPending()
+}
+
+// signalIfPending wakes the publisher again if the queue is not empty, so it
+// comes back through the select and a stop is still honored between publishes.
+func (p *SimpleAsyncGossiper) signalIfPending() {
+	p.mu.Lock()
+	pending := len(p.queue) > 0
+	p.mu.Unlock()
+	if pending {
+		p.signal()
+	}
 }
 
 // finishPublish records the outcome of a publish attempt: on success the payload
 // becomes available for reuse if the sequencer still wants it, and on failure the
-// block is retried ahead of the blocks behind it, within maxPublishAttempts.
-func (p *SimpleAsyncGossiper) finishPublish(next *queuedPayload, err error) {
+// block is put back at the front of the queue if there is room for it. It reports
+// whether it requeued, so the caller can pace the retry.
+func (p *SimpleAsyncGossiper) finishPublish(next *queuedPayload, err error) (requeued bool) {
 	p.mu.Lock()
 	p.publishInFlight = false
 	discarded := p.publishDiscarded
@@ -381,12 +416,22 @@ func (p *SimpleAsyncGossiper) finishPublish(next *queuedPayload, err error) {
 			p.currentPayload = next.payload
 		}
 		p.mu.Unlock()
-		return
+		return false
 	}
 
-	// Retrying at the front keeps the chain gap-free for peers, but never at the
-	// cost of unbounded growth or of a block the sequencer has already rejected.
-	retry := !discarded && next.attempts < maxPublishAttempts && len(p.queue) < maxPublishQueue
+	// Retrying at the front keeps the chain gap-free for peers. Queue pressure is
+	// what bounds it: the retried block sits at the head, and enqueue evicts the
+	// head when the queue overflows, so a block is retried exactly as long as
+	// production leaves room for it. A block the sequencer has already rejected
+	// is not retried at all.
+	//
+	// The attempt bound is the same number, for the case where that eviction can
+	// never come: if block production has stopped, nothing is ever enqueued, so
+	// nothing evicts the head and an unpublishable block would be offered - and
+	// logged, and counted - once per retryInterval until the process exits. A
+	// block that has been tried more times than the queue could hold has already
+	// outlived every block that would have displaced it.
+	retry := !discarded && len(p.queue) < maxPublishQueue && next.attempts < maxPublishQueue
 	if retry {
 		p.queue = append([]*queuedPayload{next}, p.queue...)
 		p.metrics.RecordPublishQueueLen(len(p.queue))
@@ -400,9 +445,7 @@ func (p *SimpleAsyncGossiper) finishPublish(next *queuedPayload, err error) {
 		"attempts", next.attempts,
 		"retrying", retry,
 		"err", err)
-	if retry {
-		p.signal()
-	}
+	return retry
 }
 
 // NoOpGossiper is a no-op implementation of AsyncGossiper

--- a/op-node/rollup/async/asyncgossiper.go
+++ b/op-node/rollup/async/asyncgossiper.go
@@ -6,6 +6,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -29,18 +30,28 @@ const (
 	// It doubles as a memory bound: an envelope can be megabytes. 32 is ~1 minute
 	// of blocks at a 2s block time.
 	maxPublishQueue = 32
+
+	// maxPublishAttempts bounds how often a single block is offered to the
+	// network before it is given up on. A block that fails to publish is retried
+	// ahead of the blocks behind it, because a peer cannot follow the chain past
+	// a block it never received - the same reason blocks go out in seal order
+	// rather than skipping to the tip. The bound keeps a signer that is simply
+	// down from holding the head, and every block behind it, forever.
+	maxPublishAttempts = 2
 )
 
 type AsyncGossiper interface {
 	Gossip(payload *eth.ExecutionPayloadEnvelope)
 	Get() *eth.ExecutionPayloadEnvelope
 	Clear()
+	Discard(hash common.Hash)
+	DiscardAll()
 	Stop()
 	Start()
 }
 
-// SimpleAsyncGossiper is a component that stores and gossips a single payload at a time
-// the payload can be accessed by the Get function to be reused when the payload was gossiped but not inserted
+// SimpleAsyncGossiper publishes sealed blocks to p2p without holding up the
+// sequencer, and holds the last published block for the sequencer to reuse.
 //
 // Publishing runs on a dedicated goroutine, and the exposed functions only take
 // a mutex: none of them waits for the network. The sequencer calls Gossip, Get
@@ -51,7 +62,7 @@ type SimpleAsyncGossiper struct {
 	running atomic.Bool
 	// wake signals the publisher goroutine that there is a payload to publish.
 	// Capacity 1, and sent to without blocking: a single queued signal suffices,
-	// because the publisher reads the pending payload after receiving one.
+	// because the publisher reads the queue after receiving one.
 	wake chan struct{}
 	// channel to request stopping the publisher goroutine
 	stop chan struct{}
@@ -62,12 +73,24 @@ type SimpleAsyncGossiper struct {
 	// block before its parent.
 	queue []*queuedPayload
 	// currentPayload is the last successfully published payload that has not
-	// been cleared since: the payload the sequencer may reuse
+	// been cleared or discarded since: the payload the sequencer may reuse
 	currentPayload *eth.ExecutionPayloadEnvelope
-	// epoch identifies the payload the sequencer currently cares about. Both
-	// Gossip and Clear advance it, so a publish that was already in flight can
-	// tell that its result has since become stale.
-	epoch uint64
+	// wanted is the block the sequencer is currently trying to make canonical.
+	// A publish that completes for any other block must not offer its payload
+	// for reuse: the sequencer has moved past it. Gossip sets it, Clear and
+	// Discard zero it.
+	wanted common.Hash
+	// publishing is the block the publisher goroutine currently has in flight,
+	// valid only while publishInFlight is set. It keeps a re-seal of that same
+	// block from being queued behind the publish that is already sending it.
+	// The flag is explicit rather than a zero-hash sentinel: a hash that
+	// happened to be zero would otherwise read as "idle" and, worse, make every
+	// block look already-in-flight and so never be published at all.
+	publishing      common.Hash
+	publishInFlight bool
+	// publishDiscarded records that the in-flight block was discarded while it
+	// was being published, so the attempt is not retried or reused on return.
+	publishDiscarded bool
 
 	ctx     context.Context
 	net     Network
@@ -75,11 +98,13 @@ type SimpleAsyncGossiper struct {
 	metrics Metrics
 }
 
-// queuedPayload is a payload awaiting publication, tagged with the epoch it was
-// handed over in.
+// queuedPayload is a payload awaiting publication.
 type queuedPayload struct {
 	payload *eth.ExecutionPayloadEnvelope
-	epoch   uint64
+	hash    common.Hash
+	// attempts counts how often this block has been handed to the network,
+	// including the attempt in flight. See maxPublishAttempts.
+	attempts int
 }
 
 // To avoid import cycles, we define a new Network interface here
@@ -117,9 +142,31 @@ func NewAsyncGossiper(ctx context.Context, net Network, log log.Logger, metrics 
 // maxPublishQueue - at which point keeping the sequencer building is worth more
 // than the gossip.
 func (p *SimpleAsyncGossiper) Gossip(payload *eth.ExecutionPayloadEnvelope) {
+	p.enqueue(payload)
+	p.signal()
+}
+
+// enqueue adds a payload to the queue, dropping the oldest entries if that puts
+// it over the cap. It holds the mutex across both the queue mutation and the
+// gauge update, so the reported depth cannot be reordered against the queue it
+// describes.
+func (p *SimpleAsyncGossiper) enqueue(payload *eth.ExecutionPayloadEnvelope) {
+	hash := payload.ExecutionPayload.BlockHash
+
 	p.mu.Lock()
-	p.epoch++
-	p.queue = append(p.queue, &queuedPayload{payload: payload, epoch: p.epoch})
+	defer p.mu.Unlock()
+
+	// This is the block the sequencer is now trying to make canonical.
+	p.wanted = hash
+	if p.isPending(hash) {
+		// A re-seal of a block already queued or in flight. The sequencer does
+		// this while an insert keeps failing temporarily, once per retry.
+		// Publishing the same block again is wasted work, and queueing it would
+		// crowd out the blocks behind it.
+		return
+	}
+
+	p.queue = append(p.queue, &queuedPayload{payload: payload, hash: hash})
 	for len(p.queue) > maxPublishQueue {
 		dropped := p.queue[0]
 		p.queue[0] = nil // do not keep the envelope alive through the backing array
@@ -130,11 +177,21 @@ func (p *SimpleAsyncGossiper) Gossip(payload *eth.ExecutionPayloadEnvelope) {
 			"len", len(p.queue))
 		p.metrics.RecordDroppedPublish()
 	}
-	length := len(p.queue)
-	p.mu.Unlock()
+	p.metrics.RecordPublishQueueLen(len(p.queue))
+}
 
-	p.metrics.RecordPublishQueueLen(length)
-	p.signal()
+// isPending reports whether the block is already queued or in flight. Callers
+// must hold p.mu.
+func (p *SimpleAsyncGossiper) isPending(hash common.Hash) bool {
+	if p.publishInFlight && p.publishing == hash {
+		return true
+	}
+	for _, queued := range p.queue {
+		if queued.hash == hash {
+			return true
+		}
+	}
+	return false
 }
 
 // signal wakes the publisher goroutine. A queued signal is enough, because the
@@ -157,14 +214,83 @@ func (p *SimpleAsyncGossiper) Get() *eth.ExecutionPayloadEnvelope {
 	return p.currentPayload
 }
 
-// Clear drops the payload held for reuse. A publish that is in flight still
-// completes - peers need the block either way - but its result no longer
-// repopulates the buffer.
+// Clear drops the payload held for reuse, for when the sequencer no longer needs
+// it because the block was inserted. Queued blocks are left to publish: they are
+// good blocks, and peers still need them.
+//
+// A publish that is in flight still completes - peers need the block either way
+// - but its result no longer repopulates the buffer.
 func (p *SimpleAsyncGossiper) Clear() {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.currentPayload = nil
-	p.epoch++
+	p.wanted = common.Hash{}
+}
+
+// Discard drops a block the sequencer has rejected - invalid, denied, or stale
+// against a chain that moved on - so it is neither published from the queue nor
+// offered back for reuse. This is the counterpart to Clear: Clear says the block
+// made it, Discard says it did not.
+//
+// A publish already in flight cannot be recalled, but it is not retried, and its
+// result is not stored.
+func (p *SimpleAsyncGossiper) Discard(hash common.Hash) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.currentPayload != nil && p.currentPayload.ExecutionPayload.BlockHash == hash {
+		p.currentPayload = nil
+	}
+	if p.wanted == hash {
+		p.wanted = common.Hash{}
+	}
+	if p.publishInFlight && p.publishing == hash {
+		p.publishDiscarded = true
+	}
+
+	kept := p.queue[:0]
+	for _, queued := range p.queue {
+		if queued.hash == hash {
+			p.log.Info("discarding unpublished block the sequencer rejected",
+				"block", queued.payload.ExecutionPayload.ID())
+			continue
+		}
+		kept = append(kept, queued)
+	}
+	for i := len(kept); i < len(p.queue); i++ {
+		p.queue[i] = nil // do not keep discarded envelopes alive through the backing array
+	}
+	p.queue = kept
+	p.metrics.RecordPublishQueueLen(len(p.queue))
+}
+
+// DiscardAll drops everything: the payload held for reuse, and every block still
+// waiting to be published. It is for when the sequencer abandons the chain it was
+// building on - a derivation reset, or a start from an unknown pre-state - after
+// which the queued blocks belong to a chain that has been rewound. Publishing
+// them would offer peers blocks the sequencer itself no longer stands behind.
+//
+// This is the bulk counterpart to Discard. Clear is deliberately not this: it is
+// also what the sequencer calls when a block is successfully inserted, where the
+// blocks queued behind it are good blocks that peers still need.
+func (p *SimpleAsyncGossiper) DiscardAll() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.currentPayload = nil
+	p.wanted = common.Hash{}
+	if p.publishInFlight {
+		p.publishDiscarded = true
+	}
+	if len(p.queue) > 0 {
+		p.log.Info("discarding unpublished blocks, the sequencer abandoned the chain they extend",
+			"len", len(p.queue))
+	}
+	for i := range p.queue {
+		p.queue[i] = nil // do not keep the envelopes alive through the backing array
+	}
+	p.queue = nil
+	p.metrics.RecordPublishQueueLen(0)
 }
 
 // Stop is a synchronous function to stop the async routine
@@ -198,26 +324,31 @@ func (p *SimpleAsyncGossiper) Start() {
 	}()
 }
 
-// dequeue takes the oldest queued payload, along with the number of entries left
-// behind. It returns nil when the queue is empty.
+// dequeue takes the oldest queued payload and marks it in flight, along with the
+// number of entries left behind. It returns nil when the queue is empty. Like
+// enqueue, it updates the gauge under the same lock as the queue mutation.
 func (p *SimpleAsyncGossiper) dequeue() (*queuedPayload, int) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if len(p.queue) == 0 {
+		p.publishInFlight = false
 		return nil, 0
 	}
 	next := p.queue[0]
 	p.queue[0] = nil // do not keep the envelope alive through the backing array
 	p.queue = p.queue[1:]
+	next.attempts++
+	p.publishing = next.hash
+	p.publishInFlight = true
+	p.publishDiscarded = false
+	p.metrics.RecordPublishQueueLen(len(p.queue))
 	return next, len(p.queue)
 }
 
-// publish publishes the next queued payload and stores it for reuse if the
-// publish succeeded and the payload is still the one the sequencer cares about.
-// It runs on the publisher goroutine and holds no lock across the network call.
+// publish publishes the next queued payload. It runs on the publisher goroutine
+// and holds no lock across the network call.
 func (p *SimpleAsyncGossiper) publish() {
 	next, remaining := p.dequeue()
-	p.metrics.RecordPublishQueueLen(remaining)
 	if next == nil {
 		return // an earlier signal already drained the queue
 	}
@@ -229,22 +360,48 @@ func (p *SimpleAsyncGossiper) publish() {
 
 	ctx, cancel := context.WithTimeout(p.ctx, publishTimeout)
 	defer cancel()
-	if err := p.net.SignAndPublishL2Payload(ctx, next.payload); err != nil {
-		p.log.Warn("failed to publish newly created block",
-			"id", next.payload.ExecutionPayload.ID(),
-			"hash", next.payload.ExecutionPayload.BlockHash,
-			"err", err)
-		p.metrics.RecordPublishingError()
+	err := p.net.SignAndPublishL2Payload(ctx, next.payload)
+	p.finishPublish(next, err)
+}
+
+// finishPublish records the outcome of a publish attempt: on success the payload
+// becomes available for reuse if the sequencer still wants it, and on failure the
+// block is retried ahead of the blocks behind it, within maxPublishAttempts.
+func (p *SimpleAsyncGossiper) finishPublish(next *queuedPayload, err error) {
+	p.mu.Lock()
+	p.publishInFlight = false
+	discarded := p.publishDiscarded
+	p.publishDiscarded = false
+
+	if err == nil {
+		// A Clear (the block was inserted), a Discard (it was rejected), or a
+		// Gossip of a later block while we were publishing all make this payload
+		// unfit for reuse: the sequencer would rebuild a block it has moved past.
+		if !discarded && p.wanted == next.hash {
+			p.currentPayload = next.payload
+		}
+		p.mu.Unlock()
 		return
 	}
 
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	// A Clear (the block was inserted) or a newer Gossip while we were
-	// publishing makes this payload unfit for reuse: the sequencer would rebuild
-	// a block it has already moved past.
-	if p.epoch == next.epoch {
-		p.currentPayload = next.payload
+	// Retrying at the front keeps the chain gap-free for peers, but never at the
+	// cost of unbounded growth or of a block the sequencer has already rejected.
+	retry := !discarded && next.attempts < maxPublishAttempts && len(p.queue) < maxPublishQueue
+	if retry {
+		p.queue = append([]*queuedPayload{next}, p.queue...)
+		p.metrics.RecordPublishQueueLen(len(p.queue))
+	}
+	p.mu.Unlock()
+
+	p.metrics.RecordPublishingError()
+	p.log.Warn("failed to publish newly created block",
+		"id", next.payload.ExecutionPayload.ID(),
+		"hash", next.payload.ExecutionPayload.BlockHash,
+		"attempts", next.attempts,
+		"retrying", retry,
+		"err", err)
+	if retry {
+		p.signal()
 	}
 }
 
@@ -255,5 +412,7 @@ type NoOpGossiper struct{}
 func (NoOpGossiper) Gossip(payload *eth.ExecutionPayloadEnvelope) {}
 func (NoOpGossiper) Get() *eth.ExecutionPayloadEnvelope           { return nil }
 func (NoOpGossiper) Clear()                                       {}
+func (NoOpGossiper) Discard(hash common.Hash)                     {}
+func (NoOpGossiper) DiscardAll()                                  {}
 func (NoOpGossiper) Stop()                                        {}
 func (NoOpGossiper) Start()                                       {}

--- a/op-node/rollup/async/asyncgossiper.go
+++ b/op-node/rollup/async/asyncgossiper.go
@@ -2,6 +2,7 @@ package async
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -41,10 +42,20 @@ const (
 	retryInterval = time.Second
 )
 
+// ErrPermanentPublish marks a publish failure that will recur identically on
+// every attempt: the block itself, or this node's configuration, is what was
+// rejected. op-node runs its own block validator inline on the publishing node,
+// so these are the common case rather than an exotic one - and a block that has
+// aged past the gossip timestamp threshold joins them, permanently.
+//
+// Retrying such a block is not merely wasted work. It sits at the head of the
+// queue holding up every block behind it, and a queue that spans more than the
+// timestamp threshold would never drain again: each head is already too old, so
+// each fails, and the blocks behind it age into the same state.
+var ErrPermanentPublish = errors.New("permanent publish failure")
+
 type AsyncGossiper interface {
 	Gossip(payload *eth.ExecutionPayloadEnvelope)
-	Get() *eth.ExecutionPayloadEnvelope
-	Clear()
 	Discard(hash common.Hash)
 	DiscardAll()
 	Stop()
@@ -52,13 +63,17 @@ type AsyncGossiper interface {
 }
 
 // SimpleAsyncGossiper publishes sealed blocks to p2p without holding up the
-// sequencer, and holds the last published block for the sequencer to reuse.
+// sequencer.
 //
 // Publishing runs on a dedicated goroutine, and the exposed functions only take
-// a mutex: none of them waits for the network. The sequencer calls Gossip, Get
-// and Clear on the hot path between sealing block N and opening the build window
-// for block N+1, and that window is computed as a residual - so any wait here is
-// subtracted 1:1 from the next block's building time.
+// a mutex: none of them waits for the network. The sequencer calls Gossip on the
+// hot path between sealing block N and opening the build window for block N+1,
+// and that window is computed as a residual - so any wait here is subtracted 1:1
+// from the next block's building time.
+//
+// It does not hold a block for the sequencer to reuse. The sequencer keeps the
+// block it sealed on its own building state, so a failed insert is retried from
+// there rather than from here.
 type SimpleAsyncGossiper struct {
 	running atomic.Bool
 	// wake signals the publisher goroutine that there is a payload to publish.
@@ -73,14 +88,6 @@ type SimpleAsyncGossiper struct {
 	// published in the order they were sealed, so a peer is not asked to accept a
 	// block before its parent.
 	queue []*queuedPayload
-	// currentPayload is the last successfully published payload that has not
-	// been cleared or discarded since: the payload the sequencer may reuse
-	currentPayload *eth.ExecutionPayloadEnvelope
-	// wanted is the block the sequencer is currently trying to make canonical.
-	// A publish that completes for any other block must not offer its payload
-	// for reuse: the sequencer has moved past it. Gossip sets it, Clear and
-	// Discard zero it.
-	wanted common.Hash
 	// publishing is the block the publisher goroutine currently has in flight,
 	// valid only while publishInFlight is set. It keeps a re-seal of that same
 	// block from being queued behind the publish that is already sending it.
@@ -165,13 +172,11 @@ func (p *SimpleAsyncGossiper) enqueue(payload *eth.ExecutionPayloadEnvelope) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	// This is the block the sequencer is now trying to make canonical.
-	p.wanted = hash
 	if p.isPending(hash) {
-		// A re-seal of a block already queued or in flight. The sequencer does
-		// this while an insert keeps failing temporarily, once per retry.
-		// Publishing the same block again is wasted work, and queueing it would
-		// crowd out the blocks behind it.
+		// The same block handed over twice. The sequencer no longer does this -
+		// it re-inserts the block it retained rather than re-sealing - but
+		// publishing one block twice is wasted work either way, and queueing it
+		// would crowd out the blocks behind it.
 		return
 	}
 
@@ -212,47 +217,16 @@ func (p *SimpleAsyncGossiper) signal() {
 	}
 }
 
-// Get returns the payload that was published and not cleared since, if any.
-//
-// It does not wait for a publish that is still in flight: a nil result means
-// there is nothing to reuse, and the sequencer seals (or re-seals) its building
-// job instead of paying for the wait out of the block's build window.
-func (p *SimpleAsyncGossiper) Get() *eth.ExecutionPayloadEnvelope {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	return p.currentPayload
-}
-
-// Clear drops the payload held for reuse, for when the sequencer no longer needs
-// it because the block was inserted. Queued blocks are left to publish: they are
-// good blocks, and peers still need them.
-//
-// A publish that is in flight still completes - peers need the block either way
-// - but its result no longer repopulates the buffer.
-func (p *SimpleAsyncGossiper) Clear() {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	p.currentPayload = nil
-	p.wanted = common.Hash{}
-}
-
 // Discard drops a block the sequencer has rejected - invalid, denied, or stale
-// against a chain that moved on - so it is neither published from the queue nor
-// offered back for reuse. This is the counterpart to Clear: Clear says the block
-// made it, Discard says it did not.
+// against a chain that moved on - so it is not published. A block that was
+// inserted successfully needs no call at all: it is already on its way, and
+// peers need it.
 //
-// A publish already in flight cannot be recalled, but it is not retried, and its
-// result is not stored.
+// A publish already in flight cannot be recalled, but it is not retried.
 func (p *SimpleAsyncGossiper) Discard(hash common.Hash) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	if p.currentPayload != nil && p.currentPayload.ExecutionPayload.BlockHash == hash {
-		p.currentPayload = nil
-	}
-	if p.wanted == hash {
-		p.wanted = common.Hash{}
-	}
 	if p.publishInFlight && p.publishing == hash {
 		p.publishDiscarded = true
 	}
@@ -273,21 +247,15 @@ func (p *SimpleAsyncGossiper) Discard(hash common.Hash) {
 	p.metrics.RecordPublishQueueLen(len(p.queue))
 }
 
-// DiscardAll drops everything: the payload held for reuse, and every block still
-// waiting to be published. It is for when the sequencer abandons the chain it was
-// building on - a derivation reset, or a start from an unknown pre-state - after
-// which the queued blocks belong to a chain that has been rewound. Publishing
-// them would offer peers blocks the sequencer itself no longer stands behind.
-//
-// This is the bulk counterpart to Discard. Clear is deliberately not this: it is
-// also what the sequencer calls when a block is successfully inserted, where the
-// blocks queued behind it are good blocks that peers still need.
+// DiscardAll drops every block still waiting to be published. It is for when the
+// sequencer abandons the chain it was building on - a derivation reset, or a
+// start from an unknown pre-state - after which the queued blocks belong to a
+// chain that has been rewound. Publishing them would offer peers blocks the
+// sequencer itself no longer stands behind.
 func (p *SimpleAsyncGossiper) DiscardAll() {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	p.currentPayload = nil
-	p.wanted = common.Hash{}
 	if p.publishInFlight {
 		p.publishDiscarded = true
 	}
@@ -398,10 +366,9 @@ func (p *SimpleAsyncGossiper) signalIfPending() {
 	}
 }
 
-// finishPublish records the outcome of a publish attempt: on success the payload
-// becomes available for reuse if the sequencer still wants it, and on failure the
-// block is put back at the front of the queue if there is room for it. It reports
-// whether it requeued, so the caller can pace the retry.
+// finishPublish records the outcome of a publish attempt: on failure the block is
+// put back at the front of the queue if there is room for it. It reports whether
+// it requeued, so the caller can pace the retry.
 func (p *SimpleAsyncGossiper) finishPublish(next *queuedPayload, err error) (requeued bool) {
 	p.mu.Lock()
 	p.publishInFlight = false
@@ -409,15 +376,14 @@ func (p *SimpleAsyncGossiper) finishPublish(next *queuedPayload, err error) (req
 	p.publishDiscarded = false
 
 	if err == nil {
-		// A Clear (the block was inserted), a Discard (it was rejected), or a
-		// Gossip of a later block while we were publishing all make this payload
-		// unfit for reuse: the sequencer would rebuild a block it has moved past.
-		if !discarded && p.wanted == next.hash {
-			p.currentPayload = next.payload
-		}
 		p.mu.Unlock()
 		return false
 	}
+
+	// A block the network will reject the same way every time is dropped now: it
+	// cannot become publishable, and holding it at the head would stall the
+	// blocks behind it.
+	permanent := errors.Is(err, ErrPermanentPublish)
 
 	// Retrying at the front keeps the chain gap-free for peers. Queue pressure is
 	// what bounds it: the retried block sits at the head, and enqueue evicts the
@@ -425,13 +391,15 @@ func (p *SimpleAsyncGossiper) finishPublish(next *queuedPayload, err error) (req
 	// production leaves room for it. A block the sequencer has already rejected
 	// is not retried at all.
 	//
-	// The attempt bound is the same number, for the case where that eviction can
-	// never come: if block production has stopped, nothing is ever enqueued, so
-	// nothing evicts the head and an unpublishable block would be offered - and
-	// logged, and counted - once per retryInterval until the process exits. A
-	// block that has been tried more times than the queue could hold has already
-	// outlived every block that would have displaced it.
-	retry := !discarded && len(p.queue) < maxPublishQueue && next.attempts < maxPublishQueue
+	// maxPublishAttempts is a hard ceiling on top of that, for the case where
+	// eviction can never come: if block production has stopped, nothing is ever
+	// enqueued, so nothing evicts the head and a block that keeps failing would be
+	// offered - and logged, and counted - once per retryInterval until the process
+	// exits. At a 1s interval it is reached in about 32s, well before 32 blocks
+	// have been produced at any normal block time, so it is the ceiling that binds
+	// first in practice rather than a restatement of queue pressure.
+	retry := !discarded && !permanent &&
+		len(p.queue) < maxPublishQueue && next.attempts < maxPublishQueue
 	if retry {
 		p.queue = append([]*queuedPayload{next}, p.queue...)
 		p.metrics.RecordPublishQueueLen(len(p.queue))
@@ -439,7 +407,15 @@ func (p *SimpleAsyncGossiper) finishPublish(next *queuedPayload, err error) (req
 	p.mu.Unlock()
 
 	p.metrics.RecordPublishingError()
-	p.log.Warn("failed to publish newly created block",
+	if !retry {
+		// Nothing else will carry this block to peers.
+		p.metrics.RecordDroppedPublish()
+	}
+	msg := "failed to publish newly created block"
+	if permanent {
+		msg = "dropping block that can never be published"
+	}
+	p.log.Warn(msg,
 		"id", next.payload.ExecutionPayload.ID(),
 		"hash", next.payload.ExecutionPayload.BlockHash,
 		"attempts", next.attempts,
@@ -453,8 +429,6 @@ func (p *SimpleAsyncGossiper) finishPublish(next *queuedPayload, err error) (req
 type NoOpGossiper struct{}
 
 func (NoOpGossiper) Gossip(payload *eth.ExecutionPayloadEnvelope) {}
-func (NoOpGossiper) Get() *eth.ExecutionPayloadEnvelope           { return nil }
-func (NoOpGossiper) Clear()                                       {}
 func (NoOpGossiper) Discard(hash common.Hash)                     {}
 func (NoOpGossiper) DiscardAll()                                  {}
 func (NoOpGossiper) Stop()                                        {}

--- a/op-node/rollup/async/asyncgossiper_test.go
+++ b/op-node/rollup/async/asyncgossiper_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -24,9 +25,33 @@ func (m *mockNetwork) SignAndPublishL2Payload(ctx context.Context, payload *eth.
 	return nil
 }
 
-type mockMetrics struct{}
+type mockMetrics struct {
+	mu       sync.Mutex
+	dropped  int
+	queueLen int
+	maxLen   int
+}
 
 func (m *mockMetrics) RecordPublishingError() {}
+
+func (m *mockMetrics) RecordPublishQueueLen(length int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.queueLen = length
+	m.maxLen = max(m.maxLen, length)
+}
+
+func (m *mockMetrics) RecordDroppedPublish() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.dropped++
+}
+
+func (m *mockMetrics) counts() (dropped, queueLen, maxLen int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.dropped, m.queueLen, m.maxLen
+}
 
 // TestAsyncGossiper tests the AsyncGossiper component
 // because the component is small and simple, it is tested as a whole
@@ -161,10 +186,13 @@ type blockingNetwork struct {
 }
 
 func newBlockingNetwork() *blockingNetwork {
+	// Buffered well past the queue cap: a publish must never wait for the test to
+	// observe it, or a test that drains a full queue wedges the publisher (and
+	// with it Stop) instead of failing an assertion.
+	const room = 4 * maxPublishQueue
 	return &blockingNetwork{
-		// buffered, so a publish never waits for the test to observe it
-		started:  make(chan *eth.ExecutionPayloadEnvelope, 10),
-		finished: make(chan *eth.ExecutionPayloadEnvelope, 10),
+		started:  make(chan *eth.ExecutionPayloadEnvelope, room),
+		finished: make(chan *eth.ExecutionPayloadEnvelope, room),
 		release:  make(chan struct{}),
 	}
 }
@@ -249,11 +277,13 @@ func TestAsyncGossiperDoesNotBlockOnPublish(t *testing.T) {
 }
 
 // TestAsyncGossiperOverlappingPublishes covers a publish still being in flight
-// when the next block is sealed: handing over the new payload must not block,
-// and the newest payload is the one that gets published next.
+// when the next blocks are sealed: handing them over must not block, and every
+// one of them is published, in the order it was sealed. A verifier cannot follow
+// the chain past a block it never received, so none may be skipped.
 func TestAsyncGossiperOverlappingPublishes(t *testing.T) {
 	m := newBlockingNetwork()
-	p := NewAsyncGossiper(context.Background(), m, testlog.Logger(t, log.LevelError), &mockMetrics{})
+	metrics := &mockMetrics{}
+	p := NewAsyncGossiper(context.Background(), m, testlog.Logger(t, log.LevelError), metrics)
 	p.Start()
 	defer p.Stop()
 	defer m.Release()
@@ -278,12 +308,89 @@ func TestAsyncGossiperOverlappingPublishes(t *testing.T) {
 		t.Fatal("Gossip blocked until the in-flight publish returned")
 	}
 
-	// the second payload was superseded before it was ever published: peers get
-	// it through sync, and the tip is what matters
 	m.Release()
-	require.Equal(t, third, requirePayload(t, m.started, "queued publish never started"))
 	require.Equal(t, first, requirePayload(t, m.finished, "first publish never finished"))
-	require.Equal(t, third, requirePayload(t, m.finished, "queued publish never finished"))
+	require.Equal(t, second, requirePayload(t, m.started, "queued second never started"))
+	require.Equal(t, second, requirePayload(t, m.finished, "queued second never finished"))
+	require.Equal(t, third, requirePayload(t, m.started, "queued third never started"))
+	require.Equal(t, third, requirePayload(t, m.finished, "queued third never finished"))
+
+	dropped, _, maxLen := metrics.counts()
+	require.Zero(t, dropped, "nothing should be dropped: every block was still publishable")
+	require.Equal(t, 2, maxLen, "the backlog behind the in-flight publish should be visible in metrics")
+}
+
+// TestAsyncGossiperDropsAgedOutPayloads covers a backlog that outlived its
+// usefulness: peers REJECT a payload older than the gossip timestamp threshold,
+// and an invalid delivery is scored against the sender, so a block that waited
+// too long is dropped rather than published.
+func TestAsyncGossiperDropsAgedOutPayloads(t *testing.T) {
+	m := newBlockingNetwork()
+	metrics := &mockMetrics{}
+	p := NewAsyncGossiper(context.Background(), m, testlog.Logger(t, log.LevelError), metrics)
+
+	// atomic, because the publisher goroutine reads the clock we advance here
+	var now atomic.Int64
+	now.Store(time.Unix(1700000000, 0).UnixNano())
+	p.timeNow = func() time.Time { return time.Unix(0, now.Load()) }
+	p.Start()
+	defer p.Stop()
+	defer m.Release()
+
+	inFlight := testEnvelope(1)
+	p.Gossip(inFlight)
+	require.Equal(t, inFlight, requirePayload(t, m.started, "first publish never started"))
+
+	// two blocks pile up behind the stuck publish, then the signer comes back
+	// well after they could have been accepted
+	p.Gossip(testEnvelope(2))
+	p.Gossip(testEnvelope(3))
+	now.Add(int64(maxPublishAge + time.Second))
+
+	fresh := testEnvelope(4)
+	p.Gossip(fresh)
+	m.Release()
+
+	// the two that aged out are skipped; the one queued at the new time is published
+	require.Equal(t, inFlight, requirePayload(t, m.finished, "in-flight publish never finished"))
+	require.Equal(t, fresh, requirePayload(t, m.started, "fresh publish never started"))
+	require.Equal(t, fresh, requirePayload(t, m.finished, "fresh publish never finished"))
+	require.Eventually(t, func() bool {
+		dropped, _, _ := metrics.counts()
+		return dropped == 2
+	}, 10*time.Second, 10*time.Millisecond, "both aged-out payloads should be counted as dropped")
+}
+
+// TestAsyncGossiperBoundsQueue covers a signer the sequencer cannot reach for
+// long enough to fill the queue: the oldest entries are dropped rather than
+// held, so the cost lands on gossip - recoverable by other means - instead of on
+// block production or on memory.
+func TestAsyncGossiperBoundsQueue(t *testing.T) {
+	m := newBlockingNetwork()
+	metrics := &mockMetrics{}
+	p := NewAsyncGossiper(context.Background(), m, testlog.Logger(t, log.LevelError), metrics)
+	p.Start()
+	defer p.Stop()
+	defer m.Release()
+
+	p.Gossip(testEnvelope(0))
+	require.Equal(t, testEnvelope(0).ExecutionPayload.BlockNumber,
+		requirePayload(t, m.started, "first publish never started").ExecutionPayload.BlockNumber)
+
+	// pile up twice the cap behind the stuck publish
+	for i := 1; i <= 2*maxPublishQueue; i++ {
+		p.Gossip(testEnvelope(uint64(i)))
+	}
+
+	dropped, queueLen, _ := metrics.counts()
+	require.Equal(t, maxPublishQueue, queueLen, "queue must not grow past the cap")
+	require.Equal(t, maxPublishQueue, dropped, "the overflow must be counted as dropped")
+
+	// the oldest were dropped, so the queue resumes from the newest run of blocks
+	m.Release()
+	next := requirePayload(t, m.started, "queued publish never started")
+	require.Equal(t, hexutil.Uint64(maxPublishQueue+1), next.ExecutionPayload.BlockNumber,
+		"the oldest entries are dropped, keeping the newest")
 }
 
 // countingNetwork records the last payload it published.

--- a/op-node/rollup/async/asyncgossiper_test.go
+++ b/op-node/rollup/async/asyncgossiper_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -318,47 +317,6 @@ func TestAsyncGossiperOverlappingPublishes(t *testing.T) {
 	dropped, _, maxLen := metrics.counts()
 	require.Zero(t, dropped, "nothing should be dropped: every block was still publishable")
 	require.Equal(t, 2, maxLen, "the backlog behind the in-flight publish should be visible in metrics")
-}
-
-// TestAsyncGossiperDropsAgedOutPayloads covers a backlog that outlived its
-// usefulness: peers REJECT a payload older than the gossip timestamp threshold,
-// and an invalid delivery is scored against the sender, so a block that waited
-// too long is dropped rather than published.
-func TestAsyncGossiperDropsAgedOutPayloads(t *testing.T) {
-	m := newBlockingNetwork()
-	metrics := &mockMetrics{}
-	p := NewAsyncGossiper(context.Background(), m, testlog.Logger(t, log.LevelError), metrics)
-
-	// atomic, because the publisher goroutine reads the clock we advance here
-	var now atomic.Int64
-	now.Store(time.Unix(1700000000, 0).UnixNano())
-	p.timeNow = func() time.Time { return time.Unix(0, now.Load()) }
-	p.Start()
-	defer p.Stop()
-	defer m.Release()
-
-	inFlight := testEnvelope(1)
-	p.Gossip(inFlight)
-	require.Equal(t, inFlight, requirePayload(t, m.started, "first publish never started"))
-
-	// two blocks pile up behind the stuck publish, then the signer comes back
-	// well after they could have been accepted
-	p.Gossip(testEnvelope(2))
-	p.Gossip(testEnvelope(3))
-	now.Add(int64(maxPublishAge + time.Second))
-
-	fresh := testEnvelope(4)
-	p.Gossip(fresh)
-	m.Release()
-
-	// the two that aged out are skipped; the one queued at the new time is published
-	require.Equal(t, inFlight, requirePayload(t, m.finished, "in-flight publish never finished"))
-	require.Equal(t, fresh, requirePayload(t, m.started, "fresh publish never started"))
-	require.Equal(t, fresh, requirePayload(t, m.finished, "fresh publish never finished"))
-	require.Eventually(t, func() bool {
-		dropped, _, _ := metrics.counts()
-		return dropped == 2
-	}, 10*time.Second, 10*time.Millisecond, "both aged-out payloads should be counted as dropped")
 }
 
 // TestAsyncGossiperBoundsQueue covers a signer the sequencer cannot reach for

--- a/op-node/rollup/async/asyncgossiper_test.go
+++ b/op-node/rollup/async/asyncgossiper_test.go
@@ -3,10 +3,13 @@ package async
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
@@ -146,4 +149,184 @@ func TestAsyncGossiperFailToPublish(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return !p.running.Load()
 	}, 10*time.Second, 10*time.Millisecond)
+}
+
+// blockingNetwork is a mock network whose publish call blocks until released,
+// standing in for a slow remote-signer round-trip.
+type blockingNetwork struct {
+	started     chan *eth.ExecutionPayloadEnvelope
+	finished    chan *eth.ExecutionPayloadEnvelope
+	release     chan struct{}
+	releaseOnce sync.Once
+}
+
+func newBlockingNetwork() *blockingNetwork {
+	return &blockingNetwork{
+		// buffered, so a publish never waits for the test to observe it
+		started:  make(chan *eth.ExecutionPayloadEnvelope, 10),
+		finished: make(chan *eth.ExecutionPayloadEnvelope, 10),
+		release:  make(chan struct{}),
+	}
+}
+
+func (b *blockingNetwork) SignAndPublishL2Payload(ctx context.Context, payload *eth.ExecutionPayloadEnvelope) error {
+	b.started <- payload
+	select {
+	case <-b.release:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	b.finished <- payload
+	return nil
+}
+
+// Release unblocks every publish, in flight and future. Safe to call repeatedly.
+func (b *blockingNetwork) Release() {
+	b.releaseOnce.Do(func() { close(b.release) })
+}
+
+func testEnvelope(num uint64) *eth.ExecutionPayloadEnvelope {
+	return &eth.ExecutionPayloadEnvelope{
+		ExecutionPayload: &eth.ExecutionPayload{
+			BlockNumber: hexutil.Uint64(num),
+			BlockHash:   common.Hash{byte(num)},
+		},
+	}
+}
+
+// requirePayload waits for a payload to appear on c, e.g. a publish starting.
+func requirePayload(t *testing.T, c chan *eth.ExecutionPayloadEnvelope, msg string) *eth.ExecutionPayloadEnvelope {
+	t.Helper()
+	select {
+	case payload := <-c:
+		return payload
+	case <-time.After(30 * time.Second):
+		t.Fatal(msg)
+		return nil
+	}
+}
+
+// TestAsyncGossiperDoesNotBlockOnPublish is the regression test for the
+// sequencer stall: the sequencer calls Clear() a millisecond or two after
+// Gossip(), i.e. while the publish is in flight, and computes the next block's
+// build window as a residual - so every millisecond spent waiting here comes
+// straight out of the next block's building time.
+func TestAsyncGossiperDoesNotBlockOnPublish(t *testing.T) {
+	m := newBlockingNetwork()
+	p := NewAsyncGossiper(context.Background(), m, testlog.Logger(t, log.LevelError), &mockMetrics{})
+	p.Start()
+	// deferred in this order so the publish is released before Stop waits on it
+	defer p.Stop()
+	defer m.Release()
+
+	envelope := testEnvelope(1)
+	p.Gossip(envelope)
+	require.Equal(t, envelope, requirePayload(t, m.started, "publish never started"))
+
+	// with the publish in flight, the sequencer's Get() and Clear() must not wait for it
+	cleared := make(chan struct{})
+	go func() {
+		defer close(cleared)
+		p.Get()
+		p.Clear()
+	}()
+	select {
+	case <-cleared:
+	case <-time.After(2 * time.Second):
+		m.Release() // let the publisher finish, so Stop can complete
+		t.Fatal("Get/Clear blocked until the in-flight publish returned")
+	}
+
+	// clearing must not cancel the publish: peers still need the block
+	m.Release()
+	require.Equal(t, envelope, requirePayload(t, m.finished, "publish never finished"))
+
+	// nor may the completing publish repopulate the buffer the sequencer just
+	// cleared: reusing it would rebuild the block that is already the head
+	require.Never(t, func() bool {
+		return p.Get() != nil
+	}, 200*time.Millisecond, 10*time.Millisecond)
+}
+
+// TestAsyncGossiperOverlappingPublishes covers a publish still being in flight
+// when the next block is sealed: handing over the new payload must not block,
+// and the newest payload is the one that gets published next.
+func TestAsyncGossiperOverlappingPublishes(t *testing.T) {
+	m := newBlockingNetwork()
+	p := NewAsyncGossiper(context.Background(), m, testlog.Logger(t, log.LevelError), &mockMetrics{})
+	p.Start()
+	defer p.Stop()
+	defer m.Release()
+
+	first := testEnvelope(1)
+	p.Gossip(first)
+	require.Equal(t, first, requirePayload(t, m.started, "first publish never started"))
+
+	second, third := testEnvelope(2), testEnvelope(3)
+	handed := make(chan struct{})
+	go func() {
+		defer close(handed)
+		p.Gossip(second)
+		p.Clear()
+		p.Gossip(third)
+		p.Clear()
+	}()
+	select {
+	case <-handed:
+	case <-time.After(2 * time.Second):
+		m.Release()
+		t.Fatal("Gossip blocked until the in-flight publish returned")
+	}
+
+	// the second payload was superseded before it was ever published: peers get
+	// it through sync, and the tip is what matters
+	m.Release()
+	require.Equal(t, third, requirePayload(t, m.started, "queued publish never started"))
+	require.Equal(t, first, requirePayload(t, m.finished, "first publish never finished"))
+	require.Equal(t, third, requirePayload(t, m.finished, "queued publish never finished"))
+}
+
+// countingNetwork records the last payload it published.
+type countingNetwork struct {
+	mu   sync.Mutex
+	last uint64
+}
+
+func (c *countingNetwork) SignAndPublishL2Payload(ctx context.Context, envelope *eth.ExecutionPayloadEnvelope) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.last = uint64(envelope.ExecutionPayload.BlockNumber)
+	return nil
+}
+
+// TestAsyncGossiperConcurrentHandoff hammers the handoff to the publisher
+// goroutine to confirm no wake-up is lost: the last payload handed over is
+// always published, however the concurrent calls interleave.
+func TestAsyncGossiperConcurrentHandoff(t *testing.T) {
+	logger := testlog.Logger(t, log.LevelError)
+	for round := 0; round < 50; round++ {
+		m := &countingNetwork{}
+		p := NewAsyncGossiper(context.Background(), m, logger, &mockMetrics{})
+		p.Start()
+
+		var wg sync.WaitGroup
+		for i := 1; i <= 20; i++ {
+			wg.Add(1)
+			go func(i uint64) {
+				defer wg.Done()
+				p.Gossip(testEnvelope(i))
+				p.Get()
+				p.Clear()
+			}(uint64(i))
+		}
+		wg.Wait()
+
+		p.Gossip(testEnvelope(999))
+		require.Eventually(t, func() bool {
+			m.mu.Lock()
+			defer m.mu.Unlock()
+			return m.last == 999
+		}, 10*time.Second, time.Millisecond, "round %d: the last payload was never published", round)
+		p.Stop()
+	}
 }

--- a/op-node/rollup/async/asyncgossiper_test.go
+++ b/op-node/rollup/async/asyncgossiper_test.go
@@ -473,6 +473,7 @@ func TestAsyncGossiperDedupesResealedBlock(t *testing.T) {
 func TestAsyncGossiperRetriesFailedPublish(t *testing.T) {
 	m := newBlockingNetwork()
 	p := NewAsyncGossiper(context.Background(), m, testlog.Logger(t, log.LevelError), &mockMetrics{})
+	p.retryInterval = time.Millisecond
 	p.Start()
 	defer p.Stop()
 	defer m.Release()
@@ -493,32 +494,43 @@ func TestAsyncGossiperRetriesFailedPublish(t *testing.T) {
 	require.Equal(t, third, requirePayload(t, m.started, "third never started"))
 }
 
-// TestAsyncGossiperGivesUpOnFailedPublish bounds the retry: a signer that is
-// down fails every attempt, and holding the head forever would stop every later
-// block from being published too.
-func TestAsyncGossiperGivesUpOnFailedPublish(t *testing.T) {
+// TestAsyncGossiperRetriesUntilQueueIsFull pins what bounds the retry. There is
+// no attempt count: a failed block is retried at the front for exactly as long as
+// production leaves room for it, because enqueue evicts the head on overflow. Once
+// the queue is full there is nowhere to put it back, so an unpublishable block
+// stops holding up the blocks behind it.
+func TestAsyncGossiperRetriesUntilQueueIsFull(t *testing.T) {
 	m := newBlockingNetwork()
 	metrics := &mockMetrics{}
-	p := NewAsyncGossiper(context.Background(), m, testlog.Logger(t, log.LevelError), metrics)
+	p := NewAsyncGossiper(context.Background(), m, testlog.Logger(t, log.LevelCrit), metrics)
+	p.retryInterval = time.Millisecond
 	p.Start()
 	defer p.Stop()
 	defer m.Release()
 
-	first, second := testEnvelope(1), testEnvelope(2)
-	m.failNext(first.ExecutionPayload.BlockHash, maxPublishAttempts)
+	// A block that can never be published: a bad hash, say, which op-node's own
+	// validator rejects inline on this node, the same way on every attempt.
+	first := testEnvelope(0)
+	m.failNext(first.ExecutionPayload.BlockHash, 1<<30)
 
 	p.Gossip(first)
 	require.Equal(t, first, requirePayload(t, m.started, "first publish never started"))
-	p.Gossip(second)
+
+	// Fill the queue behind it. The in-flight block is not itself in the queue,
+	// so this leaves exactly maxPublishQueue entries and evicts nothing.
+	for i := 1; i <= maxPublishQueue; i++ {
+		p.Gossip(testEnvelope(uint64(i)))
+	}
+	dropped, queueLen, _ := metrics.counts()
+	require.Equal(t, maxPublishQueue, queueLen, "the queue is full behind the stuck block")
+	require.Zero(t, dropped, "nothing has overflowed yet")
 
 	m.Release()
-	for i := 1; i < maxPublishAttempts; i++ {
-		require.Equal(t, first, requirePayload(t, m.started, "the failed block was never retried"))
-	}
-	require.Equal(t, second, requirePayload(t, m.started, "a block behind an unpublishable one must still go out"))
-	require.Equal(t, second, requirePayload(t, m.finished, "second never finished"))
+	next := requirePayload(t, m.started, "a block behind an unpublishable one must still go out")
+	require.Equal(t, hexutil.Uint64(1), next.ExecutionPayload.BlockNumber,
+		"with no room to requeue it, the retry stops and publishing resumes in order")
 
-	dropped, _, _ := metrics.counts()
+	dropped, _, _ = metrics.counts()
 	require.Zero(t, dropped, "a block that failed to publish is a publishing error, not a queue-overflow drop")
 }
 
@@ -641,4 +653,83 @@ func TestAsyncGossiperDiscardAll(t *testing.T) {
 		}
 	}, 300*time.Millisecond, 20*time.Millisecond,
 		"no queued block may be published after the chain was abandoned, nor offered for reuse")
+}
+
+// instantFailNetwork fails every publish immediately, with no I/O at all. This
+// is not contrived: op-node runs its own block validator inline on the
+// publishing node, so a bad block hash, an oversized block, a fork-shape
+// mismatch - or a block that has aged past the gossip timestamp threshold -
+// fails in about a millisecond, deterministically, every time.
+type instantFailNetwork struct {
+	mu       sync.Mutex
+	attempts int
+}
+
+func (f *instantFailNetwork) SignAndPublishL2Payload(ctx context.Context, envelope *eth.ExecutionPayloadEnvelope) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.attempts++
+	return errors.New("validation failed")
+}
+
+func (f *instantFailNetwork) count() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.attempts
+}
+
+// TestAsyncGossiperPacesRetries is the spin guard. Retries are bounded by queue
+// pressure rather than by an attempt count, so a block that fails instantly and
+// deterministically would otherwise be retried as fast as the goroutine can loop
+// - thousands of times a second - for as long as the queue has room, and forever
+// if block production has stopped and nothing is left to evict it.
+func TestAsyncGossiperPacesRetries(t *testing.T) {
+	m := &instantFailNetwork{}
+	p := NewAsyncGossiper(context.Background(), m, testlog.Logger(t, log.LevelCrit), &mockMetrics{})
+	p.retryInterval = 50 * time.Millisecond
+	p.Start()
+	defer p.Stop()
+
+	p.Gossip(testEnvelope(1))
+
+	const window = 500 * time.Millisecond
+	time.Sleep(window)
+
+	attempts := m.count()
+	require.Positive(t, attempts, "the block must be retried at all")
+	// Pacing means attempts track wall-clock, not loop speed. Generously bounded
+	// so this cannot flake on a slow machine, while still failing by orders of
+	// magnitude if the retry is unpaced.
+	maxExpected := int(window/p.retryInterval) + 5
+	require.LessOrEqual(t, attempts, maxExpected,
+		"retries must be paced by wall-clock, not spun as fast as the publisher can loop")
+}
+
+// TestAsyncGossiperStopsRetryingWhenIdle covers the case queue pressure cannot
+// reach: an unpublishable block with no block production behind it. Nothing is
+// ever enqueued, so nothing evicts it, and without a backstop it would be
+// offered - logged and counted each time - once per retryInterval until the
+// process exits. That is a plausible shape during an incident: the sequencer is
+// stopped or has failed over while a block it cannot publish is still queued.
+func TestAsyncGossiperStopsRetryingWhenIdle(t *testing.T) {
+	m := &instantFailNetwork{}
+	p := NewAsyncGossiper(context.Background(), m, testlog.Logger(t, log.LevelCrit), &mockMetrics{})
+	p.retryInterval = time.Millisecond
+	p.Start()
+	defer p.Stop()
+
+	p.Gossip(testEnvelope(1))
+
+	// It gives up rather than retrying forever, and then stays quiet.
+	require.Eventually(t, func() bool {
+		return m.count() >= maxPublishQueue
+	}, 10*time.Second, 5*time.Millisecond, "the block should be retried while it can be")
+
+	settled := m.count()
+	require.LessOrEqual(t, settled, maxPublishQueue+1,
+		"a block cannot be retried more times than the queue could ever have held")
+	require.Never(t, func() bool {
+		return m.count() > settled
+	}, 200*time.Millisecond, 20*time.Millisecond,
+		"with nothing arriving to evict it, the retry must stop rather than run until the process exits")
 }

--- a/op-node/rollup/async/asyncgossiper_test.go
+++ b/op-node/rollup/async/asyncgossiper_test.go
@@ -182,6 +182,11 @@ type blockingNetwork struct {
 	finished    chan *eth.ExecutionPayloadEnvelope
 	release     chan struct{}
 	releaseOnce sync.Once
+
+	mu sync.Mutex
+	// failuresLeft counts, per block hash, how many further publish attempts
+	// must fail before one is allowed to succeed. See failNext.
+	failuresLeft map[common.Hash]int
 }
 
 func newBlockingNetwork() *blockingNetwork {
@@ -203,6 +208,13 @@ func (b *blockingNetwork) SignAndPublishL2Payload(ctx context.Context, payload *
 	case <-ctx.Done():
 		return ctx.Err()
 	}
+	b.mu.Lock()
+	if left := b.failuresLeft[payload.ExecutionPayload.BlockHash]; left > 0 {
+		b.failuresLeft[payload.ExecutionPayload.BlockHash] = left - 1
+		b.mu.Unlock()
+		return errors.New("scripted publish failure")
+	}
+	b.mu.Unlock()
 	b.finished <- payload
 	return nil
 }
@@ -394,4 +406,239 @@ func TestAsyncGossiperConcurrentHandoff(t *testing.T) {
 		}, 10*time.Second, time.Millisecond, "round %d: the last payload was never published", round)
 		p.Stop()
 	}
+}
+
+// failNext scripts the next n publish attempts of a hash to fail, so a test can
+// exercise a signer that rejects or times out on a block.
+func (b *blockingNetwork) failNext(hash common.Hash, n int) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.failuresLeft == nil {
+		b.failuresLeft = make(map[common.Hash]int)
+	}
+	b.failuresLeft[hash] = n
+}
+
+// TestAsyncGossiperDedupesResealedBlock covers the sequencer retrying a block
+// whose insertion failed temporarily. Get() does not wait for the in-flight
+// publish, so the sequencer re-seals the same build job and hands the identical
+// block over again, once per retry. Those duplicates must not queue up behind
+// the publish that is already sending that very block, and must not invalidate
+// it for reuse - that would leave the sequencer re-sealing indefinitely, and
+// fill the queue with copies of one block.
+func TestAsyncGossiperDedupesResealedBlock(t *testing.T) {
+	m := newBlockingNetwork()
+	metrics := &mockMetrics{}
+	p := NewAsyncGossiper(context.Background(), m, testlog.Logger(t, log.LevelError), metrics)
+	p.Start()
+	defer p.Stop()
+	defer m.Release()
+
+	envelope := testEnvelope(1)
+	p.Gossip(envelope)
+	require.Equal(t, envelope, requirePayload(t, m.started, "publish never started"))
+
+	for i := 0; i < 5; i++ {
+		require.Nil(t, p.Get(), "the publish is still in flight, so there is nothing to reuse yet")
+		// a re-seal of the same build job: an equal block, a distinct value
+		p.Gossip(testEnvelope(1))
+	}
+	_, queueLen, maxLen := metrics.counts()
+	require.Zero(t, queueLen, "a block already being published must not be queued again")
+	require.Equal(t, 1, maxLen, "only the original block was ever queued, none of the duplicates")
+
+	m.Release()
+	require.Equal(t, envelope, requirePayload(t, m.finished, "publish never finished"))
+
+	require.Eventually(t, func() bool {
+		return p.Get() != nil
+	}, 10*time.Second, 10*time.Millisecond,
+		"the published block must be offered for reuse: the duplicates must not have invalidated it")
+
+	require.Never(t, func() bool {
+		select {
+		case <-m.started:
+			return true
+		default:
+			return false
+		}
+	}, 200*time.Millisecond, 20*time.Millisecond, "the block must be published only once")
+}
+
+// TestAsyncGossiperRetriesFailedPublish covers a publish that fails - a signer
+// blip, or the new publish timeout. Dropping that block and carrying on with its
+// descendants would leave peers a gap they cannot follow the chain past, which
+// is the same reason blocks are published in seal order rather than skipping to
+// the tip. So the failed block is retried ahead of the blocks behind it.
+func TestAsyncGossiperRetriesFailedPublish(t *testing.T) {
+	m := newBlockingNetwork()
+	p := NewAsyncGossiper(context.Background(), m, testlog.Logger(t, log.LevelError), &mockMetrics{})
+	p.Start()
+	defer p.Stop()
+	defer m.Release()
+
+	first, second, third := testEnvelope(1), testEnvelope(2), testEnvelope(3)
+	m.failNext(first.ExecutionPayload.BlockHash, 1)
+
+	p.Gossip(first)
+	require.Equal(t, first, requirePayload(t, m.started, "first publish never started"))
+	// queue the descendants behind the publish that is about to fail
+	p.Gossip(second)
+	p.Gossip(third)
+
+	m.Release()
+	require.Equal(t, first, requirePayload(t, m.started, "the failed block was never retried"))
+	require.Equal(t, first, requirePayload(t, m.finished, "the retry never succeeded"))
+	require.Equal(t, second, requirePayload(t, m.started, "second never started"))
+	require.Equal(t, third, requirePayload(t, m.started, "third never started"))
+}
+
+// TestAsyncGossiperGivesUpOnFailedPublish bounds the retry: a signer that is
+// down fails every attempt, and holding the head forever would stop every later
+// block from being published too.
+func TestAsyncGossiperGivesUpOnFailedPublish(t *testing.T) {
+	m := newBlockingNetwork()
+	metrics := &mockMetrics{}
+	p := NewAsyncGossiper(context.Background(), m, testlog.Logger(t, log.LevelError), metrics)
+	p.Start()
+	defer p.Stop()
+	defer m.Release()
+
+	first, second := testEnvelope(1), testEnvelope(2)
+	m.failNext(first.ExecutionPayload.BlockHash, maxPublishAttempts)
+
+	p.Gossip(first)
+	require.Equal(t, first, requirePayload(t, m.started, "first publish never started"))
+	p.Gossip(second)
+
+	m.Release()
+	for i := 1; i < maxPublishAttempts; i++ {
+		require.Equal(t, first, requirePayload(t, m.started, "the failed block was never retried"))
+	}
+	require.Equal(t, second, requirePayload(t, m.started, "a block behind an unpublishable one must still go out"))
+	require.Equal(t, second, requirePayload(t, m.finished, "second never finished"))
+
+	dropped, _, _ := metrics.counts()
+	require.Zero(t, dropped, "a block that failed to publish is a publishing error, not a queue-overflow drop")
+}
+
+// TestAsyncGossiperDiscardDropsQueuedBlock covers the sequencer rejecting a
+// block it had already handed over - invalid, denied, or stale against a chain
+// that moved on. Clear cannot express that: it is also what the sequencer calls
+// when a block is successfully inserted, when the queue must keep publishing. So
+// a rejected block is Discarded by hash, and only that block goes.
+func TestAsyncGossiperDiscardDropsQueuedBlock(t *testing.T) {
+	m := newBlockingNetwork()
+	metrics := &mockMetrics{}
+	p := NewAsyncGossiper(context.Background(), m, testlog.Logger(t, log.LevelError), metrics)
+	p.Start()
+	defer p.Stop()
+	defer m.Release()
+
+	first, rejected, third := testEnvelope(1), testEnvelope(2), testEnvelope(3)
+	p.Gossip(first)
+	require.Equal(t, first, requirePayload(t, m.started, "first publish never started"))
+	p.Gossip(rejected)
+	p.Gossip(third)
+
+	p.Discard(rejected.ExecutionPayload.BlockHash)
+	_, queueLen, _ := metrics.counts()
+	require.Equal(t, 1, queueLen, "only the rejected block leaves the queue")
+
+	m.Release()
+	require.Equal(t, first, requirePayload(t, m.finished, "first publish never finished"))
+	require.Equal(t, third, requirePayload(t, m.started,
+		"the rejected block must be skipped, and the good block behind it still published"))
+	require.Equal(t, third, requirePayload(t, m.finished, "third never finished"))
+}
+
+// TestAsyncGossiperClearKeepsQueue is the other half: Clear means the block was
+// inserted, so the blocks queued behind it are good blocks that peers still need.
+func TestAsyncGossiperClearKeepsQueue(t *testing.T) {
+	m := newBlockingNetwork()
+	p := NewAsyncGossiper(context.Background(), m, testlog.Logger(t, log.LevelError), &mockMetrics{})
+	p.Start()
+	defer p.Stop()
+	defer m.Release()
+
+	first, second := testEnvelope(1), testEnvelope(2)
+	p.Gossip(first)
+	require.Equal(t, first, requirePayload(t, m.started, "first publish never started"))
+	p.Gossip(second)
+	p.Clear()
+
+	m.Release()
+	require.Equal(t, first, requirePayload(t, m.finished, "first publish never finished"))
+	require.Equal(t, second, requirePayload(t, m.started, "a queued block must survive Clear"))
+	require.Equal(t, second, requirePayload(t, m.finished, "second never finished"))
+}
+
+// TestAsyncGossiperDiscardInFlightBlock covers a block rejected while its publish
+// is already in flight. That send cannot be recalled, but it must not be retried
+// when it fails, and must not come back as a payload to reuse when it succeeds.
+func TestAsyncGossiperDiscardInFlightBlock(t *testing.T) {
+	m := newBlockingNetwork()
+	p := NewAsyncGossiper(context.Background(), m, testlog.Logger(t, log.LevelError), &mockMetrics{})
+	p.Start()
+	defer p.Stop()
+	defer m.Release()
+
+	envelope, next := testEnvelope(1), testEnvelope(2)
+	m.failNext(envelope.ExecutionPayload.BlockHash, 1)
+	p.Gossip(envelope)
+	require.Equal(t, envelope, requirePayload(t, m.started, "publish never started"))
+
+	p.Discard(envelope.ExecutionPayload.BlockHash)
+	p.Gossip(next)
+
+	m.Release()
+	require.Equal(t, next, requirePayload(t, m.started,
+		"a discarded block must not be retried ahead of the blocks behind it"))
+	require.Equal(t, next, requirePayload(t, m.finished, "next never finished"))
+	require.Never(t, func() bool {
+		reusable := p.Get()
+		return reusable != nil &&
+			reusable.ExecutionPayload.BlockHash == envelope.ExecutionPayload.BlockHash
+	}, 200*time.Millisecond, 20*time.Millisecond,
+		"a discarded block must never be offered back for reuse")
+}
+
+// TestAsyncGossiperDiscardAll covers the sequencer abandoning the chain the
+// queued blocks extend - a derivation reset, or a start from an unknown
+// pre-state. Those blocks belong to a chain that has been rewound, so none of
+// them may still go out, and an in-flight publish must not come back as a
+// payload to reuse on the chain the sequencer moves to.
+func TestAsyncGossiperDiscardAll(t *testing.T) {
+	m := newBlockingNetwork()
+	metrics := &mockMetrics{}
+	p := NewAsyncGossiper(context.Background(), m, testlog.Logger(t, log.LevelError), metrics)
+	p.Start()
+	defer p.Stop()
+	defer m.Release()
+
+	inFlight := testEnvelope(1)
+	p.Gossip(inFlight)
+	require.Equal(t, inFlight, requirePayload(t, m.started, "first publish never started"))
+	for i := 2; i <= 5; i++ {
+		p.Gossip(testEnvelope(uint64(i)))
+	}
+	_, queueLen, _ := metrics.counts()
+	require.Equal(t, 4, queueLen, "the blocks behind the in-flight publish are queued")
+
+	p.DiscardAll()
+	_, queueLen, _ = metrics.counts()
+	require.Zero(t, queueLen, "a rewound chain leaves nothing worth publishing")
+
+	m.Release()
+	require.Equal(t, inFlight, requirePayload(t, m.finished,
+		"the in-flight publish cannot be recalled, and still completes"))
+	require.Never(t, func() bool {
+		select {
+		case <-m.started:
+			return true
+		default:
+			return p.Get() != nil
+		}
+	}, 300*time.Millisecond, 20*time.Millisecond,
+		"no queued block may be published after the chain was abandoned, nor offered for reuse")
 }

--- a/op-node/rollup/async/asyncgossiper_test.go
+++ b/op-node/rollup/async/asyncgossiper_test.go
@@ -3,6 +3,7 @@ package async
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -16,10 +17,13 @@ import (
 )
 
 type mockNetwork struct {
+	mu   sync.Mutex
 	reqs []*eth.ExecutionPayloadEnvelope
 }
 
 func (m *mockNetwork) SignAndPublishL2Payload(ctx context.Context, payload *eth.ExecutionPayloadEnvelope) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.reqs = append(m.reqs, payload)
 	return nil
 }
@@ -27,11 +31,22 @@ func (m *mockNetwork) SignAndPublishL2Payload(ctx context.Context, payload *eth.
 type mockMetrics struct {
 	mu       sync.Mutex
 	dropped  int
+	errors   int
 	queueLen int
 	maxLen   int
 }
 
-func (m *mockMetrics) RecordPublishingError() {}
+func (m *mockMetrics) RecordPublishingError() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.errors++
+}
+
+func (m *mockMetrics) publishErrors() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.errors
+}
 
 func (m *mockMetrics) RecordPublishQueueLen(length int) {
 	m.mu.Lock()
@@ -52,91 +67,56 @@ func (m *mockMetrics) counts() (dropped, queueLen, maxLen int) {
 	return m.dropped, m.queueLen, m.maxLen
 }
 
-// TestAsyncGossiper tests the AsyncGossiper component
-// because the component is small and simple, it is tested as a whole
-// this test starts, runs, clears and stops the AsyncGossiper
-// because the AsyncGossiper is run in an async component, it is tested with eventually
-func TestAsyncGossiper(t *testing.T) {
+// TestAsyncGossiperPublishes covers the lifecycle: the gossiper starts, hands a
+// payload to the network, and stops. The network is the observable - the gossiper
+// holds nothing for the sequencer to read back.
+func TestAsyncGossiperPublishes(t *testing.T) {
 	m := &mockNetwork{}
-	// Create a new instance of AsyncGossiper
-	p := NewAsyncGossiper(context.Background(), m, log.New(), &mockMetrics{})
-
-	// Start the AsyncGossiper
+	p := NewAsyncGossiper(context.Background(), m, testlog.Logger(t, log.LevelError), &mockMetrics{})
 	p.Start()
 
-	// Test that the AsyncGossiper is running within a short duration
 	require.Eventually(t, func() bool {
 		return p.running.Load()
 	}, 10*time.Second, 10*time.Millisecond)
 
-	// send a payload
-	payload := &eth.ExecutionPayload{
-		BlockNumber: hexutil.Uint64(1),
-	}
-	envelope := &eth.ExecutionPayloadEnvelope{
-		ExecutionPayload: payload,
-	}
+	envelope := testEnvelope(1)
 	p.Gossip(envelope)
 	require.Eventually(t, func() bool {
-		// Test that the gossiper has content at all
-		return p.Get() == envelope &&
-			// Test that the payload has been sent to the (mock) network
-			m.reqs[0] == envelope
-	}, 10*time.Second, 10*time.Millisecond)
+		m.mu.Lock()
+		defer m.mu.Unlock()
+		return len(m.reqs) == 1 && m.reqs[0] == envelope
+	}, 10*time.Second, 10*time.Millisecond, "the payload must reach the network")
 
-	p.Clear()
-	require.Eventually(t, func() bool {
-		// Test that the gossiper has no payload
-		return p.Get() == nil
-	}, 10*time.Second, 10*time.Millisecond)
-
-	// Stop the AsyncGossiper
 	p.Stop()
-
-	// Test that the AsyncGossiper stops within a short duration
 	require.Eventually(t, func() bool {
 		return !p.running.Load()
 	}, 10*time.Second, 10*time.Millisecond)
 }
 
-// TestAsyncGossiperLoop confirms that when called repeatedly, the AsyncGossiper holds the latest payload
-// and sends all payloads to the network
-func TestAsyncGossiperLoop(t *testing.T) {
+// TestAsyncGossiperPublishesEveryBlockInOrder confirms that repeated calls all
+// reach the network, in the order they were handed over. A peer cannot follow the
+// chain past a block it never received, so none may be skipped or reordered.
+func TestAsyncGossiperPublishesEveryBlockInOrder(t *testing.T) {
 	m := &mockNetwork{}
-	// Create a new instance of AsyncGossiper
-	p := NewAsyncGossiper(context.Background(), m, log.New(), &mockMetrics{})
-
-	// Start the AsyncGossiper
+	p := NewAsyncGossiper(context.Background(), m, testlog.Logger(t, log.LevelError), &mockMetrics{})
 	p.Start()
+	defer p.Stop()
 
-	// Test that the AsyncGossiper is running within a short duration
-	require.Eventually(t, func() bool {
-		return p.running.Load()
-	}, 10*time.Second, 10*time.Millisecond)
-
-	// send multiple payloads
-	for i := 0; i < 10; i++ {
-		payload := &eth.ExecutionPayload{
-			BlockNumber: hexutil.Uint64(i),
-		}
-		envelope := &eth.ExecutionPayloadEnvelope{
-			ExecutionPayload: payload,
-		}
-		p.Gossip(envelope)
-		require.Eventually(t, func() bool {
-			// Test that the gossiper has content at all
-			return p.Get() == envelope &&
-				// Test that the payload has been sent to the (mock) network
-				m.reqs[len(m.reqs)-1] == envelope
-		}, 10*time.Second, 10*time.Millisecond)
+	for i := 1; i <= 10; i++ {
+		p.Gossip(testEnvelope(uint64(i)))
 	}
-	require.Equal(t, 10, len(m.reqs))
-	// Stop the AsyncGossiper
-	p.Stop()
-	// Test that the AsyncGossiper stops within a short duration
+
 	require.Eventually(t, func() bool {
-		return !p.running.Load()
+		m.mu.Lock()
+		defer m.mu.Unlock()
+		return len(m.reqs) == 10
 	}, 10*time.Second, 10*time.Millisecond)
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for i, req := range m.reqs {
+		require.Equal(t, hexutil.Uint64(i+1), req.ExecutionPayload.BlockNumber, "published out of seal order")
+	}
 }
 
 // failingNetwork is a mock network that always fails to publish
@@ -146,30 +126,21 @@ func (f *failingNetwork) SignAndPublishL2Payload(ctx context.Context, payload *e
 	return errors.New("failed to publish")
 }
 
-// TestAsyncGossiperFailToPublish tests that the AsyncGossiper clears the stored payload if the network fails
-func TestAsyncGossiperFailToPublish(t *testing.T) {
+// TestAsyncGossiperCountsPublishingErrors covers a network that never accepts a
+// block: the failure is counted rather than swallowed, and it does not wedge Stop.
+func TestAsyncGossiperCountsPublishingErrors(t *testing.T) {
 	m := &failingNetwork{}
-	// Create a new instance of AsyncGossiper
-	p := NewAsyncGossiper(context.Background(), m, log.New(), &mockMetrics{})
-
-	// Start the AsyncGossiper
+	metrics := &mockMetrics{}
+	p := NewAsyncGossiper(context.Background(), m, testlog.Logger(t, log.LevelCrit), metrics)
+	p.retryInterval = time.Millisecond
 	p.Start()
 
-	// send a payload
-	payload := &eth.ExecutionPayload{
-		BlockNumber: hexutil.Uint64(1),
-	}
-	envelope := &eth.ExecutionPayloadEnvelope{
-		ExecutionPayload: payload,
-	}
-	p.Gossip(envelope)
-	// Rather than expect the payload to become available, we should never see it, due to the publish failure
-	require.Never(t, func() bool {
-		return p.Get() == envelope
-	}, 10*time.Second, 10*time.Millisecond)
-	// Stop the AsyncGossiper
+	p.Gossip(testEnvelope(1))
+	require.Eventually(t, func() bool {
+		return metrics.publishErrors() > 0
+	}, 10*time.Second, 10*time.Millisecond, "a failed publish must be counted")
+
 	p.Stop()
-	// Test that the AsyncGossiper stops within a short duration
 	require.Eventually(t, func() bool {
 		return !p.running.Load()
 	}, 10*time.Second, 10*time.Millisecond)
@@ -246,10 +217,10 @@ func requirePayload(t *testing.T, c chan *eth.ExecutionPayloadEnvelope, msg stri
 }
 
 // TestAsyncGossiperDoesNotBlockOnPublish is the regression test for the
-// sequencer stall: the sequencer calls Clear() a millisecond or two after
-// Gossip(), i.e. while the publish is in flight, and computes the next block's
-// build window as a residual - so every millisecond spent waiting here comes
-// straight out of the next block's building time.
+// sequencer stall: the sequencer reaches the gossiper again a millisecond or two
+// after Gossip(), i.e. while the publish is in flight, and computes the next
+// block's build window as a residual - so every millisecond spent waiting here
+// comes straight out of the next block's building time.
 func TestAsyncGossiperDoesNotBlockOnPublish(t *testing.T) {
 	m := newBlockingNetwork()
 	p := NewAsyncGossiper(context.Background(), m, testlog.Logger(t, log.LevelError), &mockMetrics{})
@@ -262,29 +233,24 @@ func TestAsyncGossiperDoesNotBlockOnPublish(t *testing.T) {
 	p.Gossip(envelope)
 	require.Equal(t, envelope, requirePayload(t, m.started, "publish never started"))
 
-	// with the publish in flight, the sequencer's Get() and Clear() must not wait for it
-	cleared := make(chan struct{})
+	// with the publish in flight, the sequencer's calls must not wait for it
+	returned := make(chan struct{})
 	go func() {
-		defer close(cleared)
-		p.Get()
-		p.Clear()
+		defer close(returned)
+		p.Gossip(testEnvelope(2))
+		p.Discard(testEnvelope(2).ExecutionPayload.BlockHash)
 	}()
 	select {
-	case <-cleared:
+	case <-returned:
 	case <-time.After(2 * time.Second):
 		m.Release() // let the publisher finish, so Stop can complete
-		t.Fatal("Get/Clear blocked until the in-flight publish returned")
+		t.Fatal("the hot path blocked until the in-flight publish returned")
 	}
 
-	// clearing must not cancel the publish: peers still need the block
+	// discarding a later block must not cancel the publish already in flight:
+	// peers still need that one
 	m.Release()
 	require.Equal(t, envelope, requirePayload(t, m.finished, "publish never finished"))
-
-	// nor may the completing publish repopulate the buffer the sequencer just
-	// cleared: reusing it would rebuild the block that is already the head
-	require.Never(t, func() bool {
-		return p.Get() != nil
-	}, 200*time.Millisecond, 10*time.Millisecond)
 }
 
 // TestAsyncGossiperOverlappingPublishes covers a publish still being in flight
@@ -308,9 +274,7 @@ func TestAsyncGossiperOverlappingPublishes(t *testing.T) {
 	go func() {
 		defer close(handed)
 		p.Gossip(second)
-		p.Clear()
 		p.Gossip(third)
-		p.Clear()
 	}()
 	select {
 	case <-handed:
@@ -392,8 +356,6 @@ func TestAsyncGossiperConcurrentHandoff(t *testing.T) {
 			go func(i uint64) {
 				defer wg.Done()
 				p.Gossip(testEnvelope(i))
-				p.Get()
-				p.Clear()
 			}(uint64(i))
 		}
 		wg.Wait()
@@ -419,13 +381,11 @@ func (b *blockingNetwork) failNext(hash common.Hash, n int) {
 	b.failuresLeft[hash] = n
 }
 
-// TestAsyncGossiperDedupesResealedBlock covers the sequencer retrying a block
-// whose insertion failed temporarily. Get() does not wait for the in-flight
-// publish, so the sequencer re-seals the same build job and hands the identical
-// block over again, once per retry. Those duplicates must not queue up behind
-// the publish that is already sending that very block, and must not invalidate
-// it for reuse - that would leave the sequencer re-sealing indefinitely, and
-// fill the queue with copies of one block.
+// TestAsyncGossiperDedupesResealedBlock covers the same block being handed over
+// more than once. The sequencer no longer does this - it re-inserts the block it
+// retained rather than re-sealing - but the guard stays, because publishing one
+// block twice is wasted work and the duplicates would crowd out the blocks behind
+// it in a bounded queue.
 func TestAsyncGossiperDedupesResealedBlock(t *testing.T) {
 	m := newBlockingNetwork()
 	metrics := &mockMetrics{}
@@ -439,7 +399,6 @@ func TestAsyncGossiperDedupesResealedBlock(t *testing.T) {
 	require.Equal(t, envelope, requirePayload(t, m.started, "publish never started"))
 
 	for i := 0; i < 5; i++ {
-		require.Nil(t, p.Get(), "the publish is still in flight, so there is nothing to reuse yet")
 		// a re-seal of the same build job: an equal block, a distinct value
 		p.Gossip(testEnvelope(1))
 	}
@@ -449,11 +408,6 @@ func TestAsyncGossiperDedupesResealedBlock(t *testing.T) {
 
 	m.Release()
 	require.Equal(t, envelope, requirePayload(t, m.finished, "publish never finished"))
-
-	require.Eventually(t, func() bool {
-		return p.Get() != nil
-	}, 10*time.Second, 10*time.Millisecond,
-		"the published block must be offered for reuse: the duplicates must not have invalidated it")
 
 	require.Never(t, func() bool {
 		select {
@@ -494,11 +448,11 @@ func TestAsyncGossiperRetriesFailedPublish(t *testing.T) {
 	require.Equal(t, third, requirePayload(t, m.started, "third never started"))
 }
 
-// TestAsyncGossiperRetriesUntilQueueIsFull pins what bounds the retry. There is
-// no attempt count: a failed block is retried at the front for exactly as long as
-// production leaves room for it, because enqueue evicts the head on overflow. Once
-// the queue is full there is nowhere to put it back, so an unpublishable block
-// stops holding up the blocks behind it.
+// TestAsyncGossiperRetriesUntilQueueIsFull pins queue pressure as a bound on the
+// retry: a failed block is retried at the front while production leaves room for
+// it, and once the queue is full there is nowhere to put it back, so it stops
+// holding up the blocks behind it. maxPublishAttempts is a second, lower ceiling
+// - see TestAsyncGossiperStopsRetryingWhenIdle.
 func TestAsyncGossiperRetriesUntilQueueIsFull(t *testing.T) {
 	m := newBlockingNetwork()
 	metrics := &mockMetrics{}
@@ -531,7 +485,8 @@ func TestAsyncGossiperRetriesUntilQueueIsFull(t *testing.T) {
 		"with no room to requeue it, the retry stops and publishing resumes in order")
 
 	dropped, _, _ = metrics.counts()
-	require.Zero(t, dropped, "a block that failed to publish is a publishing error, not a queue-overflow drop")
+	require.Equal(t, 1, dropped,
+		"giving up on a block is a block that never reached peers, and must be counted as one")
 }
 
 // TestAsyncGossiperDiscardDropsQueuedBlock covers the sequencer rejecting a
@@ -564,30 +519,9 @@ func TestAsyncGossiperDiscardDropsQueuedBlock(t *testing.T) {
 	require.Equal(t, third, requirePayload(t, m.finished, "third never finished"))
 }
 
-// TestAsyncGossiperClearKeepsQueue is the other half: Clear means the block was
-// inserted, so the blocks queued behind it are good blocks that peers still need.
-func TestAsyncGossiperClearKeepsQueue(t *testing.T) {
-	m := newBlockingNetwork()
-	p := NewAsyncGossiper(context.Background(), m, testlog.Logger(t, log.LevelError), &mockMetrics{})
-	p.Start()
-	defer p.Stop()
-	defer m.Release()
-
-	first, second := testEnvelope(1), testEnvelope(2)
-	p.Gossip(first)
-	require.Equal(t, first, requirePayload(t, m.started, "first publish never started"))
-	p.Gossip(second)
-	p.Clear()
-
-	m.Release()
-	require.Equal(t, first, requirePayload(t, m.finished, "first publish never finished"))
-	require.Equal(t, second, requirePayload(t, m.started, "a queued block must survive Clear"))
-	require.Equal(t, second, requirePayload(t, m.finished, "second never finished"))
-}
-
 // TestAsyncGossiperDiscardInFlightBlock covers a block rejected while its publish
 // is already in flight. That send cannot be recalled, but it must not be retried
-// when it fails, and must not come back as a payload to reuse when it succeeds.
+// when it fails.
 func TestAsyncGossiperDiscardInFlightBlock(t *testing.T) {
 	m := newBlockingNetwork()
 	p := NewAsyncGossiper(context.Background(), m, testlog.Logger(t, log.LevelError), &mockMetrics{})
@@ -607,19 +541,12 @@ func TestAsyncGossiperDiscardInFlightBlock(t *testing.T) {
 	require.Equal(t, next, requirePayload(t, m.started,
 		"a discarded block must not be retried ahead of the blocks behind it"))
 	require.Equal(t, next, requirePayload(t, m.finished, "next never finished"))
-	require.Never(t, func() bool {
-		reusable := p.Get()
-		return reusable != nil &&
-			reusable.ExecutionPayload.BlockHash == envelope.ExecutionPayload.BlockHash
-	}, 200*time.Millisecond, 20*time.Millisecond,
-		"a discarded block must never be offered back for reuse")
 }
 
 // TestAsyncGossiperDiscardAll covers the sequencer abandoning the chain the
 // queued blocks extend - a derivation reset, or a start from an unknown
 // pre-state. Those blocks belong to a chain that has been rewound, so none of
-// them may still go out, and an in-flight publish must not come back as a
-// payload to reuse on the chain the sequencer moves to.
+// them may still go out.
 func TestAsyncGossiperDiscardAll(t *testing.T) {
 	m := newBlockingNetwork()
 	metrics := &mockMetrics{}
@@ -649,10 +576,10 @@ func TestAsyncGossiperDiscardAll(t *testing.T) {
 		case <-m.started:
 			return true
 		default:
-			return p.Get() != nil
+			return false
 		}
 	}, 300*time.Millisecond, 20*time.Millisecond,
-		"no queued block may be published after the chain was abandoned, nor offered for reuse")
+		"no queued block may be published after the chain was abandoned")
 }
 
 // instantFailNetwork fails every publish immediately, with no I/O at all. This
@@ -732,4 +659,75 @@ func TestAsyncGossiperStopsRetryingWhenIdle(t *testing.T) {
 		return m.count() > settled
 	}, 200*time.Millisecond, 20*time.Millisecond,
 		"with nothing arriving to evict it, the retry must stop rather than run until the process exits")
+}
+
+// classifyingNetwork fails every publish with the error it is given.
+type classifyingNetwork struct {
+	mu       sync.Mutex
+	err      error
+	attempts []common.Hash
+}
+
+func (c *classifyingNetwork) SignAndPublishL2Payload(ctx context.Context, e *eth.ExecutionPayloadEnvelope) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.attempts = append(c.attempts, e.ExecutionPayload.BlockHash)
+	return c.err
+}
+
+func (c *classifyingNetwork) count() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.attempts)
+}
+
+// TestAsyncGossiperDropsPermanentFailure covers a block the network will reject
+// the same way every time - op-node runs its own validator inline on the
+// publishing node, so a bad block, or one that has aged past the gossip
+// timestamp threshold, fails in about a millisecond and will keep failing.
+// Retrying it holds up every block behind it, so it is dropped on the spot.
+func TestAsyncGossiperDropsPermanentFailure(t *testing.T) {
+	m := &classifyingNetwork{err: fmt.Errorf("%w: validation failed", ErrPermanentPublish)}
+	metrics := &mockMetrics{}
+	p := NewAsyncGossiper(context.Background(), m, testlog.Logger(t, log.LevelCrit), metrics)
+	// Long enough that a single retry would be plainly visible as a delay.
+	p.retryInterval = 30 * time.Second
+	p.Start()
+	defer p.Stop()
+
+	p.Gossip(testEnvelope(1))
+
+	require.Eventually(t, func() bool {
+		return m.count() >= 1
+	}, 10*time.Second, 5*time.Millisecond)
+	require.Never(t, func() bool {
+		return m.count() > 1
+	}, 300*time.Millisecond, 20*time.Millisecond,
+		"a block that can never be published must not be retried")
+
+	// And the queue is free for the blocks behind it rather than blocked at the head.
+	p.Gossip(testEnvelope(2))
+	require.Eventually(t, func() bool {
+		_, queueLen, _ := metrics.counts()
+		return m.count() == 2 && queueLen == 0
+	}, 10*time.Second, 5*time.Millisecond,
+		"the next block must go out at once, not wait behind the dropped one")
+}
+
+// TestAsyncGossiperRetriesContextDeadline is the guard on the classification
+// being an allowlist. Topic.Publish surfaces the caller's context error from its
+// own internals, so a publish that merely ran out of time arrives looking like
+// any other failure. Treating that as permanent would silently disable retry.
+func TestAsyncGossiperRetriesContextDeadline(t *testing.T) {
+	m := &classifyingNetwork{err: context.DeadlineExceeded}
+	p := NewAsyncGossiper(context.Background(), m, testlog.Logger(t, log.LevelCrit), &mockMetrics{})
+	p.retryInterval = time.Millisecond
+	p.Start()
+	defer p.Stop()
+
+	p.Gossip(testEnvelope(1))
+	require.Eventually(t, func() bool {
+		return m.count() > 1
+	}, 10*time.Second, 5*time.Millisecond,
+		"a publish that timed out must still be retried")
 }

--- a/op-node/rollup/driver/interfaces.go
+++ b/op-node/rollup/driver/interfaces.go
@@ -18,6 +18,8 @@ type Metrics interface {
 	RecordPipelineReset()
 	RecordFollowSourceRequest(result string)
 	RecordPublishingError()
+	RecordPublishQueueLen(length int)
+	RecordDroppedPublish()
 	RecordDerivationError()
 
 	RecordL1Ref(name string, ref eth.L1BlockRef)

--- a/op-node/rollup/sequencing/sequencer.go
+++ b/op-node/rollup/sequencing/sequencer.go
@@ -479,6 +479,12 @@ func (s *Sequencer) RunAction() {
 				// error. That block lost too: keep it out of the publish queue.
 				if gossiped := s.building.Ref.Hash; gossiped != (common.Hash{}) {
 					s.asyncGossip.Discard(gossiped)
+					// That block will now never become the head, so reconcile the
+					// sealed marker too: Stop waits for the head to catch up to
+					// it, and would otherwise wait for a block nobody is going to
+					// insert. On a first seal there is no such block and the
+					// marker is already zero.
+					s.lastSealed = s.unsafeHead
 				}
 				s.building = BuildingState{}
 				return

--- a/op-node/rollup/sequencing/sequencer.go
+++ b/op-node/rollup/sequencing/sequencer.go
@@ -50,6 +50,8 @@ type AsyncGossiper interface {
 	Gossip(payload *eth.ExecutionPayloadEnvelope)
 	Get() *eth.ExecutionPayloadEnvelope
 	Clear()
+	Discard(hash common.Hash)
+	DiscardAll()
 	Stop()
 	Start()
 }
@@ -336,14 +338,29 @@ func (s *Sequencer) onBuildStarted(x engine.BuildStartedEvent) {
 	s.log.Debug("Ignoring build-started event of sequencer-originated block", "payloadID", x.Info.ID)
 }
 
-func (s *Sequencer) handleInvalid() {
+// handleInvalid abandons the current attempt after the engine rejected it.
+// discard names the block that was already handed to the async gossiper, so it
+// is dropped from the publish queue rather than sent to peers later; it is the
+// zero hash when nothing had been gossiped yet.
+func (s *Sequencer) handleInvalid(discard common.Hash) {
 	s.metrics.RecordSequencingError()
+	// building.Ref is set only once the block has been sealed and handed to the
+	// async gossiper, so it names a block that may still be waiting to publish.
+	// The sequencer is about to build a different block at that height, so let
+	// it go rather than offering peers a block we no longer stand behind.
+	gossiped := s.building.Ref.Hash
 	s.building = BuildingState{}
 	// A block we sealed may be discarded here (invalid or denied insertion), and
 	// will then never become the head. Reconcile the sealed marker so Stop, which
 	// waits for the head to catch up to it, is not left waiting for a dead block.
 	s.lastSealed = s.unsafeHead
 	s.asyncGossip.Clear()
+	if gossiped != (common.Hash{}) {
+		s.asyncGossip.Discard(gossiped)
+	}
+	if discard != (common.Hash{}) && discard != gossiped {
+		s.asyncGossip.Discard(discard)
+	}
 	// upon error, retry after one block worth of time
 	blockTime := time.Duration(s.rollupCfg.BlockTime) * time.Second
 	s.nextAction = s.timeNow().Add(blockTime)
@@ -409,7 +426,7 @@ func (s *Sequencer) RunAction() {
 			s.log.Error("Payload from async-gossip buffer could not be turned into block-ref", "err", err)
 			// Treat like an invalid payload: drop it and retry with a fresh
 			// build after a backoff. No event echo re-arms this failure.
-			s.handleInvalid()
+			s.handleInvalid(payload.ExecutionPayload.BlockHash)
 			return
 		}
 		s.log.Info("Resuming sequencing with previously async-gossip confirmed payload",
@@ -427,7 +444,7 @@ func (s *Sequencer) RunAction() {
 				// waiting for the dropped block to become the head.
 				s.building = BuildingState{}
 				s.lastSealed = s.unsafeHead
-				s.asyncGossip.Clear()
+				s.asyncGossip.Discard(payload.ExecutionPayload.BlockHash)
 				if ref.ParentHash != s.unsafeHead.Hash {
 					// The payload was already stale against the head we know, so
 					// the forkchoice update the engine just requested carries that
@@ -438,7 +455,7 @@ func (s *Sequencer) RunAction() {
 				// Otherwise the engine moved during the call: its forkchoice update
 				// names a head we have not seen yet and re-arms us on arrival.
 			} else if errors.Is(err, engine.ErrPayloadDenied) || errors.Is(err, engine.ErrPayloadInvalid) {
-				s.handleInvalid()
+				s.handleInvalid(payload.ExecutionPayload.BlockHash)
 			}
 			return
 		}
@@ -454,15 +471,21 @@ func (s *Sequencer) RunAction() {
 		if err != nil {
 			if errors.Is(err, engine.ErrStaleBuild) {
 				// A competing block landed while we were building; drop the job
-				// without committing or gossiping the stale sibling. Parked until
-				// the engine-requested forkchoice update arrives.
+				// rather than committing the stale sibling. Parked until the
+				// engine-requested forkchoice update arrives.
 				s.log.Warn("Dropping stale sealed block, chain moved past it", "payloadID", s.building.Info.ID)
+				// A previous action may already have sealed and gossiped a block
+				// for this job, and be re-sealing it after a temporary insert
+				// error. That block lost too: keep it out of the publish queue.
+				if gossiped := s.building.Ref.Hash; gossiped != (common.Hash{}) {
+					s.asyncGossip.Discard(gossiped)
+				}
 				s.building = BuildingState{}
 				return
 			}
 			// Restart building on seal errors (expired or invalid), this way we get
 			// a block we should be able to seal (smaller, since we adapt build time).
-			s.handleInvalid()
+			s.handleInvalid(common.Hash{})
 			return
 		}
 		envelope := sealResult.Envelope
@@ -499,9 +522,9 @@ func (s *Sequencer) RunAction() {
 				s.log.Warn("Dropping stale processed block, chain moved past it", "block", sealResult.Ref)
 				s.building = BuildingState{}
 				s.lastSealed = s.unsafeHead
-				s.asyncGossip.Clear()
+				s.asyncGossip.Discard(sealResult.Ref.Hash)
 			} else if errors.Is(err, engine.ErrPayloadDenied) || errors.Is(err, engine.ErrPayloadInvalid) {
-				s.handleInvalid()
+				s.handleInvalid(sealResult.Ref.Hash)
 			}
 			return
 		}
@@ -555,6 +578,10 @@ func (s *Sequencer) onReset(x rollup.ResetEvent) {
 		s.emitter.Emit(s.ctx, engine.BuildCancelEvent{Info: s.building.Info})
 	}
 	s.building = BuildingState{}
+	// The chain these blocks extend is being rewound, so nothing still waiting to
+	// publish is worth sending: peers would get blocks off a chain the sequencer
+	// itself has abandoned.
+	s.asyncGossip.DiscardAll()
 	// A block we sealed may be discarded by this reset, and the head is rewound
 	// again right after, so clear the marker rather than pointing it at the head.
 	s.lastSealed = eth.L2BlockRef{}
@@ -831,7 +858,7 @@ func (s *Sequencer) startBuildingBlock() {
 		if errors.Is(err, engine.ErrBuildInvalid) {
 			// No recovery event reaches us for invalid attributes of our own
 			// builds; back off locally and retry with a new job.
-			s.handleInvalid()
+			s.handleInvalid(common.Hash{})
 			return
 		}
 		// Temporary, reset, or critical error: the engine emitted the matching
@@ -846,7 +873,7 @@ func (s *Sequencer) startBuildingBlock() {
 			Info:  result.Info,
 			Force: true,
 		})
-		s.handleInvalid()
+		s.handleInvalid(common.Hash{})
 		return
 	}
 	s.log.Debug("Sequencer started building new block",
@@ -939,7 +966,10 @@ func (s *Sequencer) forceStart() error {
 		// This happens if sequencing is activated on op-node startup.
 		// The op-conductor check and choice of sequencing with this pre-state already happened before op-node startup.
 		s.log.Info("Starting sequencing, without known pre-state")
-		s.asyncGossip.Clear() // if we are starting from an unknown pre-state, just clear gossip out of caution.
+		// Out of caution: with no known pre-state we cannot tell which, if any,
+		// of the blocks still waiting to publish belong to the chain we are about
+		// to sequence on, so none of them go out.
+		s.asyncGossip.DiscardAll()
 	} else {
 		// This happens when we start sequencing on an already-running node.
 		s.log.Info("Starting sequencing on top of known pre-state", "unsafe", s.unsafeHead)

--- a/op-node/rollup/sequencing/sequencer.go
+++ b/op-node/rollup/sequencing/sequencer.go
@@ -48,8 +48,6 @@ type SequencerStateListener interface {
 
 type AsyncGossiper interface {
 	Gossip(payload *eth.ExecutionPayloadEnvelope)
-	Get() *eth.ExecutionPayloadEnvelope
-	Clear()
 	Discard(hash common.Hash)
 	DiscardAll()
 	Stop()
@@ -64,6 +62,13 @@ type BuildingState struct {
 
 	// Set once known
 	Ref eth.L2BlockRef
+	// Envelope is the sealed block, retained from the moment it is committed to
+	// the conductor and handed to gossip. Its presence means the block exists and
+	// has been committed, so a retry re-inserts exactly it rather than re-sealing
+	// the job - re-sealing depends on the engine still holding the payload, and
+	// losing it would discard a committed block and build a different one at the
+	// same height.
+	Envelope *eth.ExecutionPayloadEnvelope
 }
 
 // Sequencer implements the sequencing interface of the driver: it starts and completes block building jobs.
@@ -138,9 +143,6 @@ type Sequencer struct {
 	// wakeCh coalesces wake-up signals (cap 1) for the sequencer goroutine,
 	// so inbox appends and RPC start/stop interrupt its timer wait.
 	wakeCh chan struct{}
-
-	// toBlockRef converts a payload to a block-ref, and is only configurable for test-purposes
-	toBlockRef func(rollupCfg *rollup.Config, payload *eth.ExecutionPayload) (eth.L2BlockRef, error)
 }
 
 var _ SequencerIface = (*Sequencer)(nil)
@@ -173,7 +175,6 @@ func NewSequencer(driverCtx context.Context, log log.Logger, rollupCfg *rollup.C
 		eng:              eng,
 		timeNow:          time.Now,
 		wakeCh:           make(chan struct{}, 1),
-		toBlockRef:       derive.PayloadToBlockRef,
 	}
 }
 
@@ -338,11 +339,10 @@ func (s *Sequencer) onBuildStarted(x engine.BuildStartedEvent) {
 	s.log.Debug("Ignoring build-started event of sequencer-originated block", "payloadID", x.Info.ID)
 }
 
-// handleInvalid abandons the current attempt after the engine rejected it.
-// discard names the block that was already handed to the async gossiper, so it
-// is dropped from the publish queue rather than sent to peers later; it is the
-// zero hash when nothing had been gossiped yet.
-func (s *Sequencer) handleInvalid(discard common.Hash) {
+// handleInvalid abandons the current attempt after the engine rejected it. A
+// block already handed to the async gossiper is dropped from the publish queue
+// rather than sent to peers later.
+func (s *Sequencer) handleInvalid() {
 	s.metrics.RecordSequencingError()
 	// building.Ref is set only once the block has been sealed and handed to the
 	// async gossiper, so it names a block that may still be waiting to publish.
@@ -354,12 +354,8 @@ func (s *Sequencer) handleInvalid(discard common.Hash) {
 	// will then never become the head. Reconcile the sealed marker so Stop, which
 	// waits for the head to catch up to it, is not left waiting for a dead block.
 	s.lastSealed = s.unsafeHead
-	s.asyncGossip.Clear()
 	if gossiped != (common.Hash{}) {
 		s.asyncGossip.Discard(gossiped)
-	}
-	if discard != (common.Hash{}) && discard != gossiped {
-		s.asyncGossip.Discard(discard)
 	}
 	// upon error, retry after one block worth of time
 	blockTime := time.Duration(s.rollupCfg.BlockTime) * time.Second
@@ -376,7 +372,6 @@ func (s *Sequencer) onPayloadSuccess(x payloadSuccess) {
 		return // not relevant to us
 	}
 	s.building = BuildingState{}
-	s.asyncGossip.Clear()
 }
 
 // RunAction performs one sequencer action: it processes a payload left in the
@@ -413,54 +408,42 @@ func (s *Sequencer) RunAction() {
 		s.log.Debug("Ignoring sequencer action, no action scheduled after inbox replay")
 		return
 	}
-	payload := s.asyncGossip.Get()
-	if payload != nil {
-		if s.building.Info.ID == (eth.PayloadID{}) {
-			s.log.Warn("Found reusable payload from async gossiper, and no block was being built. Reusing payload.",
-				"hash", payload.ExecutionPayload.BlockHash,
-				"number", uint64(payload.ExecutionPayload.BlockNumber),
-				"parent", payload.ExecutionPayload.ParentHash)
-		}
-		ref, err := s.toBlockRef(s.rollupCfg, payload.ExecutionPayload)
-		if err != nil {
-			s.log.Error("Payload from async-gossip buffer could not be turned into block-ref", "err", err)
-			// Treat like an invalid payload: drop it and retry with a fresh
-			// build after a backoff. No event echo re-arms this failure.
-			s.handleInvalid(payload.ExecutionPayload.BlockHash)
-			return
-		}
-		s.log.Info("Resuming sequencing with previously async-gossip confirmed payload",
-			"payload", payload.ExecutionPayload.ID())
-		// The payload is known and was already gossiped: it must have been sealed
-		// before a temporary error. Retry processing to make it canonical.
+	if s.building.Envelope != nil {
+		// This block was sealed, committed to the conductor and handed to gossip;
+		// only the local insert failed, and temporarily. Retry that insert with the
+		// block we already hold. Re-sealing instead would stake recovery on the
+		// engine still holding the payload job, and losing it would discard a block
+		// the conductor has already committed and build a different one at the same
+		// height.
+		envelope, ref := s.building.Envelope, s.building.Ref
+		s.log.Info("Retrying insertion of an already-gossiped block", "block", ref)
 		// Park the schedule first: on a temporary error the engine's
 		// EngineTemporaryErrorEvent echoes back through the mailbox and re-arms
 		// the backoff; re-firing before that echo would spin on the engine.
 		s.nextActionArmed = false
-		if err := s.eng.ProcessPayload(s.ctx, payload, ref, time.Time{}); err != nil {
+		if err := s.eng.ProcessPayload(s.ctx, envelope, ref, time.Time{}); err != nil {
 			if errors.Is(err, engine.ErrStaleBuild) {
-				// The chain moved past the buffered payload; it is worthless now.
-				// Nothing of ours is outstanding anymore: don't leave Stop
-				// waiting for the dropped block to become the head.
+				// The chain moved past our block; it is worthless now. Nothing of
+				// ours is outstanding anymore: don't leave Stop waiting for the
+				// dropped block to become the head.
 				s.building = BuildingState{}
 				s.lastSealed = s.unsafeHead
-				s.asyncGossip.Discard(payload.ExecutionPayload.BlockHash)
+				s.asyncGossip.Discard(ref.Hash)
 				if ref.ParentHash != s.unsafeHead.Hash {
-					// The payload was already stale against the head we know, so
-					// the forkchoice update the engine just requested carries that
-					// same head and will not re-plan anything. Re-plan here, or the
+					// The block was already stale against the head we know, so the
+					// forkchoice update the engine just requested carries that same
+					// head and will not re-plan anything. Re-plan here, or the
 					// sequencer parks forever waiting for an echo it has had.
 					s.scheduleNextAction(s.unsafeHead)
 				}
 				// Otherwise the engine moved during the call: its forkchoice update
 				// names a head we have not seen yet and re-arms us on arrival.
 			} else if errors.Is(err, engine.ErrPayloadDenied) || errors.Is(err, engine.ErrPayloadInvalid) {
-				s.handleInvalid(payload.ExecutionPayload.BlockHash)
+				s.handleInvalid()
 			}
 			return
 		}
 		s.building = BuildingState{}
-		s.asyncGossip.Clear()
 		s.scheduleNextAction(ref)
 		return
 	}
@@ -473,25 +456,17 @@ func (s *Sequencer) RunAction() {
 				// A competing block landed while we were building; drop the job
 				// rather than committing the stale sibling. Parked until the
 				// engine-requested forkchoice update arrives.
+				// Nothing was committed for this job: a job that had already
+				// sealed a block would have been retried from the retained
+				// envelope above, never re-sealed. So there is nothing to keep
+				// out of the publish queue and no sealed marker to reconcile.
 				s.log.Warn("Dropping stale sealed block, chain moved past it", "payloadID", s.building.Info.ID)
-				// A previous action may already have sealed and gossiped a block
-				// for this job, and be re-sealing it after a temporary insert
-				// error. That block lost too: keep it out of the publish queue.
-				if gossiped := s.building.Ref.Hash; gossiped != (common.Hash{}) {
-					s.asyncGossip.Discard(gossiped)
-					// That block will now never become the head, so reconcile the
-					// sealed marker too: Stop waits for the head to catch up to
-					// it, and would otherwise wait for a block nobody is going to
-					// insert. On a first seal there is no such block and the
-					// marker is already zero.
-					s.lastSealed = s.unsafeHead
-				}
 				s.building = BuildingState{}
 				return
 			}
 			// Restart building on seal errors (expired or invalid), this way we get
 			// a block we should be able to seal (smaller, since we adapt build time).
-			s.handleInvalid(common.Hash{})
+			s.handleInvalid()
 			return
 		}
 		envelope := sealResult.Envelope
@@ -512,10 +487,9 @@ func (s *Sequencer) RunAction() {
 		}
 
 		// Begin gossiping as soon as possible.
-		// asyncGossip.Clear() is called once the payload is successfully inserted below,
-		// or when a later action hits a non-temporary error.
 		s.asyncGossip.Gossip(envelope)
 		s.building.Ref = sealResult.Ref
+		s.building.Envelope = envelope
 		s.lastSealed = sealResult.Ref
 		// Now after having gossiped the block, try to put it in our own canonical chain.
 		if err := s.eng.ProcessPayload(s.ctx, envelope, sealResult.Ref, s.building.Started); err != nil {
@@ -530,16 +504,13 @@ func (s *Sequencer) RunAction() {
 				s.lastSealed = s.unsafeHead
 				s.asyncGossip.Discard(sealResult.Ref.Hash)
 			} else if errors.Is(err, engine.ErrPayloadDenied) || errors.Is(err, engine.ErrPayloadInvalid) {
-				s.handleInvalid(sealResult.Ref.Hash)
+				s.handleInvalid()
 			}
 			return
 		}
 		s.log.Info("Sequencer inserted block",
 			"block", sealResult.Ref, "parent", envelope.ExecutionPayload.ParentID())
 		s.building = BuildingState{}
-		// The payload was already published upon sealing.
-		// Now that we have processed it ourselves we don't need it anymore.
-		s.asyncGossip.Clear()
 		s.scheduleNextAction(sealResult.Ref)
 	} else if s.building == (BuildingState{}) {
 		// If we have not started building anything, start building.
@@ -626,6 +597,17 @@ func (s *Sequencer) onForkchoiceUpdate(x engine.ForkchoiceUpdateEvent) {
 	if s.building != (BuildingState{}) && s.building.Onto.Hash != x.UnsafeL2Head.Hash {
 		s.log.Debug("Dropping stale/completed block-building job",
 			"state", s.building.Onto, "unsafe", x.UnsafeL2Head)
+		// The job may already have sealed a block that was committed and gossiped
+		// and is still waiting to publish. The chain has adopted a different
+		// branch, so that block lost: keep it out of the publish queue rather than
+		// offering peers a block we have abandoned, and reconcile the sealed
+		// marker, which Stop waits on.
+		if gossiped := s.building.Ref.Hash; gossiped != (common.Hash{}) {
+			s.log.Warn("Discarding gossiped block, the chain adopted a competing one",
+				"dropped", s.building.Ref, "unsafe", x.UnsafeL2Head)
+			s.asyncGossip.Discard(gossiped)
+			s.lastSealed = x.UnsafeL2Head
+		}
 		// The cleared state stops the next sequencer action from sealing the stale build job.
 		s.building = BuildingState{}
 	}
@@ -864,7 +846,7 @@ func (s *Sequencer) startBuildingBlock() {
 		if errors.Is(err, engine.ErrBuildInvalid) {
 			// No recovery event reaches us for invalid attributes of our own
 			// builds; back off locally and retry with a new job.
-			s.handleInvalid(common.Hash{})
+			s.handleInvalid()
 			return
 		}
 		// Temporary, reset, or critical error: the engine emitted the matching
@@ -879,7 +861,7 @@ func (s *Sequencer) startBuildingBlock() {
 			Info:  result.Info,
 			Force: true,
 		})
-		s.handleInvalid(common.Hash{})
+		s.handleInvalid()
 		return
 	}
 	s.log.Debug("Sequencer started building new block",
@@ -972,20 +954,21 @@ func (s *Sequencer) forceStart() error {
 		// This happens if sequencing is activated on op-node startup.
 		// The op-conductor check and choice of sequencing with this pre-state already happened before op-node startup.
 		s.log.Info("Starting sequencing, without known pre-state")
-		// Out of caution: with no known pre-state we cannot tell which, if any,
-		// of the blocks still waiting to publish belong to the chain we are about
-		// to sequence on, so none of them go out.
-		s.asyncGossip.DiscardAll()
 	} else {
 		// This happens when we start sequencing on an already-running node.
 		s.log.Info("Starting sequencing on top of known pre-state", "unsafe", s.unsafeHead)
-		if payload := s.asyncGossip.Get(); payload != nil &&
-			payload.ExecutionPayload.BlockHash != s.unsafeHead.Hash {
-			s.log.Warn("Cleared old block from async-gossip buffer, sequencing pre-state is different",
-				"buffered", payload.ExecutionPayload.ID(), "prestate", s.unsafeHead)
-			s.asyncGossip.Clear()
-		}
 	}
+	// Whatever is still waiting to publish was sealed before we stopped, and this
+	// start is not responsible for it: the chain may have moved to another branch
+	// while we were inactive, and blocks queued or already in flight are not
+	// individually inspectable from here. Dropping the backlog can lose a block
+	// that was in fact canonical, which costs gossip only - it still reaches peers
+	// by L1 and derivation - whereas publishing one from an abandoned branch does
+	// not. Same reasoning as the unknown pre-state above, so it is unconditional.
+	s.asyncGossip.DiscardAll()
+	// Nothing of ours is outstanding at the moment we start: whatever Stop would
+	// have waited for belongs to the period before this start.
+	s.lastSealed = s.unsafeHead
 
 	if err := s.listener.SequencerStarted(); err != nil {
 		return fmt.Errorf("failed to notify sequencer-state listener of start: %w", err)
@@ -1054,6 +1037,12 @@ func (s *Sequencer) Stop(ctx context.Context) (common.Hash, error) {
 
 	// Cancel any inflight block building. If we don't cancel this, we can resume sequencing an old block
 	// even if we've received new unsafe heads in the interim, causing us to introduce a re-org.
+	// A block we sealed and gossiped but never inserted goes with it: we are handing
+	// over, and whoever sequences next may extend a different branch, so that block
+	// must not still reach peers as a sibling of theirs.
+	if gossiped := s.building.Ref.Hash; gossiped != (common.Hash{}) {
+		s.asyncGossip.Discard(gossiped)
+	}
 	s.building = BuildingState{} // By wiping this state we cannot continue from it later.
 
 	s.nextActionArmed = false

--- a/op-node/rollup/sequencing/sequencer_test.go
+++ b/op-node/rollup/sequencing/sequencer_test.go
@@ -136,8 +136,15 @@ func (c *FakeConductor) Close() {
 
 type FakeAsyncGossip struct {
 	payload *eth.ExecutionPayloadEnvelope
-	started bool
-	stopped bool
+	// discarded records the blocks the sequencer asked to drop from the publish
+	// queue, so tests can tell "the block was inserted, keep publishing it" from
+	// "the block was rejected, do not publish it".
+	discarded []common.Hash
+	// discardedAll counts bulk purges, for when the sequencer abandons the chain
+	// the queued blocks extend.
+	discardedAll int
+	started      bool
+	stopped      bool
 }
 
 func (f *FakeAsyncGossip) Gossip(payload *eth.ExecutionPayloadEnvelope) {
@@ -149,6 +156,18 @@ func (f *FakeAsyncGossip) Get() *eth.ExecutionPayloadEnvelope {
 }
 
 func (f *FakeAsyncGossip) Clear() {
+	f.payload = nil
+}
+
+func (f *FakeAsyncGossip) Discard(hash common.Hash) {
+	f.discarded = append(f.discarded, hash)
+	if f.payload != nil && f.payload.ExecutionPayload.BlockHash == hash {
+		f.payload = nil
+	}
+}
+
+func (f *FakeAsyncGossip) DiscardAll() {
+	f.discardedAll++
 	f.payload = nil
 }
 
@@ -936,6 +955,8 @@ func TestSequencerProcessPayloadErrors(t *testing.T) {
 
 			if tc.dropped {
 				require.Nil(t, s.deps.asyncGossip.payload, "rejected payload is dropped from gossip")
+				require.Equal(t, []common.Hash{ref.Hash}, s.deps.asyncGossip.discarded,
+					"a rejected block must be discarded by hash, so a queued copy is not published later")
 				require.Equal(t, BuildingState{}, s.seq.building)
 				next, ok := s.seq.NextAction()
 				require.True(t, ok, "restart building after backoff")
@@ -944,6 +965,8 @@ func TestSequencerProcessPayloadErrors(t *testing.T) {
 			}
 
 			require.Equal(t, envelope, s.deps.asyncGossip.payload, "payload stays in gossip for retry")
+			require.Empty(t, s.deps.asyncGossip.discarded,
+				"a temporary error is not a rejection: the block must still reach peers")
 			require.Equal(t, ref, s.seq.building.Ref, "building state is kept")
 			_, ok := s.seq.NextAction()
 			require.False(t, ok, "paused until the engine's temporary-error event re-arms the schedule")
@@ -966,6 +989,8 @@ func TestSequencerProcessPayloadErrors(t *testing.T) {
 			s.seq.RunAction()
 			require.Equal(t, envelope, retried, "gossiped payload was retried")
 			require.Nil(t, s.deps.asyncGossip.payload, "gossip cleared after successful retry")
+			require.Empty(t, s.deps.asyncGossip.discarded,
+				"the block was inserted: cleared for reuse, never discarded from the publish queue")
 			require.Equal(t, BuildingState{}, s.seq.building)
 			require.Equal(t, ref, s.seq.unsafeHead, "head updated directly after successful insert")
 			_, ok = s.seq.NextAction()
@@ -1301,9 +1326,12 @@ func createSequencer(log log.Logger) (*Sequencer, *sequencerTestDeps) {
 func TestSequencerStaysParkedUntilResetConfirmed(t *testing.T) {
 	s := newSeqSetup(t)
 
+	purgesBefore := s.deps.asyncGossip.discardedAll
 	deliver(s.seq, rollup.ResetEvent{Err: errors.New("mock reset")})
 	_, ok := s.seq.NextAction()
 	require.False(t, ok, "reset parks the sequencer")
+	require.Equal(t, purgesBefore+1, s.deps.asyncGossip.discardedAll,
+		"a reset rewinds the chain the queued blocks extend: none of them may still be published")
 
 	rewound := s.head
 	rewound.Hash = common.Hash{0x33}

--- a/op-node/rollup/sequencing/sequencer_test.go
+++ b/op-node/rollup/sequencing/sequencer_test.go
@@ -1616,3 +1616,47 @@ func TestSequencerResetClearsGossipAndBuilding(t *testing.T) {
 	require.Nil(t, s.deps.asyncGossip.payload,
 		"no payload from the rewound chain may be offered back for reuse")
 }
+
+// TestSequencerStopAfterStaleReSealDropsSealed covers the seal-time ErrStaleBuild
+// path on a re-seal. Because Get() no longer waits for an in-flight publish, the
+// sequencer re-seals its build job after a temporary insert error - and that
+// re-seal can be the point at which a competing block is found to have landed.
+// The block we already sealed and gossiped is dropped there, so the sealed marker
+// must be reconciled: Stop waits for the head to catch up to it, and would
+// otherwise wait for a block nobody is going to insert.
+func TestSequencerStopAfterStaleReSealDropsSealed(t *testing.T) {
+	s := newSeqSetup(t)
+	info := s.startBuild(t)
+	envelope, ref := s.sealedPayload()
+	s.deps.eng.sealBuildFn = func(ctx context.Context, gotInfo eth.PayloadInfo, buildStarted time.Time) (*engine.SealResult, error) {
+		require.Equal(t, info, gotInfo)
+		return &engine.SealResult{Envelope: envelope, Ref: ref}, nil
+	}
+	// Sealed and gossiped, but the local insert failed temporarily, so the block
+	// is outstanding and the building job is kept for a retry.
+	s.deps.eng.processPayloadFn = func(context.Context, *eth.ExecutionPayloadEnvelope, eth.L2BlockRef, time.Time) error {
+		return errors.New("mock temporary insert failure")
+	}
+	s.seq.RunAction()
+	require.Equal(t, ref, s.seq.lastSealed, "our gossiped block is outstanding")
+
+	// The retry finds nothing to reuse (the publish is still in flight) and
+	// re-seals - but the chain has moved past the job in the meantime.
+	s.deps.asyncGossip.withholdGet = true
+	s.deps.eng.sealBuildFn = func(ctx context.Context, gotInfo eth.PayloadInfo, buildStarted time.Time) (*engine.SealResult, error) {
+		return nil, engine.ErrStaleBuild
+	}
+	deliver(s.seq, rollup.EngineTemporaryErrorEvent{Err: errors.New("mock temporary insert failure")})
+	s.seq.RunAction()
+
+	require.Equal(t, BuildingState{}, s.seq.building, "the stale job is dropped")
+	require.Equal(t, []common.Hash{ref.Hash}, s.deps.asyncGossip.discarded,
+		"the sibling that lost must not still be published")
+	require.NotEqual(t, ref.Hash, s.seq.unsafeHead.Hash, "the sealed block is not the head")
+
+	// Stop must not wait for a block that will never become the head.
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	_, err := s.seq.Stop(ctx)
+	require.NoError(t, err, "Stop must not block on the dropped block")
+}

--- a/op-node/rollup/sequencing/sequencer_test.go
+++ b/op-node/rollup/sequencing/sequencer_test.go
@@ -143,8 +143,11 @@ type FakeAsyncGossip struct {
 	// discardedAll counts bulk purges, for when the sequencer abandons the chain
 	// the queued blocks extend.
 	discardedAll int
-	started      bool
-	stopped      bool
+	// withholdGet makes Get return nil even though a payload was gossiped, as the
+	// real gossiper does while a publish is still in flight.
+	withholdGet bool
+	started     bool
+	stopped     bool
 }
 
 func (f *FakeAsyncGossip) Gossip(payload *eth.ExecutionPayloadEnvelope) {
@@ -152,6 +155,11 @@ func (f *FakeAsyncGossip) Gossip(payload *eth.ExecutionPayloadEnvelope) {
 }
 
 func (f *FakeAsyncGossip) Get() *eth.ExecutionPayloadEnvelope {
+	if f.withholdGet {
+		// The real gossiper returns nil while a publish is still in flight: it
+		// does not wait for the network. See TestSequencerProgressesWhilePublishInFlight.
+		return nil
+	}
 	return f.payload
 }
 
@@ -1515,4 +1523,96 @@ func TestSequencerStopAfterResetDropsSealed(t *testing.T) {
 	hash, err := s.seq.Stop(ctx)
 	require.NoError(t, err, "Stop must not wait for a block the reset discarded")
 	require.Equal(t, s.seq.unsafeHead.Hash, hash)
+}
+
+// TestSequencerProgressesWhilePublishInFlight is a regression test for the shape
+// of PM-44 (Mainnet Unsafe Head Stall, 2024-02-15): the async-gossip buffer and
+// the sequencer's building state disagreed, the sequencer took a code path that
+// depended on the state that had been cleared, and it looped emitting errors
+// without ever producing a block. ~49 minutes of stalled mainnet.
+//
+// This PR reopens that surface from the other side. Get() no longer waits for an
+// in-flight publish, so it returns nil while building state IS set - the same
+// disagreement, opposite polarity. The sequencer must fall through to re-sealing
+// its build job and make progress, not spin.
+func TestSequencerProgressesWhilePublishInFlight(t *testing.T) {
+	s := newSeqSetup(t)
+	s.startBuild(t)
+	envelope, ref := s.sealedPayload()
+
+	seals := 0
+	s.deps.eng.sealBuildFn = func(ctx context.Context, info eth.PayloadInfo, buildStarted time.Time) (*engine.SealResult, error) {
+		seals++
+		// Re-sealing the same build job yields the same block, which is what
+		// makes re-sealing safe rather than equivocation.
+		return &engine.SealResult{Envelope: envelope, Ref: ref}, nil
+	}
+	s.deps.eng.processPayloadFn = func(ctx context.Context, envelope *eth.ExecutionPayloadEnvelope, ref eth.L2BlockRef, buildStarted time.Time) error {
+		return errors.New("mock temp engine error")
+	}
+
+	// The publish is slow, so the payload is gossiped but not yet reusable.
+	s.deps.asyncGossip.withholdGet = true
+
+	s.seq.RunAction()
+	require.Equal(t, 1, seals)
+	require.Equal(t, envelope, s.deps.asyncGossip.payload, "the block was handed to the gossiper")
+	require.Equal(t, ref, s.seq.building.Ref, "building state is kept for the retry")
+	require.Empty(t, s.deps.asyncGossip.discarded,
+		"a temporary error is not a rejection: the block must still reach peers")
+
+	// The temporary-error event re-arms the schedule, and the retry finds Get()
+	// still empty. It must re-seal rather than stall: the same block, so peers
+	// are never offered two blocks at this height.
+	deliver(s.seq, rollup.EngineTemporaryErrorEvent{Err: errors.New("mock temp engine error")})
+	s.seq.RunAction()
+	require.Equal(t, 2, seals, "the sequencer re-seals instead of waiting on the publish")
+	require.Equal(t, ref, s.seq.building.Ref, "still the same block, at the same height")
+
+	// Once the engine recovers, the block is inserted and the head advances.
+	// The stall in PM-44 was that this never happened.
+	deliver(s.seq, rollup.EngineTemporaryErrorEvent{Err: errors.New("mock temp engine error")})
+	s.deps.eng.processPayloadFn = func(ctx context.Context, envelope *eth.ExecutionPayloadEnvelope, ref eth.L2BlockRef, buildStarted time.Time) error {
+		return nil
+	}
+	s.seq.RunAction()
+	require.Equal(t, ref, s.seq.unsafeHead, "the sequencer made progress")
+	require.Equal(t, BuildingState{}, s.seq.building)
+	require.Empty(t, s.deps.asyncGossip.discarded,
+		"the block was inserted: cleared for reuse, never discarded from the publish queue")
+	_, ok := s.seq.NextAction()
+	require.True(t, ok, "ready to build the next block")
+}
+
+// TestSequencerResetClearsGossipAndBuilding pins the invariant PM-44 turned on:
+// the async-gossip state and the sequencer's building state are cleared together.
+// Before this PR onReset cleared building but left the gossip buffer alone, so a
+// payload from the pre-reset chain could survive and be picked up by the next
+// action. With a publish queue that would be up to maxPublishQueue blocks of an
+// abandoned chain, not one.
+func TestSequencerResetClearsGossipAndBuilding(t *testing.T) {
+	s := newSeqSetup(t)
+	s.startBuild(t)
+	envelope, ref := s.sealedPayload()
+	s.deps.eng.sealBuildFn = func(ctx context.Context, info eth.PayloadInfo, buildStarted time.Time) (*engine.SealResult, error) {
+		return &engine.SealResult{Envelope: envelope, Ref: ref}, nil
+	}
+	s.deps.eng.processPayloadFn = func(ctx context.Context, envelope *eth.ExecutionPayloadEnvelope, ref eth.L2BlockRef, buildStarted time.Time) error {
+		return errors.New("mock temp engine error")
+	}
+	s.seq.RunAction()
+	require.NotNil(t, s.deps.asyncGossip.payload, "a block is held by the gossiper")
+	require.NotEqual(t, BuildingState{}, s.seq.building)
+
+	purgesBefore := s.deps.asyncGossip.discardedAll
+	em := &testutils.MockEmitter{}
+	em.ExpectOnceType("engine.BuildCancelEvent") // the reset cancels the in-flight job
+	s.seq.AttachEmitter(em)
+	deliver(s.seq, rollup.ResetEvent{Err: errors.New("mock reset")})
+
+	require.Equal(t, BuildingState{}, s.seq.building, "building state is cleared by the reset")
+	require.Equal(t, purgesBefore+1, s.deps.asyncGossip.discardedAll,
+		"and so is everything the gossiper holds: neither may outlive the other")
+	require.Nil(t, s.deps.asyncGossip.payload,
+		"no payload from the rewound chain may be offered back for reuse")
 }

--- a/op-node/rollup/sequencing/sequencer_test.go
+++ b/op-node/rollup/sequencing/sequencer_test.go
@@ -143,28 +143,12 @@ type FakeAsyncGossip struct {
 	// discardedAll counts bulk purges, for when the sequencer abandons the chain
 	// the queued blocks extend.
 	discardedAll int
-	// withholdGet makes Get return nil even though a payload was gossiped, as the
-	// real gossiper does while a publish is still in flight.
-	withholdGet bool
-	started     bool
-	stopped     bool
+	started      bool
+	stopped      bool
 }
 
 func (f *FakeAsyncGossip) Gossip(payload *eth.ExecutionPayloadEnvelope) {
 	f.payload = payload
-}
-
-func (f *FakeAsyncGossip) Get() *eth.ExecutionPayloadEnvelope {
-	if f.withholdGet {
-		// The real gossiper returns nil while a publish is still in flight: it
-		// does not wait for the network. See TestSequencerProgressesWhilePublishInFlight.
-		return nil
-	}
-	return f.payload
-}
-
-func (f *FakeAsyncGossip) Clear() {
-	f.payload = nil
 }
 
 func (f *FakeAsyncGossip) Discard(hash common.Hash) {
@@ -508,10 +492,10 @@ func TestSequencer_StaleBuild(t *testing.T) {
 	_, ok = seq.NextAction()
 	require.True(t, ok, "new head re-arms the sequencer")
 
-	// Regression check: async-gossip is cleared upon sequencer un-pause.
-	// We could clear it earlier. But absolutely have to clear it upon Start(),
-	// to not continue from this older point.
-	require.NotNil(t, deps.asyncGossip.payload, "async-gossip still not cleared")
+	// The competing head means the block we gossiped lost, so it is dropped as
+	// soon as that head arrives - it must never reach peers as a sibling of the
+	// chain everyone else is on.
+	require.Nil(t, deps.asyncGossip.payload, "the gossiped block is dropped when a competing head arrives")
 
 	// Stop() waits for lastSealed == unsafeHead. The head advanced past our
 	// sealed block (another sequencer took over), so match lastSealed to
@@ -667,7 +651,7 @@ func TestSequencerBuild(t *testing.T) {
 	// all synchronously via direct calls.
 	seq.RunAction()
 	require.Equal(t, payloadEnvelope, deps.conductor.committed, "must commit to conductor")
-	require.Nil(t, deps.asyncGossip.payload, "async gossip should have cleared after successful insert")
+	require.Empty(t, deps.asyncGossip.discarded, "a block that was inserted must still be published")
 	require.Equal(t, BuildingState{}, seq.building, "building state cleared after successful insert")
 	require.Equal(t, payloadRef, seq.lastSealed, "sealed block recorded")
 
@@ -996,9 +980,8 @@ func TestSequencerProcessPayloadErrors(t *testing.T) {
 			}
 			s.seq.RunAction()
 			require.Equal(t, envelope, retried, "gossiped payload was retried")
-			require.Nil(t, s.deps.asyncGossip.payload, "gossip cleared after successful retry")
 			require.Empty(t, s.deps.asyncGossip.discarded,
-				"the block was inserted: cleared for reuse, never discarded from the publish queue")
+				"the block was inserted: it must still reach peers, never discarded")
 			require.Equal(t, BuildingState{}, s.seq.building)
 			require.Equal(t, ref, s.seq.unsafeHead, "head updated directly after successful insert")
 			_, ok = s.seq.NextAction()
@@ -1131,23 +1114,22 @@ func TestSequencerStopAfterStaleProcess(t *testing.T) {
 	require.Equal(t, s.seq.unsafeHead.Hash, hash)
 }
 
-// TestSequencerRearmsAfterStaleBufferedPayload covers the retry of a payload
-// left in the async-gossip buffer by an earlier temporary insertion failure.
-// If the chain has already moved on by the time it is retried, the engine
-// rejects it and requests a forkchoice update — but that update names the head
-// the sequencer already knows, so it re-plans nothing. Waiting for it would
-// park an active leader forever.
-func TestSequencerRearmsAfterStaleBufferedPayload(t *testing.T) {
+// TestSequencerCompetingHeadDropsGossipedBlock covers a competing block becoming
+// the head while a block we sealed, committed and gossiped is still waiting to
+// publish. That block lost: it must not still go out to peers, the sealed marker
+// must be reconciled so Stop does not wait for a block nobody will insert, and
+// the sequencer must re-plan on the new head rather than park - the forkchoice
+// update it would otherwise wait for is one it has already seen.
+func TestSequencerCompetingHeadDropsGossipedBlock(t *testing.T) {
 	s := newSeqSetup(t)
 	envelope, ref := s.sealedPayload()
 
-	// A previous action sealed and gossiped this payload, then failed to insert
-	// it with a temporary error, so it stayed in the buffer.
-	s.deps.asyncGossip.payload = envelope
+	// A previous action sealed this block, committed it to the conductor and
+	// handed it to gossip, then failed to insert it with a temporary error.
+	s.seq.building = BuildingState{Onto: s.head, Ref: ref, Envelope: envelope}
 	s.seq.lastSealed = ref
 
-	// Meanwhile a competing block at the same height became the head, and the
-	// sequencer has already ingested that update.
+	// Meanwhile a competing block at the same height became the head.
 	competing := eth.L2BlockRef{
 		Hash:       common.Hash{0xc1},
 		Number:     ref.Number,
@@ -1156,22 +1138,24 @@ func TestSequencerRearmsAfterStaleBufferedPayload(t *testing.T) {
 		L1Origin:   s.head.L1Origin,
 	}
 	deliver(s.seq, engine.ForkchoiceUpdateEvent{UnsafeL2Head: competing})
+
+	require.Equal(t, []common.Hash{ref.Hash}, s.deps.asyncGossip.discarded,
+		"the block that lost must not still be published")
+	require.Equal(t, competing, s.seq.lastSealed,
+		"the sealed marker is reconciled, so Stop does not wait for a dead block")
+	require.Equal(t, BuildingState{}, s.seq.building, "the stale job is dropped")
 	require.Equal(t, competing, s.seq.unsafeHead)
-	_, ok := s.seq.NextAction()
-	require.True(t, ok, "the competing head re-armed the sequencer")
 
-	// Retrying the buffered payload now fails: it does not extend the new head.
-	s.deps.eng.processPayloadFn = func(context.Context, *eth.ExecutionPayloadEnvelope, eth.L2BlockRef, time.Time) error {
-		return engine.ErrStaleBuild
-	}
-	s.seq.RunAction()
-
-	require.Nil(t, s.deps.asyncGossip.payload, "the stale payload is discarded")
 	next, ok := s.seq.NextAction()
 	require.True(t, ok, "must re-plan locally; the requested forkchoice update is one we already have")
-	require.Equal(t, competing, s.seq.unsafeHead, "the next build targets the current head")
 	require.False(t, next.After(time.Unix(int64(competing.Time+s.deps.cfg.BlockTime), 0)),
 		"scheduled no later than the next block's slot")
+
+	// And Stop must not wait for the block that was dropped.
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	_, err := s.seq.Stop(ctx)
+	require.NoError(t, err, "Stop must not block on the dropped block")
 }
 
 // TestSequencerStopAfterRejectedInsert checks that a block discarded as
@@ -1312,17 +1296,6 @@ func createSequencer(log log.Logger) (*Sequencer, *sequencerTestDeps) {
 	seq := NewSequencer(context.Background(), log, cfg, defaultSealingDuration, deps.attribBuilder,
 		deps.l1OriginSelector, deps.seqState, deps.conductor,
 		deps.asyncGossip, metrics.NoopMetrics, eng)
-	// We create mock payloads, with the epoch-id as tx[0], rather than proper L1Block-info deposit tx.
-	seq.toBlockRef = func(rollupCfg *rollup.Config, payload *eth.ExecutionPayload) (eth.L2BlockRef, error) {
-		return eth.L2BlockRef{
-			Hash:           payload.BlockHash,
-			Number:         uint64(payload.BlockNumber),
-			ParentHash:     payload.ParentHash,
-			Time:           uint64(payload.Timestamp),
-			L1Origin:       decodeID(payload.Transactions[0]),
-			SequenceNumber: 0,
-		}, nil
-	}
 	return seq, deps
 }
 
@@ -1391,27 +1364,25 @@ func TestSequencerMaxSafeLagHoldsThroughRecovery(t *testing.T) {
 	})
 }
 
-// TestSequencerPayloadSuccessClearsGossip covers the retained ingest path for
-// derivation-originated payloads: the async-gossip buffer must be cleared when
-// the inserted block is the one we were building, so a stale payload cannot be
-// reused, and left alone otherwise.
-func TestSequencerPayloadSuccessClearsGossip(t *testing.T) {
+// TestSequencerPayloadSuccessResetsBuilding covers the retained ingest path for
+// derivation-originated payloads: the building state is cleared when the inserted
+// block is the one we were building, and left alone otherwise. Gossip is not
+// touched either way - the block was inserted, so peers still want it.
+func TestSequencerPayloadSuccessResetsBuilding(t *testing.T) {
 	s := newSeqSetup(t)
 	envelope, ref := s.sealedPayload()
 
-	s.seq.building = BuildingState{Ref: ref}
-	s.deps.asyncGossip.payload = envelope
+	s.seq.building = BuildingState{Ref: ref, Envelope: envelope}
 
 	unrelated := &eth.ExecutionPayloadEnvelope{ExecutionPayload: &eth.ExecutionPayload{
 		BlockHash: common.Hash{0xaa},
 	}}
 	deliver(s.seq, engine.PayloadSuccessEvent{Envelope: unrelated})
-	require.NotNil(t, s.deps.asyncGossip.payload, "another block's insertion is not ours to act on")
-	require.Equal(t, ref, s.seq.building.Ref, "build state untouched")
+	require.Equal(t, ref, s.seq.building.Ref, "another block's insertion is not ours to act on")
 
 	deliver(s.seq, engine.PayloadSuccessEvent{Envelope: envelope})
-	require.Nil(t, s.deps.asyncGossip.payload, "our block was inserted: drop the gossip buffer")
 	require.Equal(t, BuildingState{}, s.seq.building, "our block was inserted: build state is done")
+	require.Empty(t, s.deps.asyncGossip.discarded, "an inserted block must still reach peers")
 }
 
 // TestSequencerStaysParkedOnTemporaryErrorDuringReset covers the window between
@@ -1525,17 +1496,19 @@ func TestSequencerStopAfterResetDropsSealed(t *testing.T) {
 	require.Equal(t, s.seq.unsafeHead.Hash, hash)
 }
 
-// TestSequencerProgressesWhilePublishInFlight is a regression test for the shape
+// TestSequencerRetriesRetainedEnvelope is a regression test for the shape
 // of PM-44 (Mainnet Unsafe Head Stall, 2024-02-15): the async-gossip buffer and
 // the sequencer's building state disagreed, the sequencer took a code path that
 // depended on the state that had been cleared, and it looped emitting errors
 // without ever producing a block. ~49 minutes of stalled mainnet.
 //
-// This PR reopens that surface from the other side. Get() no longer waits for an
-// in-flight publish, so it returns nil while building state IS set - the same
-// disagreement, opposite polarity. The sequencer must fall through to re-sealing
-// its build job and make progress, not spin.
-func TestSequencerProgressesWhilePublishInFlight(t *testing.T) {
+// This PR reopens that surface from the other side, so recovery must not depend
+// on any state that can disagree with the block itself. The sequencer keeps the
+// block it sealed and re-inserts exactly that, and the test pins that it does not
+// re-seal: re-sealing would stake recovery on the engine still holding the
+// payload job, and ErrSealExpired would then discard a block already committed to
+// the conductor and build a different one at the same height.
+func TestSequencerRetriesRetainedEnvelope(t *testing.T) {
 	s := newSeqSetup(t)
 	s.startBuild(t)
 	envelope, ref := s.sealedPayload()
@@ -1543,43 +1516,43 @@ func TestSequencerProgressesWhilePublishInFlight(t *testing.T) {
 	seals := 0
 	s.deps.eng.sealBuildFn = func(ctx context.Context, info eth.PayloadInfo, buildStarted time.Time) (*engine.SealResult, error) {
 		seals++
-		// Re-sealing the same build job yields the same block, which is what
-		// makes re-sealing safe rather than equivocation.
 		return &engine.SealResult{Envelope: envelope, Ref: ref}, nil
 	}
+	inserts := 0
 	s.deps.eng.processPayloadFn = func(ctx context.Context, envelope *eth.ExecutionPayloadEnvelope, ref eth.L2BlockRef, buildStarted time.Time) error {
+		inserts++
 		return errors.New("mock temp engine error")
 	}
 
-	// The publish is slow, so the payload is gossiped but not yet reusable.
-	s.deps.asyncGossip.withholdGet = true
-
 	s.seq.RunAction()
 	require.Equal(t, 1, seals)
-	require.Equal(t, envelope, s.deps.asyncGossip.payload, "the block was handed to the gossiper")
-	require.Equal(t, ref, s.seq.building.Ref, "building state is kept for the retry")
+	require.Equal(t, envelope, s.deps.conductor.committed, "committed to the conductor")
+	require.Equal(t, envelope, s.deps.asyncGossip.payload, "and handed to the gossiper")
+	require.Equal(t, envelope, s.seq.building.Envelope, "and retained, so the retry needs neither of them")
 	require.Empty(t, s.deps.asyncGossip.discarded,
 		"a temporary error is not a rejection: the block must still reach peers")
 
-	// The temporary-error event re-arms the schedule, and the retry finds Get()
-	// still empty. It must re-seal rather than stall: the same block, so peers
-	// are never offered two blocks at this height.
+	// The temporary-error event re-arms the schedule. The retry must re-insert the
+	// block we already hold rather than asking the engine to seal the job again.
 	deliver(s.seq, rollup.EngineTemporaryErrorEvent{Err: errors.New("mock temp engine error")})
-	s.seq.RunAction()
-	require.Equal(t, 2, seals, "the sequencer re-seals instead of waiting on the publish")
-	require.Equal(t, ref, s.seq.building.Ref, "still the same block, at the same height")
-
-	// Once the engine recovers, the block is inserted and the head advances.
-	// The stall in PM-44 was that this never happened.
-	deliver(s.seq, rollup.EngineTemporaryErrorEvent{Err: errors.New("mock temp engine error")})
-	s.deps.eng.processPayloadFn = func(ctx context.Context, envelope *eth.ExecutionPayloadEnvelope, ref eth.L2BlockRef, buildStarted time.Time) error {
+	s.deps.eng.sealBuildFn = func(ctx context.Context, info eth.PayloadInfo, buildStarted time.Time) (*engine.SealResult, error) {
+		seals++
+		return nil, engine.ErrSealExpired
+	}
+	s.deps.eng.processPayloadFn = func(ctx context.Context, gotEnvelope *eth.ExecutionPayloadEnvelope, gotRef eth.L2BlockRef, buildStarted time.Time) error {
+		inserts++
+		require.Equal(t, envelope, gotEnvelope, "the retry re-inserts the block we sealed")
+		require.Equal(t, ref, gotRef)
 		return nil
 	}
 	s.seq.RunAction()
+
+	require.Equal(t, 1, seals, "the retry must not re-seal: the engine may no longer hold the payload job")
+	require.Equal(t, 2, inserts, "it re-inserts the retained block instead")
 	require.Equal(t, ref, s.seq.unsafeHead, "the sequencer made progress")
 	require.Equal(t, BuildingState{}, s.seq.building)
 	require.Empty(t, s.deps.asyncGossip.discarded,
-		"the block was inserted: cleared for reuse, never discarded from the publish queue")
+		"the block was inserted: it must still reach peers, never discarded")
 	_, ok := s.seq.NextAction()
 	require.True(t, ok, "ready to build the next block")
 }
@@ -1617,14 +1590,11 @@ func TestSequencerResetClearsGossipAndBuilding(t *testing.T) {
 		"no payload from the rewound chain may be offered back for reuse")
 }
 
-// TestSequencerStopAfterStaleReSealDropsSealed covers the seal-time ErrStaleBuild
-// path on a re-seal. Because Get() no longer waits for an in-flight publish, the
-// sequencer re-seals its build job after a temporary insert error - and that
-// re-seal can be the point at which a competing block is found to have landed.
-// The block we already sealed and gossiped is dropped there, so the sealed marker
-// must be reconciled: Stop waits for the head to catch up to it, and would
-// otherwise wait for a block nobody is going to insert.
-func TestSequencerStopAfterStaleReSealDropsSealed(t *testing.T) {
+// TestSequencerStopAfterStaleRetryDropsSealed covers the retry discovering that
+// the chain has moved past the block we committed and gossiped. It is dropped
+// there, so the sealed marker must be reconciled: Stop waits for the head to
+// catch up to it, and would otherwise wait for a block nobody will insert.
+func TestSequencerStopAfterStaleRetryDropsSealed(t *testing.T) {
 	s := newSeqSetup(t)
 	info := s.startBuild(t)
 	envelope, ref := s.sealedPayload()
@@ -1632,24 +1602,22 @@ func TestSequencerStopAfterStaleReSealDropsSealed(t *testing.T) {
 		require.Equal(t, info, gotInfo)
 		return &engine.SealResult{Envelope: envelope, Ref: ref}, nil
 	}
-	// Sealed and gossiped, but the local insert failed temporarily, so the block
-	// is outstanding and the building job is kept for a retry.
+	// Sealed, committed and gossiped, but the local insert failed temporarily, so
+	// the block is outstanding and retained for a retry.
 	s.deps.eng.processPayloadFn = func(context.Context, *eth.ExecutionPayloadEnvelope, eth.L2BlockRef, time.Time) error {
 		return errors.New("mock temporary insert failure")
 	}
 	s.seq.RunAction()
 	require.Equal(t, ref, s.seq.lastSealed, "our gossiped block is outstanding")
 
-	// The retry finds nothing to reuse (the publish is still in flight) and
-	// re-seals - but the chain has moved past the job in the meantime.
-	s.deps.asyncGossip.withholdGet = true
-	s.deps.eng.sealBuildFn = func(ctx context.Context, gotInfo eth.PayloadInfo, buildStarted time.Time) (*engine.SealResult, error) {
-		return nil, engine.ErrStaleBuild
+	// The retry finds a competing block has become the head in the meantime.
+	s.deps.eng.processPayloadFn = func(context.Context, *eth.ExecutionPayloadEnvelope, eth.L2BlockRef, time.Time) error {
+		return engine.ErrStaleBuild
 	}
 	deliver(s.seq, rollup.EngineTemporaryErrorEvent{Err: errors.New("mock temporary insert failure")})
 	s.seq.RunAction()
 
-	require.Equal(t, BuildingState{}, s.seq.building, "the stale job is dropped")
+	require.Equal(t, BuildingState{}, s.seq.building, "the stale block is dropped")
 	require.Equal(t, []common.Hash{ref.Hash}, s.deps.asyncGossip.discarded,
 		"the sibling that lost must not still be published")
 	require.NotEqual(t, ref.Hash, s.seq.unsafeHead.Hash, "the sealed block is not the head")


### PR DESCRIPTION
Fixes #22554. Closes #22798.

`SimpleAsyncGossiper` published inline in its select loop, so while a publish was in flight the loop could receive nothing. `set`, `get` and `clear` were unbuffered channels served by that same loop, and with a remote signer the publish is an HTTPS round-trip — so the sequencer, which reaches the gossiper again 1–2 ms after `Gossip()`, blocked for the rest of it. The next build window is computed as a residual, so that stall came 1:1 out of the next block's building time.

Publishing now runs on a dedicated goroutine and the exposed calls only take a mutex, so none of them waits for the network.

### The sequencer keeps its own block

The gossiper used to hold the last published block so the sequencer could reuse it after a failed insert. That is now the sequencer's own business: `BuildingState` carries the sealed envelope from the moment it is committed to the conductor, and a failed insert is retried by re-inserting exactly that.

This came out of review and it matters for correctness, not just tidiness. `building.Ref` is non-zero only once the conductor quorum has committed the block, and the old path re-sealed the build job to recover — staking recovery on the engine still holding the payload. `ErrSealExpired` there would discard a committed block and build a different one at the same height.

It also deleted a lot: `Get`, `Clear`, the reuse buffer, the `wanted`-hash tracking and the `toBlockRef` hook are gone. The interface is now `Gossip` / `Discard(hash)` / `DiscardAll` / `Stop` / `Start`.

### Two verbs, where there used to be one

With a queue, "the sequencer is done with this block" comes apart into two cases, and picking the wrong one is silent — either good blocks stop reaching peers, or blocks from an abandoned chain reach them.

| | meaning | publish queue |
|---|---|---|
| *(no call)* | the block was inserted | **kept** — peers need it |
| `Discard(hash)` | the sequencer rejected this block: invalid, denied, or stale | that block removed |
| `DiscardAll()` | the chain those blocks extend was abandoned: a reset, a start, a stop | emptied |

Every path that abandons a block now pairs clearing `building` with a discard and reconciling `lastSealed`: `handleInvalid`, both stale paths, `onForkchoiceUpdate` adopting a competing head, `onReset`, and `StopSequencer`. That last one was found by sweeping for the pattern rather than by report — leadership moving while a committed block sat in the queue would have published it as a sibling of the new leader's branch.

### Retry, and when a block is dropped

A failed publish is retried at the **front** of the queue: dropping it and carrying on with its descendants leaves peers a gap they cannot follow the chain past, which is the same reason blocks go out in seal order rather than skipping to the tip.

**Queue pressure bounds it.** The retried block sits at `queue[0]` and `enqueue` evicts `queue[0]` on overflow, so a block is retried for as long as production leaves room. `maxPublishAttempts` is a hard ceiling on top, for when production has stopped and no eviction is ever coming, and `retryInterval` (1s) paces attempts — a publish can fail in about a millisecond, so unpaced retries measured **257,261 attempts in 500ms**.

**Failures that cannot succeed are dropped on the first attempt.** `Topic.Publish` runs op-node's own block validator inline and synchronously on the publishing node, so a bad block hash, an oversized block, a fork-shape mismatch, a nil signer — or a block that has aged past the gossip timestamp threshold — fails deterministically. Retrying those is not just waste: with a queue spanning ~64s against a 60s threshold, every head is already too old, the requeued head is exactly what the next arrival evicts, and the queue never drains again. A transient ~64s signer outage would have left gossip dead until restart.

`async.ErrPermanentPublish` is wrapped in `p2p` and `node` and matched with `errors.Is`, as a strict **allowlist**: `Topic.Publish` also surfaces the caller's context error, so a publish that merely hit `publishTimeout` must stay retryable. One deliberate exception — a block still ahead of the local clock is left retryable, since that is the single rejection a retry fixes.

An explicit age bound stays out, and tracing the publish path confirmed why: the threshold is already enforced sender-side, inline, against the *configured* value. A stale block fails locally and never reaches peers, so it costs neither a delivery nor peer score.

### Shutdown, and what is *not* fixed here

`OpNode.Stop` closes p2p and the signer before `Driver.Close`, which is the only thing that stops the publisher — so with `Clear` no longer waiting, a publish in flight plus up to 32 queued can run against a closed topic and a closed signer. It degrades to a logged error, and it is unchanged from today.

I tried both obvious reorderings and each broke a different CI job: closing p2p after the driver also puts it after `resourcesClose`, which cancels the context the pubsub instance was built on, so `Topic.Close` fails; and closing the driver early leaves the rest of the node running against a cancelled driver context, which spins the derivation system resetting. The ordering is therefore unchanged, with the reasoning recorded at the call site. The real fix is to stop only the publisher ahead of both, which needs a hook that does not exist yet — follow-up rather than more churn here.

### Metrics

`op_node_publish_queue_len` (gauge) and `op_node_dropped_publishes` (counter), both updated under the same lock as the queue mutation so the reported depth cannot be reordered against the queue it describes. `dropped_publishes` counts every sealed block that never reaches peers — queue overflow *or* giving up — since on `publishing_errors` alone a final failure is indistinguishable from one that was retried. In steady state the queue sits at 0.

### Testing

Every behaviour here has a test that fails without it, checked by reverting the fix rather than assumed:

- `TestAsyncGossiperDedupesResealedBlock` — 5 duplicates of one block queued on the previous revision.
- `TestAsyncGossiperPacesRetries` — 257,261 attempts in 500ms unpaced.
- `TestAsyncGossiperDropsPermanentFailure` — the head-of-line block; hangs without the classification.
- `TestSequencerRetriesRetainedEnvelope` — pins `seals == 1`, with `SealBuild` scripted to fail so a re-seal would be loud.
- `TestSequencerStopAfterStaleRetryDropsSealed` — `Stop` hangs to the context deadline without the marker reconciliation.
- `TestAsyncGossiperRetriesContextDeadline` and `TestClassifyPublishError` — the allowlist, which silently disables retry if it is too broad.

Plus ordering (`TestAsyncGossiperOverlappingPublishes`), the two ways a retry ends (`RetriesUntilQueueIsFull`, `StopsRetryingWhenIdle`), the discard verbs against each other, queue overflow, and the concurrency hammer.

`go vet ./...` clean repo-wide, `./op-node/...` green, `p2p`/`async`/`sequencing`/`node` green under `-race`, `./linter/bin/op-golangci-lint run ./op-node/...` reports 0 issues, `go mod tidy -diff` clean.

### Review

Reviewed against `docs/ai/go-dev.md`. Two rounds of review findings are folded in above; net across the last round is **−35 lines**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
