### PR TITLE
op-deployer: backport target-chain gas estimation to v0.7

### DIFF
--- a/op-deployer/pkg/deployer/broadcaster/keyed.go
+++ b/op-deployer/pkg/deployer/broadcaster/keyed.go
@@ -2,7 +2,6 @@ package broadcaster
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"math/big"
 	"sync"
@@ -17,20 +16,14 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr/metrics"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
-)
-
-const (
-	GasPadFactor = 1.2
 )
 
 type KeyedBroadcaster struct {
 	lgr    log.Logger
 	mgr    txmgr.TxManager
 	bcasts []script.Broadcast
-	client *ethclient.Client
 	mtx    sync.Mutex
 }
 
@@ -84,9 +77,8 @@ func NewKeyedBroadcaster(cfg KeyedBroadcasterOpts) (*KeyedBroadcaster, error) {
 	}
 
 	return &KeyedBroadcaster{
-		lgr:    cfg.Logger,
-		mgr:    mgr,
-		client: cfg.Client,
+		lgr: cfg.Logger,
+		mgr: mgr,
 	}, nil
 }
 
@@ -110,87 +102,58 @@ func (t *KeyedBroadcaster) Broadcast(ctx context.Context) ([]BroadcastResult, er
 		return nil, nil
 	}
 
-	results := make([]BroadcastResult, len(bcasts))
-	futures := make([]<-chan txmgr.SendResponse, len(bcasts))
-	ids := make([]common.Hash, len(bcasts))
-
-	latestBlock, err := t.client.BlockByNumber(ctx, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get latest block: %w", err)
-	}
-
+	results := make([]BroadcastResult, 0, len(bcasts))
 	for i, bcast := range bcasts {
-		futures[i], ids[i] = t.broadcast(ctx, bcast, latestBlock.GasLimit())
-		t.lgr.Info(
-			"transaction broadcasted",
-			"id", ids[i],
-			"nonce", bcast.Nonce,
-		)
-	}
+		id := bcast.ID()
+		t.lgr.Info("broadcasting transaction", "id", id, "nonce", bcast.Nonce)
 
-	var txErr error
-	var completed int
-	for i, fut := range futures {
-		bcastRes := <-fut
-		completed++
-		outRes := BroadcastResult{
-			Broadcast: bcasts[i],
-		}
-
-		if bcastRes.Err == nil {
-			outRes.Receipt = bcastRes.Receipt
-			outRes.TxHash = bcastRes.Receipt.TxHash
-
-			if bcastRes.Receipt.Status == 0 {
-				failErr := fmt.Errorf("transaction failed: %s", outRes.Receipt.TxHash.String())
-				txErr = errors.Join(txErr, failErr)
-				outRes.Err = failErr
-				t.lgr.Error(
-					"transaction failed on chain",
-					"id", ids[i],
-					"completed", completed,
-					"total", len(bcasts),
-					"hash", outRes.Receipt.TxHash.String(),
-					"nonce", outRes.Broadcast.Nonce,
-				)
-			} else {
-				t.lgr.Info(
-					"transaction confirmed",
-					"id", ids[i],
-					"completed", completed,
-					"total", len(bcasts),
-					"hash", outRes.Receipt.TxHash.String(),
-					"nonce", outRes.Broadcast.Nonce,
-					"creation", outRes.Receipt.ContractAddress,
-				)
-			}
-		} else {
-			txErr = errors.Join(txErr, bcastRes.Err)
-			outRes.Err = bcastRes.Err
+		// A zero gas limit makes txmgr estimate against the target chain. Waiting
+		// for confirmation ensures the next estimate sees this transaction's state.
+		receipt, err := t.mgr.Send(ctx, asTxCandidate(bcast, 0))
+		outRes := BroadcastResult{Broadcast: bcast, Receipt: receipt, Err: err}
+		if err != nil {
 			t.lgr.Error(
 				"transaction failed",
-				"id", ids[i],
-				"completed", completed,
+				"id", id,
+				"completed", i+1,
 				"total", len(bcasts),
-				"err", bcastRes.Err,
+				"err", err,
 			)
+			results = append(results, outRes)
+			return results, err
 		}
 
-		results[i] = outRes
+		outRes.TxHash = receipt.TxHash
+		if receipt.Status == 0 {
+			failErr := fmt.Errorf("transaction failed: %s", receipt.TxHash)
+			outRes.Err = failErr
+			t.lgr.Error(
+				"transaction failed on chain",
+				"id", id,
+				"completed", i+1,
+				"total", len(bcasts),
+				"hash", receipt.TxHash,
+				"nonce", bcast.Nonce,
+			)
+			results = append(results, outRes)
+			return results, failErr
+		}
+
+		t.lgr.Info(
+			"transaction confirmed",
+			"id", id,
+			"completed", i+1,
+			"total", len(bcasts),
+			"hash", receipt.TxHash,
+			"nonce", bcast.Nonce,
+			"creation", receipt.ContractAddress,
+		)
+		results = append(results, outRes)
 	}
-	return results, txErr
+	return results, nil
 }
 
