### PR TITLE
op-reth: meter PostExec structural validation failures

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -13420,6 +13420,8 @@ dependencies = [
  "alloy-op-evm",
  "alloy-primitives",
  "alloy-rpc-types-eth 2.1.1",
+ "metrics",
+ "metrics-util",
  "op-alloy-consensus",
  "op-alloy-rpc-types",
  "op-alloy-rpc-types-engine",

--- a/rust/op-reth/crates/evm/Cargo.toml
+++ b/rust/op-reth/crates/evm/Cargo.toml
@@ -43,9 +43,11 @@ revm.workspace = true
 op-revm.workspace = true
 
 # misc
+metrics = { workspace = true, optional = true }
 thiserror.workspace = true
 
 [dev-dependencies]
+metrics-util = { workspace = true, features = ["debugging"] }
 reth-evm = { workspace = true, features = ["test-utils"] }
 reth-revm = { workspace = true, features = ["test-utils"] }
 alloy-genesis.workspace = true
@@ -56,6 +58,7 @@ reth-optimism-chainspec = { workspace = true, features = ["superchain-configs"] 
 [features]
 default = ["std"]
 std = [
+	"dep:metrics",
 	"reth-revm/std",
 	"alloy-consensus/std",
 	"alloy-eips/std",

--- a/rust/op-reth/crates/evm/src/lib.rs
+++ b/rust/op-reth/crates/evm/src/lib.rs
@@ -63,6 +63,8 @@ pub use build::OpBlockAssembler;
 mod error;
 pub use error::{L1BlockInfoError, OpBlockExecutionError};
 
+pub mod metrics;
+
 pub mod tx;
 pub use tx::OpTx;
 
@@ -163,7 +165,13 @@ where
     T: OpConsensusTransaction + 'a,
 {
     parse_post_exec_payload_from_transactions(transactions, block_number, sdm_active)
-        .map_err(|_| EIP1559ParamError::InvalidPostExecPayload)
+        .map_err(|error| {
+            #[cfg(feature = "std")]
+            metrics::record_post_exec_validation_failure((&error).into());
+            #[cfg(not(feature = "std"))]
+            let _ = error;
+            EIP1559ParamError::InvalidPostExecPayload
+        })
         .map(|parsed| {
             parsed.map_or_else(PostExecMode::default, |parsed| PostExecMode::Verify(parsed.payload))
         })

--- a/rust/op-reth/crates/evm/src/metrics.rs
+++ b/rust/op-reth/crates/evm/src/metrics.rs
@@ -1,0 +1,139 @@
+//! Metrics for Optimism-specific EVM validation.
+
+#[cfg(feature = "std")]
+use metrics::{counter, describe_counter};
+use op_alloy_consensus::PostExecPayloadValidationError;
+
+/// Counter incremented when an execution-client path rejects `PostExec` block structure.
+pub const POST_EXEC_VALIDATION_FAILURES: &str = "optimism_post_exec.validation_failures";
+
+/// Stable, bounded reason labels for `PostExec` structural validation failures.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PostExecValidationFailureReason {
+    /// The `0x7D` transaction or its schema could not be decoded.
+    InvalidEncodingOrSchema,
+    /// A block contained `0x7D` before SDM activation.
+    SdmInactive,
+    /// A block contained more than one `0x7D` transaction.
+    MultipleTransactions,
+    /// The `0x7D` transaction was not the final transaction.
+    NotLast,
+    /// The payload block number did not match the containing block.
+    BlockNumberMismatch,
+}
+
+impl PostExecValidationFailureReason {
+    /// Returns the stable metric label for this failure reason.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::InvalidEncodingOrSchema => "invalid_encoding_or_schema",
+            Self::SdmInactive => "sdm_inactive",
+            Self::MultipleTransactions => "multiple_transactions",
+            Self::NotLast => "not_last",
+            Self::BlockNumberMismatch => "block_number_mismatch",
+        }
+    }
+}
+
+impl From<&PostExecPayloadValidationError> for PostExecValidationFailureReason {
+    fn from(error: &PostExecPayloadValidationError) -> Self {
+        match error {
+            PostExecPayloadValidationError::UnexpectedPostExecTx { .. } => Self::SdmInactive,
+            PostExecPayloadValidationError::MultiplePostExecTxs { .. } => {
+                Self::MultipleTransactions
+            }
+            PostExecPayloadValidationError::PostExecTxNotLast { .. } => Self::NotLast,
+            PostExecPayloadValidationError::BlockNumberMismatch { .. } => Self::BlockNumberMismatch,
+        }
+    }
+}
+
+/// Records a `PostExec` structural validation failure.
+///
+/// Callers must classify failures with [`PostExecValidationFailureReason`] so the `reason` label
+/// remains low-cardinality.
+pub fn record_post_exec_validation_failure(reason: PostExecValidationFailureReason) {
+    #[cfg(feature = "std")]
+    {
+        describe_counter!(
+            POST_EXEC_VALIDATION_FAILURES,
+            "PostExec structural validation failures by reason"
+        );
+        counter!(POST_EXEC_VALIDATION_FAILURES, "reason" => reason.as_str()).increment(1);
+    }
+    #[cfg(not(feature = "std"))]
+    let _ = reason;
+}
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+    use metrics_util::debugging::{DebugValue, DebuggingRecorder, Snapshot};
+
+    fn failure_count(snapshot: Snapshot, reason: PostExecValidationFailureReason) -> u64 {
+        snapshot
+            .into_vec()
+            .into_iter()
+            .find_map(|(composite_key, _, _, value)| {
+                let key = composite_key.key();
+                let matches = key.name() == POST_EXEC_VALIDATION_FAILURES &&
+                    key.labels().any(|label| {
+                        label.key() == "reason" && label.value() == reason.as_str()
+                    });
+                matches.then_some(match value {
+                    DebugValue::Counter(value) => value,
+                    _ => 0,
+                })
+            })
+            .unwrap_or_default()
+    }
+
+    #[test]
+    fn records_reason_labeled_post_exec_validation_failure() {
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+        metrics::with_local_recorder(&recorder, || {
+            record_post_exec_validation_failure(
+                PostExecValidationFailureReason::BlockNumberMismatch,
+            );
+        });
+
+        assert_eq!(
+            failure_count(
+                snapshotter.snapshot(),
+                PostExecValidationFailureReason::BlockNumberMismatch
+            ),
+            1
+        );
+    }
+
+    #[test]
+    fn maps_structural_errors_to_stable_reasons() {
+        for (error, expected) in [
+            (
+                PostExecPayloadValidationError::UnexpectedPostExecTx { tx_index: 0 },
+                PostExecValidationFailureReason::SdmInactive,
+            ),
+            (
+                PostExecPayloadValidationError::MultiplePostExecTxs {
+                    first_index: 0,
+                    duplicate_index: 1,
+                },
+                PostExecValidationFailureReason::MultipleTransactions,
+            ),
+            (
+                PostExecPayloadValidationError::PostExecTxNotLast { tx_index: 0, last_index: 1 },
+                PostExecValidationFailureReason::NotLast,
+            ),
+            (
+                PostExecPayloadValidationError::BlockNumberMismatch {
+                    payload_block_number: 1,
+                    block_number: 2,
+                },
+                PostExecValidationFailureReason::BlockNumberMismatch,
+            ),
+        ] {
+            assert_eq!(PostExecValidationFailureReason::from(&error), expected);
+        }
+    }
+}

