### PR TITLE
kona-sp1-proposer: default proof strategies to auction

### DIFF
--- a/rust/kona/sp1/README.md
+++ b/rust/kona/sp1/README.md
@@ -239,8 +239,8 @@ SP1 network configuration applies when `KONA_SP1_PROPOSER_PROOF_PROVIDER=network
 | `KONA_SP1_PROPOSER_NETWORK_PRIVATE_KEY` | SPN requester private key, or AWS KMS key ARN when KMS is enabled |
 | `KONA_SP1_PROPOSER_NETWORK_RPC_URL` | SPN RPC override; absent or empty uses the SP1 SDK default for the selected network mode |
 | `KONA_SP1_PROPOSER_USE_KMS_REQUESTER` | use AWS KMS for request signing (default `false`) |
-| `KONA_SP1_PROPOSER_RANGE_PROOF_STRATEGY` | range fulfillment strategy (default `reserved`) |
-| `KONA_SP1_PROPOSER_AGG_PROOF_STRATEGY` | aggregation fulfillment strategy (default `reserved`) |
+| `KONA_SP1_PROPOSER_RANGE_PROOF_STRATEGY` | range fulfillment strategy (default `auction`) |
+| `KONA_SP1_PROPOSER_AGG_PROOF_STRATEGY` | aggregation fulfillment strategy (default `auction`) |
 | `KONA_SP1_PROPOSER_SP1_TIMEOUT_SECONDS` | overall proof timeout (default `14400`) |
 | `KONA_SP1_PROPOSER_NETWORK_CALLS_TIMEOUT` | individual network-call timeout (default `15`) |
 | `KONA_SP1_PROPOSER_AUCTION_TIMEOUT` | unassigned mainnet request timeout (default `60`) |

--- a/rust/kona/sp1/crates/proposer/src/config.rs
+++ b/rust/kona/sp1/crates/proposer/src/config.rs
@@ -368,14 +368,11 @@ impl ProofProviderConfig {
             auction_timeout,
             range_proof_strategy: parse_fulfillment_strategy(env_or(
                 "RANGE_PROOF_STRATEGY",
-                "reserved",
+                "auction",
             ))
             .with_context(|| format!("invalid {}", env_var("RANGE_PROOF_STRATEGY")))?,
-            agg_proof_strategy: parse_fulfillment_strategy(env_or(
-                "AGG_PROOF_STRATEGY",
-                "reserved",
-            ))
-            .with_context(|| format!("invalid {}", env_var("AGG_PROOF_STRATEGY")))?,
+            agg_proof_strategy: parse_fulfillment_strategy(env_or("AGG_PROOF_STRATEGY", "auction"))
+                .with_context(|| format!("invalid {}", env_var("AGG_PROOF_STRATEGY")))?,
             range_cycle_limit: parsed_env_or("RANGE_CYCLE_LIMIT", DEFAULT_PROOF_LIMIT)?,
             range_gas_limit: parsed_env_or("RANGE_GAS_LIMIT", DEFAULT_PROOF_LIMIT)?,
             agg_cycle_limit: parsed_env_or("AGG_CYCLE_LIMIT", DEFAULT_PROOF_LIMIT)?,
@@ -763,6 +760,14 @@ mod tests {
             assert!(!config.fast_finality_mode);
             assert_eq!(config.fast_finality_proving_limit.get(), 1);
             assert_eq!(config.proof_provider_config.timeout, 14_400);
+            assert_eq!(
+                config.proof_provider_config.range_proof_strategy,
+                FulfillmentStrategy::Auction
+            );
+            assert_eq!(
+                config.proof_provider_config.agg_proof_strategy,
+                FulfillmentStrategy::Auction
+            );
         }
 
         /// A zero defense cap would silently disable defense entirely;


### PR DESCRIPTION
Default both kona-sp1-proposer proof strategies to `auction` instead of `reserved`.