-func (t *KeyedBroadcaster) broadcast(ctx context.Context, bcast script.Broadcast, blockGasLimit uint64) (<-chan txmgr.SendResponse, common.Hash) {
-	ch := make(chan txmgr.SendResponse, 1)
-
-	id := bcast.ID()
-	candidate := asTxCandidate(bcast, blockGasLimit)
-	t.mgr.SendAsync(ctx, candidate, ch)
-	return ch, id
-}
-
-func asTxCandidate(bcast script.Broadcast, blockGasLimit uint64) txmgr.TxCandidate {
+func asTxCandidate(bcast script.Broadcast, gasLimit uint64) txmgr.TxCandidate {
 	value := ((*uint256.Int)(bcast.Value)).ToBig()
 	var candidate txmgr.TxCandidate
 	switch bcast.Type {
@@ -200,13 +163,13 @@ func asTxCandidate(bcast script.Broadcast, blockGasLimit uint64) txmgr.TxCandida
 			TxData:   bcast.Input,
 			To:       to,
 			Value:    value,
-			GasLimit: padGasLimit(bcast.Input, bcast.GasUsed, false, blockGasLimit),
+			GasLimit: gasLimit,
 		}
 	case script.BroadcastCreate:
 		candidate = txmgr.TxCandidate{
 			TxData:   bcast.Input,
 			To:       nil,
-			GasLimit: padGasLimit(bcast.Input, bcast.GasUsed, true, blockGasLimit),
+			GasLimit: gasLimit,
 		}
 	case script.BroadcastCreate2:
 		txData := make([]byte, len(bcast.Salt)+len(bcast.Input))
@@ -217,39 +180,10 @@ func asTxCandidate(bcast script.Broadcast, blockGasLimit uint64) txmgr.TxCandida
 			TxData:   txData,
 			To:       &script.DeterministicDeployerAddress,
 			Value:    value,
-			GasLimit: padGasLimit(bcast.Input, bcast.GasUsed, true, blockGasLimit),
+			GasLimit: gasLimit,
 		}
 	default:
 		panic(fmt.Sprintf("unrecognized broadcast type: '%s'", bcast.Type))
 	}
 	return candidate
-}
-
-// padGasLimit calculates the gas limit for a transaction based on the intrinsic gas and the gas used by
-// the underlying call. Values are multiplied by a pad factor to account for any discrepancies. The output
-// is clamped to the block gas limit since Geth will reject transactions that exceed it before letting them
-// into the mempool.
-func padGasLimit(data []byte, gasUsed uint64, creation bool, blockGasLimit uint64) uint64 {
-	intrinsicGas, err := core.IntrinsicGas(data, nil, nil, creation, true, true, false)
-	// This method never errors - we should look into it if it does.
-	if err != nil {
-		panic(err)
-	}
-
-	floorDataGas, err := core.FloorDataGas(data)
-	// We should never cause an overflow here.
-	if err != nil {
-		panic(err)
-	}
-
-	gas := intrinsicGas + gasUsed
-	if floorDataGas > gas {
-		gas = floorDataGas
-	}
-
-	limit := uint64(float64(gas) * GasPadFactor)
-	if limit > blockGasLimit {
-		return blockGasLimit
-	}
-	return limit
 }

