### PR TITLE
kona-gossip: Allowlist gossip subscription topics

### DIFF
--- a/rust/kona/crates/node/gossip/src/behaviour.rs
+++ b/rust/kona/crates/node/gossip/src/behaviour.rs
@@ -57,10 +57,6 @@ impl Behaviour {
 
         let topics = handlers.iter().flat_map(|handler| handler.topics()).collect::<Vec<_>>();
 
-        // Accept subscriptions only for the topics the handlers serve. libp2p otherwise accepts a
-        // subscription for any topic a peer announces, which lets one peer grow its entry in the
-        // swarm's peer table and mint unbounded `topic` metric label values. op-node applies the
-        // same allowlist in `BuildSubscriptionFilter`.
         let mut gossipsub = libp2p::gossipsub::Behaviour::new_with_subscription_filter(
             MessageAuthenticity::Anonymous,
             cfg,
@@ -126,12 +122,11 @@ mod tests {
         let handlers: Vec<Box<dyn Handler>> = vec![Box::new(block_handler)];
         let mut behaviour = Behaviour::new(key.public(), cfg, &handlers).unwrap();
 
-        // The subscription filter gates our own subscriptions and the ones peers announce, so a
-        // refusal here proves an inbound announcement for the same topic is dropped.
+        // The filter gates our own subscriptions and the ones peers announce.
         let result = behaviour.gossipsub.subscribe(&IdentTopic::new("/optimism/10/9/blocks"));
         assert!(matches!(result, Err(SubscriptionError::NotAllowed)), "unexpected: {result:?}");
 
-        // A handler topic still passes the filter. `Ok(false)` means we already subscribed.
+        // `Ok(false)` means we already subscribed.
         let result = behaviour.gossipsub.subscribe(&IdentTopic::new("/optimism/10/0/blocks"));
         assert!(matches!(result, Ok(false)), "unexpected: {result:?}");
 

--- a/rust/kona/crates/node/gossip/src/behaviour.rs
+++ b/rust/kona/crates/node/gossip/src/behaviour.rs
@@ -2,7 +2,9 @@
 
 use derive_more::Debug;
 use libp2p::{
-    gossipsub::{Config, IdentTopic, MessageAuthenticity},
+    gossipsub::{
+        Config, IdentTopic, IdentityTransform, MessageAuthenticity, WhitelistSubscriptionFilter,
+    },
     swarm::NetworkBehaviour,
 };
 
@@ -22,6 +24,9 @@ pub enum BehaviourError {
     PeerScoreFailed(String),
 }
 
+/// The gossipsub behaviour, restricted to the topics the handlers serve.
+pub type Gossipsub = libp2p::gossipsub::Behaviour<IdentityTransform, WhitelistSubscriptionFilter>;
+
 /// Specifies the [`NetworkBehaviour`] of the node
 #[derive(NetworkBehaviour, Debug)]
 #[behaviour(out_event = "Event")]
@@ -30,7 +35,7 @@ pub struct Behaviour {
     #[debug(skip)]
     pub ping: libp2p::ping::Behaviour,
     /// Enables gossipsub as the routing layer.
-    pub gossipsub: libp2p::gossipsub::Behaviour,
+    pub gossipsub: Gossipsub,
     /// Enables the identify protocol.
     #[debug(skip)]
     pub identify: libp2p::identify::Behaviour,
@@ -50,8 +55,18 @@ impl Behaviour {
     ) -> Result<Self, BehaviourError> {
         let ping = libp2p::ping::Behaviour::default();
 
-        let mut gossipsub = libp2p::gossipsub::Behaviour::new(MessageAuthenticity::Anonymous, cfg)
-            .map_err(|_| BehaviourError::GossipsubCreationFailed)?;
+        let topics = handlers.iter().flat_map(|handler| handler.topics()).collect::<Vec<_>>();
+
+        // Accept subscriptions only for the topics the handlers serve. libp2p otherwise accepts a
+        // subscription for any topic a peer announces, which lets one peer grow its entry in the
+        // swarm's peer table and mint unbounded `topic` metric label values. op-node applies the
+        // same allowlist in `BuildSubscriptionFilter`.
+        let mut gossipsub = libp2p::gossipsub::Behaviour::new_with_subscription_filter(
+            MessageAuthenticity::Anonymous,
+            cfg,
+            WhitelistSubscriptionFilter(topics.iter().cloned().collect()),
+        )
+        .map_err(|_| BehaviourError::GossipsubCreationFailed)?;
 
         let identify = libp2p::identify::Behaviour::new(
             libp2p::identify::Config::new(String::new(), public_key)
@@ -60,27 +75,12 @@ impl Behaviour {
 
         let sync_req_resp = libp2p_stream::Behaviour::new();
 
-        let subscriptions = handlers
-            .iter()
-            .flat_map(|handler| {
-                handler
-                    .topics()
-                    .iter()
-                    .map(|topic| {
-                        let topic = IdentTopic::new(topic.to_string());
-                        gossipsub
-                            .subscribe(&topic)
-                            .map_err(|_| BehaviourError::SubscriptionFailed)?;
-                        Ok(topic.to_string())
-                    })
-                    .collect::<Vec<_>>()
-            })
-            .collect::<Result<Vec<String>, BehaviourError>>()?;
-
-        if !subscriptions.is_empty() {
+        if !topics.is_empty() {
             tracing::info!(target: "gossip", "Subscribed to topics:");
         }
-        for topic in subscriptions {
+        for topic in &topics {
+            let topic = IdentTopic::new(topic.to_string());
+            gossipsub.subscribe(&topic).map_err(|_| BehaviourError::SubscriptionFailed)?;
             tracing::info!(target: "gossip", "-> {}", topic);
         }
 
@@ -95,7 +95,7 @@ mod tests {
     use alloy_chains::Chain;
     use alloy_primitives::Address;
     use kona_genesis::RollupConfig;
-    use libp2p::gossipsub::{IdentTopic, TopicHash};
+    use libp2p::gossipsub::{IdentTopic, SubscriptionError, TopicHash};
 
     fn op_mainnet_topics() -> Vec<TopicHash> {
         vec![
@@ -112,6 +112,30 @@ mod tests {
         let cfg = config::default_config();
         let handlers = vec![];
         let _ = Behaviour::new(key.public(), cfg, &handlers).unwrap();
+    }
+
+    #[test]
+    fn test_behaviour_rejects_topics_outside_the_handler_set() {
+        let key = libp2p::identity::Keypair::generate_secp256k1();
+        let cfg = config::default_config();
+        let (_, recv) = tokio::sync::watch::channel(Address::default());
+        let block_handler = BlockHandler::new(
+            RollupConfig { l2_chain_id: Chain::optimism_mainnet(), ..Default::default() },
+            recv,
+        );
+        let handlers: Vec<Box<dyn Handler>> = vec![Box::new(block_handler)];
+        let mut behaviour = Behaviour::new(key.public(), cfg, &handlers).unwrap();
+
+        // The subscription filter gates our own subscriptions and the ones peers announce, so a
+        // refusal here proves an inbound announcement for the same topic is dropped.
+        let result = behaviour.gossipsub.subscribe(&IdentTopic::new("/optimism/10/9/blocks"));
+        assert!(matches!(result, Err(SubscriptionError::NotAllowed)), "unexpected: {result:?}");
+
+        // A handler topic still passes the filter. `Ok(false)` means we already subscribed.
+        let result = behaviour.gossipsub.subscribe(&IdentTopic::new("/optimism/10/0/blocks"));
+        assert!(matches!(result, Ok(false)), "unexpected: {result:?}");
+
+        assert_eq!(behaviour.gossipsub.topics().count(), op_mainnet_topics().len());
     }
 
     #[test]

--- a/rust/kona/crates/node/gossip/src/lib.rs
+++ b/rust/kona/crates/node/gossip/src/lib.rs
@@ -36,7 +36,7 @@ pub use rpc::{
 };
 
 mod behaviour;
-pub use behaviour::{Behaviour, BehaviourError};
+pub use behaviour::{Behaviour, BehaviourError, Gossipsub};
 
 mod config;
 pub use config::{


### PR DESCRIPTION
Kona built the gossipsub behaviour with the default `AllowAllSubscriptionFilter`. libp2p therefore accepted a subscription for any topic a peer announced. A connected peer could grow its uncapped `PeerDetails.topics` set, and mint unbounded `topic` label values on the `kona_node_gossip_events` gauge. The recorder has no idle timeout, so those series live for the life of the process.

This is an availability problem, not a correctness one. Gossipsub already drops messages on topics we do not subscribe to.

This change installs a `WhitelistSubscriptionFilter` built from the handler topics. The same predicate gates our subscriptions and inbound announcements, so the allowlist cannot drift.

op-node applies the same allowlist in `BuildSubscriptionFilter`. Neither node conditions the topic set on scheduled forks, so all four block topics stay allowed at all times.

The `gossipsub` field gains type parameters. A new public `Gossipsub` alias hides them.

Found while reviewing #22569. That PR could not pre-create the `topic` label values because the set was unbounded. A follow-up can now do so.

Reviews run: `rust-code-reviewer`, no blocking findings. Two suggestions dismissed: a direct unit test on `filter_incoming_subscriptions` needs `libp2p::gossipsub::Subscription`, which the crate does not export; a comment about the empty-handler case is unnecessary because the builder always passes one handler.
