### PR TITLE
kona-sp1: raise SPN auction defaults so requests draw bids

### DIFF
--- a/rust/kona/sp1/README.md
+++ b/rust/kona/sp1/README.md
@@ -243,13 +243,20 @@ SP1 network configuration applies when `KONA_SP1_PROPOSER_PROOF_PROVIDER=network
 | `KONA_SP1_PROPOSER_AGG_PROOF_STRATEGY` | aggregation fulfillment strategy (default `auction`) |
 | `KONA_SP1_PROPOSER_SP1_TIMEOUT_SECONDS` | overall proof timeout (default `14400`) |
 | `KONA_SP1_PROPOSER_NETWORK_CALLS_TIMEOUT` | individual network-call timeout (default `15`) |
-| `KONA_SP1_PROPOSER_AUCTION_TIMEOUT` | unassigned mainnet request timeout (default `60`) |
+| `KONA_SP1_PROPOSER_AUCTION_TIMEOUT` | unassigned mainnet request timeout (default `300`) |
 | `KONA_SP1_PROPOSER_RANGE_CYCLE_LIMIT` | range request cycle limit (default `1e12`) |
 | `KONA_SP1_PROPOSER_RANGE_GAS_LIMIT` | range request gas limit (default `1e12`) |
 | `KONA_SP1_PROPOSER_AGG_CYCLE_LIMIT` | aggregation request cycle limit (default `1e12`) |
 | `KONA_SP1_PROPOSER_AGG_GAS_LIMIT` | aggregation request gas limit (default `1e12`) |
-| `KONA_SP1_PROPOSER_MAX_PRICE_PER_PGU` | maximum price per proving gas unit (default `3e8`) |
-| `KONA_SP1_PROPOSER_MIN_AUCTION_PERIOD` | minimum auction period in seconds (default `1`) |
+| `KONA_SP1_PROPOSER_MAX_PRICE_PER_PGU` | maximum price per proving gas unit (default `1e9`, i.e. 1.0 PROVE per billion PGU) |
+| `KONA_SP1_PROPOSER_MIN_AUCTION_PERIOD` | minimum auction period in seconds (default `30`) |
+
+`MAX_PRICE_PER_PGU` is a ceiling, not the price paid: the auction settles at the
+winning bid, which tracks the network's clearing price. A ceiling *below* that
+price leaves a request unbid until its deadline, since nothing re-auctions it.
+`MIN_AUCTION_PERIOD` is a floor every request waits out, so it needs to cover bid
+arrival (3-10s) and no more, and must stay under `AUCTION_TIMEOUT` — which is
+generous because cancelling discards the whole defense task's witness work.
 
 Transaction signing requires one of these configurations:
 

--- a/rust/kona/sp1/crates/proposer/src/config.rs
+++ b/rust/kona/sp1/crates/proposer/src/config.rs
@@ -307,6 +307,25 @@ fn parse_url_list(value: &str) -> Result<Vec<Url>> {
 
 const DEFAULT_PROOF_LIMIT: u64 = 1_000_000_000_000;
 
+/// Ceiling for one request, in wei of PROVE per PGU (1e9 = 1.0 PROVE per bPGU).
+/// A ceiling under the network's clearing price draws no bids at all, and that
+/// price moves, so this sits well above it rather than near it.
+const DEFAULT_MAX_PRICE_PER_PGU: u64 = 1_000_000_000;
+
+/// Floor on how long an auction stays open, so the field can bid and undercut
+/// rather than the fastest poller winning at the ceiling. Observed arrivals are
+/// 3-10s, on other requesters' traffic; this doubles that for margin, at the
+/// cost of ~90s per defense (range, consolidation and agg wait it out in turn).
+const DEFAULT_MIN_AUCTION_PERIOD_SECONDS: u64 = 30;
+
+/// Grace for an unassigned request. Cancelling fails the whole defense task and
+/// discards every chunk's witness work, so waiting beats restarting.
+const DEFAULT_AUCTION_TIMEOUT_SECONDS: u64 = 300;
+
+/// Room between an auction closing and its request being cancelled: the
+/// auctioneer still has to assign the winner, and the proposer to observe it.
+const AUCTION_ASSIGNMENT_MARGIN_SECONDS: u64 = 30;
+
 /// SP1 proof-provider settings (timeouts, strategies, limits, prices).
 ///
 /// Parsed in mock mode too, but all values have defaults and require no credentials.
@@ -356,10 +375,20 @@ impl ProofProviderConfig {
             "{} must be positive: 0 would time out every SPN call before any I/O completes",
             env_var("NETWORK_CALLS_TIMEOUT")
         );
-        let auction_timeout = parsed_env_or("AUCTION_TIMEOUT", 60u64)?;
+        let auction_timeout = parsed_env_or("AUCTION_TIMEOUT", DEFAULT_AUCTION_TIMEOUT_SECONDS)?;
         anyhow::ensure!(
             auction_timeout > 0,
             "{} must be positive: 0 would cancel every mainnet request by its second poll",
+            env_var("AUCTION_TIMEOUT")
+        );
+        let min_auction_period =
+            parsed_env_or("MIN_AUCTION_PERIOD", DEFAULT_MIN_AUCTION_PERIOD_SECONDS)?;
+        anyhow::ensure!(
+            min_auction_period + AUCTION_ASSIGNMENT_MARGIN_SECONDS <= auction_timeout,
+            "{} ({min_auction_period}s) must leave {AUCTION_ASSIGNMENT_MARGIN_SECONDS}s under {} \
+             ({auction_timeout}s): requests would be cancelled before a closing auction could be \
+             assigned",
+            env_var("MIN_AUCTION_PERIOD"),
             env_var("AUCTION_TIMEOUT")
         );
         Ok(Self {
@@ -377,8 +406,8 @@ impl ProofProviderConfig {
             range_gas_limit: parsed_env_or("RANGE_GAS_LIMIT", DEFAULT_PROOF_LIMIT)?,
             agg_cycle_limit: parsed_env_or("AGG_CYCLE_LIMIT", DEFAULT_PROOF_LIMIT)?,
             agg_gas_limit: parsed_env_or("AGG_GAS_LIMIT", DEFAULT_PROOF_LIMIT)?,
-            max_price_per_pgu: parsed_env_or("MAX_PRICE_PER_PGU", 300_000_000u64)?,
-            min_auction_period: parsed_env_or("MIN_AUCTION_PERIOD", 1u64)?,
+            max_price_per_pgu: parsed_env_or("MAX_PRICE_PER_PGU", DEFAULT_MAX_PRICE_PER_PGU)?,
+            min_auction_period,
         })
     }
 }
@@ -725,6 +754,24 @@ mod tests {
             // Degenerate spans are rejected.
             assert!(RangeSplitCount::one().split(5, 5).is_err());
             assert!(RangeSplitCount::one().split(6, 5).is_err());
+        }
+
+        /// Safe under nextest's process-per-test model; environment mutation
+        /// is `unsafe` on edition 2024.
+        #[test]
+        fn auction_period_crowding_the_cancel_timeout_is_rejected() {
+            // Otherwise requests are cancelled around the moment their auction
+            // closes, discarding a whole defense task's witness work each time.
+            set_proposer_env("AUCTION_TIMEOUT", "300");
+            for crowding in ["300", "290"] {
+                set_proposer_env("MIN_AUCTION_PERIOD", crowding);
+                let err = ProofProviderConfig::from_env().unwrap_err().to_string();
+                assert!(err.contains("KONA_SP1_PROPOSER_MIN_AUCTION_PERIOD"), "unexpected: {err}");
+                assert!(err.contains("KONA_SP1_PROPOSER_AUCTION_TIMEOUT"), "unexpected: {err}");
+            }
+
+            set_proposer_env("MIN_AUCTION_PERIOD", "270");
+            assert_eq!(ProofProviderConfig::from_env().unwrap().min_auction_period, 270);
         }
 
         /// Safe under nextest's process-per-test model; environment mutation


### PR DESCRIPTION
A production proof request sat unfulfilled for hours on 2026-08-21 with **zero bids**. The price ceiling defaulted to `3e8` (0.3 PROVE per billion PGU) while the network's published clearing price was ~0.69, so provers took better-paid work — and nothing re-auctions a request that draws no bids, so it idled until its deadline while the proposer submitted nothing further.

The ceiling is not the price paid: the auction settles at the winning bid, which tracks the clearing price. Another requester on the network paid 0.69 with a 0.828 ceiling, bid by the same provers who bid *our* ceiling exactly while it sat below market. Headroom above the market is close to free where there is competition to undercut.

## Changes

- **`MAX_PRICE_PER_PGU` `3e8` → `1e9`** — ordinary market movement no longer strands requests.
- **`MIN_AUCTION_PERIOD` `1` → `30`** — bids arrive +3–4s with stragglers at +10s, so a 1-second window closed the auction before most of the field could bid and undercut. Other production requesters use 15; 30 doubles the observed arrival window for margin, since our own arrival distribution is unmeasured (at a below-market price only one operator ever bid). It costs ~90s per defense, as range, consolidation and aggregation each wait out the floor in turn.
- **`AUCTION_TIMEOUT` `60` → `300`** — cancelling fails the whole defense task and discards the witness generation and stdin upload behind every chunk of that game, so waiting out a transient supply gap beats restarting from scratch.
- **New parse-time check** that `min_auction_period + 30s <= auction_timeout`. `check_auction` cancels any request still `Requested` at `created_at + auction_timeout`, so a deployment setting the window near or above the timeout would cancel requests around the moment their auctions closed, burning a defense task's witness work every time.

## Notes for reviewers

- **This is not a porting regression.** Upstream `succinctlabs/op-succinct` carries the same static-ceiling design and the same `3e8`/`1` defaults, and calls `GetMarketPricePerPgu` nowhere. The design drifts against a moving market by construction, so these values will need revisiting; pricing each request off the published clearing price would remove the drift entirely and is worth doing separately — including upstream, where every operator inherits the same gap.
- **Worst-case spend per request rises.** `max_price_per_pgu × range_gas_limit` (`1e12`) moves the bound from ~300 to ~1000 PROVE. That bound is only reached if a request both consumes its full gas limit and clears at the ceiling; expected cost tracks the clearing price and the actual gas used (~63 bPGU, so ~44 PROVE at 0.69).
- **Deployments that pin any of these three env vars override these defaults** and will keep stalling. Inventories setting them need updating alongside this change; netchef reserves none of the three, so they are settable from `spec.values.env`.
- **Unexplained, and not fixed here:** the stuck request should have been cancelled and retried within 60s by the existing `AUCTION_TIMEOUT` path, and wasn't — it stayed `REQUESTED` for hours with nothing behind it. Either that deployment overrides the timeout, the proposer stopped polling, or `cancel_request` failed silently. These defaults make a stall less likely; they do not explain why the recovery path was silent, which still needs investigating.