--- a/op-deployer/pkg/deployer/broadcaster/keyed_test.go
+++ b/op-deployer/pkg/deployer/broadcaster/keyed_test.go
@@ -1,0 +1,106 @@
+package broadcaster
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-chain-ops/script"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-service/txmgr"
+	txmocks "github.com/ethereum-optimism/optimism/op-service/txmgr/mocks"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKeyedBroadcasterSendsSequentiallyWithGasEstimation(t *testing.T) {
+	bcasts := []script.Broadcast{
+		{
+			Type:  script.BroadcastCreate,
+			Input: []byte{0x60, 0x00},
+			Value: (*hexutil.U256)(new(uint256.Int)),
+		},
+		{
+			Type:  script.BroadcastCall,
+			To:    common.Address{'T'},
+			Input: []byte{0x12, 0x34},
+			Value: (*hexutil.U256)(new(uint256.Int)),
+		},
+	}
+
+	mgr := txmocks.NewTxManager(t)
+	next := 0
+	mgr.On("Send", mock.Anything, mock.Anything).Return(
+		func(_ context.Context, candidate txmgr.TxCandidate) (*types.Receipt, error) {
+			require.Less(t, next, len(bcasts))
+			require.Zero(t, candidate.GasLimit)
+			require.Equal(t, []byte(bcasts[next].Input), candidate.TxData)
+			if bcasts[next].Type == script.BroadcastCreate {
+				require.Nil(t, candidate.To)
+			} else {
+				require.Equal(t, bcasts[next].To, *candidate.To)
+			}
+
+			next++
+			return &types.Receipt{
+				Status: types.ReceiptStatusSuccessful,
+				TxHash: common.Hash{byte(next)},
+			}, nil
+		},
+	)
+
+	broadcaster := &KeyedBroadcaster{
+		lgr:    testlog.Logger(t, log.LevelError),
+		mgr:    mgr,
+		bcasts: bcasts,
+	}
+	results, err := broadcaster.Broadcast(context.Background())
+	require.NoError(t, err)
+	require.Len(t, results, len(bcasts))
+	require.Equal(t, len(bcasts), next)
+	for i, result := range results {
+		require.Equal(t, bcasts[i], result.Broadcast)
+		require.Equal(t, common.Hash{byte(i + 1)}, result.TxHash)
+		require.NoError(t, result.Err)
+	}
+}
+
+func TestKeyedBroadcasterStopsAfterFailure(t *testing.T) {
+	bcasts := []script.Broadcast{
+		{Type: script.BroadcastCall, To: common.Address{'A'}, Value: (*hexutil.U256)(new(uint256.Int))},
+		{Type: script.BroadcastCall, To: common.Address{'B'}, Value: (*hexutil.U256)(new(uint256.Int))},
+		{Type: script.BroadcastCall, To: common.Address{'C'}, Value: (*hexutil.U256)(new(uint256.Int))},
+	}
+	sendErr := errors.New("send failed")
+
+	mgr := txmocks.NewTxManager(t)
+	calls := 0
+	mgr.On("Send", mock.Anything, mock.Anything).Return(
+		func(_ context.Context, _ txmgr.TxCandidate) (*types.Receipt, error) {
+			calls++
+			if calls == 2 {
+				return nil, sendErr
+			}
+			return &types.Receipt{
+				Status: types.ReceiptStatusSuccessful,
+				TxHash: common.Hash{byte(calls)},
+			}, nil
+		},
+	)
+
+	broadcaster := &KeyedBroadcaster{
+		lgr:    testlog.Logger(t, log.LevelError),
+		mgr:    mgr,
+		bcasts: bcasts,
+	}
+	results, err := broadcaster.Broadcast(context.Background())
+	require.ErrorIs(t, err, sendErr)
+	require.Len(t, results, 2)
+	require.Equal(t, 2, calls)
+	require.ErrorIs(t, results[1].Err, sendErr)
+}

--- a/op-service/txmgr/txmgr.go
+++ b/op-service/txmgr/txmgr.go
@@ -19,7 +19,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto/kzg4844"
 	"github.com/ethereum/go-ethereum/log"
-	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/holiman/uint256"
 
@@ -490,7 +489,7 @@ func (m *SimpleTxManager) estimateOrValidateCandidateTxGas(ctx context.Context, 
 	}
 	// If the gas limit is set, we can use that as the gas
 	if candidate.GasLimit == 0 {
-		callMsg.Gas = params.MaxTxGas
+		// Leave CallMsg.Gas unset so the target node chooses a ceiling based on its active fork rules.
 		gas, err := m.backend.EstimateGas(ctx, callMsg)
 		if err != nil {
 			return 0, fmt.Errorf("failed to estimate gas: %w", errutil.TryAddRevertReason(err))

--- a/op-service/txplan/txplan.go
+++ b/op-service/txplan/txplan.go
@@ -222,10 +222,11 @@ func WithEstimator(cl Estimator, invalidateOnNewBlock bool) Option {
 			tx.Gas.DependOn(&tx.AgainstBlock)
 		}
 		tx.Gas.Fn(func(ctx context.Context) (uint64, error) {
+			// Leave CallMsg.Gas unset so the target node applies the estimation ceiling for its active
+			// fork.
 			msg := ethereum.CallMsg{
 				From:       tx.Sender.Value(),
 				To:         tx.To.Value(),
-				Gas:        params.MaxTxGas, // max gas, will be estimated
 				GasPrice:   nil,
 				GasFeeCap:  tx.GasFeeCap.Value(),
 				GasTipCap:  tx.GasTipCap.Value(),


### PR DESCRIPTION
Backports [#22217](https://github.com/ethereum-optimism/optimism/pull/22217) and the broadcaster portion of [#21728](https://github.com/ethereum-optimism/optimism/pull/21728) to the op-deployer v0.7 release branch.

`op-deployer/v0.7.1` derives keyed transaction gas limits from its Cancun-era local script simulation. On a post-Glamsterdam/EIP-8037 L1, the resulting ~10.7M limit is too low for a deployment that now requires ~55.7M gas. This currently blocks [devnets-private#1542](https://github.com/ethereum-optimism/devnets-private/pull/1542).

After this merges, please cut `op-deployer/v0.7.2`. A v0.7 release is required so the fixed broadcaster remains paired with the v0.7 embedded contract artifacts; the existing v0.8 test binaries embed incompatible v0.8 artifacts.

Tests:
- `just lint-go`
- `go test ./op-deployer/pkg/deployer/broadcaster ./op-service/txmgr ./op-service/txplan`
- Built the backport with the v0.7.1 embedded artifact bundle and ran the failed deployment against Plataberget through a broadcast-blocking RPC proxy. `eth_estimateGas` was sent without an explicit ceiling, returned `55,664,397`, and txmgr constructed that gas limit. The proxy rejected `eth_sendRawTransaction`; no transaction was broadcast.

Local Go review: `lint-go` green; no findings.
