### PR TITLE
op-reth-test-engine: UDS JSON-RPC server + shared engineipc Go client

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -839,13 +839,14 @@ jobs:
       - rust-build:
           directory: rust
           profile: release
-          package: "op-reth op-reth-sdm-fixture"
+          package: "op-reth op-reth-sdm-fixture op-reth-test-engine"
           save_cache: false
       - persist_to_workspace:
           root: "."
           paths:
             - "rust/target/release/op-reth"
             - "rust/target/release/op-reth-sdm-fixture"
+            - "rust/target/release/op-reth-test-engine"
 
   initialize:
     docker:
@@ -1808,10 +1809,15 @@ jobs:
       - attach_workspace:
           at: .
       - run:
-          name: Configure op-reth binary path
+          name: Configure op-reth binary paths
           command: |
             ROOT_DIR="$(pwd)"
             echo "export RUST_BINARY_PATH_OP_RETH=$ROOT_DIR/rust/target/release/op-reth" >> "$BASH_ENV"
+            # op-service/engineipc's TestMain uses the prebuilt engine from the attached
+            # rust-op-reth-binary workspace. REQUIRE_RUST_ENGINE forbids its local cargo-build
+            # fallback (which needs libclang, absent from this image) so a missing binary fails loudly.
+            echo "export RUST_BINARY_PATH_OP_RETH_TEST_ENGINE=$ROOT_DIR/rust/target/release/op-reth-test-engine" >> "$BASH_ENV"
+            echo "export REQUIRE_RUST_ENGINE=1" >> "$BASH_ENV"
       - go-restore-cache:
           namespace: go-tests
       - run:

--- a/op-service/engineipc/deathsig_linux.go
+++ b/op-service/engineipc/deathsig_linux.go
@@ -1,0 +1,17 @@
+//go:build linux
+
+package engineipc
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// setDeathSignal makes the OS send SIGKILL to the spawned engine when the parent (this Go process)
+// dies, so a hard-killed test can't leak long-lived engine subprocesses. Linux-only.
+func setDeathSignal(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Pdeathsig = syscall.SIGKILL
+}

--- a/op-service/engineipc/deathsig_other.go
+++ b/op-service/engineipc/deathsig_other.go
@@ -1,0 +1,9 @@
+//go:build !linux
+
+package engineipc
+
+import "os/exec"
+
+// setDeathSignal is a no-op on non-Linux platforms (Pdeathsig is Linux-specific). Callers still
+// Close() the engine explicitly; this only guards against a hard-killed parent.
+func setDeathSignal(_ *exec.Cmd) {}