--- a/rust/op-reth/crates/node/src/engine.rs
+++ b/rust/op-reth/crates/node/src/engine.rs
@@ -1,6 +1,7 @@
 use alloy_consensus::BlockHeader;
-use alloy_primitives::B256;
+use alloy_primitives::{B256, Bytes};
 use alloy_rpc_types_engine::{ExecutionPayloadEnvelopeV2, ExecutionPayloadV1};
+use op_alloy_consensus::{POST_EXEC_TX_TYPE_ID, PostExecPayload};
 use op_alloy_rpc_types_engine::{
     OpExecutionData, OpExecutionPayloadEnvelope, OpExecutionPayloadEnvelopeV3,
     OpExecutionPayloadEnvelopeV4,
@@ -17,6 +18,9 @@ use reth_node_api::{
     validate_version_specific_fields,
 };
 use reth_optimism_consensus::isthmus;
+use reth_optimism_evm::metrics::{
+    PostExecValidationFailureReason, record_post_exec_validation_failure,
+};
 use reth_optimism_forks::OpHardforks;
 use reth_optimism_payload_builder::{
     OpExecData, OpExecutionPayloadValidator, OpPayloadAttrs, OpPayloadTypes,
@@ -123,6 +127,14 @@ where
     }
 }
 
+fn has_invalid_post_exec_encoding(transactions: &[Bytes]) -> bool {
+    transactions.iter().any(|encoded| {
+        let bytes = encoded.as_ref();
+        bytes.first() == Some(&POST_EXEC_TX_TYPE_ID) &&
+            PostExecPayload::from_rlp_bytes(&bytes[1..]).is_err()
+    })
+}
+
 impl<P, Tx, ChainSpec, Types> PayloadValidator<Types> for OpEngineValidator<P, Tx, ChainSpec>
 where
     P: StateProviderFactory + Unpin + 'static,
