### PR TITLE
op-reth: use the engine's shared execution cache on the payload build path

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -13617,6 +13617,7 @@ dependencies = [
  "reth-basic-payload-builder",
  "reth-chainspec",
  "reth-evm",
+ "reth-execution-cache",
  "reth-execution-types",
  "reth-metrics",
  "reth-optimism-chainspec",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -388,6 +388,7 @@ reth-evm = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e1
 reth-evm-ethereum = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1" }
 reth-exex = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1" }
 reth-exex-test-utils = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1" }
+reth-execution-cache = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1" }
 reth-execution-errors = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1", default-features = false }
 reth-execution-types = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1", default-features = false }
 reth-fs-util = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1" }

--- a/rust/op-reth/crates/payload/Cargo.toml
+++ b/rust/op-reth/crates/payload/Cargo.toml
@@ -19,6 +19,7 @@ reth-revm = { workspace = true, features = ["witness"] }
 reth-transaction-pool.workspace = true
 reth-storage-api.workspace = true
 reth-evm.workspace = true
+reth-execution-cache.workspace = true
 reth-execution-types.workspace = true
 reth-payload-builder-primitives.workspace = true
 reth-payload-util.workspace = true

--- a/rust/op-reth/crates/payload/src/builder.rs
+++ b/rust/op-reth/crates/payload/src/builder.rs
@@ -22,6 +22,7 @@ use reth_evm::{
         BlockBuilder, BlockBuilderOutcome, BlockExecutionError, BlockExecutor, BlockValidationError,
     },
 };
+use reth_execution_cache::{CachedStateMetrics, CachedStateMetricsSource, CachedStateProvider};
 use reth_execution_types::BlockExecutionOutput;
 use reth_metrics::{
     Metrics,
@@ -254,7 +255,9 @@ where
         Txs:
             PayloadTransactions<Transaction: PoolTransaction<Consensus = N::SignedTx> + OpPooledTx>,
     {
-        let BuildArguments { mut cached_reads, config, cancel, best_payload, .. } = args;
+        let BuildArguments {
+            mut cached_reads, execution_cache, config, cancel, best_payload, ..
+        } = args;
 
         let ctx = OpPayloadBuilderCtx {
             evm_config: self.evm_config.clone(),
@@ -267,7 +270,26 @@ where
 
         let builder = OpBuilder::new(best);
 
-        let state_provider = self.client.state_by_block_hash(ctx.parent().hash())?;
+        let mut state_provider = self.client.state_by_block_hash(ctx.parent().hash())?;
+
+        // Serve account, storage and bytecode reads from the engine's cache when it shares one.
+        // Trie and proof reads still go to the inner provider, which `CachedStateProvider`
+        // delegates to, so the state root walk in `BlockBuilder::finish` is unaffected. The
+        // provider reads without ever filling (`CacheFillMode::LookupOnly`), keeping the builder
+        // out of the engine's way.
+        if let Some(execution_cache) = execution_cache {
+            // The cache is only sound on the parent it was populated against. `get_cache_for`
+            // repairs a stale slot with `clear_with_hash(parent_hash)` before handing it out, so a
+            // mismatch means reth broke that contract, not a case to handle at runtime.
+            debug_assert_eq!(execution_cache.executed_block_hash(), ctx.parent().hash());
+
+            state_provider = Box::new(CachedStateProvider::new(
+                state_provider,
+                execution_cache.cache().clone(),
+                Some(CachedStateMetrics::zeroed(CachedStateMetricsSource::Builder)),
+            ));
+        }
+
         let state = StateProviderDatabase::new(&state_provider);
 
         if ctx.attributes().no_tx_pool() {


### PR DESCRIPTION
op-reth's payload builder threw away the execution cache the engine hands it, so
`--engine.share-execution-cache-with-payload-builder` did nothing on the build path: every payload
read accounts, storage and bytecode straight from the provider, even when the engine had a warm
cache ready for that exact parent. This wires it through, same as reth's Ethereum builder.

## What was wrong

`OpPayloadBuilder::build_payload` swept `execution_cache` into the `..` of its `BuildArguments`
destructure (`rust/op-reth/crates/payload/src/builder.rs:258`). Everything leading up to that line
already worked: the engine checks out a `SavedCache` on FCU-with-attributes, `BasicPayloadJob`
clones it into every build attempt, and op-reth's own `convert_build_args` forwards it faithfully
(`builder.rs:404-430`). Then the builder dropped it.

## What this does

Wraps the state provider in a `CachedStateProvider` before the database is built, matching
`crates/ethereum/payload/src/lib.rs:173-181` at the pinned rev line for line, per-build
`CachedStateMetrics::zeroed(Builder)` handle included.

The cache serves `basic_account`, `storage` and `bytecode_by_hash`. Trie, proof and storage-root
reads delegate to the inner provider, so the state root walk in `BlockBuilder::finish` is
unaffected. `CachedStateProvider::new` selects `CacheFillMode::LookupOnly`, so the builder reads
without ever writing into the engine's cache.

## Relationship to other PRs

Independent of #22566, which pulls `state_root_handle` out of the same destructure. The two conflict
textually and nowhere else, so whichever lands second is a one-line resolution. #22495 leaves
`BuildArguments` flat, so this survives the v2.5.0 bump with only the manifest line changing.

## Verified

- `cargo test -p reth-optimism-payload-builder`: 25 passed.
- `cargo test -p reth-optimism-node --all-features --test e2e_testsuite`: 2 passed, 1 pre-existing
  ignore.
- `cargo +nightly fmt --check` and `cargo clippy --all-targets` clean.
