### PR TITLE
docs: document SDM operator opt-in flag and link Lagoon hardfork page

### DIFF
--- a/docs/public-docs/chain-operators/guides/features/sequencer-defined-metering.mdx
+++ b/docs/public-docs/chain-operators/guides/features/sequencer-defined-metering.mdx
@@ -32,7 +32,7 @@ clients derive the trailing PostExec transaction from L1 data like any other tra
 
 ## Protocol activation
 
-SDM is gated by the **Lagoon** hardfork. Before Lagoon, a PostExec transaction is invalid. At or
+SDM is gated by the [**Lagoon** hardfork](/op-stack/protocol/hardforks/lagoon). Before Lagoon, a PostExec transaction is invalid. At or
 after activation, an SDM-aware verifier accepts a structurally valid producer-supplied PostExec
 transaction and verifies its consensus effects.
 
@@ -50,6 +50,10 @@ never appends a PostExec transaction, even when Lagoon is active and
 `admin_setOperatorSdmOptIn(true)` has been called. The admin surface remains available for protocol
 compatibility and downstream producer integrations; it is not a policy-selection interface in
 stock `op-reth`.
+
+The opt-in state can be seeded at boot with the `--rollup.operator-sdm-opt-in` CLI flag or the
+`OP_RETH_OPERATOR_SDM_OPT_IN` environment variable; both take `true` or `false` and default to
+`false`. At runtime, `admin_setOperatorSdmOptIn` toggles the state and `admin_sdmStatus` reports it.
 
 The `op-reth-sdm-fixture` binary in the source tree is only a deterministic acceptance-test fixture.
 It is excluded from release packaging, images, and deployment manifests.


### PR DESCRIPTION
## Overview

Closes #21545 ("Revisit SDM operator docs"). The issue's two follow-up items from #21211 are resolved as follows.

### 1. Environment variables

#21360 was closed by #21551, which left op-reth as the sole carrier of the operator gate: `--rollup.operator-sdm-opt-in` with env binding `OP_RETH_OPERATOR_SDM_OPT_IN` (default `false`), hot-togglable via `admin_setOperatorSdmOptIn` and reported by `admin_sdmStatus`. op-rbuilder and rollup-boost have since been removed from the monorepo (#22222), so there are no other SDM operator options to env-bind.

- **All options supported via EVs**: already true in code (env binding verified by `test_operator_sdm_opt_in_is_bound_to_env_var` in `rust/op-reth/crates/node/src/args.rs`); no code change needed.
- **All EVs documented**: this PR adds the CLI flag and environment variable to the SDM chain-operator guide, which previously mentioned only the admin RPC.

### 2. Release-related documentation

The issue anticipated referencing an Upgrade 20 page. That page now exists (`notices/upgrade-20.mdx`) but turned out to be an L1 contract upgrade (Super Root Dispute Games) with no L2 hardfork — unrelated to SDM. SDM activation is gated by the **Lagoon** hardfork, which has its own registry page that already lists SDM under "What's included". This PR links the SDM guide's Lagoon mention to that page instead. No reverse link from the Lagoon page is added: the SDM guide is deliberately `hidden: true` (nav-allowlisted) until SDM ships.

## Verification

- `lint:nav` and `lint:redirects` pass.
- Docs-only change; no new tests, behavior unchanged.
- No review agents apply (no Go/Rust/CI/contract changes); general review skipped as the diff is two prose edits to one `.mdx` file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)