@@ -162,6 +174,11 @@ where
         &self,
         payload: OpExecData,
     ) -> Result<SealedBlock<Self::Block>, NewPayloadError> {
+        if has_invalid_post_exec_encoding(payload.0.payload.transactions()) {
+            record_post_exec_validation_failure(
+                PostExecValidationFailureReason::InvalidEncodingOrSchema,
+            );
+        }
         self.inner.ensure_well_formed_payload(payload.0).map_err(NewPayloadError::other)
     }
 }
@@ -333,6 +350,25 @@ mod test {
                 other => panic!("expected InvalidParams, got {other:?}"),
             }
         }};
+    }
+
+    #[test]
+    fn detects_invalid_post_exec_encoding_or_schema() {
+        let valid_payload = PostExecPayload {
+            version: op_alloy_consensus::POST_EXEC_PAYLOAD_VERSION,
+            block_number: 1,
+            gas_refund_entries: vec![],
+        };
+        let mut valid = vec![POST_EXEC_TX_TYPE_ID];
+        valid.extend_from_slice(&valid_payload.to_rlp_bytes());
+
+        let mut invalid_schema = vec![POST_EXEC_TX_TYPE_ID];
+        invalid_schema
+            .extend_from_slice(&PostExecPayload { version: 2, ..valid_payload }.to_rlp_bytes());
+
+        assert!(!has_invalid_post_exec_encoding(&[Bytes::from(valid)]));
+        assert!(has_invalid_post_exec_encoding(&[Bytes::from(invalid_schema)]));
+        assert!(!has_invalid_post_exec_encoding(&[Bytes::from_static(&[0x02, 0x01])]));
     }
 
     fn get_attributes(

--- a/rust/op-reth/crates/payload/src/builder.rs
+++ b/rust/op-reth/crates/payload/src/builder.rs
@@ -29,6 +29,7 @@ use reth_metrics::{
 };
 use reth_optimism_evm::{
     ConfigurePostExecEvm, PostExecExecutorExt, PostExecMode, PreRefundGasUsed,
+    metrics::record_post_exec_validation_failure,
 };
 use reth_optimism_forks::OpHardforks;
 use reth_optimism_primitives::{L2_TO_L1_MESSAGE_PASSER_ADDRESS, OpTransaction};
@@ -899,7 +900,10 @@ where
             next_block_number,
             sdm_active,
         )
-        .map_err(PayloadBuilderError::other)
+        .map_err(|error| {
+            record_post_exec_validation_failure((&error).into());
+            PayloadBuilderError::other(error)
+        })
     }
 
     /// Decides this payload's SDM post-exec mode: *produce*, *verify*, or `Disabled`.


### PR DESCRIPTION
## Description

Adds a reason-labelled execution-client counter for PostExec block-level structural validation failures:

`optimism_post_exec.validation_failures{reason="..."}`

The bounded reason labels cover:

- `invalid_encoding_or_schema`
- `sdm_inactive`
- `multiple_transactions`
- `not_last`
- `block_number_mismatch`

The counter is recorded when op-reth rejects malformed PostExec structure while converting an Engine API payload, preparing block execution, or rebuilding derived payload attributes.

This addresses the observability question raised in https://github.com/ethereum-optimism/design-docs/pull/388#discussion_r3829898758.

## Tests

- `cd rust && just fmt-check`
- `cd rust && cargo clippy -p reth-optimism-evm -p reth-optimism-payload-builder -p reth-optimism-node --all-targets --all-features -- -D warnings`
- `cd rust && cargo nextest run -p reth-optimism-evm -p reth-optimism-payload-builder -p reth-optimism-node --lib`
- `cd rust && cargo check -p reth-optimism-evm --no-default-features`

## Review

The automated Rust review agent was unavailable in this harness; the change was manually reviewed against `docs/ai/rust-dev.md`.
