### PR TITLE
op-acceptance-tests: stabilize Lagoon boundary test

### DIFF
--- a/op-acceptance-tests/tests/sdm/boundary_test.go
+++ b/op-acceptance-tests/tests/sdm/boundary_test.go
@@ -2,6 +2,7 @@ package sdm
 
 import (
 	"testing"
+	"time"
 
 	"github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/sdm/sdmtest"
 	sdmpkg "github.com/ethereum-optimism/optimism/op-chain-ops/pkg/sdm"
@@ -26,6 +27,7 @@ func TestSDMPostExecSpanCrossesInteropBoundary(gt *testing.T) {
 	sys := newSDMRethSystemWithLagoonOffset(t, &offset, withCrossActivationSpanBatcher)
 	sdmtest.VerifySDMFixture(t, sys.L2EL)
 	sdmtest.VerifyOpReth(t, sys.L2ELVerifier)
+	sys.L2CL.StartSequencer()
 
 	activationBlock := sys.L2Network.AwaitActivation(t, forks.Lagoon)
 	activationRef := sys.L2EL.BlockRefByNumber(activationBlock.Number)
@@ -78,11 +80,23 @@ func TestSDMActivatesAtLagoonBoundary(gt *testing.T) {
 	t.Require().False(sys.L2Network.IsForkActive(forks.Lagoon),
 		"Lagoon must not be active yet at the start of the boundary test")
 
-	// Phase 1: pre-Lagoon workload. We may need a few attempts to land the densest
-	// block before the activation timestamp; sdmtest.MustFindRepeatedSlotBlock retries
-	// internally and sdmpkg.FindPostExecTransaction tolerates absence.
-	preBlock, preIncluded, preBlockNum := sdmtest.MustFindRepeatedSlotBlock(t, sys, 2, 3)
-	t.Require().GreaterOrEqual(len(preIncluded), 2, "pre-Lagoon target block must contain user txs")
+	// Phase 1: queue funding transactions while sequencing is stopped. Waiting for both to enter
+	// the mempool before starting the sequencer guarantees they land in block 1, independently of
+	// how much wall-clock time system setup consumed.
+	const preUserTxCount = 2
+	fundedUsersCh := make(chan []*dsl.EOA, 1)
+	go func() {
+		defer close(fundedUsersCh)
+		fundedUsersCh <- sys.FunderL2.NewFundedEOAs(preUserTxCount, eth.OneEther)
+	}()
+	sys.L2EL.WaitForPendingNonceMatch(sys.FunderL2.Address(), preUserTxCount, 100, 100*time.Millisecond)
+	sys.L2CL.StartSequencer()
+	t.Require().Len(<-fundedUsersCh, preUserTxCount, "pre-Lagoon users must be funded")
+
+	const preBlockNum = 1
+	preBlock := sdmtest.GetBlockWithTxs(t, sys.L2EL, preBlockNum)
+	t.Require().GreaterOrEqual(len(preBlock.Transactions), preUserTxCount+1,
+		"pre-Lagoon block must contain the L1-info deposit and funding transactions")
 	preRef := sys.L2EL.BlockRefByNumber(preBlockNum)
 	t.Require().False(sys.L2Network.IsForkActiveAt(forks.Lagoon, preRef.Time),
 		"pre-Lagoon workload block %d (ts=%d) must land before Lagoon activation",

--- a/op-acceptance-tests/tests/sdm/init_test.go
+++ b/op-acceptance-tests/tests/sdm/init_test.go
@@ -19,11 +19,11 @@ func newSDMRethSystemWithBatcherOptions(t devtest.T, sdmEnabled bool, batcherOpt
 	// SDM rides the Lagoon hardfork. The stock constructor covers the disabled and
 	// null-policy regressions while still provisioning the dependency set required
 	// whenever Lagoon is scheduled.
-	return buildSDMRethSystem(t, sdmEnabled, false, false, nil, batcherOpts...)
+	return buildSDMRethSystem(t, sdmEnabled, false, false, false, nil, batcherOpts...)
 }
 
 func newFixtureSDMRethSystem(t devtest.T, batcherOpts ...sysgo.BatcherOption) *sdmtest.RethSystem {
-	return buildSDMRethSystem(t, true, true, false, nil, batcherOpts...)
+	return buildSDMRethSystem(t, true, true, false, false, nil, batcherOpts...)
 }
 
 // newSDMRethSystemWithIsolatedVerifier builds the SDM system (Interop/SDM at genesis) with the
@@ -42,7 +42,7 @@ func newSDMRethSystemWithIsolatedVerifier(t devtest.T) *sdmtest.RethSystem {
 	if sysgo.ResolveMixedL2CLKind() == sysgo.MixedL2CLKona {
 		t.Skip("isolated-verifier force-build path is not supported by kona-node (no L1-only EL-sync bootstrap); op-node only")
 	}
-	return buildSDMRethSystem(t, true, true, true, nil)
+	return buildSDMRethSystem(t, true, true, true, false, nil)
 }
 
 // newSDMRethSystemWithLagoonOffset builds the SDM system with Lagoon scheduled at the given
@@ -64,9 +64,9 @@ func newSDMRethSystemWithLagoonOffset(
 				l2Cfg.WithForkAtOffset(forks.Lagoon, &offset)
 			}
 		})
-		return buildSDMRethSystem(t, true, true, false, deployerOpts, batcherOpts...)
+		return buildSDMRethSystem(t, true, true, false, true, deployerOpts, batcherOpts...)
 	}
-	return buildSDMRethSystem(t, false, true, false, deployerOpts, batcherOpts...)
+	return buildSDMRethSystem(t, false, true, false, false, deployerOpts, batcherOpts...)
 }
 
 func buildSDMRethSystem(
@@ -74,6 +74,7 @@ func buildSDMRethSystem(
 	interopAtGenesis bool,
 	fixtureSequencer bool,
 	isolateVerifier bool,
+	sequencerStopped bool,
 	deployerOpts []sysgo.DeployerOption,
 	batcherOpts ...sysgo.BatcherOption,
 ) *sdmtest.RethSystem {
@@ -108,12 +109,13 @@ func buildSDMRethSystem(
 	runtime := sysgo.NewMixedSingleChainRuntime(t, sysgo.MixedSingleChainPresetConfig{
 		NodeSpecs: []sysgo.MixedSingleChainNodeSpec{
 			{
-				ELKey:       sequencerKey,
-				CLKey:       "sequencer",
-				ELKind:      sysgo.MixedL2ELOpReth,
-				CLKind:      clKind,
-				IsSequencer: true,
-				OpRethOpts:  sequencerOpts,
+				ELKey:            sequencerKey,
+				CLKey:            "sequencer",
+				ELKind:           sysgo.MixedL2ELOpReth,
+				CLKind:           clKind,
+				IsSequencer:      true,
+				SequencerStopped: sequencerStopped,
+				OpRethOpts:       sequencerOpts,
 			},
 			{
 				ELKey:            "verifier-op-reth",

--- a/op-devstack/sysgo/mixed_runtime.go
+++ b/op-devstack/sysgo/mixed_runtime.go
@@ -172,6 +172,9 @@ type MixedSingleChainNodeSpec struct {
 	ELKind      MixedL2ELKind
 	CLKind      MixedL2CLKind
 	IsSequencer bool
+	// SequencerStopped starts a sequencer node paused so tests can populate its mempool before
+	// the first L2 block. It has no effect on verifier nodes.
+	SequencerStopped bool
 	// IsolateFromL2P2P keeps this node off the L2 CL/EL P2P mesh: it is never peered with the
 	// other nodes, so it receives no gossiped or req-resp'd unsafe blocks and must advance purely
 	// by deriving from L1. Used to exercise the derivation/force-build path (FCU-with-attributes)
@@ -269,11 +272,12 @@ func NewMixedSingleChainRuntime(t devtest.T, cfg MixedSingleChainPresetConfig) *
 		switch spec.CLKind {
 		case MixedL2CLOpNode:
 			cl = startL2CLNode(t, keys, l1Net, l2Net, l1EL, l1CL, el, jwtSecret, l2CLNodeStartConfig{
-				Key:           spec.CLKey,
-				IsSequencer:   spec.IsSequencer,
-				NoDiscovery:   true,
-				EnableReqResp: true,
-				DependencySet: depSet,
+				Key:              spec.CLKey,
+				IsSequencer:      spec.IsSequencer,
+				NoDiscovery:      true,
+				EnableReqResp:    true,
+				DependencySet:    depSet,
+				SequencerStopped: spec.SequencerStopped,
 			})
 		case MixedL2CLKona:
 			cl = startMixedKonaNode(
@@ -287,6 +291,7 @@ func NewMixedSingleChainRuntime(t devtest.T, cfg MixedSingleChainPresetConfig) *
 				spec.CLKey,
 				spec.ELKey,
 				spec.IsSequencer,
+				spec.SequencerStopped,
 				depSet,
 			)
 		default:
@@ -551,6 +556,7 @@ func startMixedKonaNode(
 	clKey string,
 	elKey string,
 	isSequencer bool,
+	sequencerStopped bool,
 	depSet coredepset.DependencySet,
 ) *KonaNode {
 	tempKonaDir := t.TempDirWithPrefix("l2-cl-kona-" + NewComponentTarget(clKey, l2Net.ChainID()).String())
@@ -611,6 +617,9 @@ func startMixedKonaNode(
 			"KONA_NODE_SEQUENCER_L1_CONFS=2",
 			"KONA_NODE_MODE=Sequencer",
 		)
+		if sequencerStopped {
+			envVars = append(envVars, "KONA_NODE_SEQUENCER_STOPPED=true")
+		}
 	} else {
 		envVars = append(envVars, "KONA_NODE_MODE=Validator")
 	}

--- a/op-devstack/sysgo/singlechain_build.go
+++ b/op-devstack/sysgo/singlechain_build.go
@@ -168,7 +168,7 @@ func startL2CLForKey(
 ) L2CLNode {
 	switch devstackL2CLKind() {
 	case MixedL2CLKona:
-		return startMixedKonaNode(t, keys, l1Net, l2Net, l1EL, l1CL, l2EL, clKey, elKey, isSequencer, nil)
+		return startMixedKonaNode(t, keys, l1Net, l2Net, l1EL, l1CL, l2EL, clKey, elKey, isSequencer, false, nil)
 	default: // op-node
 		return startL2CLNode(t, keys, l1Net, l2Net, l1EL, l1CL, l2EL, jwtSecret, l2CLNodeStartConfig{
 			Key:            clKey,


### PR DESCRIPTION
## Summary

- expose the existing stopped-sequencer setting through mixed single-chain node specifications for op-node and kona-node
- start future-Lagoon SDM boundary systems with sequencing paused
- queue a deterministic pre-Lagoon workload before starting sequencing, and explicitly start the neighboring cross-activation test

## Root cause

`TestSDMActivatesAtLagoonBoundary` schedules Lagoon 30 seconds after L2 genesis, but genesis time is captured before the expensive system setup. The sequencer previously started while setup was still running and caught synthetic L2 timestamps up to wall clock.

In the observed failure, genesis was `1787326838`, Lagoon was `1787326868`, and block 15 at the activation timestamp was sealed before setup returned. The initial `IsForkActive` assertion therefore correctly observed Lagoon as active. Variable process-start and setup latency made this intermittent.

The immediately preceding run of the same eight-shard job passed. CircleCI Insights had not yet indexed the test when the tracking issue was created; one failure has been directly observed.

## Fix

The future-Lagoon test systems now start their sequencer paused. `TestSDMActivatesAtLagoonBoundary` submits two funding transactions from the existing genesis-prefunded account, waits until pending nonce `2` proves that contiguous nonces `0` and `1` are queued, and only then starts sequencing.

Both transactions are therefore eligible for block 1 at genesis plus two seconds, structurally guaranteeing a pre-Lagoon workload regardless of setup duration. The sequencer can catch up only after block 1 has been produced; increasing the 30-second offset or adding sleeps is unnecessary.

The mixed-runtime option maps to the existing op-node `SequencerStopped` setting and Kona `KONA_NODE_SEQUENCER_STOPPED` flag. Defaults remain unchanged for other callers.

## Validation

A temporary setup-delay hook reproduced the original assertion deterministically and was removed before commit:

- baseline: 2/2 failed at `Lagoon must not be active yet at the start of the boundary test`
- fixed: 2/2 passed under the same forced delay

Focused checks:

```text
RUST_JIT_BUILD=1 mise exec -- just test -count=1 -run "^(TestSDMActivatesAtLagoonBoundary|TestSDMPostExecSpanCrossesInteropBoundary)$" ./op-acceptance-tests/tests/sdm
RUST_JIT_BUILD=1 DEVSTACK_L2CL_KIND=kona-node mise exec -- just test -count=1 -run "^TestSDMActivatesAtLagoonBoundary$" ./op-acceptance-tests/tests/sdm
mise exec -- just lint-go
```

All passed. Independent Go review and adversarial root-cause review approved the change. Security review remains required before marking this draft ready.

Closes #22630