### PR TITLE
op-challenger: read interop game inputs status from superroot_atTimestamp

### DIFF
--- a/op-challenger/runner/game_inputs.go
+++ b/op-challenger/runner/game_inputs.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math/big"
 	"math/rand/v2"
+	"time"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/super"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/utils"
@@ -28,13 +29,13 @@ const (
 	disputeL1OffsetBlocks = uint64(7 * 24 * 60 * 60 / 12)  // 50400
 )
 
-func createGameInputs(ctx context.Context, log log.Logger, rollupClient *sources.RollupClient, superNodeClient *sources.SuperNodeClient, l1Client *ethclient.Client, typeName string, gameType gameTypes.GameType, ageGameInputs bool) (utils.LocalGameInputs, error) {
+func createGameInputs(ctx context.Context, log log.Logger, rollupClient *sources.RollupClient, superRoots super.SuperNodeRootProvider, l1Client *ethclient.Client, typeName string, gameType gameTypes.GameType, ageGameInputs bool) (utils.LocalGameInputs, error) {
 	switch gameType {
 	case gameTypes.SuperCannonKonaGameType:
-		if superNodeClient == nil {
+		if superRoots == nil {
 			return utils.LocalGameInputs{}, fmt.Errorf("game type %s requires super root RPC to be set", gameType)
 		}
-		return createGameInputsInterop(ctx, log, superNodeClient, typeName)
+		return createGameInputsInterop(ctx, log, superRoots, typeName)
 	default:
 		if rollupClient == nil {
 			return utils.LocalGameInputs{}, fmt.Errorf("game type %s requires rollup rpc to be set", gameType)
@@ -164,14 +165,18 @@ func hasNonZeroSafeHead(ctx context.Context, client *sources.RollupClient, l1Num
 	return safeHead.SafeHead.Number > 0, nil
 }
 
-func createGameInputsInterop(ctx context.Context, log log.Logger, client *sources.SuperNodeClient, typeName string) (utils.LocalGameInputs, error) {
-	status, err := client.SyncStatus(ctx)
+func createGameInputsInterop(ctx context.Context, log log.Logger, client super.SuperNodeRootProvider, typeName string) (utils.LocalGameInputs, error) {
+	// superroot_atTimestamp carries the same finalized timestamp and L1 head as
+	// supernode_syncStatus, and is served by op-supernode and by op-node (which has no
+	// supernode namespace), so a single-chain rollup can be its own super root source.
+	// A timestamp past the head omits chain data but still reports both fields.
+	status, err := client.SuperRootAtTimestamp(ctx, uint64(time.Now().Unix()))
 	if err != nil {
-		return utils.LocalGameInputs{}, fmt.Errorf("failed to get super root RPC sync status: %w", err)
+		return utils.LocalGameInputs{}, fmt.Errorf("failed to get super root status: %w", err)
 	}
-	log.Info("Got sync status", "status", status, "type", typeName)
+	log.Info("Got super root status", "status", status, "type", typeName)
 
-	claimTimestamp := status.FinalizedTimestamp
+	claimTimestamp := status.CurrentFinalizedTimestamp
 	agreedTimestamp := claimTimestamp - 1
 	if claimTimestamp == 0 {
 		return utils.LocalGameInputs{}, errors.New("finalized timestamp is 0")

--- a/op-challenger/runner/game_inputs_test.go
+++ b/op-challenger/runner/game_inputs_test.go
@@ -1,0 +1,93 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+)
+
+type stubSuperRootProvider struct {
+	resp      eth.SuperRootAtTimestampResponse
+	err       error
+	requested []uint64
+}
+
+func (s *stubSuperRootProvider) SuperRootAtTimestamp(_ context.Context, timestamp uint64) (eth.SuperRootAtTimestampResponse, error) {
+	s.requested = append(s.requested, timestamp)
+	return s.resp, s.err
+}
+
+// Interop inputs come from superroot_atTimestamp, which op-node serves for single-chain
+// rollups, rather than the supernode-only supernode_syncStatus.
+func TestCreateGameInputsInteropReadsStatusFromSuperRoot(t *testing.T) {
+	logger := testlog.Logger(t, log.LvlInfo)
+	before := uint64(time.Now().Unix())
+	client := &stubSuperRootProvider{resp: eth.SuperRootAtTimestampResponse{
+		CurrentFinalizedTimestamp: 0, // stop before any trace work
+		CurrentL1:                 eth.BlockID{Number: 100, Hash: common.Hash{0xaa}},
+	}}
+
+	_, err := createGameInputsInterop(context.Background(), logger, client, "test")
+	require.ErrorContains(t, err, "finalized timestamp is 0")
+
+	require.Len(t, client.requested, 1, "should read status with a single super root call")
+	require.GreaterOrEqual(t, client.requested[0], before, "should request the current timestamp")
+}
+
+func TestCreateGameInputsInteropStatusFailure(t *testing.T) {
+	logger := testlog.Logger(t, log.LvlInfo)
+	boom := errors.New("boom")
+	client := &stubSuperRootProvider{err: boom}
+
+	_, err := createGameInputsInterop(context.Background(), logger, client, "test")
+	require.ErrorIs(t, err, boom)
+	require.ErrorContains(t, err, "super root status")
+}
+
+// A finalized timestamp of zero means nothing is finalized yet: there is no super root to
+// dispute, and claimTimestamp-1 would underflow.
+func TestCreateGameInputsInteropRejectsZeroFinalizedTimestamp(t *testing.T) {
+	logger := testlog.Logger(t, log.LvlInfo)
+	client := &stubSuperRootProvider{resp: eth.SuperRootAtTimestampResponse{
+		CurrentFinalizedTimestamp: 0,
+		CurrentL1:                 eth.BlockID{Number: 100},
+	}}
+
+	_, err := createGameInputsInterop(context.Background(), logger, client, "test")
+	require.ErrorContains(t, err, "finalized timestamp is 0")
+}
+
+func TestCreateGameInputsInteropRejectsZeroL1Head(t *testing.T) {
+	logger := testlog.Logger(t, log.LvlInfo)
+	client := &stubSuperRootProvider{resp: eth.SuperRootAtTimestampResponse{
+		CurrentFinalizedTimestamp: 5000,
+		CurrentL1:                 eth.BlockID{Number: 0},
+	}}
+
+	_, err := createGameInputsInterop(context.Background(), logger, client, "test")
+	require.ErrorContains(t, err, "l1 head is 0")
+}
+
+// Super root games need a source; without one the run fails rather than silently falling
+// back to single-chain inputs.
+func TestCreateGameInputsRequiresSuperRootSource(t *testing.T) {
+	logger := testlog.Logger(t, log.LvlInfo)
+
+	_, err := createGameInputs(context.Background(), logger, nil, nil, nil, "test", gameTypes.SuperCannonKonaGameType, false)
+	require.ErrorContains(t, err, "requires super root RPC to be set")
+}
+
+func TestCreateGameInputsRequiresRollupClient(t *testing.T) {
+	logger := testlog.Logger(t, log.LvlInfo)
+
+	_, err := createGameInputs(context.Background(), logger, nil, nil, nil, "test", gameTypes.CannonKonaGameType, false)
+	require.ErrorContains(t, err, "requires rollup rpc to be set")
+}

--- a/op-challenger/runner/runner.go
+++ b/op-challenger/runner/runner.go
@@ -23,6 +23,7 @@ import (
 	"github.com/ethereum-optimism/optimism/cannon/mipsevm"
 	"github.com/ethereum-optimism/optimism/op-challenger/config"
 	contractMetrics "github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts/metrics"
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/super"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/utils"
 	trace "github.com/ethereum-optimism/optimism/op-challenger/game/fault/trace/vm"
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
@@ -116,14 +117,16 @@ func (r *Runner) Start(ctx context.Context) error {
 		}
 		rollupClient = cl
 	}
-	var superNodeClient *sources.SuperNodeClient
+	// Declared as the interface so an undialled source stays a nil interface rather than a
+	// non-nil interface holding a nil pointer.
+	var superRoots super.SuperNodeRootProvider
 	if r.cfg.SuperRootRPC != "" {
 		r.log.Info("Dialling super root RPC client", "url", r.cfg.SuperRootRPC)
 		cl, err := dial.DialSuperNodeClientWithTimeout(ctx, r.log, r.cfg.SuperRootRPC)
 		if err != nil {
 			return fmt.Errorf("failed to dial super root RPC client: %w", err)
 		}
-		superNodeClient = cl
+		superRoots = cl
 	}
 
 	l1Client, err := dial.DialRPCClientWithTimeout(ctx, r.log, r.cfg.L1EthRpc)
@@ -135,20 +138,20 @@ func (r *Runner) Start(ctx context.Context) error {
 
 	for _, runConfig := range r.runConfigs {
 		r.wg.Add(1)
-		go r.loop(ctx, runConfig, rollupClient, superNodeClient, l1EthClient, caller)
+		go r.loop(ctx, runConfig, rollupClient, superRoots, l1EthClient, caller)
 	}
 
 	r.log.Info("Runners started", "num", len(r.runConfigs))
 	return nil
 }
 
-func (r *Runner) loop(ctx context.Context, runConfig RunConfig, rollupClient *sources.RollupClient, superNodeClient *sources.SuperNodeClient, l1EthClient *ethclient.Client, caller *batching.MultiCaller) {
+func (r *Runner) loop(ctx context.Context, runConfig RunConfig, rollupClient *sources.RollupClient, superRoots super.SuperNodeRootProvider, l1EthClient *ethclient.Client, caller *batching.MultiCaller) {
 	defer r.wg.Done()
 	t := time.NewTicker(1 * time.Minute)
 	defer t.Stop()
 	for {
 		baseLog := r.log.New("run_id", generateRunID())
-		r.runAndRecordOnce(ctx, baseLog, runConfig, rollupClient, superNodeClient, l1EthClient, caller)
+		r.runAndRecordOnce(ctx, baseLog, runConfig, rollupClient, superRoots, l1EthClient, caller)
 		select {
 		case <-t.C:
 		case <-ctx.Done():
@@ -157,7 +160,7 @@ func (r *Runner) loop(ctx context.Context, runConfig RunConfig, rollupClient *so
 	}
 }
 
-func (r *Runner) runAndRecordOnce(ctx context.Context, rlog log.Logger, runConfig RunConfig, rollupClient *sources.RollupClient, superNodeClient *sources.SuperNodeClient, l1EthClient *ethclient.Client, caller *batching.MultiCaller) {
+func (r *Runner) runAndRecordOnce(ctx context.Context, rlog log.Logger, runConfig RunConfig, rollupClient *sources.RollupClient, superRoots super.SuperNodeRootProvider, l1EthClient *ethclient.Client, caller *batching.MultiCaller) {
 	recordError := func(err error, configName string, m Metricer, log log.Logger) {
 		if errors.Is(err, ErrUnexpectedStatusCode) {
 			log.Error("Incorrect status code", "type", runConfig.Name, "err", err)
@@ -198,7 +201,7 @@ func (r *Runner) runAndRecordOnce(ctx context.Context, rlog log.Logger, runConfi
 		prestateSource = &HashPrestateFetcher{prestateHash: runConfig.Prestate}
 	}
 
-	localInputs, err := createGameInputs(ctx, rlog, rollupClient, superNodeClient, l1EthClient, runConfig.Name, runConfig.GameType, r.ageGameInputs)
+	localInputs, err := createGameInputs(ctx, rlog, rollupClient, superRoots, l1EthClient, runConfig.Name, runConfig.GameType, r.ageGameInputs)
 	if err != nil {
 		recordError(err, runConfig.Name, r.m, rlog)
 		return


### PR DESCRIPTION
## Summary

`op-challenger run-trace` builds `super-cannon-kona` game inputs from `supernode_syncStatus`,
which only op-supernode implements. It now reads the same two values from
`superroot_atTimestamp`, which op-supernode **and** op-node both serve — so a single-chain
rollup can be its own super root source, as `--superroot-rpc` already documents.

## Why

The runner needed two methods for interop game inputs:

| Method | Purpose | op-node |
|---|---|---|
| `supernode_syncStatus` | which timestamp to dispute, and the L1 head | ✗ no `supernode` namespace |
| `superroot_atTimestamp` | the super roots themselves | ✓ always-on |

It called the unsupported one first, so pointing `--superroot-rpc` at an op-node failed
immediately — even though everything downstream needs only `superroot_atTimestamp`
(`super.SuperNodeRootProvider` is a one-method interface).

That dependency was unnecessary: both status values are already on the superroot response,
with the same derivations and the same JSON tags.

| Runner needs | `supernode_syncStatus` | `superroot_atTimestamp` |
|---|---|---|
| finalized timestamp | `FinalizedTimestamp` | `CurrentFinalizedTimestamp` |
| L1 head | `CurrentL1` | `CurrentL1` |

`Chains` (per-chain sync status) is the only thing unique to `supernode_syncStatus`, and the
runner never read it.

## What changed

`createGameInputsInterop` reads status from `superroot_atTimestamp` at the current
timestamp instead of `supernode_syncStatus`. A timestamp past the head is safe on both
servers: op-node returns its response skeleton with the status fields populated, and
op-supernode's `buildOptimisticBranch` skips not-found chains and still reports the
aggregate. The acceptance tests already use this call shape
(`SuperRootAtTimestamp(ctx, uint64(time.Now().Unix()))`).

The runner's plumbing now carries `super.SuperNodeRootProvider` rather than the concrete
`*sources.SuperNodeClient`, which is what makes it testable. It is declared as the interface
in `Start` so an undialled source stays a nil interface rather than a non-nil interface
holding a nil pointer.

No config, validation, or flag changes. `--superroot-rpc` stays required for
`super-cannon-kona`; it can now point at an op-node for a single-chain rollup.

## Caveat

op-node computes super roots over its own chain only (`chainID := eth.ChainIDFromBig(s.cfg.L2ChainID)`),
so it is a valid source only while the dependency set is that one chain — which is what the
rest of the `--superroot-rpc` usage string warns about.

## Tests

`op-challenger/runner/game_inputs_test.go` (new — the file had no coverage):

- status is read via a single `superroot_atTimestamp` call at the current timestamp
- client errors are wrapped
- a zero finalized timestamp is rejected (it would underflow `claimTimestamp - 1`)
- a zero L1 head is rejected
- super root games without a source, and non-super games without a rollup client, fail with
  actionable errors

`go build ./...` clean; `go test ./op-challenger/runner/...` passes; `op-golangci-lint`
reports 0 issues for the package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