--- a/op-service/engineipc/engineipc.go
+++ b/op-service/engineipc/engineipc.go
@@ -1,0 +1,160 @@
+// Package engineipc spawns a subprocess execution engine that serves JSON-RPC over a Unix domain
+// socket (go-ethereum rpc.DialIPC-compatible, reth-ipc newline framing) and manages its lifecycle.
+//
+// It is the shared transport layer for driving out-of-process Rust engines from Go tests: it owns
+// the temp socket path, starts the child with a death-signal so a hard-killed parent leaks nothing,
+// drains the child's stderr, waits for readiness, and dials the socket. Argument construction and
+// the typed RPC method set stay with each consumer — this package is transport only, with no
+// op-node, op-e2e, or op-chain-ops dependencies.
+package engineipc
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+// DefaultSocketFlag is the CLI flag under which the engine binary expects its Unix socket path.
+const DefaultSocketFlag = "--socket"
+
+// DefaultReadyTimeout bounds how long Spawn waits for the child to create and serve its socket.
+const DefaultReadyTimeout = 30 * time.Second
+
+// Opts tunes Spawn. The zero value is valid and uses the defaults above.
+type Opts struct {
+	// SocketFlag overrides the flag under which the socket path is passed (default "--socket").
+	SocketFlag string
+	// ReadyTimeout overrides how long to wait for the socket (default 30s).
+	ReadyTimeout time.Duration
+	// SocketName overrides the socket file name inside the temp dir (default "engine.sock").
+	SocketName string
+}
+
+func (o *Opts) socketFlag() string {
+	if o != nil && o.SocketFlag != "" {
+		return o.SocketFlag
+	}
+	return DefaultSocketFlag
+}
+
+func (o *Opts) readyTimeout() time.Duration {
+	if o != nil && o.ReadyTimeout > 0 {
+		return o.ReadyTimeout
+	}
+	return DefaultReadyTimeout
+}
+
+func (o *Opts) socketName() string {
+	if o != nil && o.SocketName != "" {
+		return o.SocketName
+	}
+	return "engine.sock"
+}
+
+// Proc is a handle to a spawned engine subprocess and its dialed IPC client.
+type Proc struct {
+	cmd    *exec.Cmd
+	client *rpc.Client
+	tmpDir string
+	sock   string
+}
+
+// Spawn launches binPath with args plus the socket flag (whose value it owns), waits for the
+// socket, and dials it. The child's stderr is forwarded to logw. The returned Proc must be closed.
+//
+// Spawn appends the socket flag itself — callers pass every other argument (e.g. "--genesis <path>")
+// in args. This keeps socket lifecycle (temp dir, unique path, cleanup) entirely inside the package.
+func Spawn(binPath string, args []string, logw io.Writer, opts *Opts) (*Proc, error) {
+	tmpDir, err := os.MkdirTemp("", "engineipc")
+	if err != nil {
+		return nil, fmt.Errorf("create temp dir: %w", err)
+	}
+	sock := filepath.Join(tmpDir, opts.socketName())
+
+	fullArgs := make([]string, 0, len(args)+2)
+	fullArgs = append(fullArgs, args...)
+	fullArgs = append(fullArgs, opts.socketFlag(), sock)
+
+	cmd := exec.Command(binPath, fullArgs...)
+	setDeathSignal(cmd) // SIGKILL the engine if this process dies (no leaked engines)
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		_ = os.RemoveAll(tmpDir)
+		return nil, fmt.Errorf("pipe stderr: %w", err)
+	}
+	if err := cmd.Start(); err != nil {
+		_ = os.RemoveAll(tmpDir)
+		return nil, fmt.Errorf("start %s: %w", binPath, err)
+	}
+
+	go drainStderr(stderr, logw)
+
+	p := &Proc{cmd: cmd, tmpDir: tmpDir, sock: sock}
+	deadline := time.Now().Add(opts.readyTimeout())
+	for {
+		if _, statErr := os.Stat(sock); statErr == nil {
+			if cl, dialErr := rpc.DialIPC(context.Background(), sock); dialErr == nil {
+				p.client = cl
+				return p, nil
+			}
+		}
+		if time.Now().After(deadline) {
+			p.Close()
+			return nil, fmt.Errorf("engine never became ready on %s within %s", sock, opts.readyTimeout())
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+// drainStderr forwards the child's stderr to logw. It uses a bufio.Reader rather than a Scanner so
+// a single long log line can't hit Scanner's 64KiB token cap, stop the drain, fill the pipe, and
+// hang the engine.
+func drainStderr(stderr io.Reader, logw io.Writer) {
+	br := bufio.NewReader(stderr)
+	for {
+		line, err := br.ReadString('\n')
+		if len(line) > 0 && logw != nil {
+			fmt.Fprintf(logw, "[engine] %s", line)
+		}
+		if err != nil {
+			return
+		}
+	}
+}
+
+// Client returns the dialed go-ethereum IPC client. Valid until Close.
+func (p *Proc) Client() *rpc.Client {
+	return p.client
+}
+
+// SocketPath returns the Unix socket path the engine listens on.
+func (p *Proc) SocketPath() string {
+	return p.sock
+}
+
+// Close terminates the engine and removes its temp dir. It is idempotent.
+func (p *Proc) Close() {
+	if p == nil {
+		return
+	}
+	if p.client != nil {
+		p.client.Close()
+		p.client = nil
+	}
+	if p.cmd != nil && p.cmd.Process != nil {
+		_ = p.cmd.Process.Kill()
+		_ = p.cmd.Wait()
+		p.cmd = nil
+	}
+	if p.tmpDir != "" {
+		_ = os.RemoveAll(p.tmpDir)
+		p.tmpDir = ""
+	}
+}

--- a/op-service/engineipc/engineipc_smoke_test.go
+++ b/op-service/engineipc/engineipc_smoke_test.go
@@ -1,0 +1,323 @@
+package engineipc_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/stretchr/testify/require"
+
+	opservice "github.com/ethereum-optimism/optimism/op-service"
+	"github.com/ethereum-optimism/optimism/op-service/engineipc"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+// enginePath is the resolved op-reth-test-engine binary, provisioned once in TestMain.
+var enginePath string
+
+// TestMain provisions the Rust engine binary once for the package. It honours a prebuilt-binary
+// path from the environment (as CI supplies) and otherwise builds it with cargo. It never skips:
+// a missing binary or a failed build is a hard failure, so the smoke gate can't silently pass.
+func TestMain(m *testing.M) {
+	path, err := provisionEngine()
+	if err != nil {
+		panic(fmt.Sprintf("provision op-reth-test-engine: %v", err))
+	}
+	enginePath = path
+	os.Exit(m.Run())
+}
+
+func provisionEngine() (string, error) {
+	if override := os.Getenv("RUST_BINARY_PATH_OP_RETH_TEST_ENGINE"); override != "" {
+		if _, err := os.Stat(override); err != nil {
+			return "", fmt.Errorf("RUST_BINARY_PATH_OP_RETH_TEST_ENGINE=%s: %w", override, err)
+		}
+		return override, nil
+	}
+	// REQUIRE_RUST_ENGINE arms CI: with it set, a missing prebuilt-binary path is a hard error rather
+	// than a slow cargo fallback, so a misconfigured job fails loudly instead of masking the config
+	// bug behind a 20-minute rebuild.
+	if os.Getenv("REQUIRE_RUST_ENGINE") != "" {
+		return "", fmt.Errorf("REQUIRE_RUST_ENGINE is set but RUST_BINARY_PATH_OP_RETH_TEST_ENGINE is empty: refusing to fall back to a cargo build")
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	root, err := opservice.FindMonorepoRoot(cwd)
+	if err != nil {
+		return "", err
+	}
+	rustDir := filepath.Join(root, "rust")
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "cargo", "build", "-p", "op-reth-test-engine", "--bin", "op-reth-test-engine")
+	cmd.Dir = rustDir
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("cargo build op-reth-test-engine (in %s): %w", rustDir, err)
+	}
+	return filepath.Join(rustDir, "target", "debug", "op-reth-test-engine"), nil
+}
+
+// A synthetic OP chain id — deliberately not OP Mainnet (10), whose genesis hash op-reth pins to
+// the registry value (which the state-computed hash cannot reproduce). A synthetic genesis under
+// id 10 would be indexed under that pinned hash, so op-geth's genesis hash and the engine's would
+// diverge and the first forkchoice update would fail to find the parent.
+const chainID = 901
+
+// TestEngineSmoke drives the full sequencer flow over the Unix socket — spawn → forkchoiceUpdated
+// with attributes → optest_includeTx → getPayload → newPayload → forkchoiceUpdated — twice, and
+// asserts the result is a valid chain of two blocks (parent-linked, distinct hashes, ascending
+// numbers) read back via eth_getBlockByNumber. This is the end-to-end gate for the RPC binary and
+// the shared engineipc transport.
+func TestEngineSmoke(t *testing.T) {
+	key, err := crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+	require.NoError(t, err)
+	funded := crypto.PubkeyToAddress(key.PublicKey)
+	signer := types.LatestSignerForChainID(big.NewInt(chainID))
+
+	genesisPath := writeGenesis(t, funded)
+
+	var logs bytes.Buffer
+	proc, err := engineipc.Spawn(enginePath, []string{"--genesis", genesisPath}, &logs, nil)
+	require.NoError(t, err, "spawn engine\n%s", logs.String())
+	defer func() {
+		proc.Close()
+		if t.Failed() {
+			t.Logf("engine stderr:\n%s", logs.String())
+		}
+	}()
+	cl := proc.Client()
+	ctx := context.Background()
+
+	// The genesis block anchors the chain.
+	genesis := getBlock(t, cl, "earliest")
+	require.EqualValues(t, 0, genesis.Number)
+
+	// signTx builds a signed EIP-1559 value transfer from the funded account.
+	signTx := func(nonce uint64) hexutil.Bytes {
+		tx, err := types.SignNewTx(key, signer, &types.DynamicFeeTx{
+			ChainID:   big.NewInt(chainID),
+			Nonce:     nonce,
+			GasTipCap: big.NewInt(0),
+			GasFeeCap: big.NewInt(10_000_000_000),
+			Gas:       21_000,
+			To:        &common.Address{},
+		})
+		require.NoError(t, err)
+		raw, err := tx.MarshalBinary()
+		require.NoError(t, err)
+		return raw
+	}
+
+	// buildBlock runs one sequencer round on top of parent and returns the new head hash.
+	buildBlock := func(parent common.Hash, timestamp uint64, deposits []hexutil.Bytes, userTx hexutil.Bytes) common.Hash {
+		fcState := eth.ForkchoiceState{HeadBlockHash: parent, SafeBlockHash: parent, FinalizedBlockHash: parent}
+		attrs := payloadAttributes(timestamp, deposits)
+
+		var fcuRes eth.ForkchoiceUpdatedResult
+		require.NoError(t, cl.CallContext(ctx, &fcuRes, "engine_forkchoiceUpdatedV3", fcState, attrs),
+			"forkchoiceUpdated(attrs)")
+		require.Equal(t, eth.ExecutionValid, fcuRes.PayloadStatus.Status, "FCU status")
+		require.NotNil(t, fcuRes.PayloadID, "payload id returned")
+
+		var inc struct {
+			TxHash  common.Hash `json:"txHash"`
+			GasUsed uint64      `json:"gasUsed"`
+		}
+		require.NoError(t, cl.CallContext(ctx, &inc, "optest_includeTx", hexutil.Bytes(userTx)),
+			"optest_includeTx")
+		require.NotZero(t, inc.GasUsed, "user tx consumed gas")
+
+		var envelope eth.ExecutionPayloadEnvelope
+		require.NoError(t, cl.CallContext(ctx, &envelope, "engine_getPayloadV4", fcuRes.PayloadID),
+			"getPayload")
+		require.NotNil(t, envelope.ExecutionPayload)
+
+		var status eth.PayloadStatusV1
+		require.NoError(t, cl.CallContext(ctx, &status, "engine_newPayloadV4",
+			envelope.ExecutionPayload, []common.Hash{}, envelope.ParentBeaconBlockRoot, []hexutil.Bytes{}),
+			"newPayload")
+		require.Equal(t, eth.ExecutionValid, status.Status, "newPayload status: %+v", status)
+		require.NotNil(t, status.LatestValidHash)
+		head := *status.LatestValidHash
+		require.Equal(t, common.Hash(envelope.ExecutionPayload.BlockHash), head, "newPayload head == built block")
+
+		var advanced eth.ForkchoiceUpdatedResult
+		newState := eth.ForkchoiceState{HeadBlockHash: head, SafeBlockHash: head, FinalizedBlockHash: head}
+		require.NoError(t, cl.CallContext(ctx, &advanced, "engine_forkchoiceUpdatedV3", newState, nil),
+			"forkchoiceUpdated(advance)")
+		require.Equal(t, eth.ExecutionValid, advanced.PayloadStatus.Status, "advance FCU status")
+		return head
+	}
+
+	// Block 1: one forced deposit plus a user tx.
+	block1 := buildBlock(common.Hash(genesis.Hash), 2, []hexutil.Bytes{depositTx()}, signTx(0))
+	// Block 2 builds on block 1 with a second user tx (no deposit).
+	block2 := buildBlock(block1, 4, nil, signTx(1))
+
+	// A valid chain of two blocks on top of genesis, read back over eth_.
+	h1 := getBlock(t, cl, "0x1")
+	h2 := getBlock(t, cl, "0x2")
+	require.EqualValues(t, 1, h1.Number)
+	require.Equal(t, common.Hash(genesis.Hash), common.Hash(h1.ParentHash), "block1 parent is genesis")
+	require.Equal(t, block1, common.Hash(h1.Hash))
+	require.EqualValues(t, 2, h2.Number)
+	require.Equal(t, block1, common.Hash(h2.ParentHash), "block2 parent is block1")
+	require.Equal(t, block2, common.Hash(h2.Hash))
+	require.NotEqual(t, block1, block2, "distinct block hashes")
+
+	// The safe/finalized pointers moved with the head (forkchoice was applied over the socket).
+	latest := getBlock(t, cl, "latest")
+	require.Equal(t, block2, common.Hash(latest.Hash))
+	safe := getBlock(t, cl, "safe")
+	require.Equal(t, block2, common.Hash(safe.Hash))
+}
+
+// rpcBlock is the subset of an eth_getBlock* result the smoke test asserts on.
+type rpcBlock struct {
+	Number     hexutil.Uint64 `json:"number"`
+	Hash       common.Hash    `json:"hash"`
+	ParentHash common.Hash    `json:"parentHash"`
+}
+
+func getBlock(t *testing.T, cl interface {
+	CallContext(ctx context.Context, result any, method string, args ...any) error
+}, tag string) rpcBlock {
+	t.Helper()
+	var raw json.RawMessage
+	require.NoError(t, cl.CallContext(context.Background(), &raw, "eth_getBlockByNumber", tag, false),
+		"eth_getBlockByNumber(%s)", tag)
+	require.NotEqual(t, "null", string(raw), "block %s present", tag)
+	var block rpcBlock
+	require.NoError(t, json.Unmarshal(raw, &block))
+	return block
+}
+
+// payloadAttributes builds Karst-level attributes: withdrawals + parent-beacon-root (Ecotone/
+// Canyon), the Holocene EIP-1559 params, and the Jovian minimum base fee, mirroring the Rust
+// testsupport so block assembly succeeds.
+func payloadAttributes(timestamp uint64, deposits []hexutil.Bytes) *eth.PayloadAttributes {
+	gasLimit := eth.Uint64Quantity(30_000_000)
+	minBaseFee := uint64(0)
+	txs := make([]eth.Data, len(deposits))
+	for i, d := range deposits {
+		txs[i] = eth.Data(d)
+	}
+	return &eth.PayloadAttributes{
+		Timestamp:             eth.Uint64Quantity(timestamp),
+		PrevRandao:            eth.Bytes32{},
+		SuggestedFeeRecipient: common.Address{},
+		Withdrawals:           &types.Withdrawals{},
+		ParentBeaconBlockRoot: &common.Hash{},
+		Transactions:          txs,
+		NoTxPool:              false,
+		GasLimit:              &gasLimit,
+		EIP1559Params:         &eth.Bytes8{},
+		MinBaseFee:            &minBaseFee,
+	}
+}
+
+// depositTx builds a minimal deposit (type 0x7E) mirroring the Rust testsupport's deposit_tx.
+func depositTx() hexutil.Bytes {
+	depositor := common.BytesToAddress([]byte{0xde})
+	tx := types.NewTx(&types.DepositTx{
+		From:  depositor,
+		To:    &depositor,
+		Value: big.NewInt(0),
+		Gas:   21_000,
+	})
+	raw, err := tx.MarshalBinary()
+	if err != nil {
+		panic(err)
+	}
+	return raw
+}
+
+// writeGenesis builds an op-geth core.Genesis with all OP hardforks active at genesis (through
+// Karst), the L1Block predeploy seeded with the L1-cost inputs, and funded given a spendable
+// balance — the op-geth JSON the Rust engine parses into its chain spec. It mirrors the Rust
+// testsupport chain so the two engines agree on block construction.
+func writeGenesis(t *testing.T, funded common.Address) string {
+	t.Helper()
+	zero := uint64(0)
+	config := &params.ChainConfig{
+		ChainID:                 big.NewInt(chainID),
+		HomesteadBlock:          big.NewInt(0),
+		EIP150Block:             big.NewInt(0),
+		EIP155Block:             big.NewInt(0),
+		EIP158Block:             big.NewInt(0),
+		ByzantiumBlock:          big.NewInt(0),
+		ConstantinopleBlock:     big.NewInt(0),
+		PetersburgBlock:         big.NewInt(0),
+		IstanbulBlock:           big.NewInt(0),
+		MuirGlacierBlock:        big.NewInt(0),
+		BerlinBlock:             big.NewInt(0),
+		LondonBlock:             big.NewInt(0),
+		ArrowGlacierBlock:       big.NewInt(0),
+		GrayGlacierBlock:        big.NewInt(0),
+		MergeNetsplitBlock:      big.NewInt(0),
+		BedrockBlock:            big.NewInt(0),
+		ShanghaiTime:            &zero,
+		CancunTime:              &zero,
+		PragueTime:              &zero,
+		RegolithTime:            &zero,
+		CanyonTime:              &zero,
+		EcotoneTime:             &zero,
+		FjordTime:               &zero,
+		GraniteTime:             &zero,
+		HoloceneTime:            &zero,
+		IsthmusTime:             &zero,
+		JovianTime:              &zero,
+		KarstTime:               &zero,
+		TerminalTotalDifficulty: big.NewInt(0),
+		Optimism: &params.OptimismConfig{
+			EIP1559Elasticity:  6,
+			EIP1559Denominator: 250,
+		},
+	}
+
+	l1Block := common.HexToAddress("0x4200000000000000000000000000000000000015")
+	storage := map[common.Hash]common.Hash{
+		common.BigToHash(big.NewInt(1)): common.BigToHash(big.NewInt(1_000_000_000)),
+		common.BigToHash(big.NewInt(7)): common.BigToHash(big.NewInt(1)),
+		common.BigToHash(big.NewInt(3)): common.HexToHash("0x0000000000000000000000000000000000001db0000d27300000000000000005"),
+	}
+
+	genesis := &core.Genesis{
+		Config:        config,
+		GasLimit:      30_000_000,
+		BaseFee:       big.NewInt(1_000_000_000),
+		Difficulty:    big.NewInt(0),
+		ExcessBlobGas: &zero,
+		BlobGasUsed:   &zero,
+		// Jovian EIP-1559 extra data: version 1, canyon params (denominator 250, elasticity 6),
+		// minimum base fee 0.
+		ExtraData: []byte{0x01, 0, 0, 0, 250, 0, 0, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0},
+		Alloc: types.GenesisAlloc{
+			l1Block: {Nonce: 1, Balance: big.NewInt(0), Storage: storage},
+			funded:  {Balance: new(big.Int).SetUint64(1_000_000_000_000_000_000)},
+		},
+	}
+
+	data, err := json.Marshal(genesis)
+	require.NoError(t, err)
+	path := filepath.Join(t.TempDir(), "genesis.json")
+	require.NoError(t, os.WriteFile(path, data, 0o644))
+	return path
+}

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -9556,7 +9556,10 @@ dependencies = [
  "alloy-network 2.1.1",
  "alloy-primitives",
  "alloy-rpc-types-engine",
+ "alloy-rpc-types-eth 2.1.1",
  "alloy-signer-local 2.1.1",
+ "clap",
+ "jsonrpsee",
  "op-alloy-consensus",
  "op-alloy-rpc-types-engine",
  "op-revm",
@@ -9566,6 +9569,7 @@ dependencies = [
  "reth-db-common",
  "reth-evm",
  "reth-execution-types",
+ "reth-ipc",
  "reth-node-api",
  "reth-optimism-chainspec",
  "reth-optimism-evm",
@@ -9579,7 +9583,12 @@ dependencies = [
  "reth-revm",
  "reth-storage-api",
  "reth-trie",
+ "serde",
+ "serde_json",
  "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -391,6 +391,7 @@ reth-exex-test-utils = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef9
 reth-execution-errors = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1", default-features = false }
 reth-execution-types = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1", default-features = false }
 reth-fs-util = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1" }
+reth-ipc = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1" }
 reth-metrics = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1" }
 reth-network = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1" }
 reth-network-api = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1" }

--- a/rust/op-reth-test-engine/Cargo.toml
+++ b/rust/op-reth-test-engine/Cargo.toml
@@ -9,6 +9,10 @@ description = "Library-first, ephemeral, OP-flavored execution layer for op-e2e/
 [lints]
 workspace = true
 
+[[bin]]
+name = "op-reth-test-engine"
+path = "src/bin/op-reth-test-engine.rs"
+
 [dependencies]
 # op-reth
 reth-optimism-chainspec.workspace = true
@@ -36,12 +40,30 @@ reth-primitives-traits.workspace = true
 
 # ethereum / alloy / op-alloy
 alloy-genesis.workspace = true
-alloy-primitives.workspace = true
-alloy-consensus.workspace = true
-alloy-eips.workspace = true
-alloy-rpc-types-engine.workspace = true
-op-alloy-rpc-types-engine.workspace = true
+alloy-primitives = { workspace = true, features = ["serde"] }
+alloy-consensus = { workspace = true, features = ["serde"] }
+alloy-eips = { workspace = true, features = ["serde"] }
+alloy-rpc-types-engine = { workspace = true, features = ["serde"] }
+alloy-rpc-types-eth = { workspace = true, features = ["serde"] }
+op-alloy-rpc-types-engine = { workspace = true, features = ["serde"] }
 op-revm.workspace = true
+
+# rpc / transport / cli (used by the library RPC module and the binary)
+jsonrpsee.workspace = true
+reth-ipc.workspace = true
+tokio = { workspace = true, features = [
+  "rt-multi-thread",
+  "macros",
+  "signal",
+  "sync",
+  "net",
+  "time",
+] }
+serde.workspace = true
+serde_json.workspace = true
+clap = { workspace = true, features = ["derive"] }
+tracing = { workspace = true, features = ["std"] }
+tracing-subscriber = { workspace = true, features = ["std", "fmt", "env-filter"] }
 
 # errors
 thiserror.workspace = true

--- a/rust/op-reth-test-engine/src/bin/op-reth-test-engine.rs
+++ b/rust/op-reth-test-engine/src/bin/op-reth-test-engine.rs
@@ -1,0 +1,61 @@
+//! Unix-socket JSON-RPC server exposing one [`TestEngine`] over the `engine_*`, `eth_*`, and
+//! `optest_*` namespaces (reth-ipc, go-ethereum `rpc.DialIPC`-compatible).
+//!
+//! The engine is configured entirely from its genesis (the op-geth `core.Genesis` JSON that the Go
+//! action tests already build): the fork schedule, chain id, and predeploy state all come from
+//! there. Logging goes to stderr, which the Go harness drains.
+
+use std::sync::{Arc, Mutex};
+
+use alloy_genesis::Genesis;
+use clap::Parser;
+use op_reth_test_engine::{TestEngine, rpc::build_module};
+
+#[derive(Parser, Debug)]
+#[command(about = "Ephemeral OP execution engine for op-e2e/actions parity tests")]
+struct Args {
+    /// Unix socket path to listen on.
+    #[arg(long)]
+    socket: String,
+    /// Path to the op-geth `core.Genesis` JSON describing the chain (fork schedule, chain id,
+    /// allocation).
+    #[arg(long)]
+    genesis: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
+
+    let args = Args::parse();
+
+    let genesis_json = std::fs::read_to_string(&args.genesis)
+        .map_err(|e| format!("read genesis {}: {e}", args.genesis))?;
+    let genesis: Genesis =
+        serde_json::from_str(&genesis_json).map_err(|e| format!("parse genesis JSON: {e}"))?;
+    let engine = TestEngine::new(genesis).map_err(|e| format!("init engine: {e}"))?;
+    let module = build_module(Arc::new(Mutex::new(engine)));
+
+    // Fresh socket path each run (Go passes a unique tmp path); remove any stale file.
+    let _ = std::fs::remove_file(&args.socket);
+
+    let server = reth_ipc::server::Builder::default().build(args.socket.clone());
+    let handle = server.start(module).await?;
+    tracing::info!(socket = %args.socket, "op-reth-test-engine listening");
+    // A readiness line the Go harness can wait on (in addition to the socket appearing).
+    eprintln!("op-reth-test-engine: ready on {}", args.socket);
+
+    tokio::select! {
+        () = handle.clone().stopped() => {}
+        result = tokio::signal::ctrl_c() => {
+            result?;
+        }
+    }
+    Ok(())
+}

--- a/rust/op-reth-test-engine/src/chain.rs
+++ b/rust/op-reth-test-engine/src/chain.rs
@@ -112,6 +112,26 @@ impl EphemeralChain {
         Ok(self.provider.header(hash)?.map(|header| SealedHeader::new(header, hash)))
     }
 
+    /// The chain id.
+    pub fn chain_id(&self) -> u64 {
+        self.chain_spec.chain().id()
+    }
+
+    /// The sealed header of the current canonical head (the `latest` block).
+    pub fn latest_header(&self) -> SealedHeader {
+        self.provider.canonical_in_memory_state().get_canonical_head()
+    }
+
+    /// The sealed header of the current `safe` block, or `None` if unset.
+    pub fn safe_header(&self) -> Option<SealedHeader> {
+        self.provider.canonical_in_memory_state().get_safe_header()
+    }
+
+    /// The sealed header of the current `finalized` block, or `None` if unset.
+    pub fn finalized_header(&self) -> Option<SealedHeader> {
+        self.provider.canonical_in_memory_state().get_finalized_header()
+    }
+
     /// Assemble a block on top of `parent_hash` from `next_env` and `txs`, computing all roots.
     ///
     /// This drives reth's [`BlockBuilder`] end-to-end: it opens a fresh bundle state over the

--- a/rust/op-reth-test-engine/src/lib.rs
+++ b/rust/op-reth-test-engine/src/lib.rs
@@ -12,6 +12,7 @@
 mod builder;
 mod chain;
 mod exec;
+pub mod rpc;
 #[cfg(test)]
 mod testsupport;
 

--- a/rust/op-reth-test-engine/src/rpc.rs
+++ b/rust/op-reth-test-engine/src/rpc.rs
@@ -1,0 +1,243 @@
+//! JSON-RPC surface for the test engine, served over a Unix socket (reth-ipc, go-ethereum
+//! `rpc.DialIPC`-compatible — the #20415 transport) by the companion binary.
+//!
+//! Three namespaces mirror what `op-e2e/actions` drives against the in-process op-geth engine:
+//! `engine_*` (the versioned newPayload/forkchoiceUpdated/getPayload trio), read-only `eth_*`
+//! queries, and `optest_*` — the sequencing hooks (`includeTx`, `remainingBlockGas`,
+//! `forcedEmpty`, `setForceEmpty`) that replace the direct `L2EngineAPI` method calls.
+//!
+//! The engine's methods take `&mut self`, so the module context is an `Arc<Mutex<TestEngine>>`.
+//! Action tests are single-threaded, so the coarse lock is not a throughput concern; a poisoned
+//! lock is recovered rather than propagated so one failed request can't wedge the process.
+
+use std::sync::{Arc, Mutex};
+
+use alloy_eips::{eip2718::Encodable2718, eip7685::Requests};
+use alloy_primitives::{B256, Bytes, keccak256};
+use alloy_rpc_types_engine::{
+    CancunPayloadFields, ForkchoiceState, PayloadId, PraguePayloadFields,
+};
+use jsonrpsee::{RpcModule, types::ErrorObjectOwned};
+use op_alloy_rpc_types_engine::{
+    OpExecutionData, OpExecutionPayload, OpExecutionPayloadEnvelope, OpExecutionPayloadSidecar,
+    OpPayloadAttributes,
+};
+use reth_optimism_primitives::OpBlock;
+use serde_json::{Value, json};
+
+use crate::{IncludeTxOutcome, TestEngine};
+
+/// Shared, mutably-accessed engine behind the RPC module.
+pub type SharedEngine = Arc<Mutex<TestEngine>>;
+
+/// JSON-RPC error code for engine/execution errors (in go-ethereum's server error range).
+const ERR_CODE: i32 = -38000;
+
+fn rpc_err(msg: impl std::fmt::Display) -> ErrorObjectOwned {
+    ErrorObjectOwned::owned(ERR_CODE, msg.to_string(), None::<()>)
+}
+
+/// Lock the engine, recovering the guard if a previous handler panicked while holding it.
+fn lock(engine: &SharedEngine) -> std::sync::MutexGuard<'_, TestEngine> {
+    engine.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+/// Reconstruct an [`OpExecutionData`] from `engine_newPayload*` arguments.
+///
+/// The sidecar carries the fork-specific fields: pre-Ecotone payloads have none, Ecotone/Fjord/
+/// Granite/Holocene are v3 (Cancun beacon-root + blob versioned hashes), and Isthmus onward are v4
+/// (additionally the Prague execution requests).
+fn execution_data(
+    payload: OpExecutionPayload,
+    versioned_hashes: Vec<B256>,
+    parent_beacon_block_root: Option<B256>,
+    execution_requests: Vec<Bytes>,
+) -> OpExecutionData {
+    let sidecar =
+        parent_beacon_block_root.map_or_else(OpExecutionPayloadSidecar::default, |root| {
+            let cancun = CancunPayloadFields::new(root, versioned_hashes);
+            if matches!(payload, OpExecutionPayload::V4(_)) {
+                OpExecutionPayloadSidecar::v4(
+                    cancun,
+                    PraguePayloadFields::new(Requests::from_requests(execution_requests)),
+                )
+            } else {
+                OpExecutionPayloadSidecar::v3(cancun)
+            }
+        });
+    OpExecutionData::new(payload, sidecar)
+}
+
+/// Serialize an OP block as an `eth_getBlock*` result: the RPC header (which carries the block
+/// hash) plus the block's transaction hashes. Faithful enough for the chain-shape assertions the
+/// action tests make; full transaction objects are not needed by any caller yet.
+fn block_json(block: &OpBlock) -> Result<Value, ErrorObjectOwned> {
+    let header = alloy_rpc_types_eth::Header::new(block.header.clone());
+    let mut value = serde_json::to_value(&header).map_err(rpc_err)?;
+    let tx_hashes: Vec<B256> =
+        block.body.transactions.iter().map(|tx| keccak256(tx.encoded_2718())).collect();
+    if let Value::Object(map) = &mut value {
+        map.insert("transactions".into(), serde_json::to_value(tx_hashes).map_err(rpc_err)?);
+        map.insert("uncles".into(), json!([]));
+    }
+    Ok(value)
+}
+
+/// Resolve a block-number-or-tag string (`latest`/`safe`/`finalized`/`earliest`/`pending` or a
+/// `0x`-hex number) to a block, or `None` if unknown.
+fn resolve_block(engine: &TestEngine, tag: &str) -> Result<Option<OpBlock>, ErrorObjectOwned> {
+    let hash = match tag {
+        "latest" | "pending" => Some(engine.chain.latest_header().hash()),
+        "safe" => engine.chain.safe_header().map(|h| h.hash()),
+        "finalized" => engine.chain.finalized_header().map(|h| h.hash()),
+        "earliest" => return engine.block_by_number(0).map_err(rpc_err),
+        num => {
+            let n = u64::from_str_radix(num.trim_start_matches("0x"), 16)
+                .map_err(|e| rpc_err(format!("invalid block number {num:?}: {e}")))?;
+            return engine.block_by_number(n).map_err(rpc_err);
+        }
+    };
+    hash.map_or_else(|| Ok(None), |hash| engine.block_by_hash(hash).map_err(rpc_err))
+}
+
+/// Encode a `u64` as a `0x`-prefixed hex quantity — the JSON form `eth_*` numeric results use.
+fn quantity(n: u64) -> Value {
+    Value::String(format!("0x{n:x}"))
+}
+
+/// Build the JSON-RPC module serving `engine_*`, `eth_*`, and `optest_*` over `engine`.
+pub fn build_module(engine: SharedEngine) -> RpcModule<SharedEngine> {
+    let mut m = RpcModule::new(engine);
+
+    // --- engine_ ---
+
+    let register_fcu = |m: &mut RpcModule<SharedEngine>, name: &'static str| {
+        m.register_method(name, |params, ctx, _| {
+            let (state, attrs): (ForkchoiceState, Option<OpPayloadAttributes>) =
+                params.parse().map_err(rpc_err)?;
+            let updated = lock(ctx).forkchoice_updated(state, attrs).map_err(rpc_err)?;
+            serde_json::to_value(updated).map_err(rpc_err)
+        })
+        .expect("register method");
+    };
+    register_fcu(&mut m, "engine_forkchoiceUpdatedV1");
+    register_fcu(&mut m, "engine_forkchoiceUpdatedV2");
+    register_fcu(&mut m, "engine_forkchoiceUpdatedV3");
+
+    let register_get_payload = |m: &mut RpcModule<SharedEngine>, name: &'static str| {
+        m.register_method(name, |params, ctx, _| {
+            let id: PayloadId = params.one().map_err(rpc_err)?;
+            let data = lock(ctx).get_payload(id).map_err(rpc_err)?;
+            let envelope = OpExecutionPayloadEnvelope::try_from(data).map_err(rpc_err)?;
+            serde_json::to_value(envelope).map_err(rpc_err)
+        })
+        .expect("register method");
+    };
+    register_get_payload(&mut m, "engine_getPayloadV2");
+    register_get_payload(&mut m, "engine_getPayloadV3");
+    register_get_payload(&mut m, "engine_getPayloadV4");
+
+    m.register_method("engine_newPayloadV2", |params, ctx, _| {
+        let payload: OpExecutionPayload = params.one().map_err(rpc_err)?;
+        let data = execution_data(payload, Vec::new(), None, Vec::new());
+        let status = lock(ctx).new_payload(data).map_err(rpc_err)?;
+        serde_json::to_value(status).map_err(rpc_err)
+    })
+    .expect("register method");
+
+    m.register_method("engine_newPayloadV3", |params, ctx, _| {
+        let (payload, versioned_hashes, beacon_root): (
+            OpExecutionPayload,
+            Vec<B256>,
+            Option<B256>,
+        ) = params.parse().map_err(rpc_err)?;
+        let data = execution_data(payload, versioned_hashes, beacon_root, Vec::new());
+        let status = lock(ctx).new_payload(data).map_err(rpc_err)?;
+        serde_json::to_value(status).map_err(rpc_err)
+    })
+    .expect("register method");
+
+    m.register_method("engine_newPayloadV4", |params, ctx, _| {
+        let (payload, versioned_hashes, beacon_root, execution_requests): (
+            OpExecutionPayload,
+            Vec<B256>,
+            Option<B256>,
+            Vec<Bytes>,
+        ) = params.parse().map_err(rpc_err)?;
+        let data = execution_data(payload, versioned_hashes, beacon_root, execution_requests);
+        let status = lock(ctx).new_payload(data).map_err(rpc_err)?;
+        serde_json::to_value(status).map_err(rpc_err)
+    })
+    .expect("register method");
+
+    // --- optest_ ---
+
+    m.register_method("optest_includeTx", |params, ctx, _| {
+        let raw: Bytes = params.one().map_err(rpc_err)?;
+        let value = match lock(ctx).include_tx(None, raw.as_ref()).map_err(rpc_err)? {
+            IncludeTxOutcome::Included { tx_hash, gas_used } => {
+                json!({ "txHash": tx_hash, "gasUsed": gas_used })
+            }
+            // Force-empty dropped the tx (op-geth returns nil, nil); the caller treats null as "not
+            // included".
+            IncludeTxOutcome::Skipped => Value::Null,
+        };
+        Ok::<Value, ErrorObjectOwned>(value)
+    })
+    .expect("register method");
+
+    m.register_method("optest_remainingBlockGas", |_params, ctx, _| {
+        Ok::<_, ErrorObjectOwned>(Value::from(lock(ctx).remaining_block_gas(None)))
+    })
+    .expect("register method");
+
+    m.register_method("optest_forcedEmpty", |_params, ctx, _| {
+        Ok::<_, ErrorObjectOwned>(Value::from(lock(ctx).forced_empty(None)))
+    })
+    .expect("register method");
+
+    m.register_method("optest_setForceEmpty", |params, ctx, _| {
+        let value: bool = params.one().map_err(rpc_err)?;
+        lock(ctx).set_force_empty(None, value).map_err(rpc_err)?;
+        Ok::<Value, ErrorObjectOwned>(Value::Bool(true))
+    })
+    .expect("register method");
+
+    // --- eth_ ---
+
+    m.register_method("eth_chainId", |_params, ctx, _| {
+        Ok::<_, ErrorObjectOwned>(quantity(lock(ctx).chain.chain_id()))
+    })
+    .expect("register method");
+
+    m.register_method("eth_blockNumber", |_params, ctx, _| {
+        Ok::<_, ErrorObjectOwned>(quantity(lock(ctx).chain.latest_header().number))
+    })
+    .expect("register method");
+
+    m.register_method("eth_getBlockByNumber", |params, ctx, _| {
+        // Second param (full-transactions) is accepted for compatibility but ignored: results
+        // always carry transaction hashes.
+        let (tag, _full): (String, Option<bool>) = params.parse().map_err(rpc_err)?;
+        let engine = lock(ctx);
+        let value = match resolve_block(&engine, &tag)? {
+            Some(block) => block_json(&block)?,
+            None => Value::Null,
+        };
+        Ok::<Value, ErrorObjectOwned>(value)
+    })
+    .expect("register method");
+
+    m.register_method("eth_getBlockByHash", |params, ctx, _| {
+        let (hash, _full): (B256, Option<bool>) = params.parse().map_err(rpc_err)?;
+        let engine = lock(ctx);
+        let value = match engine.block_by_hash(hash).map_err(rpc_err)? {
+            Some(block) => block_json(&block)?,
+            None => Value::Null,
+        };
+        Ok::<Value, ErrorObjectOwned>(value)
+    })
+    .expect("register method");
+
+    m
+}


### PR DESCRIPTION
Splits the IPC boundary out of #21242: the engine crate gains a Unix-domain-socket JSON-RPC server (the `op-reth-test-engine` binary), and `op-service/engineipc` provides the shared Go client that owns the socket lifecycle, spawns the child with a death signal, drains its stderr, and dials it. A smoke test drives a two-block chain over the socket (forkchoiceUpdated-with-attrs → includeTx → getPayload → newPayload → forkchoiceUpdated).

CI: `rust-op-reth-binary` builds and persists the engine binary; `go-tests` arms `REQUIRE_RUST_ENGINE` so a missing binary fails the smoke test loudly instead of silently falling back to a local cargo build.

Part of #21196 (Go side) and #20415 (engine design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
