### PR TITLE
kona-sp1: Fix misleading guest warning

### DIFF
--- a/rust/kona/sp1/crates/ethereum/client/src/super_range.rs
+++ b/rust/kona/sp1/crates/ethereum/client/src/super_range.rs
@@ -95,8 +95,11 @@ where
     {
         dependency_set.clone()
     } else {
+        #[cfg(target_os = "zkvm")]
         eprintln!(
-            "No embedded dependency set found for proof chain ids {:?}, falling back to preimage oracle. This is insecure in production without additional validation!",
+            "The SP1 guest has no embedded dependency set for proof chain ids {:?}; falling \
+             back to preimage oracle. This is insecure in production without additional \
+             validation!",
             chain_ids
         );
         let serialized = oracle


### PR DESCRIPTION
super_range.rs is used by the super-range guest program and the kona-sp1-proposer host. The warning is inappropriate to be displayed in the host because the dependency set is expected to be supplied as a proposer input (or implied from the kona-registry). And there's no "oracle fallback" in the host.