### PR TITLE
op-reth,kona: implement sequencer-defined fees

### DIFF
--- a/docs/public-docs/chain-operators/guides/features/sequencer-defined-metering.mdx
+++ b/docs/public-docs/chain-operators/guides/features/sequencer-defined-metering.mdx
@@ -1,40 +1,42 @@
 ---
-title: "SDM: Sequencer Defined Metering"
-description: "Technical guide for chain operators integrating or verifying Sequencer Defined Metering (SDM)."
+title: "Sequencer Defined Fees and Metering"
+description: "Technical guide for chain operators integrating or verifying SDF and SDM."
 diataxis: how-to
 hidden: true
 ---
 
 <Warning>
-SDM is not yet live. Stock public `op-reth` supports the SDM consensus and verification
-mechanism, but it does **not** implement a refund-producing policy. Enabling its operator gate does
-not cause it to issue refunds or append PostExec transactions.
+Sequencer Defined Fees (SDF) and Sequencer Defined Metering (SDM) are not yet live. Stock public
+`op-reth` supports their consensus and verification mechanisms and uses the legacy Jovian base fee
+as its producer policy. It does **not** implement a refund-producing policy.
 </Warning>
 
-**Sequencer Defined Metering (SDM)** lets a block producer define per-transaction gas rebates and
-commit them in a synthetic **PostExec transaction**. The public OP Stack implementation keeps the
-consensus format, validation, derivation, receipt settlement, and fault-proof support open while
-leaving policy selection to producers.
+**Sequencer Defined Fees (SDF)** lets a block producer select the block base fee.
+**Sequencer Defined Metering (SDM)** lets it define per-transaction gas rebates. Both are committed
+in a synthetic **PostExec transaction**. The public OP Stack implementation keeps the consensus
+format, validation, derivation, receipt settlement, and fault-proof support open while leaving
+production policy selection to producers.
 
-## How rebates are recorded
+## How fees and rebates are recorded
 
-When a producer issues rebates, it appends one PostExec transaction (type `0x7D`) as the last
-transaction in the block. The transaction is non-executable and carries an RLP-encoded payload of
-transaction indexes and gas refunds.
+Every Lagoon block has one PostExec transaction (type `0x7D`) as its last transaction. The
+transaction is non-executable and carries an RLP-encoded payload containing the selected base fee
+and a possibly empty list of transaction indexes and gas refunds.
 
 A rebated transaction receipt includes `opGasRefund`. Its `gasUsed` is the canonical amount charged;
 the pre-rebate amount is `gasUsed + opGasRefund`. Deposits and the PostExec transaction cannot
 receive refunds, and a refund cannot exceed the transaction's pre-refund EVM gas usage.
 
-Verifier nodes do not execute the producer's private policy. They validate the committed payload,
-apply its settlement effects, and reproduce the same receipts and state root. Consensus-layer
-clients derive the trailing PostExec transaction from L1 data like any other transaction.
+Verifier nodes do not execute the producer's private policies. They require the selected fee to
+match the block header, apply any refund settlement effects, and reproduce the same receipts and
+state root. Consensus-layer clients transport the trailing PostExec transaction from batch data
+like any other transaction.
 
 ## Protocol activation
 
-SDM is gated by the **Lagoon** hardfork. Before Lagoon, a PostExec transaction is invalid. At or
-after activation, an SDM-aware verifier accepts a structurally valid producer-supplied PostExec
-transaction and verifies its consensus effects.
+SDF and SDM activate together at the **Lagoon** hardfork, with no separate feature flag. Before
+Lagoon, a PostExec transaction is invalid and the parent-derived EIP-1559 base fee rules apply. At
+or after activation, a PostExec commitment is required in every block.
 
 Run SDM-capable versions of:
 
@@ -45,19 +47,18 @@ Verifier operators need no policy opt-in.
 
 ## Stock `op-reth` production behavior
 
-Released public `op-reth` uses a null refund policy. It never creates a non-empty refund payload and
-never appends a PostExec transaction, even when Lagoon is active and
-`admin_setOperatorSdmOptIn(true)` has been called. The admin surface remains available for protocol
-compatibility and downstream producer integrations; it is not a policy-selection interface in
-stock `op-reth`.
+Released public `op-reth` uses the legacy Jovian result as its base fee policy and a null refund
+policy. At Lagoon it appends the required PostExec commitment, including when the refund list is
+empty. Calling `admin_setOperatorSdmOptIn(true)` enables refund collection but does not by itself
+install a non-null refund policy. The admin surface is not a base fee policy-selection interface.
 
 The `op-reth-sdm-fixture` binary in the source tree is only a deterministic acceptance-test fixture.
 It is excluded from release packaging, images, and deployment manifests.
 Do not deploy it as a sequencer.
 
-If you use a third-party or proprietary SDM producer, follow that producer's policy and opt-in
-documentation. The producer must emit blocks that stock verifier nodes accept; no producer-specific
-policy code is required on verifiers.
+If you use a third-party or proprietary SDF or SDM producer, follow that producer's policy and
+opt-in documentation. The producer must emit blocks that stock verifier nodes accept; no
+producer-specific policy code is required on verifiers.
 
 ## Confirming producer output
 
@@ -68,8 +69,8 @@ cast receipt <TX_HASH> --rpc-url <RPC_URL> --json | jq '.opGasRefund'
 ```
 
 You can also fetch the containing block and check whether its last transaction has type `0x7D`.
-A block without rebates has no PostExec transaction, so absence alone does not indicate whether the
-protocol is active.
+Every Lagoon block has this transaction, including blocks without rebates. Its committed selected
+base fee must equal the block header's `baseFeePerGas`.
 
 ## Debug replay
 

--- a/docs/public-docs/chain-operators/reference/fee-parameters.mdx
+++ b/docs/public-docs/chain-operators/reference/fee-parameters.mdx
@@ -12,6 +12,13 @@ For when and how to adjust these parameters, see the [fee tuning guide](/chain-o
 Only the [SystemConfig owner](/op-stack/protocol/privileged-roles) can call the setter methods listed below.
 </Info>
 
+<Warning>
+At Lagoon, the sequencer's configured base fee policy replaces the parent-derived EIP-1559 formula.
+`eip1559Denominator`, `eip1559Elasticity`, and `minBaseFee` continue to be transported as
+compatibility metadata and may be policy inputs, but they no longer constrain the block base fee by
+consensus. L1 data fee and operator fee parameters are unaffected.
+</Warning>
+
 ## Fee formulas
 
 On an OP Stack chain a transaction's **Total Fee** is made of three main components:

--- a/docs/public-docs/op-stack/transactions/fees.mdx
+++ b/docs/public-docs/op-stack/transactions/fees.mdx
@@ -60,9 +60,16 @@ The [base fee](https://ethereum.org/en/developers/docs/gas/#base-fee) is the min
 Transactions must specify a maximum base fee higher than the block base fee to be included.
 The actual fee charged is the block base fee, even if the transaction specifies a higher maximum base fee.
 
-The OP Mainnet base fee behaves exactly like the Ethereum base fee, with a few small parameter changes to account for the much shorter block times on OP Mainnet.
-None of these parameters should significantly impact your application, but you can read more about each of these parameters on the [OP Mainnet differences](/op-stack/protocol/differences#eip-1559-parameters) page.
-Read more about the base fee in the [Ethereum.org documentation](https://ethereum.org/en/developers/docs/gas/#base-fee).
+Before Lagoon, the OP Mainnet base fee follows Ethereum's EIP-1559 update with a few parameter
+changes for shorter block times. At Lagoon, the sequencer selects the block base fee through its
+configured policy and commits it in the block's final PostExec transaction. Transaction validity,
+priority fees, the `BASEFEE` opcode, and Base Fee Vault accounting continue to use that selected
+block base fee.
+
+The Lagoon change does not affect L1 data fees or operator fees. Read more about the legacy
+parameters on the [OP Mainnet differences](/op-stack/protocol/differences#eip-1559-parameters) page
+and about base fee semantics in the
+[Ethereum.org documentation](https://ethereum.org/en/developers/docs/gas/#base-fee).
 
 ### Priority fee
 

--- a/op-acceptance-tests/tests/sdm/block_test.go
+++ b/op-acceptance-tests/tests/sdm/block_test.go
@@ -1,6 +1,7 @@
 package sdm
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/sdm/sdmtest"
@@ -24,8 +25,7 @@ func TestSDMDisabledNoRefunds(gt *testing.T) {
 	block, included, targetBlockNum := sdmtest.MustFindRepeatedSlotBlock(t, sys, 2, 3)
 	t.Require().GreaterOrEqual(len(included), 2, "target block must contain multiple user txs")
 
-	postExecTx, _ := sdmpkg.FindPostExecTransaction(block)
-	t.Require().Nil(postExecTx, "SDM-disabled sequencer must not include a post-exec tx")
+	assertEmptyPostExecCommitment(t, block, "SDM-disabled sequencer")
 
 	for _, receipt := range included {
 		refund, present := getOPGasRefund(t, sys.L2EL, receipt.TxHash)
@@ -43,8 +43,7 @@ func TestSDMOptInIsInertOnStockOpReth(gt *testing.T) {
 
 	block, included, targetBlockNum := sdmtest.MustFindRepeatedSlotBlock(t, sys, 2, 3)
 	t.Require().GreaterOrEqual(len(included), 2, "stock-null target block must contain user txs")
-	postExecTx, _ := sdmpkg.FindPostExecTransaction(block)
-	t.Require().Nil(postExecTx, "active and opted-in stock op-reth must not produce a post-exec tx")
+	assertEmptyPostExecCommitment(t, block, "active stock op-reth")
 	for _, receipt := range included {
 		refund, present := getOPGasRefund(t, sys.L2EL, receipt.TxHash)
 		t.Require().False(present, "stock-null receipt must omit opGasRefund")
@@ -54,8 +53,7 @@ func TestSDMOptInIsInertOnStockOpReth(gt *testing.T) {
 	for _, enabled := range []bool{false, true} {
 		sdmtest.SetSDMEnabled(t, sys.L2EL, enabled)
 		probeBlock, probeReceipt := submitFixtureProbe(t, sys)
-		probePostExec, _ := sdmpkg.FindPostExecTransaction(probeBlock)
-		t.Require().Nil(probePostExec, "stock op-reth opt-in=%v must remain inert", enabled)
+		assertEmptyPostExecCommitment(t, probeBlock, fmt.Sprintf("stock op-reth opt-in=%v", enabled))
 		_, present := getOPGasRefund(t, sys.L2EL, probeReceipt.TxHash)
 		t.Require().False(present, "stock op-reth opt-in=%v receipt must omit opGasRefund", enabled)
 	}
@@ -100,8 +98,7 @@ func TestSDMFixtureOperatorOptInControlsProduction(gt *testing.T) {
 
 	sdmtest.SetSDMEnabled(t, sys.L2EL, false)
 	offBlock, offReceipt := submitFixtureProbe(t, sys)
-	offPostExec, _ := sdmpkg.FindPostExecTransaction(offBlock)
-	t.Require().Nil(offPostExec, "opt-in off must suppress fixture post-exec production")
+	assertEmptyPostExecCommitment(t, offBlock, "fixture opt-in off")
 	_, present := getOPGasRefund(t, sys.L2EL, offReceipt.TxHash)
 	t.Require().False(present, "opt-in off receipt must omit opGasRefund")
 
@@ -111,10 +108,19 @@ func TestSDMFixtureOperatorOptInControlsProduction(gt *testing.T) {
 
 	sdmtest.SetSDMEnabled(t, sys.L2EL, false)
 	offAgainBlock, offAgainReceipt := submitFixtureProbe(t, sys)
-	offAgainPostExec, _ := sdmpkg.FindPostExecTransaction(offAgainBlock)
-	t.Require().Nil(offAgainPostExec, "second opt-in off must suppress fixture post-exec production")
+	assertEmptyPostExecCommitment(t, offAgainBlock, "fixture opt-in off again")
 	_, present = getOPGasRefund(t, sys.L2EL, offAgainReceipt.TxHash)
 	t.Require().False(present, "second opt-in off receipt must omit opGasRefund")
+}
+
+func assertEmptyPostExecCommitment(t devtest.T, block *sdmpkg.RPCBlock, producer string) {
+	postExecTx, postExecPos := sdmpkg.FindPostExecTransaction(block)
+	t.Require().NotNil(postExecTx, "%s must include the Lagoon post-exec commitment", producer)
+	t.Require().Equal(len(block.Transactions)-1, postExecPos, "%s post-exec commitment must be trailing", producer)
+	payload, err := optypes.DecodePostExecPayload(postExecTx.Input)
+	t.Require().NoError(err, "%s post-exec commitment must decode", producer)
+	t.Require().Equal(uint64(block.Number), payload.BlockNumber, "%s commitment must match its block", producer)
+	t.Require().Empty(payload.GasRefundEntries, "%s must not commit SDM refunds", producer)
 }
 
 func submitFixtureProbe(t devtest.T, sys *sdmtest.RethSystem) (*sdmpkg.RPCBlock, *types.Receipt) {

--- a/op-acceptance-tests/tests/sdm/block_test.go
+++ b/op-acceptance-tests/tests/sdm/block_test.go
@@ -2,6 +2,7 @@ package sdm
 
 import (
 	"fmt"
+	"math/big"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/sdm/sdmtest"
@@ -25,7 +26,8 @@ func TestSDMDisabledNoRefunds(gt *testing.T) {
 	block, included, targetBlockNum := sdmtest.MustFindRepeatedSlotBlock(t, sys, 2, 3)
 	t.Require().GreaterOrEqual(len(included), 2, "target block must contain multiple user txs")
 
-	assertEmptyPostExecCommitment(t, block, "SDM-disabled sequencer")
+	postExecTx, _ := sdmpkg.FindPostExecTransaction(block)
+	t.Require().Nil(postExecTx, "pre-Lagoon sequencer must not include a post-exec tx")
 
 	for _, receipt := range included {
 		refund, present := getOPGasRefund(t, sys.L2EL, receipt.TxHash)
@@ -120,6 +122,10 @@ func assertEmptyPostExecCommitment(t devtest.T, block *sdmpkg.RPCBlock, producer
 	payload, err := optypes.DecodePostExecPayload(postExecTx.Input)
 	t.Require().NoError(err, "%s post-exec commitment must decode", producer)
 	t.Require().Equal(uint64(block.Number), payload.BlockNumber, "%s commitment must match its block", producer)
+	t.Require().NotNil(block.BaseFeePerGas, "%s block must expose baseFeePerGas", producer)
+	t.Require().True((*big.Int)(block.BaseFeePerGas).IsUint64(), "%s baseFeePerGas must fit in uint64", producer)
+	t.Require().Equal((*big.Int)(block.BaseFeePerGas).Uint64(), payload.SelectedBaseFeePerGas,
+		"%s commitment must match the block base fee", producer)
 	t.Require().Empty(payload.GasRefundEntries, "%s must not commit SDM refunds", producer)
 }
 

--- a/op-acceptance-tests/tests/sdm/block_test.go
+++ b/op-acceptance-tests/tests/sdm/block_test.go
@@ -124,7 +124,7 @@ func assertEmptyPostExecCommitment(t devtest.T, block *sdmpkg.RPCBlock, producer
 	t.Require().Equal(uint64(block.Number), payload.BlockNumber, "%s commitment must match its block", producer)
 	t.Require().NotNil(block.BaseFeePerGas, "%s block must expose baseFeePerGas", producer)
 	t.Require().True((*big.Int)(block.BaseFeePerGas).IsUint64(), "%s baseFeePerGas must fit in uint64", producer)
-	t.Require().Equal((*big.Int)(block.BaseFeePerGas).Uint64(), payload.SelectedBaseFeePerGas,
+	t.Require().Equal(bigs.Uint64Strict((*big.Int)(block.BaseFeePerGas)), payload.SelectedBaseFeePerGas,
 		"%s commitment must match the block base fee", producer)
 	t.Require().Empty(payload.GasRefundEntries, "%s must not commit SDM refunds", producer)
 }

--- a/op-chain-ops/pkg/sdm/workload.go
+++ b/op-chain-ops/pkg/sdm/workload.go
@@ -244,8 +244,9 @@ func ValidatePostExecBlock(ctx context.Context, rpcClient Caller, blockNum uint6
 	if !baseFee.IsUint64() {
 		return nil, fmt.Errorf("block %d baseFeePerGas %s does not fit in uint64", blockNum, baseFee)
 	}
-	if payload.SelectedBaseFeePerGas != baseFee.Uint64() {
-		return nil, fmt.Errorf("post-exec selected_base_fee_per_gas %d, want block baseFeePerGas %d", payload.SelectedBaseFeePerGas, baseFee.Uint64())
+	selectedBaseFee := bigs.Uint64Strict(baseFee)
+	if payload.SelectedBaseFeePerGas != selectedBaseFee {
+		return nil, fmt.Errorf("post-exec selected_base_fee_per_gas %d, want block baseFeePerGas %d", payload.SelectedBaseFeePerGas, selectedBaseFee)
 	}
 
 	result := &ValidationResult{

--- a/op-chain-ops/pkg/sdm/workload.go
+++ b/op-chain-ops/pkg/sdm/workload.go
@@ -53,10 +53,11 @@ type RPCTransaction struct {
 
 // RPCBlock is a minimal block object returned by eth_getBlockByNumber(..., true).
 type RPCBlock struct {
-	Number       hexutil.Uint64   `json:"number"`
-	Hash         common.Hash      `json:"hash"`
-	GasUsed      hexutil.Uint64   `json:"gasUsed"`
-	Transactions []RPCTransaction `json:"transactions"`
+	Number        hexutil.Uint64   `json:"number"`
+	Hash          common.Hash      `json:"hash"`
+	GasUsed       hexutil.Uint64   `json:"gasUsed"`
+	BaseFeePerGas *hexutil.Big     `json:"baseFeePerGas"`
+	Transactions  []RPCTransaction `json:"transactions"`
 }
 
 // RPCReceipt is a minimal raw JSON receipt. It avoids ethclient's typed receipt decoding, which
@@ -236,8 +237,15 @@ func ValidatePostExecBlock(ctx context.Context, rpcClient Caller, blockNum uint6
 	if payload.BlockNumber != blockNum {
 		return nil, fmt.Errorf("post-exec payload block_number %d, want %d", payload.BlockNumber, blockNum)
 	}
-	if len(payload.GasRefundEntries) == 0 {
-		return nil, fmt.Errorf("block %d post-exec payload has no SDM refund entries", blockNum)
+	if block.BaseFeePerGas == nil {
+		return nil, fmt.Errorf("block %d has no baseFeePerGas", blockNum)
+	}
+	baseFee := (*big.Int)(block.BaseFeePerGas)
+	if !baseFee.IsUint64() {
+		return nil, fmt.Errorf("block %d baseFeePerGas %s does not fit in uint64", blockNum, baseFee)
+	}
+	if payload.SelectedBaseFeePerGas != baseFee.Uint64() {
+		return nil, fmt.Errorf("post-exec selected_base_fee_per_gas %d, want block baseFeePerGas %d", payload.SelectedBaseFeePerGas, baseFee.Uint64())
 	}
 
 	result := &ValidationResult{

--- a/op-core/types/post_exec_payload.go
+++ b/op-core/types/post_exec_payload.go
@@ -21,9 +21,10 @@ type SDMGasEntry struct {
 // PostExecPayload is the payload RLP-encoded into the Data of a [PostExecTx].
 // Field order must match op-alloy's PostExecPayload.
 type PostExecPayload struct {
-	Version          uint64        `json:"version"`
-	BlockNumber      uint64        `json:"block_number,omitempty"`
-	GasRefundEntries []SDMGasEntry `json:"gas_refund_entries"`
+	Version               uint64        `json:"version"`
+	BlockNumber           uint64        `json:"block_number,omitempty"`
+	SelectedBaseFeePerGas uint64        `json:"selected_base_fee_per_gas"`
+	GasRefundEntries      []SDMGasEntry `json:"gas_refund_entries"`
 }
 
 // DecodePostExecPayload decodes the bytes that follow the [PostExecTxType] type byte,

--- a/op-core/types/post_exec_payload_test.go
+++ b/op-core/types/post_exec_payload_test.go
@@ -10,8 +10,9 @@ import (
 // Keep decoding behavior aligned with op-alloy.
 func TestDecodePostExecPayload(t *testing.T) {
 	valid := PostExecPayload{
-		Version:     PostExecPayloadVersion,
-		BlockNumber: 42,
+		Version:               PostExecPayloadVersion,
+		BlockNumber:           42,
+		SelectedBaseFeePerGas: 123,
 		GasRefundEntries: []SDMGasEntry{
 			{Index: 1, GasRefund: 2500},
 			{Index: 3, GasRefund: 2000},
@@ -28,15 +29,17 @@ func TestDecodePostExecPayload(t *testing.T) {
 
 	t.Run("accepts an empty entry set", func(t *testing.T) {
 		raw, err := rlp.EncodeToBytes(&PostExecPayload{
-			Version:          PostExecPayloadVersion,
-			BlockNumber:      1,
-			GasRefundEntries: []SDMGasEntry{},
+			Version:               PostExecPayloadVersion,
+			BlockNumber:           1,
+			SelectedBaseFeePerGas: 123,
+			GasRefundEntries:      []SDMGasEntry{},
 		})
 		require.NoError(t, err)
 		got, err := DecodePostExecPayload(raw)
 		require.NoError(t, err)
 		require.Empty(t, got.GasRefundEntries)
 		require.Equal(t, uint64(1), got.BlockNumber)
+		require.Equal(t, uint64(123), got.SelectedBaseFeePerGas)
 	})
 
 	t.Run("rejects empty input", func(t *testing.T) {
@@ -57,7 +60,7 @@ func TestDecodePostExecPayload(t *testing.T) {
 	})
 
 	t.Run("rejects a list with too few fields", func(t *testing.T) {
-		// [1, []] is the old fixture's invalid two-field shape.
+		// [1, []] is an invalid two-field shape.
 		_, err := DecodePostExecPayload([]byte{0xc2, 0x01, 0xc0})
 		require.ErrorContains(t, err, "decode post-exec payload")
 	})

--- a/op-core/types/post_exec_tx_test.go
+++ b/op-core/types/post_exec_tx_test.go
@@ -38,12 +38,12 @@ func TestPostExecTxMarshalBinaryDifferential(t *testing.T) {
 
 // TestPostExecTxHashGoldenVector pins the cross-client post-exec (0x7D) tx hash: op-geth and
 // op-reth must agree on keccak256(0x7D || Data), the canonical EIP-2718 rule. data is op-alloy's
-// build_post_exec_tx(42, [{3,7}]); opRethTxHash is the value op-alloy pins for TxPostExec::tx_hash.
+// build_post_exec_tx(42, 123, [{3,7}]); opRethTxHash is the value op-alloy pins for TxPostExec::tx_hash.
 // Guards the op-geth hash fix against regression when the op-geth pin moves (old op-geth returned
 // keccak256(0x7D || RLP([Data]))).
 func TestPostExecTxHashGoldenVector(t *testing.T) {
-	data := hexutil.MustDecode("0xc6012ac3c20307")
-	const opRethTxHash = "0xcbc64a9665039744307b562634bf760d96f3bed235fecd9e09a1f1276a1823c7"
+	data := hexutil.MustDecode("0xc7012a7bc3c20307")
+	const opRethTxHash = "0xdf031dde1c8c591f49866e7877be7e81c86aa4ea4a170f806d21a390c01583bb"
 
 	gethHash := gethtypes.NewTx(&gethtypes.PostExecTx{Data: data}).Hash()
 	require.Equal(t, opRethTxHash, gethHash.Hex(),

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -11490,7 +11490,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -11517,7 +11517,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -11550,7 +11550,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.1.1",
@@ -11570,7 +11570,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -11583,7 +11583,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.1.1",
@@ -11672,7 +11672,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -11682,7 +11682,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-eips 2.1.1",
  "alloy-primitives",
@@ -11735,7 +11735,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -11751,7 +11751,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eip7928 0.4.5",
@@ -11765,7 +11765,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -11778,7 +11778,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -11803,7 +11803,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -11832,7 +11832,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -11858,7 +11858,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-genesis",
@@ -11888,7 +11888,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-eips 2.1.1",
  "alloy-primitives",
@@ -11903,7 +11903,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -11928,7 +11928,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -11952,7 +11952,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -11976,7 +11976,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -12011,7 +12011,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -12068,7 +12068,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -12095,7 +12095,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -12118,7 +12118,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -12145,7 +12145,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eip7928 0.4.5",
@@ -12200,7 +12200,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -12230,7 +12230,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -12248,7 +12248,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -12264,7 +12264,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -12287,7 +12287,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -12298,7 +12298,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -12327,7 +12327,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.1.1",
@@ -12352,7 +12352,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth 2.1.1",
@@ -12393,7 +12393,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "clap",
  "eyre",
@@ -12416,7 +12416,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -12432,7 +12432,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-eips 2.1.1",
  "alloy-primitives",
@@ -12448,7 +12448,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -12462,7 +12462,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -12492,7 +12492,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -12506,7 +12506,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -12516,7 +12516,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eip7928 0.4.5",
@@ -12541,7 +12541,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -12561,7 +12561,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -12579,7 +12579,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -12592,7 +12592,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -12611,7 +12611,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -12649,7 +12649,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-test-utils"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-eips 2.1.1",
  "eyre",
@@ -12681,7 +12681,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-eips 2.1.1",
  "alloy-primitives",
@@ -12695,7 +12695,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "serde",
  "serde_json",
@@ -12705,7 +12705,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -12731,7 +12731,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "bytes",
  "futures",
@@ -12751,7 +12751,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -12768,7 +12768,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "bindgen",
  "cc",
@@ -12777,7 +12777,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "futures",
  "metrics",
@@ -12790,7 +12790,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -12799,7 +12799,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "futures-util",
  "if-addrs 0.14.0",
@@ -12813,7 +12813,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -12871,7 +12871,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -12896,7 +12896,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eip7928 0.4.5",
@@ -12920,7 +12920,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -12935,7 +12935,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -12949,7 +12949,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -12966,7 +12966,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -12990,7 +12990,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -13058,7 +13058,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -13113,7 +13113,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -13162,7 +13162,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -13186,7 +13186,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -13210,7 +13210,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "bytes",
  "eyre",
@@ -13239,7 +13239,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -13870,7 +13870,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -13894,7 +13894,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -13906,7 +13906,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -13929,7 +13929,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-util"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -13939,7 +13939,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-rpc-types-engine",
@@ -13982,7 +13982,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eip7928 0.4.5",
@@ -14030,7 +14030,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -14057,7 +14057,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -14073,7 +14073,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -14088,7 +14088,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-dyn-abi",
@@ -14165,7 +14165,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-eips 2.1.1",
  "alloy-genesis",
@@ -14195,7 +14195,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-network 2.1.1",
  "alloy-provider",
@@ -14238,7 +14238,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-evm",
@@ -14258,7 +14258,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-eips 2.1.1",
  "alloy-primitives",
@@ -14289,7 +14289,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-dyn-abi",
@@ -14336,7 +14336,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.1.1",
@@ -14387,7 +14387,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -14401,7 +14401,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-eips 2.1.1",
  "alloy-primitives",
@@ -14432,7 +14432,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -14483,7 +14483,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-eips 2.1.1",
  "alloy-primitives",
@@ -14511,7 +14511,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -14525,7 +14525,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -14545,7 +14545,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -14560,7 +14560,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eip7928 0.4.5",
@@ -14586,7 +14586,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-eips 2.1.1",
  "alloy-primitives",
@@ -14603,7 +14603,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -14624,7 +14624,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -14640,7 +14640,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -14650,7 +14650,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "clap",
  "eyre",
@@ -14670,7 +14670,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -14689,7 +14689,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -14734,7 +14734,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -14759,7 +14759,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -14786,7 +14786,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -14805,7 +14805,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -14829,7 +14829,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
+source = "git+https://github.com/ethereum-optimism/reth?rev=ab694ead9065cd8c5bd3ae80c1663ac771152564#ab694ead9065cd8c5bd3ae80c1663ac771152564"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -11490,7 +11490,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -11517,7 +11517,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -11550,7 +11550,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.1.1",
@@ -11570,7 +11570,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -11583,7 +11583,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.1.1",
@@ -11672,7 +11672,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -11682,7 +11682,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-eips 2.1.1",
  "alloy-primitives",
@@ -11735,7 +11735,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -11751,7 +11751,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eip7928 0.4.5",
@@ -11765,7 +11765,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -11778,7 +11778,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -11803,7 +11803,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -11832,7 +11832,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -11858,7 +11858,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-genesis",
@@ -11888,7 +11888,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-eips 2.1.1",
  "alloy-primitives",
@@ -11903,7 +11903,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -11928,7 +11928,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -11952,7 +11952,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -11976,7 +11976,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -12011,7 +12011,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -12068,7 +12068,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -12095,7 +12095,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -12118,7 +12118,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -12145,7 +12145,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eip7928 0.4.5",
@@ -12200,7 +12200,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -12230,7 +12230,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -12248,7 +12248,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -12264,7 +12264,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -12287,7 +12287,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -12298,7 +12298,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -12327,7 +12327,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.1.1",
@@ -12352,7 +12352,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth 2.1.1",
@@ -12393,7 +12393,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "clap",
  "eyre",
@@ -12416,7 +12416,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -12432,7 +12432,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-eips 2.1.1",
  "alloy-primitives",
@@ -12448,7 +12448,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -12462,7 +12462,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -12492,7 +12492,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -12506,7 +12506,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -12516,7 +12516,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eip7928 0.4.5",
@@ -12541,7 +12541,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -12561,7 +12561,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -12579,7 +12579,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -12592,7 +12592,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -12611,7 +12611,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -12649,7 +12649,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-test-utils"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-eips 2.1.1",
  "eyre",
@@ -12681,7 +12681,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-eips 2.1.1",
  "alloy-primitives",
@@ -12695,7 +12695,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "serde",
  "serde_json",
@@ -12705,7 +12705,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -12731,7 +12731,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "bytes",
  "futures",
@@ -12751,7 +12751,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -12768,7 +12768,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "bindgen",
  "cc",
@@ -12777,7 +12777,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "futures",
  "metrics",
@@ -12790,7 +12790,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -12799,7 +12799,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "futures-util",
  "if-addrs 0.14.0",
@@ -12813,7 +12813,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -12871,7 +12871,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -12896,7 +12896,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eip7928 0.4.5",
@@ -12920,7 +12920,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -12935,7 +12935,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -12949,7 +12949,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -12966,7 +12966,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -12990,7 +12990,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -13058,7 +13058,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -13113,7 +13113,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -13162,7 +13162,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -13186,7 +13186,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -13210,7 +13210,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "bytes",
  "eyre",
@@ -13239,7 +13239,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -13869,7 +13869,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -13893,7 +13893,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -13905,7 +13905,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -13928,7 +13928,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-util"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -13938,7 +13938,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-rpc-types-engine",
@@ -13981,7 +13981,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eip7928 0.4.5",
@@ -14029,7 +14029,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -14056,7 +14056,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -14072,7 +14072,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -14087,7 +14087,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-dyn-abi",
@@ -14164,7 +14164,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-eips 2.1.1",
  "alloy-genesis",
@@ -14194,7 +14194,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-network 2.1.1",
  "alloy-provider",
@@ -14237,7 +14237,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-evm",
@@ -14257,7 +14257,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-eips 2.1.1",
  "alloy-primitives",
@@ -14288,7 +14288,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-dyn-abi",
@@ -14335,7 +14335,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.1.1",
@@ -14386,7 +14386,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -14400,7 +14400,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-eips 2.1.1",
  "alloy-primitives",
@@ -14431,7 +14431,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -14482,7 +14482,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-eips 2.1.1",
  "alloy-primitives",
@@ -14510,7 +14510,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -14524,7 +14524,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -14544,7 +14544,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -14559,7 +14559,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eip7928 0.4.5",
@@ -14585,7 +14585,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-eips 2.1.1",
  "alloy-primitives",
@@ -14602,7 +14602,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -14623,7 +14623,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -14639,7 +14639,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -14649,7 +14649,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "clap",
  "eyre",
@@ -14669,7 +14669,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -14688,7 +14688,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -14733,7 +14733,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -14758,7 +14758,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -14785,7 +14785,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -14804,7 +14804,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -14828,7 +14828,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.4.0"
-source = "git+https://github.com/op-rs/reth?rev=aef8d3ef92117f91455e16969f0adf5bf7c6e9e1#aef8d3ef92117f91455e16969f0adf5bf7c6e9e1"
+source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -11490,7 +11490,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -11517,7 +11517,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -11550,7 +11550,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.1.1",
@@ -11570,7 +11570,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -11583,7 +11583,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.1.1",
@@ -11672,7 +11672,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -11682,7 +11682,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-eips 2.1.1",
  "alloy-primitives",
@@ -11735,7 +11735,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -11751,7 +11751,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eip7928 0.4.5",
@@ -11765,7 +11765,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -11778,7 +11778,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -11803,7 +11803,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -11832,7 +11832,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -11858,7 +11858,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-genesis",
@@ -11888,7 +11888,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-eips 2.1.1",
  "alloy-primitives",
@@ -11903,7 +11903,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -11928,7 +11928,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -11952,7 +11952,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -11976,7 +11976,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -12011,7 +12011,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -12068,7 +12068,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -12095,7 +12095,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -12118,7 +12118,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -12145,7 +12145,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eip7928 0.4.5",
@@ -12200,7 +12200,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -12230,7 +12230,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -12248,7 +12248,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -12264,7 +12264,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -12287,7 +12287,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -12298,7 +12298,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -12327,7 +12327,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.1.1",
@@ -12352,7 +12352,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth 2.1.1",
@@ -12393,7 +12393,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "clap",
  "eyre",
@@ -12416,7 +12416,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -12432,7 +12432,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-eips 2.1.1",
  "alloy-primitives",
@@ -12448,7 +12448,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -12462,7 +12462,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -12492,7 +12492,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -12506,7 +12506,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -12516,7 +12516,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eip7928 0.4.5",
@@ -12541,7 +12541,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -12561,7 +12561,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -12579,7 +12579,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -12592,7 +12592,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -12611,7 +12611,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -12649,7 +12649,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-test-utils"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-eips 2.1.1",
  "eyre",
@@ -12681,7 +12681,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-eips 2.1.1",
  "alloy-primitives",
@@ -12695,7 +12695,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "serde",
  "serde_json",
@@ -12705,7 +12705,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -12731,7 +12731,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "bytes",
  "futures",
@@ -12751,7 +12751,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -12768,7 +12768,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "bindgen",
  "cc",
@@ -12777,7 +12777,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "futures",
  "metrics",
@@ -12790,7 +12790,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -12799,7 +12799,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "futures-util",
  "if-addrs 0.14.0",
@@ -12813,7 +12813,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -12871,7 +12871,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -12896,7 +12896,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eip7928 0.4.5",
@@ -12920,7 +12920,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -12935,7 +12935,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -12949,7 +12949,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -12966,7 +12966,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -12990,7 +12990,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -13058,7 +13058,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -13113,7 +13113,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -13162,7 +13162,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -13186,7 +13186,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -13210,7 +13210,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "bytes",
  "eyre",
@@ -13239,7 +13239,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -13870,7 +13870,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -13894,7 +13894,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -13906,7 +13906,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -13929,7 +13929,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-util"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -13939,7 +13939,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-rpc-types-engine",
@@ -13982,7 +13982,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eip7928 0.4.5",
@@ -14030,7 +14030,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -14057,7 +14057,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -14073,7 +14073,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -14088,7 +14088,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-dyn-abi",
@@ -14165,7 +14165,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-eips 2.1.1",
  "alloy-genesis",
@@ -14195,7 +14195,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-network 2.1.1",
  "alloy-provider",
@@ -14238,7 +14238,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-evm",
@@ -14258,7 +14258,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-eips 2.1.1",
  "alloy-primitives",
@@ -14289,7 +14289,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-dyn-abi",
@@ -14336,7 +14336,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.1.1",
@@ -14387,7 +14387,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -14401,7 +14401,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-eips 2.1.1",
  "alloy-primitives",
@@ -14432,7 +14432,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -14483,7 +14483,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-eips 2.1.1",
  "alloy-primitives",
@@ -14511,7 +14511,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -14525,7 +14525,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -14545,7 +14545,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -14560,7 +14560,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eip7928 0.4.5",
@@ -14586,7 +14586,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-eips 2.1.1",
  "alloy-primitives",
@@ -14603,7 +14603,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -14624,7 +14624,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -14640,7 +14640,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -14650,7 +14650,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "clap",
  "eyre",
@@ -14670,7 +14670,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -14689,7 +14689,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -14734,7 +14734,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -14759,7 +14759,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -14786,7 +14786,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -14805,7 +14805,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -14829,7 +14829,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.4.0"
-source = "git+https://github.com/joshklop/reth?rev=2e6fd33456d76e54fe4cb98f8af44f856b0426f7#2e6fd33456d76e54fe4cb98f8af44f856b0426f7"
+source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -11490,7 +11490,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -11517,7 +11517,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -11550,7 +11550,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.1.1",
@@ -11570,7 +11570,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -11583,7 +11583,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.1.1",
@@ -11672,7 +11672,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -11682,7 +11682,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-eips 2.1.1",
  "alloy-primitives",
@@ -11735,7 +11735,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -11751,7 +11751,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eip7928 0.4.5",
@@ -11765,7 +11765,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -11778,7 +11778,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -11803,7 +11803,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -11832,7 +11832,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -11858,7 +11858,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-genesis",
@@ -11888,7 +11888,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-eips 2.1.1",
  "alloy-primitives",
@@ -11903,7 +11903,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -11928,7 +11928,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -11952,7 +11952,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -11976,7 +11976,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -12011,7 +12011,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -12068,7 +12068,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -12095,7 +12095,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -12118,7 +12118,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -12145,7 +12145,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eip7928 0.4.5",
@@ -12200,7 +12200,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -12230,7 +12230,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -12248,7 +12248,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -12264,7 +12264,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -12287,7 +12287,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -12298,7 +12298,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -12327,7 +12327,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.1.1",
@@ -12352,7 +12352,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth 2.1.1",
@@ -12393,7 +12393,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "clap",
  "eyre",
@@ -12416,7 +12416,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -12432,7 +12432,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-eips 2.1.1",
  "alloy-primitives",
@@ -12448,7 +12448,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -12462,7 +12462,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -12492,7 +12492,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -12506,7 +12506,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -12516,7 +12516,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eip7928 0.4.5",
@@ -12541,7 +12541,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -12561,7 +12561,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -12579,7 +12579,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -12592,7 +12592,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -12611,7 +12611,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -12649,7 +12649,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-test-utils"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-eips 2.1.1",
  "eyre",
@@ -12681,7 +12681,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-eips 2.1.1",
  "alloy-primitives",
@@ -12695,7 +12695,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "serde",
  "serde_json",
@@ -12705,7 +12705,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -12731,7 +12731,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "bytes",
  "futures",
@@ -12751,7 +12751,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -12768,7 +12768,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "bindgen",
  "cc",
@@ -12777,7 +12777,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "futures",
  "metrics",
@@ -12790,7 +12790,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -12799,7 +12799,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "futures-util",
  "if-addrs 0.14.0",
@@ -12813,7 +12813,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -12871,7 +12871,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -12896,7 +12896,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eip7928 0.4.5",
@@ -12920,7 +12920,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -12935,7 +12935,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -12949,7 +12949,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -12966,7 +12966,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -12990,7 +12990,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -13058,7 +13058,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -13113,7 +13113,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -13162,7 +13162,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -13186,7 +13186,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -13210,7 +13210,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "bytes",
  "eyre",
@@ -13239,7 +13239,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -13870,7 +13870,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -13894,7 +13894,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -13906,7 +13906,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -13929,7 +13929,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-util"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -13939,7 +13939,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-rpc-types-engine",
@@ -13982,7 +13982,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eip7928 0.4.5",
@@ -14030,7 +14030,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -14057,7 +14057,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -14073,7 +14073,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -14088,7 +14088,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-dyn-abi",
@@ -14165,7 +14165,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-eips 2.1.1",
  "alloy-genesis",
@@ -14195,7 +14195,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-network 2.1.1",
  "alloy-provider",
@@ -14238,7 +14238,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-evm",
@@ -14258,7 +14258,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-eips 2.1.1",
  "alloy-primitives",
@@ -14289,7 +14289,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-dyn-abi",
@@ -14336,7 +14336,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.1.1",
@@ -14387,7 +14387,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -14401,7 +14401,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-eips 2.1.1",
  "alloy-primitives",
@@ -14432,7 +14432,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -14483,7 +14483,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-eips 2.1.1",
  "alloy-primitives",
@@ -14511,7 +14511,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -14525,7 +14525,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -14545,7 +14545,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -14560,7 +14560,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eip7928 0.4.5",
@@ -14586,7 +14586,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-eips 2.1.1",
  "alloy-primitives",
@@ -14603,7 +14603,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -14624,7 +14624,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -14640,7 +14640,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -14650,7 +14650,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "clap",
  "eyre",
@@ -14670,7 +14670,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -14689,7 +14689,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -14734,7 +14734,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -14759,7 +14759,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -14786,7 +14786,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -14805,7 +14805,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -14829,7 +14829,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
+source = "git+https://github.com/ethereum-optimism/reth?rev=a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77#a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -11490,7 +11490,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -11517,7 +11517,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -11550,7 +11550,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.1.1",
@@ -11570,7 +11570,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -11583,7 +11583,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.1.1",
@@ -11672,7 +11672,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -11682,7 +11682,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-eips 2.1.1",
  "alloy-primitives",
@@ -11735,7 +11735,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -11751,7 +11751,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eip7928 0.4.5",
@@ -11765,7 +11765,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -11778,7 +11778,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -11803,7 +11803,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -11832,7 +11832,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -11858,7 +11858,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-genesis",
@@ -11888,7 +11888,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-eips 2.1.1",
  "alloy-primitives",
@@ -11903,7 +11903,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -11928,7 +11928,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -11952,7 +11952,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -11976,7 +11976,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -12011,7 +12011,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -12068,7 +12068,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -12095,7 +12095,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -12118,7 +12118,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -12145,7 +12145,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eip7928 0.4.5",
@@ -12200,7 +12200,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -12230,7 +12230,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -12248,7 +12248,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -12264,7 +12264,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -12287,7 +12287,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -12298,7 +12298,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -12327,7 +12327,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.1.1",
@@ -12352,7 +12352,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth 2.1.1",
@@ -12393,7 +12393,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "clap",
  "eyre",
@@ -12416,7 +12416,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -12432,7 +12432,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-eips 2.1.1",
  "alloy-primitives",
@@ -12448,7 +12448,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -12462,7 +12462,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -12492,7 +12492,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -12506,7 +12506,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -12516,7 +12516,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eip7928 0.4.5",
@@ -12541,7 +12541,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -12561,7 +12561,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -12579,7 +12579,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -12592,7 +12592,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -12611,7 +12611,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -12649,7 +12649,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-test-utils"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-eips 2.1.1",
  "eyre",
@@ -12681,7 +12681,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-eips 2.1.1",
  "alloy-primitives",
@@ -12695,7 +12695,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "serde",
  "serde_json",
@@ -12705,7 +12705,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -12731,7 +12731,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "bytes",
  "futures",
@@ -12751,7 +12751,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -12768,7 +12768,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "bindgen",
  "cc",
@@ -12777,7 +12777,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "futures",
  "metrics",
@@ -12790,7 +12790,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -12799,7 +12799,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "futures-util",
  "if-addrs 0.14.0",
@@ -12813,7 +12813,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -12871,7 +12871,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -12896,7 +12896,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eip7928 0.4.5",
@@ -12920,7 +12920,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -12935,7 +12935,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -12949,7 +12949,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -12966,7 +12966,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -12990,7 +12990,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -13058,7 +13058,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -13113,7 +13113,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -13162,7 +13162,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -13186,7 +13186,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -13210,7 +13210,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "bytes",
  "eyre",
@@ -13239,7 +13239,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -13870,7 +13870,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -13894,7 +13894,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -13906,7 +13906,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -13929,7 +13929,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-util"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -13939,7 +13939,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-rpc-types-engine",
@@ -13982,7 +13982,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eip7928 0.4.5",
@@ -14030,7 +14030,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -14057,7 +14057,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -14073,7 +14073,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -14088,7 +14088,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-dyn-abi",
@@ -14165,7 +14165,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-eips 2.1.1",
  "alloy-genesis",
@@ -14195,7 +14195,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-network 2.1.1",
  "alloy-provider",
@@ -14238,7 +14238,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-evm",
@@ -14258,7 +14258,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-eips 2.1.1",
  "alloy-primitives",
@@ -14289,7 +14289,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-dyn-abi",
@@ -14336,7 +14336,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.1.1",
@@ -14387,7 +14387,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -14401,7 +14401,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-eips 2.1.1",
  "alloy-primitives",
@@ -14432,7 +14432,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -14483,7 +14483,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-eips 2.1.1",
  "alloy-primitives",
@@ -14511,7 +14511,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -14525,7 +14525,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -14545,7 +14545,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -14560,7 +14560,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eip7928 0.4.5",
@@ -14586,7 +14586,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-eips 2.1.1",
  "alloy-primitives",
@@ -14603,7 +14603,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -14624,7 +14624,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -14640,7 +14640,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -14650,7 +14650,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "clap",
  "eyre",
@@ -14670,7 +14670,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -14689,7 +14689,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -14734,7 +14734,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
@@ -14759,7 +14759,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-primitives",
@@ -14786,7 +14786,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -14805,7 +14805,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -14829,7 +14829,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.4.0"
-source = "git+https://github.com/ethereum-optimism/reth?rev=b983c155b936f50acb91f30b5c6705ff39063601#b983c155b936f50acb91f30b5c6705ff39063601"
+source = "git+https://github.com/ethereum-optimism/reth?rev=5cf3cdc99e354578ac1006448f1636c0d47ecc43#5cf3cdc99e354578ac1006448f1636c0d47ecc43"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -13724,6 +13724,7 @@ dependencies = [
  "reth-basic-payload-builder",
  "reth-chain-state",
  "reth-chainspec",
+ "reth-errors",
  "reth-evm",
  "reth-metrics",
  "reth-node-api",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -359,76 +359,76 @@ reth-rpc-traits = { version = "0.5.0", default-features = false }
 reth-zstd-compressors = { version = "0.5.0", default-features = false }
 
 # ==================== RETH CRATES (git) ====================
-reth = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1" }
-reth-basic-payload-builder = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1" }
-reth-chain-state = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1" }
-reth-chainspec = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1", default-features = false }
-reth-cli = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1" }
-reth-cli-commands = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1" }
-reth-cli-runner = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1" }
-reth-cli-util = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1" }
-reth-consensus = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1", default-features = false }
-reth-consensus-common = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1", default-features = false }
-reth-db = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1", default-features = false }
-reth-db-api = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1" }
-reth-db-common = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1" }
-reth-downloaders = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1" }
-reth-e2e-test-utils = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1" }
-reth-engine-local = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1" }
-reth-engine-primitives = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1", default-features = false }
-reth-errors = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1" }
-reth-eth-wire = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1" }
-reth-eth-wire-types = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1" }
-reth-ethereum = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1" }
-reth-ethereum-cli = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1" }
-reth-ethereum-consensus = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1" }
-reth-ethereum-forks = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1", default-features = false }
-reth-ethereum-primitives = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1" }
-reth-evm = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1", default-features = false }
-reth-evm-ethereum = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1" }
-reth-exex = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1" }
-reth-exex-test-utils = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1" }
-reth-execution-errors = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1", default-features = false }
-reth-execution-types = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1", default-features = false }
-reth-fs-util = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1" }
-reth-metrics = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1" }
-reth-network = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1" }
-reth-network-api = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1" }
-reth-network-peers = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1", default-features = false }
-reth-node-api = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1" }
-reth-node-builder = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1" }
-reth-node-core = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1" }
-reth-node-ethereum = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1" }
-reth-node-events = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1" }
-reth-node-metrics = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1" }
-reth-payload-builder = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1" }
-reth-payload-builder-primitives = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1" }
-reth-payload-primitives = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1" }
-reth-payload-util = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1" }
-reth-payload-validator = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1" }
-reth-provider = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1" }
-reth-prune = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1" }
-reth-prune-types = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1", default-features = false }
-reth-revm = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1", default-features = false }
-reth-rpc = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1" }
-reth-rpc-api = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1" }
-reth-rpc-builder = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1" }
-reth-rpc-engine-api = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1" }
-reth-rpc-eth-api = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1" }
-reth-rpc-eth-types = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1", default-features = false }
-reth-rpc-server-types = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1" }
-reth-stages = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1" }
-reth-stages-types = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1", default-features = false }
-reth-static-file = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1" }
-reth-static-file-types = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1", default-features = false }
-reth-storage-api = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1", default-features = false }
-reth-storage-errors = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1", default-features = false }
-reth-tasks = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1" }
-reth-tracing = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1", default-features = false }
-reth-transaction-pool = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1" }
-reth-trie = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1" }
-reth-trie-common = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1", default-features = false }
-reth-trie-db = { git = "https://github.com/op-rs/reth", rev = "aef8d3ef92117f91455e16969f0adf5bf7c6e9e1" }
+reth = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
+reth-basic-payload-builder = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
+reth-chain-state = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
+reth-chainspec = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7", default-features = false }
+reth-cli = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
+reth-cli-commands = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
+reth-cli-runner = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
+reth-cli-util = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
+reth-consensus = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7", default-features = false }
+reth-consensus-common = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7", default-features = false }
+reth-db = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7", default-features = false }
+reth-db-api = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
+reth-db-common = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
+reth-downloaders = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
+reth-e2e-test-utils = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
+reth-engine-local = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
+reth-engine-primitives = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7", default-features = false }
+reth-errors = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
+reth-eth-wire = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
+reth-eth-wire-types = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
+reth-ethereum = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
+reth-ethereum-cli = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
+reth-ethereum-consensus = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
+reth-ethereum-forks = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7", default-features = false }
+reth-ethereum-primitives = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
+reth-evm = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7", default-features = false }
+reth-evm-ethereum = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
+reth-exex = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
+reth-exex-test-utils = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
+reth-execution-errors = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7", default-features = false }
+reth-execution-types = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7", default-features = false }
+reth-fs-util = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
+reth-metrics = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
+reth-network = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
+reth-network-api = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
+reth-network-peers = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7", default-features = false }
+reth-node-api = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
+reth-node-builder = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
+reth-node-core = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
+reth-node-ethereum = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
+reth-node-events = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
+reth-node-metrics = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
+reth-payload-builder = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
+reth-payload-builder-primitives = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
+reth-payload-primitives = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
+reth-payload-util = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
+reth-payload-validator = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
+reth-provider = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
+reth-prune = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
+reth-prune-types = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7", default-features = false }
+reth-revm = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7", default-features = false }
+reth-rpc = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
+reth-rpc-api = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
+reth-rpc-builder = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
+reth-rpc-engine-api = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
+reth-rpc-eth-api = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
+reth-rpc-eth-types = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7", default-features = false }
+reth-rpc-server-types = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
+reth-stages = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
+reth-stages-types = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7", default-features = false }
+reth-static-file = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
+reth-static-file-types = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7", default-features = false }
+reth-storage-api = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7", default-features = false }
+reth-storage-errors = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7", default-features = false }
+reth-tasks = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
+reth-tracing = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7", default-features = false }
+reth-transaction-pool = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
+reth-trie = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
+reth-trie-common = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7", default-features = false }
+reth-trie-db = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
 
 # ==================== REVM (latest: op-reth versions) ====================
 revm = { version = "41.0.0", default-features = false }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -359,76 +359,76 @@ reth-rpc-traits = { version = "0.5.0", default-features = false }
 reth-zstd-compressors = { version = "0.5.0", default-features = false }
 
 # ==================== RETH CRATES (git) ====================
-reth = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
-reth-basic-payload-builder = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
-reth-chain-state = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
-reth-chainspec = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7", default-features = false }
-reth-cli = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
-reth-cli-commands = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
-reth-cli-runner = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
-reth-cli-util = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
-reth-consensus = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7", default-features = false }
-reth-consensus-common = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7", default-features = false }
-reth-db = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7", default-features = false }
-reth-db-api = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
-reth-db-common = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
-reth-downloaders = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
-reth-e2e-test-utils = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
-reth-engine-local = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
-reth-engine-primitives = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7", default-features = false }
-reth-errors = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
-reth-eth-wire = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
-reth-eth-wire-types = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
-reth-ethereum = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
-reth-ethereum-cli = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
-reth-ethereum-consensus = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
-reth-ethereum-forks = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7", default-features = false }
-reth-ethereum-primitives = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
-reth-evm = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7", default-features = false }
-reth-evm-ethereum = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
-reth-exex = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
-reth-exex-test-utils = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
-reth-execution-errors = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7", default-features = false }
-reth-execution-types = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7", default-features = false }
-reth-fs-util = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
-reth-metrics = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
-reth-network = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
-reth-network-api = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
-reth-network-peers = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7", default-features = false }
-reth-node-api = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
-reth-node-builder = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
-reth-node-core = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
-reth-node-ethereum = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
-reth-node-events = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
-reth-node-metrics = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
-reth-payload-builder = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
-reth-payload-builder-primitives = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
-reth-payload-primitives = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
-reth-payload-util = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
-reth-payload-validator = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
-reth-provider = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
-reth-prune = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
-reth-prune-types = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7", default-features = false }
-reth-revm = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7", default-features = false }
-reth-rpc = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
-reth-rpc-api = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
-reth-rpc-builder = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
-reth-rpc-engine-api = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
-reth-rpc-eth-api = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
-reth-rpc-eth-types = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7", default-features = false }
-reth-rpc-server-types = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
-reth-stages = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
-reth-stages-types = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7", default-features = false }
-reth-static-file = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
-reth-static-file-types = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7", default-features = false }
-reth-storage-api = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7", default-features = false }
-reth-storage-errors = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7", default-features = false }
-reth-tasks = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
-reth-tracing = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7", default-features = false }
-reth-transaction-pool = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
-reth-trie = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
-reth-trie-common = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7", default-features = false }
-reth-trie-db = { git = "https://github.com/joshklop/reth", rev = "2e6fd33456d76e54fe4cb98f8af44f856b0426f7" }
+reth = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
+reth-basic-payload-builder = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
+reth-chain-state = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
+reth-chainspec = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601", default-features = false }
+reth-cli = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
+reth-cli-commands = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
+reth-cli-runner = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
+reth-cli-util = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
+reth-consensus = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601", default-features = false }
+reth-consensus-common = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601", default-features = false }
+reth-db = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601", default-features = false }
+reth-db-api = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
+reth-db-common = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
+reth-downloaders = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
+reth-e2e-test-utils = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
+reth-engine-local = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
+reth-engine-primitives = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601", default-features = false }
+reth-errors = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
+reth-eth-wire = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
+reth-eth-wire-types = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
+reth-ethereum = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
+reth-ethereum-cli = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
+reth-ethereum-consensus = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
+reth-ethereum-forks = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601", default-features = false }
+reth-ethereum-primitives = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
+reth-evm = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601", default-features = false }
+reth-evm-ethereum = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
+reth-exex = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
+reth-exex-test-utils = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
+reth-execution-errors = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601", default-features = false }
+reth-execution-types = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601", default-features = false }
+reth-fs-util = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
+reth-metrics = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
+reth-network = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
+reth-network-api = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
+reth-network-peers = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601", default-features = false }
+reth-node-api = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
+reth-node-builder = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
+reth-node-core = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
+reth-node-ethereum = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
+reth-node-events = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
+reth-node-metrics = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
+reth-payload-builder = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
+reth-payload-builder-primitives = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
+reth-payload-primitives = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
+reth-payload-util = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
+reth-payload-validator = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
+reth-provider = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
+reth-prune = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
+reth-prune-types = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601", default-features = false }
+reth-revm = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601", default-features = false }
+reth-rpc = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
+reth-rpc-api = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
+reth-rpc-builder = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
+reth-rpc-engine-api = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
+reth-rpc-eth-api = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
+reth-rpc-eth-types = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601", default-features = false }
+reth-rpc-server-types = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
+reth-stages = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
+reth-stages-types = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601", default-features = false }
+reth-static-file = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
+reth-static-file-types = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601", default-features = false }
+reth-storage-api = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601", default-features = false }
+reth-storage-errors = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601", default-features = false }
+reth-tasks = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
+reth-tracing = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601", default-features = false }
+reth-transaction-pool = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
+reth-trie = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
+reth-trie-common = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601", default-features = false }
+reth-trie-db = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
 
 # ==================== REVM (latest: op-reth versions) ====================
 revm = { version = "41.0.0", default-features = false }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -359,76 +359,76 @@ reth-rpc-traits = { version = "0.5.0", default-features = false }
 reth-zstd-compressors = { version = "0.5.0", default-features = false }
 
 # ==================== RETH CRATES (git) ====================
-reth = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
-reth-basic-payload-builder = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
-reth-chain-state = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
-reth-chainspec = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43", default-features = false }
-reth-cli = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
-reth-cli-commands = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
-reth-cli-runner = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
-reth-cli-util = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
-reth-consensus = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43", default-features = false }
-reth-consensus-common = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43", default-features = false }
-reth-db = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43", default-features = false }
-reth-db-api = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
-reth-db-common = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
-reth-downloaders = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
-reth-e2e-test-utils = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
-reth-engine-local = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
-reth-engine-primitives = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43", default-features = false }
-reth-errors = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
-reth-eth-wire = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
-reth-eth-wire-types = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
-reth-ethereum = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
-reth-ethereum-cli = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
-reth-ethereum-consensus = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
-reth-ethereum-forks = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43", default-features = false }
-reth-ethereum-primitives = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
-reth-evm = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43", default-features = false }
-reth-evm-ethereum = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
-reth-exex = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
-reth-exex-test-utils = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
-reth-execution-errors = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43", default-features = false }
-reth-execution-types = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43", default-features = false }
-reth-fs-util = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
-reth-metrics = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
-reth-network = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
-reth-network-api = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
-reth-network-peers = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43", default-features = false }
-reth-node-api = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
-reth-node-builder = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
-reth-node-core = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
-reth-node-ethereum = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
-reth-node-events = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
-reth-node-metrics = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
-reth-payload-builder = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
-reth-payload-builder-primitives = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
-reth-payload-primitives = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
-reth-payload-util = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
-reth-payload-validator = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
-reth-provider = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
-reth-prune = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
-reth-prune-types = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43", default-features = false }
-reth-revm = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43", default-features = false }
-reth-rpc = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
-reth-rpc-api = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
-reth-rpc-builder = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
-reth-rpc-engine-api = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
-reth-rpc-eth-api = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
-reth-rpc-eth-types = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43", default-features = false }
-reth-rpc-server-types = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
-reth-stages = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
-reth-stages-types = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43", default-features = false }
-reth-static-file = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
-reth-static-file-types = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43", default-features = false }
-reth-storage-api = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43", default-features = false }
-reth-storage-errors = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43", default-features = false }
-reth-tasks = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
-reth-tracing = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43", default-features = false }
-reth-transaction-pool = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
-reth-trie = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
-reth-trie-common = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43", default-features = false }
-reth-trie-db = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
+reth = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
+reth-basic-payload-builder = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
+reth-chain-state = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
+reth-chainspec = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77", default-features = false }
+reth-cli = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
+reth-cli-commands = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
+reth-cli-runner = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
+reth-cli-util = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
+reth-consensus = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77", default-features = false }
+reth-consensus-common = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77", default-features = false }
+reth-db = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77", default-features = false }
+reth-db-api = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
+reth-db-common = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
+reth-downloaders = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
+reth-e2e-test-utils = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
+reth-engine-local = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
+reth-engine-primitives = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77", default-features = false }
+reth-errors = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
+reth-eth-wire = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
+reth-eth-wire-types = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
+reth-ethereum = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
+reth-ethereum-cli = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
+reth-ethereum-consensus = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
+reth-ethereum-forks = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77", default-features = false }
+reth-ethereum-primitives = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
+reth-evm = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77", default-features = false }
+reth-evm-ethereum = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
+reth-exex = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
+reth-exex-test-utils = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
+reth-execution-errors = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77", default-features = false }
+reth-execution-types = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77", default-features = false }
+reth-fs-util = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
+reth-metrics = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
+reth-network = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
+reth-network-api = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
+reth-network-peers = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77", default-features = false }
+reth-node-api = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
+reth-node-builder = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
+reth-node-core = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
+reth-node-ethereum = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
+reth-node-events = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
+reth-node-metrics = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
+reth-payload-builder = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
+reth-payload-builder-primitives = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
+reth-payload-primitives = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
+reth-payload-util = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
+reth-payload-validator = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
+reth-provider = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
+reth-prune = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
+reth-prune-types = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77", default-features = false }
+reth-revm = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77", default-features = false }
+reth-rpc = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
+reth-rpc-api = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
+reth-rpc-builder = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
+reth-rpc-engine-api = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
+reth-rpc-eth-api = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
+reth-rpc-eth-types = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77", default-features = false }
+reth-rpc-server-types = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
+reth-stages = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
+reth-stages-types = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77", default-features = false }
+reth-static-file = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
+reth-static-file-types = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77", default-features = false }
+reth-storage-api = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77", default-features = false }
+reth-storage-errors = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77", default-features = false }
+reth-tasks = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
+reth-tracing = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77", default-features = false }
+reth-transaction-pool = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
+reth-trie = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
+reth-trie-common = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77", default-features = false }
+reth-trie-db = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
 
 # ==================== REVM (latest: op-reth versions) ====================
 revm = { version = "41.0.0", default-features = false }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -359,76 +359,76 @@ reth-rpc-traits = { version = "0.5.0", default-features = false }
 reth-zstd-compressors = { version = "0.5.0", default-features = false }
 
 # ==================== RETH CRATES (git) ====================
-reth = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
-reth-basic-payload-builder = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
-reth-chain-state = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
-reth-chainspec = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77", default-features = false }
-reth-cli = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
-reth-cli-commands = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
-reth-cli-runner = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
-reth-cli-util = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
-reth-consensus = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77", default-features = false }
-reth-consensus-common = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77", default-features = false }
-reth-db = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77", default-features = false }
-reth-db-api = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
-reth-db-common = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
-reth-downloaders = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
-reth-e2e-test-utils = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
-reth-engine-local = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
-reth-engine-primitives = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77", default-features = false }
-reth-errors = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
-reth-eth-wire = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
-reth-eth-wire-types = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
-reth-ethereum = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
-reth-ethereum-cli = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
-reth-ethereum-consensus = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
-reth-ethereum-forks = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77", default-features = false }
-reth-ethereum-primitives = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
-reth-evm = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77", default-features = false }
-reth-evm-ethereum = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
-reth-exex = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
-reth-exex-test-utils = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
-reth-execution-errors = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77", default-features = false }
-reth-execution-types = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77", default-features = false }
-reth-fs-util = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
-reth-metrics = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
-reth-network = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
-reth-network-api = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
-reth-network-peers = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77", default-features = false }
-reth-node-api = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
-reth-node-builder = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
-reth-node-core = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
-reth-node-ethereum = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
-reth-node-events = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
-reth-node-metrics = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
-reth-payload-builder = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
-reth-payload-builder-primitives = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
-reth-payload-primitives = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
-reth-payload-util = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
-reth-payload-validator = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
-reth-provider = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
-reth-prune = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
-reth-prune-types = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77", default-features = false }
-reth-revm = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77", default-features = false }
-reth-rpc = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
-reth-rpc-api = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
-reth-rpc-builder = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
-reth-rpc-engine-api = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
-reth-rpc-eth-api = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
-reth-rpc-eth-types = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77", default-features = false }
-reth-rpc-server-types = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
-reth-stages = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
-reth-stages-types = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77", default-features = false }
-reth-static-file = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
-reth-static-file-types = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77", default-features = false }
-reth-storage-api = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77", default-features = false }
-reth-storage-errors = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77", default-features = false }
-reth-tasks = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
-reth-tracing = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77", default-features = false }
-reth-transaction-pool = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
-reth-trie = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
-reth-trie-common = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77", default-features = false }
-reth-trie-db = { git = "https://github.com/ethereum-optimism/reth", rev = "a7a983a081bc9d6ae1443b94c6a9f9b8b166bd77" }
+reth = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564" }
+reth-basic-payload-builder = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564" }
+reth-chain-state = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564" }
+reth-chainspec = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564", default-features = false }
+reth-cli = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564" }
+reth-cli-commands = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564" }
+reth-cli-runner = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564" }
+reth-cli-util = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564" }
+reth-consensus = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564", default-features = false }
+reth-consensus-common = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564", default-features = false }
+reth-db = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564", default-features = false }
+reth-db-api = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564" }
+reth-db-common = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564" }
+reth-downloaders = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564" }
+reth-e2e-test-utils = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564" }
+reth-engine-local = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564" }
+reth-engine-primitives = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564", default-features = false }
+reth-errors = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564" }
+reth-eth-wire = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564" }
+reth-eth-wire-types = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564" }
+reth-ethereum = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564" }
+reth-ethereum-cli = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564" }
+reth-ethereum-consensus = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564" }
+reth-ethereum-forks = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564", default-features = false }
+reth-ethereum-primitives = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564" }
+reth-evm = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564", default-features = false }
+reth-evm-ethereum = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564" }
+reth-exex = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564" }
+reth-exex-test-utils = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564" }
+reth-execution-errors = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564", default-features = false }
+reth-execution-types = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564", default-features = false }
+reth-fs-util = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564" }
+reth-metrics = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564" }
+reth-network = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564" }
+reth-network-api = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564" }
+reth-network-peers = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564", default-features = false }
+reth-node-api = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564" }
+reth-node-builder = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564" }
+reth-node-core = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564" }
+reth-node-ethereum = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564" }
+reth-node-events = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564" }
+reth-node-metrics = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564" }
+reth-payload-builder = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564" }
+reth-payload-builder-primitives = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564" }
+reth-payload-primitives = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564" }
+reth-payload-util = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564" }
+reth-payload-validator = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564" }
+reth-provider = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564" }
+reth-prune = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564" }
+reth-prune-types = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564", default-features = false }
+reth-revm = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564", default-features = false }
+reth-rpc = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564" }
+reth-rpc-api = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564" }
+reth-rpc-builder = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564" }
+reth-rpc-engine-api = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564" }
+reth-rpc-eth-api = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564" }
+reth-rpc-eth-types = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564", default-features = false }
+reth-rpc-server-types = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564" }
+reth-stages = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564" }
+reth-stages-types = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564", default-features = false }
+reth-static-file = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564" }
+reth-static-file-types = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564", default-features = false }
+reth-storage-api = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564", default-features = false }
+reth-storage-errors = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564", default-features = false }
+reth-tasks = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564" }
+reth-tracing = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564", default-features = false }
+reth-transaction-pool = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564" }
+reth-trie = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564" }
+reth-trie-common = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564", default-features = false }
+reth-trie-db = { git = "https://github.com/ethereum-optimism/reth", rev = "ab694ead9065cd8c5bd3ae80c1663ac771152564" }
 
 # ==================== REVM (latest: op-reth versions) ====================
 revm = { version = "41.0.0", default-features = false }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -359,76 +359,76 @@ reth-rpc-traits = { version = "0.5.0", default-features = false }
 reth-zstd-compressors = { version = "0.5.0", default-features = false }
 
 # ==================== RETH CRATES (git) ====================
-reth = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
-reth-basic-payload-builder = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
-reth-chain-state = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
-reth-chainspec = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601", default-features = false }
-reth-cli = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
-reth-cli-commands = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
-reth-cli-runner = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
-reth-cli-util = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
-reth-consensus = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601", default-features = false }
-reth-consensus-common = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601", default-features = false }
-reth-db = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601", default-features = false }
-reth-db-api = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
-reth-db-common = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
-reth-downloaders = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
-reth-e2e-test-utils = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
-reth-engine-local = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
-reth-engine-primitives = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601", default-features = false }
-reth-errors = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
-reth-eth-wire = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
-reth-eth-wire-types = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
-reth-ethereum = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
-reth-ethereum-cli = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
-reth-ethereum-consensus = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
-reth-ethereum-forks = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601", default-features = false }
-reth-ethereum-primitives = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
-reth-evm = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601", default-features = false }
-reth-evm-ethereum = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
-reth-exex = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
-reth-exex-test-utils = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
-reth-execution-errors = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601", default-features = false }
-reth-execution-types = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601", default-features = false }
-reth-fs-util = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
-reth-metrics = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
-reth-network = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
-reth-network-api = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
-reth-network-peers = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601", default-features = false }
-reth-node-api = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
-reth-node-builder = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
-reth-node-core = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
-reth-node-ethereum = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
-reth-node-events = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
-reth-node-metrics = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
-reth-payload-builder = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
-reth-payload-builder-primitives = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
-reth-payload-primitives = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
-reth-payload-util = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
-reth-payload-validator = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
-reth-provider = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
-reth-prune = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
-reth-prune-types = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601", default-features = false }
-reth-revm = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601", default-features = false }
-reth-rpc = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
-reth-rpc-api = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
-reth-rpc-builder = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
-reth-rpc-engine-api = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
-reth-rpc-eth-api = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
-reth-rpc-eth-types = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601", default-features = false }
-reth-rpc-server-types = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
-reth-stages = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
-reth-stages-types = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601", default-features = false }
-reth-static-file = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
-reth-static-file-types = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601", default-features = false }
-reth-storage-api = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601", default-features = false }
-reth-storage-errors = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601", default-features = false }
-reth-tasks = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
-reth-tracing = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601", default-features = false }
-reth-transaction-pool = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
-reth-trie = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
-reth-trie-common = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601", default-features = false }
-reth-trie-db = { git = "https://github.com/ethereum-optimism/reth", rev = "b983c155b936f50acb91f30b5c6705ff39063601" }
+reth = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
+reth-basic-payload-builder = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
+reth-chain-state = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
+reth-chainspec = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43", default-features = false }
+reth-cli = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
+reth-cli-commands = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
+reth-cli-runner = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
+reth-cli-util = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
+reth-consensus = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43", default-features = false }
+reth-consensus-common = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43", default-features = false }
+reth-db = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43", default-features = false }
+reth-db-api = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
+reth-db-common = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
+reth-downloaders = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
+reth-e2e-test-utils = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
+reth-engine-local = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
+reth-engine-primitives = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43", default-features = false }
+reth-errors = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
+reth-eth-wire = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
+reth-eth-wire-types = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
+reth-ethereum = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
+reth-ethereum-cli = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
+reth-ethereum-consensus = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
+reth-ethereum-forks = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43", default-features = false }
+reth-ethereum-primitives = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
+reth-evm = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43", default-features = false }
+reth-evm-ethereum = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
+reth-exex = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
+reth-exex-test-utils = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
+reth-execution-errors = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43", default-features = false }
+reth-execution-types = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43", default-features = false }
+reth-fs-util = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
+reth-metrics = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
+reth-network = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
+reth-network-api = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
+reth-network-peers = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43", default-features = false }
+reth-node-api = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
+reth-node-builder = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
+reth-node-core = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
+reth-node-ethereum = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
+reth-node-events = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
+reth-node-metrics = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
+reth-payload-builder = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
+reth-payload-builder-primitives = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
+reth-payload-primitives = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
+reth-payload-util = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
+reth-payload-validator = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
+reth-provider = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
+reth-prune = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
+reth-prune-types = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43", default-features = false }
+reth-revm = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43", default-features = false }
+reth-rpc = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
+reth-rpc-api = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
+reth-rpc-builder = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
+reth-rpc-engine-api = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
+reth-rpc-eth-api = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
+reth-rpc-eth-types = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43", default-features = false }
+reth-rpc-server-types = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
+reth-stages = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
+reth-stages-types = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43", default-features = false }
+reth-static-file = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
+reth-static-file-types = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43", default-features = false }
+reth-storage-api = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43", default-features = false }
+reth-storage-errors = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43", default-features = false }
+reth-tasks = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
+reth-tracing = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43", default-features = false }
+reth-transaction-pool = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
+reth-trie = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
+reth-trie-common = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43", default-features = false }
+reth-trie-db = { git = "https://github.com/ethereum-optimism/reth", rev = "5cf3cdc99e354578ac1006448f1636c0d47ecc43" }
 
 # ==================== REVM (latest: op-reth versions) ====================
 revm = { version = "41.0.0", default-features = false }

--- a/rust/alloy-op-evm/src/block/mod.rs
+++ b/rust/alloy-op-evm/src/block/mod.rs
@@ -72,9 +72,11 @@ pub enum PostExecMode {
     /// Execute with legacy gas accounting.
     #[default]
     Disabled,
+    /// Produce a canonical post-exec commitment without collecting SDM refunds.
+    Commit,
     /// Produce canonical post-exec refunds locally and append them to the block later.
     Produce,
-    /// Verify canonical gas accounting using an post-exec payload embedded in the block.
+    /// Verify canonical gas accounting using a post-exec payload embedded in the block.
     Verify(PostExecPayload),
 }
 
@@ -90,6 +92,8 @@ impl From<bool> for PostExecMode {
 pub enum PostExecState {
     /// Execute with legacy gas accounting.
     Disabled,
+    /// Produce a canonical post-exec commitment without collecting SDM refunds.
+    Committing,
     /// Produce canonical post-exec refunds locally and append them to the block later.
     Producing {
         /// Accumulated per-tx refunds for post-exec tx assembly.
@@ -116,6 +120,7 @@ impl PostExecState {
     fn new(mode: PostExecMode) -> Self {
         match mode {
             PostExecMode::Disabled => Self::Disabled,
+            PostExecMode::Commit => Self::Committing,
             PostExecMode::Produce => Self::Producing { entries: Vec::new() },
             PostExecMode::Verify(payload) => {
                 let mut remaining = BTreeMap::new();
@@ -220,7 +225,7 @@ impl PostExecState {
                 *saw_post_exec_tx = true;
                 Ok(())
             }
-            Self::Producing { .. } => Ok(()),
+            Self::Committing | Self::Producing { .. } => Ok(()),
             Self::Disabled => Err(format!(
                 "unexpected post-exec tx at index {tx_index}: SDM not active for this block"
             )),
@@ -898,6 +903,13 @@ where
                 })?;
             if let Err(reason) = self.post_exec.verify_post_exec_tx(tx_index, payload) {
                 return Err(Self::invalid_post_exec_payload(reason));
+            }
+            let block_base_fee = self.evm.block().basefee();
+            if payload.selected_base_fee_per_gas != block_base_fee {
+                return Err(Self::invalid_post_exec_payload(format!(
+                    "post-exec selected base fee {} does not match block base fee {block_base_fee}",
+                    payload.selected_base_fee_per_gas,
+                )));
             }
             // Validates that no Verify payload entry targets this tx index; refund is always 0.
             self.verifier_post_exec_refund_for_tx(tx_index, false, true, 0)?;

--- a/rust/alloy-op-evm/src/block/tests.rs
+++ b/rust/alloy-op-evm/src/block/tests.rs
@@ -246,6 +246,7 @@ impl JovianExecutorFixture {
         self.executor_with_post_exec_mode(PostExecMode::Verify(PostExecPayload {
             version: 1,
             block_number,
+            selected_base_fee_per_gas: self.base_fee,
             gas_refund_entries: entries,
         }))
     }

--- a/rust/alloy-op-evm/src/block/tests/structural_tests.rs
+++ b/rust/alloy-op-evm/src/block/tests/structural_tests.rs
@@ -1,9 +1,15 @@
 use super::*;
 use crate::post_exec::NullRefundPolicy;
 
-fn recovered_post_exec(block_number: u64, entries: Vec<SDMGasEntry>) -> Recovered<OpTxEnvelope> {
+fn recovered_post_exec(
+    block_number: u64,
+    selected_base_fee_per_gas: u64,
+    entries: Vec<SDMGasEntry>,
+) -> Recovered<OpTxEnvelope> {
     Recovered::new_unchecked(
-        OpTxEnvelope::PostExec(build_post_exec_tx(block_number, 1, entries).seal_slow()),
+        OpTxEnvelope::PostExec(
+            build_post_exec_tx(block_number, selected_base_fee_per_gas, entries).seal_slow(),
+        ),
         Address::ZERO,
     )
 }
@@ -179,7 +185,7 @@ fn fixed_policy_producer_verifier_roundtrip() {
     producer.execute_transaction(&tx).expect("producer executes normal tx");
     let entries = producer.post_exec_entries().to_vec();
     assert_eq!(entries, vec![SDMGasEntry { index: 0, gas_refund: 1 }]);
-    let post_exec = recovered_post_exec(0, entries.clone());
+    let post_exec = recovered_post_exec(0, 0, entries.clone());
     producer.execute_transaction(&post_exec).expect("producer executes post-exec tx");
     let (_, produced) = producer.finish().expect("producer finishes block");
 
@@ -262,7 +268,7 @@ where
 
         let entries = producer.take_post_exec_entries();
         if !entries.is_empty() {
-            let post_exec = recovered_post_exec(0, entries.clone());
+            let post_exec = recovered_post_exec(0, BASE_FEE, entries.clone());
             producer.execute_transaction(&post_exec).expect("producer executes post-exec tx");
         }
         // Dropping the EVM releases its borrow of `db` so the audit can read balances.
@@ -699,7 +705,7 @@ fn test_verifier_accepts_payload_when_pre_refund_stays_below_limit() {
     verifier
         .execute_transaction(&tx2)
         .expect("tx declared within the remaining pre-refund budget is accepted");
-    let post_exec_recovered = recovered_post_exec(0, entries);
+    let post_exec_recovered = recovered_post_exec(0, 0, entries);
     verifier.execute_transaction(&post_exec_recovered).expect("post-exec tx verifies");
     verifier.finish().expect("verifier finishes accepted boundary block");
 }
@@ -840,7 +846,7 @@ fn test_disabled_mode_rejects_post_exec_tx() {
     let mut executor = fixture.executor();
     assert!(matches!(executor.post_exec, PostExecState::Disabled));
 
-    let tx = recovered_post_exec(0, vec![]);
+    let tx = recovered_post_exec(0, 0, vec![]);
     let err = executor.execute_transaction(&tx).expect_err("0x7D tx in Disabled mode must fail");
     assert_invalid_post_exec(
         err,
@@ -866,7 +872,7 @@ fn test_post_exec_tx_does_not_accrue_da_footprint() {
     let footprint_before = producer.da_footprint_used;
     assert!(footprint_before > 0, "the user tx must accrue a footprint for this test to bite");
 
-    let post_exec = recovered_post_exec(0, vec![SDMGasEntry { index: 0, gas_refund: 7 }]);
+    let post_exec = recovered_post_exec(0, 0, vec![SDMGasEntry { index: 0, gas_refund: 7 }]);
 
     // The minimum-size floor ensures a counted 0x7D would have a non-zero footprint, so the
     // assertion below is about the exclusion and not about a 0x7D that is simply too small to
@@ -1062,7 +1068,7 @@ mod warm_set_leak {
         producer.execute_transaction(&failing_a).expect_err(a_error_context);
         producer.execute_transaction(&probe_tx()).expect("probe tx B executes");
         let entries = producer.take_post_exec_entries();
-        let post_exec_tx = recovered_post_exec(0, entries.clone());
+        let post_exec_tx = recovered_post_exec(0, 0, entries.clone());
         producer.execute_transaction(&post_exec_tx).expect("producer appends 0x7D tx");
         let (_, produced) = producer.finish().expect("producer finishes block");
 
@@ -1079,7 +1085,7 @@ mod warm_set_leak {
         verifier.set_post_exec_mode(PostExecMode::Verify(PostExecPayload {
             version: 1,
             block_number: 0,
-            selected_base_fee_per_gas: 1,
+            selected_base_fee_per_gas: 0,
             gas_refund_entries: entries,
         }));
         verifier.execute_transaction(&probe_tx()).expect("validator executes B");

--- a/rust/alloy-op-evm/src/block/tests/structural_tests.rs
+++ b/rust/alloy-op-evm/src/block/tests/structural_tests.rs
@@ -3,7 +3,7 @@ use crate::post_exec::NullRefundPolicy;
 
 fn recovered_post_exec(block_number: u64, entries: Vec<SDMGasEntry>) -> Recovered<OpTxEnvelope> {
     Recovered::new_unchecked(
-        OpTxEnvelope::PostExec(build_post_exec_tx(block_number, entries).seal_slow()),
+        OpTxEnvelope::PostExec(build_post_exec_tx(block_number, 1, entries).seal_slow()),
         Address::ZERO,
     )
 }
@@ -1079,6 +1079,7 @@ mod warm_set_leak {
         verifier.set_post_exec_mode(PostExecMode::Verify(PostExecPayload {
             version: 1,
             block_number: 0,
+            selected_base_fee_per_gas: 1,
             gas_refund_entries: entries,
         }));
         verifier.execute_transaction(&probe_tx()).expect("validator executes B");

--- a/rust/alloy-op-evm/src/lib.rs
+++ b/rust/alloy-op-evm/src/lib.rs
@@ -431,7 +431,7 @@ where
 ///
 /// The `R` type parameter fixes the post-exec refund inspector and its block-scoped snapshot.
 /// It defaults to [`NullRefundPolicy`](post_exec::NullRefundPolicy), so released public binaries
-/// cannot produce a non-empty post-exec payload.
+/// cannot produce a non-empty post-exec refund list.
 #[derive(Debug)]
 pub struct OpEvmFactory<Tx = OpTx, R = post_exec::NullRefundPolicy>(PhantomData<(Tx, R)>);
 

--- a/rust/alloy-op-evm/src/tests.rs
+++ b/rust/alloy-op-evm/src/tests.rs
@@ -111,7 +111,7 @@ fn legacy_op_tx(nonce: u64, caller: Address, target: Address, gas_limit: u64) ->
 }
 
 fn post_exec_op_tx() -> OpTx {
-    let tx = op_alloy::consensus::post_exec::build_post_exec_tx(1, vec![]);
+    let tx = op_alloy::consensus::post_exec::build_post_exec_tx(1, 1, vec![]);
     OpTx::from_recovered_tx(&tx, Address::ZERO)
 }
 

--- a/rust/alloy-op-evm/src/tx.rs
+++ b/rust/alloy-op-evm/src/tx.rs
@@ -303,7 +303,7 @@ mod tests {
 
     #[test]
     fn post_exec_tx_env_reflects_transaction_fields() {
-        let tx = build_post_exec_tx(42, vec![SDMGasEntry { index: 0, gas_refund: 7 }]);
+        let tx = build_post_exec_tx(42, 1, vec![SDMGasEntry { index: 0, gas_refund: 7 }]);
 
         let env = OpTx::from_recovered_tx(&tx, Address::from([0x11; 20]));
 
@@ -318,7 +318,7 @@ mod tests {
 
     #[test]
     fn post_exec_tx_env_mirrors_transaction() {
-        let tx = build_post_exec_tx(7, vec![SDMGasEntry { index: 0, gas_refund: 42 }]);
+        let tx = build_post_exec_tx(7, 1, vec![SDMGasEntry { index: 0, gas_refund: 42 }]);
         let env = OpTx::from_encoded_tx(&tx, Address::ZERO, tx.encoded_2718().into());
 
         let expected = TxEnv {

--- a/rust/kona/bin/client/src/fpvm_evm/tx.rs
+++ b/rust/kona/bin/client/src/fpvm_evm/tx.rs
@@ -243,7 +243,7 @@ mod tests {
     /// inspects the env (and fail revm's chain-id validation outright on non-mainnet chains).
     #[test]
     fn post_exec_tx_env_reflects_transaction_fields() {
-        let tx = build_post_exec_tx(7, vec![]);
+        let tx = build_post_exec_tx(7, 1, vec![]);
 
         let FpvmOpTx(op_tx) = FpvmOpTx::from_recovered_tx(&tx, Address::ZERO);
 
@@ -256,7 +256,7 @@ mod tests {
 
     #[test]
     fn post_exec_tx_env_mirrors_transaction() {
-        let tx = build_post_exec_tx(7, vec![SDMGasEntry { index: 0, gas_refund: 42 }]);
+        let tx = build_post_exec_tx(7, 1, vec![SDMGasEntry { index: 0, gas_refund: 42 }]);
         let env = FpvmOpTx::from_encoded_tx(&tx, Address::ZERO, tx.encoded_2718().into());
 
         let expected = TxEnv {

--- a/rust/kona/crates/proof/driver/src/core.rs
+++ b/rust/kona/crates/proof/driver/src/core.rs
@@ -342,7 +342,11 @@ where
             self.cursor.write().advance(origin, tip_cursor);
 
             // Update the latest safe head artifacts.
-            self.safe_head_artifacts = Some((outcome, attributes.transactions.unwrap_or_default()));
+            // The executor may synthesize validator data (currently Lagoon PostExec) that was not
+            // present in the derived attributes. Persist the exact transaction list committed by
+            // the returned header so interop trie preimages remain consistent.
+            let effective_transactions = outcome.transactions.clone();
+            self.safe_head_artifacts = Some((outcome, effective_transactions));
         }
     }
 }

--- a/rust/kona/crates/proof/executor/src/builder/core.rs
+++ b/rust/kona/crates/proof/executor/src/builder/core.rs
@@ -20,7 +20,9 @@ use alloy_op_hardforks::OpHardforks;
 use core::fmt::Debug;
 use kona_genesis::RollupConfig;
 use kona_mpt::TrieHinter;
-use op_alloy_consensus::{OpTxEnvelope, parse_post_exec_payload_from_transactions};
+use op_alloy_consensus::{
+    OpTxEnvelope, build_post_exec_tx, parse_post_exec_payload_from_transactions,
+};
 use op_alloy_rpc_types_engine::OpPayloadAttributes;
 use op_revm::OpSpecId;
 use revm::{
@@ -248,26 +250,75 @@ where
     /// - I/O patterns optimized through trie hinter guidance
     pub fn build_block(
         &mut self,
-        attrs: OpPayloadAttributes,
+        mut attrs: OpPayloadAttributes,
     ) -> ExecutorResult<BlockBuildingOutcome<R::Receipt>> {
+        let timestamp = attrs.payload_attributes.timestamp;
+        let post_exec_active = self.is_sdm_active(timestamp);
+        let block_number = self.trie_db.parent_block_header().number.saturating_add(1);
+
+        // Decode before constructing the EVM environment so Lagoon can recover the selected fee
+        // from the trailing PostExec commitment. Deterministic derived builds without a commitment
+        // carry forward the parent fee and synthesize the canonical empty commitment.
+        attrs.transactions.as_ref().ok_or(ExecutorError::MissingTransactions)?;
+        let initial_transactions = attrs
+            .recovered_transactions_with_encoded()
+            .collect::<Result<Vec<_>, RecoveryError>>()
+            .map_err(ExecutorError::Recovery)?;
+        let parsed = parse_post_exec_payload_from_transactions(
+            initial_transactions.iter().map(RecoveredTx::tx),
+            block_number,
+            post_exec_active,
+        )
+        .map_err(|err| ExecutorError::InvalidPostExecPayload(err.into_string()))?;
+
+        if post_exec_active && parsed.is_none() {
+            let selected_base_fee_per_gas =
+                self.trie_db.parent_block_header().base_fee_per_gas.unwrap_or_default();
+            let post_exec = build_post_exec_tx(block_number, selected_base_fee_per_gas, Vec::new());
+            let mut encoded = Vec::with_capacity(post_exec.eip2718_encoded_length());
+            post_exec.encode_2718(&mut encoded);
+            attrs
+                .transactions
+                .as_mut()
+                .expect("transactions presence checked above")
+                .push(encoded.into());
+        }
+
+        let transactions = attrs
+            .recovered_transactions_with_encoded()
+            .collect::<Result<Vec<_>, RecoveryError>>()
+            .map_err(ExecutorError::Recovery)?;
+        let parsed = parse_post_exec_payload_from_transactions(
+            transactions.iter().map(RecoveredTx::tx),
+            block_number,
+            post_exec_active,
+        )
+        .map_err(|err| ExecutorError::InvalidPostExecPayload(err.into_string()))?;
+        let committed_base_fee =
+            parsed.as_ref().map(|parsed| parsed.payload.selected_base_fee_per_gas);
+        let post_exec_mode =
+            parsed.map(|parsed| PostExecMode::Verify(parsed.payload)).unwrap_or_default();
+
         // Step 1. Set up the execution environment.
         let (base_fee_params, min_base_fee) = Self::active_base_fee_params(
             self.config,
             self.trie_db.parent_block_header(),
-            attrs.payload_attributes.timestamp,
+            timestamp,
         )?;
         let evm_env = self.evm_env(
             self.trie_db.parent_block_header(),
             &attrs,
             &base_fee_params,
             min_base_fee,
+            post_exec_active,
+            committed_base_fee,
         )?;
         let block_env = evm_env.block_env().clone();
         let parent_hash = self.trie_db.parent_block_header().seal();
         // Computed here, before `self.trie_db` is borrowed mutably below.
         let no_user_tx_activation_block = self.config.is_no_user_tx_activation_block(
             self.trie_db.parent_block_header().timestamp,
-            attrs.payload_attributes.timestamp,
+            timestamp,
         );
 
         // Attempt to send a payload witness hint to the host. This hint instructs the host to
@@ -288,27 +339,11 @@ where
             "Beginning block building."
         );
 
-        // Compute SDM activation before borrowing `self.trie_db` mutably below.
-        let sdm_active = self.is_sdm_active(block_env.timestamp.saturating_to());
-
         // Step 2. Create the executor, using the trie database.
         let mut state =
             State::builder().with_database(&mut self.trie_db).with_bundle_update().build();
         let evm = self.factory.evm_factory().create_evm(&mut state, evm_env);
-        // Step 3. Decode and validate the block transactions within the payload attributes.
-        let transactions = attrs
-            .recovered_transactions_with_encoded()
-            .collect::<Result<Vec<_>, RecoveryError>>()
-            .map_err(ExecutorError::Recovery)?;
-        let post_exec_mode = parse_post_exec_payload_from_transactions(
-            transactions.iter().map(RecoveredTx::tx),
-            block_env.number.saturating_to(),
-            sdm_active,
-        )
-        .map_err(|err| ExecutorError::InvalidPostExecPayload(err.into_string()))?
-        .map(|parsed| PostExecMode::Verify(parsed.payload))
-        .unwrap_or_default();
-
+        // Step 3. Execute the decoded and validated block transactions.
         let ctx = OpBlockExecutionCtx {
             parent_hash,
             no_user_tx_activation_block,

--- a/rust/kona/crates/proof/executor/src/builder/core.rs
+++ b/rust/kona/crates/proof/executor/src/builder/core.rs
@@ -403,7 +403,7 @@ pub struct BlockBuildingOutcome<Receipt> {
     /// Exact EIP-2718 transaction encodings committed by the block header.
     ///
     /// This may differ from the input attributes when deterministic Lagoon execution synthesizes
-    /// the mandatory trailing PostExec commitment.
+    /// the mandatory trailing `PostExec` commitment.
     pub transactions: Vec<Bytes>,
 }
 

--- a/rust/kona/crates/proof/executor/src/builder/core.rs
+++ b/rust/kona/crates/proof/executor/src/builder/core.rs
@@ -17,6 +17,7 @@ use alloy_op_evm::{
     block::{OpTxEnv, receipt_builder::OpReceiptBuilder},
 };
 use alloy_op_hardforks::OpHardforks;
+use alloy_primitives::Bytes;
 use core::fmt::Debug;
 use kona_genesis::RollupConfig;
 use kona_mpt::TrieHinter;
@@ -380,7 +381,11 @@ where
 
         // Update the parent block hash in the state database, preparing for the next block.
         self.trie_db.set_parent_block_header(header.clone());
-        Ok((header, ex_result).into())
+        Ok(BlockBuildingOutcome {
+            header,
+            execution_result: ex_result,
+            transactions: attrs.transactions.unwrap_or_default(),
+        })
     }
 }
 
@@ -395,14 +400,11 @@ pub struct BlockBuildingOutcome<Receipt> {
     pub header: Sealed<Header>,
     /// The block execution result.
     pub execution_result: BlockExecutionResult<Receipt>,
-}
-
-impl<Receipt> From<(Sealed<Header>, BlockExecutionResult<Receipt>)>
-    for BlockBuildingOutcome<Receipt>
-{
-    fn from((header, execution_result): (Sealed<Header>, BlockExecutionResult<Receipt>)) -> Self {
-        Self { header, execution_result }
-    }
+    /// Exact EIP-2718 transaction encodings committed by the block header.
+    ///
+    /// This may differ from the input attributes when deterministic Lagoon execution synthesizes
+    /// the mandatory trailing PostExec commitment.
+    pub transactions: Vec<Bytes>,
 }
 
 #[cfg(test)]

--- a/rust/kona/crates/proof/executor/src/builder/core/tests.rs
+++ b/rust/kona/crates/proof/executor/src/builder/core/tests.rs
@@ -25,7 +25,7 @@ fn append_post_exec_tx(
     block_number: u64,
     gas_refund_entries: Vec<SDMGasEntry>,
 ) {
-    let tx = build_post_exec_tx(block_number, gas_refund_entries);
+    let tx = build_post_exec_tx(block_number, 1, gas_refund_entries);
     let mut encoded = Vec::with_capacity(tx.eip2718_encoded_length());
     tx.encode_2718(&mut encoded);
     transactions.push(encoded.into());

--- a/rust/kona/crates/proof/executor/src/builder/core/tests.rs
+++ b/rust/kona/crates/proof/executor/src/builder/core/tests.rs
@@ -25,7 +25,16 @@ fn append_post_exec_tx(
     block_number: u64,
     gas_refund_entries: Vec<SDMGasEntry>,
 ) {
-    let tx = build_post_exec_tx(block_number, 1, gas_refund_entries);
+    append_post_exec_tx_with_base_fee(transactions, block_number, 1, gas_refund_entries);
+}
+
+fn append_post_exec_tx_with_base_fee(
+    transactions: &mut Vec<alloy_primitives::Bytes>,
+    block_number: u64,
+    selected_base_fee_per_gas: u64,
+    gas_refund_entries: Vec<SDMGasEntry>,
+) {
+    let tx = build_post_exec_tx(block_number, selected_base_fee_per_gas, gas_refund_entries);
     let mut encoded = Vec::with_capacity(tx.eip2718_encoded_length());
     tx.encode_2718(&mut encoded);
     transactions.push(encoded.into());
@@ -112,31 +121,66 @@ async fn post_exec_sdm_enabled_rejects_duplicate_post_exec_txs() {
 }
 
 #[tokio::test]
-async fn post_exec_valid_empty_payload_executes_without_state_or_gas_change() {
+async fn post_exec_missing_payload_synthesizes_parent_fee_commitment() {
     let baseline = execute_loaded_fixture(load_test_fixture(post_exec_fixture_path()).await, None)
         .expect("baseline fixture must execute");
+    let loaded = load_test_fixture(post_exec_fixture_path()).await;
+    let parent_base_fee = loaded.fixture.parent_header.base_fee_per_gas.unwrap_or_default();
+
+    let outcome = execute_loaded_fixture(loaded, Some(true)).expect("fallback fixture executes");
+    assert_eq!(outcome.header.base_fee_per_gas, Some(parent_base_fee));
+    assert_eq!(
+        outcome.execution_result.receipts.len(),
+        baseline.execution_result.receipts.len() + 1,
+    );
+    assert!(matches!(
+        outcome.execution_result.receipts.last(),
+        Some(OpReceiptEnvelope::PostExec(_))
+    ));
+    assert_eq!(outcome.header.state_root, baseline.header.state_root);
+    assert_ne!(outcome.header.transactions_root, baseline.header.transactions_root);
+}
+
+#[tokio::test]
+async fn post_exec_committed_fee_sets_block_base_fee() {
+    let mut loaded = load_test_fixture(post_exec_fixture_path()).await;
+    let block_number = fixture_block_number(&loaded.fixture.parent_header);
+    append_post_exec_tx_with_base_fee(
+        loaded.fixture.executing_payload.transactions.as_mut().unwrap(),
+        block_number,
+        777,
+        Vec::new(),
+    );
+
+    let outcome = execute_loaded_fixture(loaded, Some(true)).expect("committed fee executes");
+    assert_eq!(outcome.header.base_fee_per_gas, Some(777));
+}
+
+#[tokio::test]
+async fn post_exec_valid_empty_payload_matches_synthesized_commitment() {
+    let baseline =
+        execute_loaded_fixture(load_test_fixture(post_exec_fixture_path()).await, Some(true))
+            .expect("fallback fixture must execute");
 
     let mut loaded = load_test_fixture(post_exec_fixture_path()).await;
     let block_number = fixture_block_number(&loaded.fixture.parent_header);
-    append_post_exec_tx(
+    let parent_base_fee = loaded.fixture.parent_header.base_fee_per_gas.unwrap_or_default();
+    append_post_exec_tx_with_base_fee(
         loaded.fixture.executing_payload.transactions.as_mut().unwrap(),
         block_number,
+        parent_base_fee,
         Vec::new(),
     );
 
     let outcome = execute_loaded_fixture(loaded, Some(true)).expect("post-exec fixture executes");
-    assert_eq!(
-        outcome.execution_result.receipts.len(),
-        baseline.execution_result.receipts.len() + 1
-    );
     assert!(matches!(
         outcome.execution_result.receipts.last(),
         Some(OpReceiptEnvelope::PostExec(_))
     ));
     assert_eq!(outcome.execution_result.gas_used, baseline.execution_result.gas_used);
     assert_eq!(outcome.header.state_root, baseline.header.state_root);
-    assert_ne!(outcome.header.transactions_root, baseline.header.transactions_root);
-    assert_ne!(outcome.header.receipts_root, baseline.header.receipts_root);
+    assert_eq!(outcome.header.transactions_root, baseline.header.transactions_root);
+    assert_eq!(outcome.header.receipts_root, baseline.header.receipts_root);
 }
 
 #[tokio::test]

--- a/rust/kona/crates/proof/executor/src/builder/core/tests.rs
+++ b/rust/kona/crates/proof/executor/src/builder/core/tests.rs
@@ -181,6 +181,8 @@ async fn post_exec_valid_empty_payload_matches_synthesized_commitment() {
     assert_eq!(outcome.header.state_root, baseline.header.state_root);
     assert_eq!(outcome.header.transactions_root, baseline.header.transactions_root);
     assert_eq!(outcome.header.receipts_root, baseline.header.receipts_root);
+    assert_eq!(outcome.transactions, baseline.transactions);
+    assert_eq!(baseline.transactions.last().and_then(|tx| tx.first()), Some(&0x7d));
 }
 
 #[tokio::test]

--- a/rust/kona/crates/proof/executor/src/builder/env.rs
+++ b/rust/kona/crates/proof/executor/src/builder/env.rs
@@ -29,11 +29,16 @@ where
         payload_attrs: &OpPayloadAttributes,
         base_fee_params: &BaseFeeParams,
         min_base_fee: u64,
+        post_exec_active: bool,
+        committed_base_fee: Option<u64>,
     ) -> ExecutorResult<EvmEnv<OpSpecId>> {
         let gas_limit = payload_attrs.gas_limit.ok_or(ExecutorError::MissingGasLimit)?;
-        let next_block_base_fee = self
-            .next_block_base_fee(*base_fee_params, parent_header, min_base_fee)
-            .unwrap_or_default();
+        let next_block_base_fee = if post_exec_active {
+            committed_base_fee.unwrap_or_else(|| parent_header.base_fee_per_gas.unwrap_or_default())
+        } else {
+            self.next_block_base_fee(*base_fee_params, parent_header, min_base_fee)
+                .unwrap_or_default()
+        };
 
         Ok(evm_env_for_op_next_block(
             parent_header,

--- a/rust/kona/crates/protocol/protocol/src/batch/single.rs
+++ b/rust/kona/crates/protocol/protocol/src/batch/single.rs
@@ -537,6 +537,7 @@ mod tests {
         let tx: OpTxEnvelope = TxPostExec::new(PostExecPayload {
             version: POST_EXEC_PAYLOAD_VERSION,
             block_number: 1,
+            selected_base_fee_per_gas: 1,
             gas_refund_entries: vec![],
         })
         .into();
@@ -569,6 +570,7 @@ mod tests {
         let tx: OpTxEnvelope = TxPostExec::new(PostExecPayload {
             version: POST_EXEC_PAYLOAD_VERSION,
             block_number: 1,
+            selected_base_fee_per_gas: 1,
             gas_refund_entries: vec![],
         })
         .into();

--- a/rust/kona/crates/protocol/protocol/src/batch/transactions.rs
+++ b/rust/kona/crates/protocol/protocol/src/batch/transactions.rs
@@ -600,6 +600,7 @@ mod tests {
         let tx: OpTxEnvelope = TxPostExec::new(PostExecPayload {
             version: POST_EXEC_PAYLOAD_VERSION,
             block_number: 42,
+            selected_base_fee_per_gas: 1,
             gas_refund_entries: vec![],
         })
         .into();

--- a/rust/op-alloy/crates/consensus/src/post_exec.rs
+++ b/rust/op-alloy/crates/consensus/src/post_exec.rs
@@ -36,8 +36,8 @@ pub struct SDMGasEntry {
 
 /// Payload for the post-execution transaction.
 ///
-/// Today this only carries the SDM gas refund data, but additional post-exec fields may
-/// be added in the future.
+/// This carries the sequencer-selected base-fee commitment and SDM gas-refund data. Additional
+/// post-exec fields may be added in the future.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, RlpEncodable, RlpDecodable)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
@@ -49,6 +49,8 @@ pub struct PostExecPayload {
     /// This is included in the encoded post-exec transaction so otherwise identical
     /// payloads in different blocks produce distinct transaction hashes.
     pub block_number: u64,
+    /// Base fee per gas selected by the sequencer for the containing block.
+    pub selected_base_fee_per_gas: u64,
     /// Initial SDM gas refund entries keyed by transaction index.
     pub gas_refund_entries: Vec<SDMGasEntry>,
 }
@@ -62,6 +64,7 @@ impl<'a> arbitrary::Arbitrary<'a> for PostExecPayload {
         Ok(Self {
             version: POST_EXEC_PAYLOAD_VERSION,
             block_number: u64::arbitrary(u)?,
+            selected_base_fee_per_gas: u64::arbitrary(u)?,
             gas_refund_entries: <Vec<SDMGasEntry>>::arbitrary(u)?,
         })
     }
@@ -462,10 +465,15 @@ impl From<TxPostExec> for alloy_rpc_types_eth::TransactionRequest {
 }
 
 /// Build a post-execution transaction from a block number and refund entries.
-pub fn build_post_exec_tx(block_number: u64, gas_refund_entries: Vec<SDMGasEntry>) -> TxPostExec {
+pub fn build_post_exec_tx(
+    block_number: u64,
+    selected_base_fee_per_gas: u64,
+    gas_refund_entries: Vec<SDMGasEntry>,
+) -> TxPostExec {
     TxPostExec::new(PostExecPayload {
         version: POST_EXEC_PAYLOAD_VERSION,
         block_number,
+        selected_base_fee_per_gas,
         gas_refund_entries,
     })
 }

--- a/rust/op-alloy/crates/consensus/src/post_exec/tests.rs
+++ b/rust/op-alloy/crates/consensus/src/post_exec/tests.rs
@@ -2,11 +2,14 @@
 
 use super::*;
 
+const TEST_BASE_FEE: u64 = 123;
+
 #[test]
 fn post_exec_payload_rlp_roundtrip_preserves_block_number() {
     let payload = PostExecPayload {
         version: 1,
         block_number: 42,
+        selected_base_fee_per_gas: TEST_BASE_FEE,
         gas_refund_entries: vec![SDMGasEntry { index: 3, gas_refund: 7 }],
     };
 
@@ -21,6 +24,7 @@ fn post_exec_payload_rlp_decode_rejects_unknown_version() {
     let payload = PostExecPayload {
         version: POST_EXEC_PAYLOAD_VERSION + 1,
         block_number: 42,
+        selected_base_fee_per_gas: TEST_BASE_FEE,
         gas_refund_entries: vec![SDMGasEntry { index: 3, gas_refund: 7 }],
     };
 
@@ -35,6 +39,7 @@ fn post_exec_payload_rlp_decode_rejects_trailing_bytes() {
     let payload = PostExecPayload {
         version: 1,
         block_number: 42,
+        selected_base_fee_per_gas: TEST_BASE_FEE,
         gas_refund_entries: vec![SDMGasEntry { index: 3, gas_refund: 7 }],
     };
 
@@ -48,8 +53,8 @@ fn post_exec_payload_rlp_decode_rejects_trailing_bytes() {
 #[test]
 fn post_exec_tx_hash_depends_on_block_number() {
     let entries = vec![SDMGasEntry { index: 3, gas_refund: 7 }];
-    let tx_a = build_post_exec_tx(42, entries.clone());
-    let tx_b = build_post_exec_tx(43, entries);
+    let tx_a = build_post_exec_tx(42, TEST_BASE_FEE, entries.clone());
+    let tx_b = build_post_exec_tx(43, TEST_BASE_FEE, entries);
 
     assert_ne!(tx_a.tx_hash(), tx_b.tx_hash());
 }
@@ -61,10 +66,10 @@ fn post_exec_tx_hash_depends_on_block_number() {
 fn post_exec_tx_hash_is_keccak_of_canonical_encoding() {
     use alloy_primitives::{b256, hex};
 
-    let tx = build_post_exec_tx(42, vec![SDMGasEntry { index: 3, gas_refund: 7 }]);
+    let tx = build_post_exec_tx(42, TEST_BASE_FEE, vec![SDMGasEntry { index: 3, gas_refund: 7 }]);
 
     // Canonical payload bytes (== op-geth PostExecTx.Data).
-    let data = hex!("c6012ac3c20307");
+    let data = hex!("c7012a7bc3c20307");
     assert_eq!(tx.input.as_ref(), data.as_slice(), "post-exec input bytes drifted");
 
     // keccak256(0x7D || Data), derived independently and pinned.
@@ -73,14 +78,14 @@ fn post_exec_tx_hash_is_keccak_of_canonical_encoding() {
     assert_eq!(tx.tx_hash(), keccak256(&canonical), "tx_hash must be keccak256 of encode_2718");
     assert_eq!(
         tx.tx_hash(),
-        b256!("0xcbc64a9665039744307b562634bf760d96f3bed235fecd9e09a1f1276a1823c7"),
+        b256!("0xdf031dde1c8c591f49866e7877be7e81c86aa4ea4a170f806d21a390c01583bb"),
         "post-exec tx hash must be keccak256(0x7D || Data), matching the TxDeposit rule",
     );
 
     // Guard against the pre-#805 `keccak256(0x7D || RLP([Data]))` value.
     assert_ne!(
         tx.tx_hash(),
-        b256!("0xf54f4d695af011e5639b49ec48a5090434fbad09fa56ff572e36c28f691cb126"),
+        b256!("0xe01604d51b32778b1b47dcecfc99b5758e1ae20eb3db2294bdd16775f0ae5ba2"),
         "must not regress to the pre-#805 keccak256(0x7D || RLP([Data])) hash",
     );
 }
@@ -89,6 +94,7 @@ fn post_exec_tx_hash_is_keccak_of_canonical_encoding() {
 fn post_exec_tx_eip2718_roundtrip() {
     let tx = build_post_exec_tx(
         99,
+        TEST_BASE_FEE,
         vec![SDMGasEntry { index: 0, gas_refund: 100 }, SDMGasEntry { index: 5, gas_refund: 200 }],
     );
 
@@ -105,6 +111,7 @@ fn post_exec_tx_eip2718_decode_rejects_unknown_version() {
     let payload = PostExecPayload {
         version: POST_EXEC_PAYLOAD_VERSION + 1,
         block_number: 42,
+        selected_base_fee_per_gas: TEST_BASE_FEE,
         gas_refund_entries: vec![SDMGasEntry { index: 3, gas_refund: 7 }],
     };
 
@@ -130,6 +137,7 @@ fn post_exec_tx_rlp_decode_rejects_unknown_version() {
     let payload = PostExecPayload {
         version: POST_EXEC_PAYLOAD_VERSION + 1,
         block_number: 42,
+        selected_base_fee_per_gas: TEST_BASE_FEE,
         gas_refund_entries: vec![SDMGasEntry { index: 3, gas_refund: 7 }],
     };
     let mut buf = Vec::new();
@@ -142,7 +150,7 @@ fn post_exec_tx_rlp_decode_rejects_unknown_version() {
 
 #[test]
 fn post_exec_tx_eip2718_roundtrip_empty_refunds() {
-    let tx = build_post_exec_tx(1, vec![]);
+    let tx = build_post_exec_tx(1, TEST_BASE_FEE, vec![]);
 
     let mut buf = Vec::new();
     tx.encode_2718(&mut buf);
@@ -154,7 +162,7 @@ fn post_exec_tx_eip2718_roundtrip_empty_refunds() {
 #[cfg(feature = "serde")]
 #[test]
 fn post_exec_tx_serde_serializes_as_payload() {
-    let tx = build_post_exec_tx(42, vec![SDMGasEntry { index: 3, gas_refund: 7 }]);
+    let tx = build_post_exec_tx(42, TEST_BASE_FEE, vec![SDMGasEntry { index: 3, gas_refund: 7 }]);
     let value = serde_json::to_value(&tx).expect("serialize tx");
 
     assert_eq!(value, serde_json::to_value(&tx.payload).expect("serialize payload"));
@@ -163,7 +171,7 @@ fn post_exec_tx_serde_serializes_as_payload() {
 #[cfg(feature = "serde")]
 #[test]
 fn post_exec_tx_serde_roundtrip_preserves_cached_input() {
-    let tx = build_post_exec_tx(42, vec![SDMGasEntry { index: 3, gas_refund: 7 }]);
+    let tx = build_post_exec_tx(42, TEST_BASE_FEE, vec![SDMGasEntry { index: 3, gas_refund: 7 }]);
     let value = serde_json::to_value(&tx).expect("serialize tx");
 
     let decoded: TxPostExec = serde_json::from_value(value).expect("deserialize tx");
@@ -176,7 +184,7 @@ fn post_exec_tx_serde_roundtrip_preserves_cached_input() {
 fn post_exec_envelope_rpc_serde_roundtrip() {
     use crate::OpTxEnvelope;
 
-    let tx = build_post_exec_tx(42, vec![SDMGasEntry { index: 3, gas_refund: 7 }]);
+    let tx = build_post_exec_tx(42, TEST_BASE_FEE, vec![SDMGasEntry { index: 3, gas_refund: 7 }]);
     let envelope = OpTxEnvelope::PostExec(tx.seal_slow());
 
     // Serializes via `serde_post_exec_tx_rpc` (the RPC `{hash,type,gas,value,input}` shape)
@@ -194,7 +202,7 @@ fn post_exec_envelope_rpc_deserialize_ignores_extra_fields() {
 
     // Mirrors the object op-geth emits in `eth_getBlockByHash` full-transaction responses:
     // the canonical data lives in `input`, with derived placeholder/metadata fields alongside.
-    let tx = build_post_exec_tx(27, vec![SDMGasEntry { index: 1, gas_refund: 9 }]);
+    let tx = build_post_exec_tx(27, TEST_BASE_FEE, vec![SDMGasEntry { index: 1, gas_refund: 9 }]);
     let sealed = tx.clone().seal_slow();
     let json = serde_json::json!({
         "type": "0x7d",
@@ -231,7 +239,12 @@ fn filler_tx() -> crate::OpTxEnvelope {
 
 fn post_exec_tx(block_number: u64) -> crate::OpTxEnvelope {
     crate::OpTxEnvelope::PostExec(
-        build_post_exec_tx(block_number, vec![SDMGasEntry { index: 1, gas_refund: 9 }]).seal_slow(),
+        build_post_exec_tx(
+            block_number,
+            TEST_BASE_FEE,
+            vec![SDMGasEntry { index: 1, gas_refund: 9 }],
+        )
+        .seal_slow(),
     )
 }
 
@@ -245,6 +258,7 @@ fn parse_accepts_trailing_post_exec_tx() {
 
     assert_eq!(parsed.tx_index, 2);
     assert_eq!(parsed.payload.block_number, PARSE_BLOCK);
+    assert_eq!(parsed.payload.selected_base_fee_per_gas, TEST_BASE_FEE);
     assert_eq!(parsed.payload.gas_refund_entries, vec![SDMGasEntry { index: 1, gas_refund: 9 }]);
 }
 

--- a/rust/op-alloy/crates/rpc-types/src/transaction.rs
+++ b/rust/op-alloy/crates/rpc-types/src/transaction.rs
@@ -398,7 +398,7 @@ mod tests {
 
     #[test]
     fn can_serialize_post_exec_rpc_transaction() {
-        let post_exec = build_post_exec_tx(42, vec![SDMGasEntry { index: 3, gas_refund: 7 }]);
+        let post_exec = build_post_exec_tx(42, 1, vec![SDMGasEntry { index: 3, gas_refund: 7 }]);
         let expected_input = serde_json::to_value(post_exec.input.clone()).unwrap();
         let expected_hash = serde_json::to_value(post_exec.tx_hash()).unwrap();
 

--- a/rust/op-reth/crates/consensus/Cargo.toml
+++ b/rust/op-reth/crates/consensus/Cargo.toml
@@ -23,6 +23,7 @@ reth-storage-errors.workspace = true
 reth-trie-common.workspace = true
 
 # op-reth
+op-alloy-consensus.workspace = true
 reth-optimism-forks.workspace = true
 reth-optimism-primitives.workspace = true
 
@@ -47,8 +48,6 @@ reth-trie.workspace = true
 reth-optimism-node.workspace = true
 
 alloy-chains.workspace = true
-
-op-alloy-consensus.workspace = true
 
 [features]
 default = ["std"]

--- a/rust/op-reth/crates/consensus/src/lib.rs
+++ b/rust/op-reth/crates/consensus/src/lib.rs
@@ -17,6 +17,7 @@ use alloy_consensus::{
 };
 use alloy_primitives::{B64, B256};
 use core::fmt::Debug;
+use op_alloy_consensus::OpTransaction as OpConsensusTransaction;
 use reth_chainspec::EthChainSpec;
 use reth_consensus::{Consensus, ConsensusError, FullConsensus, HeaderValidator, ReceiptRootBloom};
 use reth_consensus_common::validation::{
@@ -72,7 +73,7 @@ impl<ChainSpec> OpBeaconConsensus<ChainSpec> {
 
 impl<N, ChainSpec> FullConsensus<N> for OpBeaconConsensus<ChainSpec>
 where
-    N: NodePrimitives<Receipt: DepositReceipt>,
+    N: NodePrimitives<Receipt: DepositReceipt, SignedTx: OpConsensusTransaction>,
     ChainSpec: EthChainSpec<Header = N::BlockHeader> + OpHardforks + Debug + Send + Sync,
 {
     fn validate_block_post_execution(
@@ -89,6 +90,7 @@ where
 impl<B, ChainSpec> Consensus<B> for OpBeaconConsensus<ChainSpec>
 where
     B: Block,
+    B::Body: BlockBody<Transaction: OpConsensusTransaction>,
     ChainSpec: EthChainSpec<Header = B::Header> + OpHardforks + Debug + Send + Sync,
 {
     fn validate_body_against_header(
@@ -197,11 +199,15 @@ where
             validate_against_parent_timestamp(header.header(), parent.header())?;
         }
 
-        validate_against_parent_eip1559_base_fee(
-            header.header(),
-            parent.header(),
-            &self.chain_spec,
-        )?;
+        // Lagoon delegates base-fee selection to the sequencer. The replacement consensus check
+        // compares the header fee with the trailing PostExec commitment when validating the body.
+        if !self.chain_spec.is_lagoon_active_at_timestamp(header.timestamp()) {
+            validate_against_parent_eip1559_base_fee(
+                header.header(),
+                parent.header(),
+                &self.chain_spec,
+            )?;
+        }
 
         // Ensure that the blob gas fields for this block are correctly set.
         // In the op-stack, the excess blob gas is always 0 for all blocks after ecotone.
@@ -494,6 +500,37 @@ mod tests {
             ConsensusError::BlobGasUsedDiff(diff)
                 if diff.got == BLOB_GAS_USED + 1 && diff.expected == BLOB_GAS_USED
         ));
+    }
+
+    #[test]
+    fn test_header_accepts_sequencer_selected_base_fee_at_lagoon() {
+        let chain_spec = OpChainSpecBuilder::default()
+            .lagoon_activated()
+            .genesis(OP_MAINNET.genesis.clone())
+            .chain(OP_MAINNET.chain)
+            .build();
+        let consensus = OpBeaconConsensus::new(Arc::new(chain_spec));
+        let parent = SealedHeader::seal_slow(Header {
+            number: 0,
+            timestamp: 1,
+            base_fee_per_gas: Some(100),
+            gas_limit: 30_000_000,
+            blob_gas_used: Some(0),
+            excess_blob_gas: Some(0),
+            ..Default::default()
+        });
+        let header = SealedHeader::seal_slow(Header {
+            number: 1,
+            timestamp: 2,
+            parent_hash: parent.hash(),
+            base_fee_per_gas: Some(777),
+            gas_limit: 30_000_000,
+            blob_gas_used: Some(0),
+            excess_blob_gas: Some(0),
+            ..Default::default()
+        });
+
+        consensus.validate_header_against_parent(&header, &parent).unwrap();
     }
 
     #[test]

--- a/rust/op-reth/crates/consensus/src/lib.rs
+++ b/rust/op-reth/crates/consensus/src/lib.rs
@@ -102,22 +102,14 @@ where
     }
 
     fn validate_block_pre_execution(&self, block: &SealedBlock<B>) -> Result<(), ConsensusError> {
-        // Check ommers hash
-        let ommers_hash = block.body().calculate_ommers_root();
-        if Some(block.ommers_hash()) != ommers_hash {
-            return Err(ConsensusError::BodyOmmersHashDiff(
-                GotExpected {
-                    got: ommers_hash.unwrap_or(EMPTY_OMMER_ROOT_HASH),
-                    expected: block.ommers_hash(),
-                }
-                .into(),
-            ));
-        }
-
-        // Check transaction root
-        if let Err(error) = block.ensure_transaction_root_valid() {
-            return Err(ConsensusError::BodyTransactionRootDiff(error.into()));
-        }
+        // Engine API imports enter through pre-execution validation rather than the separate
+        // body-against-header path used by downloaded blocks. Keep all body commitments,
+        // including Lagoon's selected base fee, identical on both paths.
+        validation::validate_body_against_header_op(
+            &self.chain_spec,
+            block.body(),
+            block.header(),
+        )?;
 
         // Check empty shanghai-withdrawals
         if self.chain_spec.is_canyon_active_at_timestamp(block.timestamp()) {
@@ -500,6 +492,36 @@ mod tests {
             ConsensusError::BlobGasUsedDiff(diff)
                 if diff.got == BLOB_GAS_USED + 1 && diff.expected == BLOB_GAS_USED
         ));
+    }
+
+    #[test]
+    fn test_pre_execution_rejects_missing_lagoon_post_exec() {
+        let chain_spec = OpChainSpecBuilder::default()
+            .lagoon_activated()
+            .genesis(OP_MAINNET.genesis.clone())
+            .chain(OP_MAINNET.chain)
+            .build();
+        let consensus = OpBeaconConsensus::new(Arc::new(chain_spec));
+        let transaction = mock_tx(0);
+        let header = Header {
+            base_fee_per_gas: Some(777),
+            withdrawals_root: Some(proofs::calculate_withdrawals_root(&[])),
+            blob_gas_used: Some(0),
+            transactions_root: proofs::calculate_transaction_root(std::slice::from_ref(
+                &transaction,
+            )),
+            timestamp: u64::MAX,
+            ..Default::default()
+        };
+        let body = BlockBody {
+            transactions: vec![transaction],
+            ommers: vec![],
+            withdrawals: Some(Withdrawals::default()),
+        };
+        let block = SealedBlock::seal_slow(alloy_consensus::Block { header, body });
+
+        let err = consensus.validate_block_pre_execution(&block).unwrap_err();
+        assert!(err.to_string().contains("missing post-exec transaction in Lagoon block"));
     }
 
     #[test]

--- a/rust/op-reth/crates/consensus/src/validation/mod.rs
+++ b/rust/op-reth/crates/consensus/src/validation/mod.rs
@@ -8,11 +8,14 @@ use reth_execution_types::BlockExecutionResult;
 pub use reth_optimism_chainspec::decode_holocene_base_fee;
 
 use crate::proof::calculate_receipt_root_optimism;
-use alloc::vec::Vec;
+use alloc::{format, vec::Vec};
 use alloy_consensus::{BlockHeader, EMPTY_OMMER_ROOT_HASH, TxReceipt};
 use alloy_eips::Encodable2718;
 use alloy_primitives::{B256, Bloom, Bytes};
 use alloy_trie::EMPTY_ROOT_HASH;
+use op_alloy_consensus::{
+    OpTransaction as OpConsensusTransaction, parse_post_exec_payload_from_transactions,
+};
 use reth_consensus::ConsensusError;
 use reth_optimism_forks::OpHardforks;
 use reth_optimism_primitives::DepositReceipt;
@@ -30,7 +33,7 @@ pub fn validate_body_against_header_op<B, H>(
     header: &H,
 ) -> Result<(), ConsensusError>
 where
-    B: BlockBody,
+    B: BlockBody<Transaction: OpConsensusTransaction>,
     H: reth_primitives_traits::BlockHeader,
 {
     let ommers_hash = body.calculate_ommers_root();
@@ -49,6 +52,28 @@ where
         return Err(ConsensusError::BodyTransactionRootDiff(
             GotExpected { got: tx_root, expected: header.transactions_root() }.into(),
         ));
+    }
+
+    let lagoon_active = chain_spec.is_lagoon_active_at_timestamp(header.timestamp());
+    let post_exec = parse_post_exec_payload_from_transactions(
+        body.transactions(),
+        header.number(),
+        lagoon_active,
+    )
+    .map_err(|err| ConsensusError::msg(format!("invalid post-exec payload: {err}")))?;
+
+    if lagoon_active {
+        let post_exec = post_exec
+            .ok_or_else(|| ConsensusError::msg("missing post-exec transaction in Lagoon block"))?;
+        let header_base_fee = header
+            .base_fee_per_gas()
+            .ok_or_else(|| ConsensusError::msg("missing base fee in Lagoon block"))?;
+        if post_exec.payload.selected_base_fee_per_gas != header_base_fee {
+            return Err(ConsensusError::msg(format!(
+                "post-exec selected base fee {} does not match header base fee {header_base_fee}",
+                post_exec.payload.selected_base_fee_per_gas,
+            )));
+        }
     }
 
     match (header.withdrawals_root(), body.calculate_withdrawals_root()) {
@@ -207,12 +232,12 @@ fn compare_receipts_root_and_logs_bloom(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_consensus::Header;
+    use alloy_consensus::{BlockBody as AlloyBlockBody, Header, Sealable};
     use alloy_eips::eip7685::Requests;
     use alloy_primitives::{Bytes, U256, b256, hex};
-    use op_alloy_consensus::{OpTxEnvelope, encode_jovian_extra_data};
+    use op_alloy_consensus::{OpTxEnvelope, build_post_exec_tx, encode_jovian_extra_data};
     use reth_chainspec::{BaseFeeParams, ChainSpec, EthChainSpec, ForkCondition, Hardfork};
-    use reth_optimism_chainspec::{OP_SEPOLIA, OpChainSpec};
+    use reth_optimism_chainspec::{OP_SEPOLIA, OpChainSpec, OpChainSpecBuilder};
     use reth_optimism_forks::OpHardfork;
     use reth_optimism_primitives::OpReceipt;
     use std::sync::Arc;
@@ -238,6 +263,14 @@ mod tests {
                 ..Default::default()
             },
         })
+    }
+
+    fn lagoon_chainspec() -> OpChainSpec {
+        OpChainSpecBuilder::default()
+            .chain(OP_SEPOLIA.chain)
+            .genesis(OP_SEPOLIA.genesis.clone())
+            .lagoon_activated()
+            .build()
     }
 
     fn isthmus_chainspec() -> OpChainSpec {
@@ -515,6 +548,67 @@ mod tests {
                 .next_block_base_fee(&parent, JOVIAN_TIMESTAMP + BLOCK_TIME_SECONDS)
                 .unwrap()
         );
+    }
+
+    #[test]
+    fn body_against_header_lagoon_requires_matching_post_exec_fee() {
+        let chainspec = lagoon_chainspec();
+        let post_exec = OpTxEnvelope::PostExec(build_post_exec_tx(1, 777, vec![]).seal_slow());
+        let body = AlloyBlockBody::<OpTxEnvelope, Header> {
+            transactions: vec![post_exec],
+            ommers: vec![],
+            withdrawals: None,
+        };
+        let header = Header {
+            number: 1,
+            timestamp: 1,
+            base_fee_per_gas: Some(777),
+            transactions_root: body.calculate_tx_root(),
+            ..Default::default()
+        };
+
+        validate_body_against_header_op(&chainspec, &body, &header).unwrap();
+
+        let mismatched = Header { base_fee_per_gas: Some(778), ..header };
+        let err = validate_body_against_header_op(&chainspec, &body, &mismatched).unwrap_err();
+        assert!(err.to_string().contains("does not match header base fee"));
+    }
+
+    #[test]
+    fn body_against_header_lagoon_rejects_missing_post_exec() {
+        let chainspec = lagoon_chainspec();
+        let body = AlloyBlockBody::<OpTxEnvelope>::default();
+        let header = Header {
+            number: 1,
+            timestamp: 1,
+            base_fee_per_gas: Some(777),
+            transactions_root: body.calculate_tx_root(),
+            ..Default::default()
+        };
+
+        let err = validate_body_against_header_op(&chainspec, &body, &header).unwrap_err();
+        assert!(err.to_string().contains("missing post-exec transaction"));
+    }
+
+    #[test]
+    fn body_against_header_rejects_post_exec_before_lagoon() {
+        let chainspec = OP_SEPOLIA.as_ref().clone();
+        let post_exec = OpTxEnvelope::PostExec(build_post_exec_tx(1, 777, vec![]).seal_slow());
+        let body = AlloyBlockBody::<OpTxEnvelope, Header> {
+            transactions: vec![post_exec],
+            ommers: vec![],
+            withdrawals: None,
+        };
+        let header = Header {
+            number: 1,
+            timestamp: 1,
+            base_fee_per_gas: Some(777),
+            transactions_root: body.calculate_tx_root(),
+            ..Default::default()
+        };
+
+        let err = validate_body_against_header_op(&chainspec, &body, &header).unwrap_err();
+        assert!(err.to_string().contains("invalid post-exec payload"));
     }
 
     #[test]

--- a/rust/op-reth/crates/evm/src/config.rs
+++ b/rust/op-reth/crates/evm/src/config.rs
@@ -38,17 +38,41 @@ impl<H: alloy_consensus::BlockHeader> reth_rpc_eth_api::helpers::pending_block::
             extra_data: parent.extra_data().clone(),
         };
 
-        // Only the beacon root override must be applied here: it is consumed during EVM
-        // environment construction. All other `BlockOverrides` fields are applied directly
-        // to the constructed environment by the caller, matching the upstream
-        // `NextBlockEnvAttributes::build_pending_env` behavior.
-        if attributes.parent_beacon_block_root.is_some() &&
-            let Some(beacon_root) = block_overrides.and_then(|overrides| overrides.beacon_root)
-        {
-            attributes.parent_beacon_block_root = Some(beacon_root);
+        // Timestamp and beacon root are consumed while constructing the EVM environment, before
+        // the caller applies the remaining overrides directly to the finished block environment.
+        // In particular, OP hardfork selection and sequencer fee quoting must observe the sanitized
+        // simulation timestamp rather than the Ethereum 12-second pending default.
+        if let Some(overrides) = block_overrides {
+            if let Some(timestamp) = overrides.time {
+                attributes.timestamp = timestamp;
+            }
+            if attributes.parent_beacon_block_root.is_some() &&
+                let Some(beacon_root) = overrides.beacon_root
+            {
+                attributes.parent_beacon_block_root = Some(beacon_root);
+            }
         }
 
         attributes
+    }
+}
+
+#[cfg(all(test, feature = "rpc"))]
+mod tests {
+    use super::*;
+    use alloy_consensus::Header;
+    use alloy_rpc_types_eth::BlockOverrides;
+    use reth_primitives_traits::SealedHeader;
+    use reth_rpc_eth_api::helpers::pending_block::BuildPendingEnv;
+
+    #[test]
+    fn pending_env_applies_simulation_timestamp() {
+        let parent = SealedHeader::new(Header { timestamp: 100, ..Default::default() }, B256::ZERO);
+        let overrides = BlockOverrides { time: Some(102), ..Default::default() };
+
+        let attributes = OpNextBlockEnvAttributes::build_pending_env(&parent, Some(&overrides));
+
+        assert_eq!(attributes.timestamp, 102);
     }
 }
 

--- a/rust/op-reth/crates/evm/src/lib.rs
+++ b/rust/op-reth/crates/evm/src/lib.rs
@@ -504,6 +504,7 @@ mod tests {
                 transactions: vec![OpTransactionSigned::PostExec(
                     build_post_exec_tx(
                         tx_block_number,
+                        1,
                         vec![SDMGasEntry { index: 0, gas_refund: 1 }],
                     )
                     .seal_slow(),

--- a/rust/op-reth/crates/evm/src/lib.rs
+++ b/rust/op-reth/crates/evm/src/lib.rs
@@ -493,6 +493,35 @@ mod tests {
         assert!(!evm_config.is_sdm_active_at_timestamp(u64::MAX));
     }
 
+    #[test]
+    fn next_evm_env_uses_selected_base_fee() {
+        let evm_config = OpEvmConfig::optimism(lagoon_at_timestamp_chain_spec(0));
+        let parent = Header {
+            number: 7,
+            timestamp: 100,
+            gas_limit: 30_000_000,
+            gas_used: 15_000_000,
+            base_fee_per_gas: Some(100),
+            ..Default::default()
+        };
+        let attributes = OpNextBlockEnvAttributes {
+            timestamp: 102,
+            suggested_fee_recipient: Address::ZERO,
+            prev_randao: B256::ZERO,
+            gas_limit: parent.gas_limit,
+            parent_beacon_block_root: None,
+            extra_data: Default::default(),
+        };
+
+        let evm_env = evm_config
+            .next_evm_env_with_base_fee(&parent, &attributes, 777)
+            .expect("next EVM environment should be valid");
+
+        assert_eq!(evm_env.block_env.basefee, 777);
+        assert_eq!(evm_env.block_env.number, 8);
+        assert_eq!(evm_env.block_env.timestamp, 102);
+    }
+
     fn block_with_post_exec_tx(
         number: u64,
         timestamp: u64,

--- a/rust/op-reth/crates/evm/src/post_exec_ext.rs
+++ b/rust/op-reth/crates/evm/src/post_exec_ext.rs
@@ -11,7 +11,7 @@ use op_alloy_consensus::OpTransaction as OpConsensusTransaction;
 use op_revm::OpSpecId;
 use reth_chainspec::EthChainSpec;
 use reth_evm::{
-    ConfigureEvm, Database,
+    ConfigureEvm, Database, EvmEnvFor,
     execute::{BasicBlockBuilder, BlockBuilder},
     precompiles::PrecompilesMap,
 };
@@ -28,6 +28,14 @@ pub trait ConfigurePostExecEvm: ConfigureEvm {
     /// Opaque block-scoped carry-forward state of the refund inspector the produced executors run.
     /// Matches [`PostExecExecutorExt::Snapshot`] of those executors.
     type Snapshot: Clone;
+
+    /// Derives the next-block EVM environment and overrides its base fee.
+    fn next_evm_env_with_base_fee(
+        &self,
+        parent: &<Self::Primitives as NodePrimitives>::BlockHeader,
+        attributes: &Self::NextBlockEnvCtx,
+        selected_base_fee_per_gas: u64,
+    ) -> Result<EvmEnvFor<Self>, Self::Error>;
 
     /// Returns a block executor for the given block with explicit post-exec entry access.
     ///
@@ -96,6 +104,17 @@ where
 {
     type Snapshot = ();
 
+    fn next_evm_env_with_base_fee(
+        &self,
+        parent: &<Self::Primitives as NodePrimitives>::BlockHeader,
+        attributes: &Self::NextBlockEnvCtx,
+        selected_base_fee_per_gas: u64,
+    ) -> Result<EvmEnvFor<Self>, Self::Error> {
+        let mut evm_env = self.next_evm_env(parent, attributes)?;
+        evm_env.block_env.basefee = selected_base_fee_per_gas;
+        Ok(evm_env)
+    }
+
     fn post_exec_executor_for_block<'a, DB: Database>(
         &'a self,
         db: &'a mut State<DB>,
@@ -138,8 +157,8 @@ where
         > + 'a,
         Self::Error,
     > {
-        let mut evm_env = self.next_evm_env(parent, &attributes)?;
-        evm_env.block_env.basefee = selected_base_fee_per_gas;
+        let evm_env =
+            self.next_evm_env_with_base_fee(parent, &attributes, selected_base_fee_per_gas)?;
         let evm = self.evm_with_env(db, evm_env);
         let ctx =
             self.context_for_next_block_with_post_exec_mode(parent, attributes, post_exec_mode);
@@ -204,6 +223,17 @@ where
 {
     type Snapshot = F::Snapshot;
 
+    fn next_evm_env_with_base_fee(
+        &self,
+        parent: &<Self::Primitives as NodePrimitives>::BlockHeader,
+        attributes: &Self::NextBlockEnvCtx,
+        selected_base_fee_per_gas: u64,
+    ) -> Result<EvmEnvFor<Self>, Self::Error> {
+        let mut evm_env = self.next_evm_env(parent, attributes)?;
+        evm_env.block_env.basefee = selected_base_fee_per_gas;
+        Ok(evm_env)
+    }
+
     fn post_exec_executor_for_block<'a, DB: Database>(
         &'a self,
         db: &'a mut State<DB>,
@@ -246,8 +276,8 @@ where
         > + 'a,
         Self::Error,
     > {
-        let mut evm_env = self.next_evm_env(parent, &attributes)?;
-        evm_env.block_env.basefee = selected_base_fee_per_gas;
+        let evm_env =
+            self.next_evm_env_with_base_fee(parent, &attributes, selected_base_fee_per_gas)?;
         let evm = self.evm_with_env(db, evm_env);
         let ctx =
             self.context_for_next_block_with_post_exec_mode(parent, attributes, post_exec_mode);

--- a/rust/op-reth/crates/evm/src/post_exec_ext.rs
+++ b/rust/op-reth/crates/evm/src/post_exec_ext.rs
@@ -59,6 +59,7 @@ pub trait ConfigurePostExecEvm: ConfigureEvm {
         parent: &'a SealedHeader<<Self::Primitives as NodePrimitives>::BlockHeader>,
         attributes: Self::NextBlockEnvCtx,
         post_exec_mode: PostExecMode,
+        selected_base_fee_per_gas: u64,
     ) -> Result<
         impl BlockBuilder<
             Primitives = Self::Primitives,
@@ -125,6 +126,7 @@ where
         parent: &'a SealedHeader<<Self::Primitives as NodePrimitives>::BlockHeader>,
         attributes: Self::NextBlockEnvCtx,
         post_exec_mode: PostExecMode,
+        selected_base_fee_per_gas: u64,
     ) -> Result<
         impl BlockBuilder<
             Primitives = Self::Primitives,
@@ -136,7 +138,8 @@ where
         > + 'a,
         Self::Error,
     > {
-        let evm_env = self.next_evm_env(parent, &attributes)?;
+        let mut evm_env = self.next_evm_env(parent, &attributes)?;
+        evm_env.block_env.basefee = selected_base_fee_per_gas;
         let evm = self.evm_with_env(db, evm_env);
         let ctx =
             self.context_for_next_block_with_post_exec_mode(parent, attributes, post_exec_mode);
@@ -231,6 +234,7 @@ where
         parent: &'a SealedHeader<<Self::Primitives as NodePrimitives>::BlockHeader>,
         attributes: Self::NextBlockEnvCtx,
         post_exec_mode: PostExecMode,
+        selected_base_fee_per_gas: u64,
     ) -> Result<
         impl BlockBuilder<
             Primitives = Self::Primitives,
@@ -242,7 +246,8 @@ where
         > + 'a,
         Self::Error,
     > {
-        let evm_env = self.next_evm_env(parent, &attributes)?;
+        let mut evm_env = self.next_evm_env(parent, &attributes)?;
+        evm_env.block_env.basefee = selected_base_fee_per_gas;
         let evm = self.evm_with_env(db, evm_env);
         let ctx =
             self.context_for_next_block_with_post_exec_mode(parent, attributes, post_exec_mode);

--- a/rust/op-reth/crates/flashblocks/Cargo.toml
+++ b/rust/op-reth/crates/flashblocks/Cargo.toml
@@ -37,6 +37,7 @@ alloy-rpc-types.workspace = true
 alloy-consensus.workspace = true
 
 # op-alloy
+op-alloy-consensus.workspace = true
 op-alloy-rpc-types-engine = { workspace = true, features = ["k256"] }
 
 # io

--- a/rust/op-reth/crates/flashblocks/Cargo.toml
+++ b/rust/op-reth/crates/flashblocks/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 [dependencies]
 # reth
 reth-optimism-primitives = { workspace = true, features = ["serde"] }
+reth-optimism-evm.workspace = true
 reth-chain-state = { workspace = true, features = ["serde"] }
 reth-primitives-traits = { workspace = true, features = ["serde"] }
 reth-engine-primitives = { workspace = true, features = ["std"] }
@@ -65,5 +66,4 @@ alloy-signer-local.workspace = true
 op-alloy-consensus.workspace = true
 op-revm.workspace = true
 reth-optimism-chainspec = { workspace = true, features = ["superchain-configs"] }
-reth-optimism-evm.workspace = true
 reth-provider = { workspace = true, features = ["test-utils"] }

--- a/rust/op-reth/crates/flashblocks/src/cache.rs
+++ b/rust/op-reth/crates/flashblocks/src/cache.rs
@@ -534,6 +534,7 @@ impl<T: SignedTransaction> SequenceManager<T> {
             args: BuildArgs {
                 base,
                 transactions,
+                post_exec_tx: last_flashblock.diff.post_exec_tx.clone(),
                 cached_state,
                 last_flashblock_index: last_flashblock.index,
                 last_flashblock_hash: last_flashblock.diff.block_hash,

--- a/rust/op-reth/crates/flashblocks/src/service.rs
+++ b/rust/op-reth/crates/flashblocks/src/service.rs
@@ -7,9 +7,12 @@ use crate::{
     validation::{CanonicalBlockFingerprint, ReconciliationStrategy},
     worker::{BuildResult, FlashBlockBuilder, FlashblockCachedReceipt},
 };
+use alloy_consensus::transaction::SignerRecoverable;
+use alloy_eips::Decodable2718;
 use alloy_primitives::B256;
 use futures_util::{FutureExt, Stream, StreamExt};
 use metrics::{Counter, Gauge, Histogram};
+use op_alloy_consensus::OpTransaction;
 use op_alloy_rpc_types_engine::OpFlashblockPayloadBase;
 use reth_metrics::Metrics;
 use reth_optimism_evm::ConfigurePostExecEvm;
@@ -96,6 +99,7 @@ impl<N, S, EvmConfig, Provider> FlashBlockService<N, S, EvmConfig, Provider>
 where
     N: NodePrimitives,
     N::Receipt: FlashblockCachedReceipt,
+    N::SignedTx: Decodable2718 + OpTransaction + SignerRecoverable,
     S: Stream<Item = eyre::Result<FlashBlock>> + Unpin + 'static,
     EvmConfig: ConfigurePostExecEvm<Primitives = N, NextBlockEnvCtx: From<OpFlashblockPayloadBase> + Unpin>
         + Clone

--- a/rust/op-reth/crates/flashblocks/src/service.rs
+++ b/rust/op-reth/crates/flashblocks/src/service.rs
@@ -11,8 +11,8 @@ use alloy_primitives::B256;
 use futures_util::{FutureExt, Stream, StreamExt};
 use metrics::{Counter, Gauge, Histogram};
 use op_alloy_rpc_types_engine::OpFlashblockPayloadBase;
-use reth_evm::ConfigureEvm;
 use reth_metrics::Metrics;
+use reth_optimism_evm::ConfigurePostExecEvm;
 use reth_primitives_traits::{AlloyBlockHeader, BlockTy, HeaderTy, NodePrimitives, ReceiptTy};
 use reth_storage_api::{BlockReaderIdExt, StateProviderFactory};
 use reth_tasks::TaskExecutor;
@@ -54,7 +54,7 @@ pub struct CanonicalBlockNotification {
 pub struct FlashBlockService<
     N: NodePrimitives,
     S,
-    EvmConfig: ConfigureEvm<Primitives = N, NextBlockEnvCtx: From<OpFlashblockPayloadBase> + Unpin>,
+    EvmConfig: ConfigurePostExecEvm<Primitives = N, NextBlockEnvCtx: From<OpFlashblockPayloadBase> + Unpin>,
     Provider,
 > {
     /// Incoming flashblock stream.
@@ -97,7 +97,7 @@ where
     N: NodePrimitives,
     N::Receipt: FlashblockCachedReceipt,
     S: Stream<Item = eyre::Result<FlashBlock>> + Unpin + 'static,
-    EvmConfig: ConfigureEvm<Primitives = N, NextBlockEnvCtx: From<OpFlashblockPayloadBase> + Unpin>
+    EvmConfig: ConfigurePostExecEvm<Primitives = N, NextBlockEnvCtx: From<OpFlashblockPayloadBase> + Unpin>
         + Clone
         + 'static,
     Provider: StateProviderFactory

--- a/rust/op-reth/crates/flashblocks/src/service.rs
+++ b/rust/op-reth/crates/flashblocks/src/service.rs
@@ -12,7 +12,6 @@ use alloy_eips::Decodable2718;
 use alloy_primitives::B256;
 use futures_util::{FutureExt, Stream, StreamExt};
 use metrics::{Counter, Gauge, Histogram};
-use op_alloy_consensus::OpTransaction;
 use op_alloy_rpc_types_engine::OpFlashblockPayloadBase;
 use reth_metrics::Metrics;
 use reth_optimism_evm::ConfigurePostExecEvm;
@@ -99,7 +98,7 @@ impl<N, S, EvmConfig, Provider> FlashBlockService<N, S, EvmConfig, Provider>
 where
     N: NodePrimitives,
     N::Receipt: FlashblockCachedReceipt,
-    N::SignedTx: Decodable2718 + OpTransaction + SignerRecoverable,
+    N::SignedTx: Decodable2718 + SignerRecoverable,
     S: Stream<Item = eyre::Result<FlashBlock>> + Unpin + 'static,
     EvmConfig: ConfigurePostExecEvm<Primitives = N, NextBlockEnvCtx: From<OpFlashblockPayloadBase> + Unpin>
         + Clone

--- a/rust/op-reth/crates/flashblocks/src/worker.rs
+++ b/rust/op-reth/crates/flashblocks/src/worker.rs
@@ -6,7 +6,7 @@ use crate::{
 use alloy_consensus::transaction::SignerRecoverable;
 use alloy_eips::{BlockNumberOrTag, Decodable2718, eip2718::WithEncoded};
 use alloy_primitives::{B256, Bytes};
-use op_alloy_consensus::OpTransaction;
+use op_alloy_consensus::TxPostExec;
 use op_alloy_rpc_types_engine::OpFlashblockPayloadBase;
 use reth_chain_state::ExecutedBlock;
 use reth_errors::RethError;
@@ -121,7 +121,7 @@ impl<N, EvmConfig, Provider> FlashBlockBuilder<EvmConfig, Provider>
 where
     N: NodePrimitives,
     N::Receipt: FlashblockCachedReceipt,
-    N::SignedTx: Decodable2718 + OpTransaction + SignerRecoverable,
+    N::SignedTx: Decodable2718 + SignerRecoverable,
     EvmConfig: ConfigurePostExecEvm<Primitives = N, NextBlockEnvCtx: From<OpFlashblockPayloadBase> + Unpin>,
     Provider: StateProviderFactory
         + BlockReaderIdExt<
@@ -178,12 +178,11 @@ where
         let post_exec_mode = if let Some(raw) = args.post_exec_tx.take() {
             let tx = N::SignedTx::decode_2718_exact(&raw)
                 .map_err(|err| eyre::eyre!("failed to decode flashblock post-exec tx: {err}"))?;
-            let payload = tx
-                .as_post_exec()
-                .ok_or_else(|| eyre::eyre!("flashblock post_exec_tx is not type 0x7d"))?
-                .inner()
-                .payload
-                .clone();
+            let payload = TxPostExec::decode_2718_exact(&raw)
+                .map_err(|err| {
+                    eyre::eyre!("flashblock post_exec_tx is not valid type 0x7d: {err}")
+                })?
+                .payload;
             if payload.block_number != args.base.block_number {
                 return Err(eyre::eyre!(
                     "flashblock post-exec block number {} does not match {}",

--- a/rust/op-reth/crates/flashblocks/src/worker.rs
+++ b/rust/op-reth/crates/flashblocks/src/worker.rs
@@ -3,8 +3,10 @@ use crate::{
     pending_state::PendingBlockState,
     tx_cache::{CachedExecutionMeta, TransactionCache},
 };
-use alloy_eips::{BlockNumberOrTag, eip2718::WithEncoded};
-use alloy_primitives::B256;
+use alloy_consensus::transaction::SignerRecoverable;
+use alloy_eips::{BlockNumberOrTag, Decodable2718, eip2718::WithEncoded};
+use alloy_primitives::{B256, Bytes};
+use op_alloy_consensus::OpTransaction;
 use op_alloy_rpc_types_engine::OpFlashblockPayloadBase;
 use reth_chain_state::ExecutedBlock;
 use reth_errors::RethError;
@@ -58,6 +60,8 @@ impl<EvmConfig, Provider> FlashBlockBuilder<EvmConfig, Provider> {
 pub(crate) struct BuildArgs<I, N: NodePrimitives> {
     pub(crate) base: OpFlashblockPayloadBase,
     pub(crate) transactions: I,
+    /// Latest out-of-band PostExec snapshot for this sequence.
+    pub(crate) post_exec_tx: Option<Bytes>,
     pub(crate) cached_state: Option<(B256, CachedReads)>,
     pub(crate) last_flashblock_index: u64,
     pub(crate) last_flashblock_hash: B256,
@@ -117,6 +121,7 @@ impl<N, EvmConfig, Provider> FlashBlockBuilder<EvmConfig, Provider>
 where
     N: NodePrimitives,
     N::Receipt: FlashblockCachedReceipt,
+    N::SignedTx: Decodable2718 + OpTransaction + SignerRecoverable,
     EvmConfig: ConfigurePostExecEvm<Primitives = N, NextBlockEnvCtx: From<OpFlashblockPayloadBase> + Unpin>,
     Provider: StateProviderFactory
         + BlockReaderIdExt<
@@ -167,8 +172,43 @@ where
             return Ok(None);
         }
 
-        // Collect transactions and extract hashes for cache lookup
-        let transactions: Vec<_> = args.transactions.into_iter().collect();
+        // Collect transactions, then materialize the latest out-of-band PostExec snapshot exactly
+        // once as the trailing transaction.
+        let mut transactions: Vec<_> = args.transactions.into_iter().collect();
+        let post_exec_mode = if let Some(raw) = args.post_exec_tx.take() {
+            let tx = N::SignedTx::decode_2718_exact(&raw)
+                .map_err(|err| eyre::eyre!("failed to decode flashblock post-exec tx: {err}"))?;
+            let payload = tx
+                .as_post_exec()
+                .ok_or_else(|| eyre::eyre!("flashblock post_exec_tx is not type 0x7d"))?
+                .inner()
+                .payload
+                .clone();
+            if payload.block_number != args.base.block_number {
+                return Err(eyre::eyre!(
+                    "flashblock post-exec block number {} does not match {}",
+                    payload.block_number,
+                    args.base.block_number
+                ));
+            }
+            let selected_base_fee_per_gas = u64::try_from(args.base.base_fee_per_gas)
+                .map_err(|_| eyre::eyre!("flashblock base fee does not fit in u64"))?;
+            if payload.selected_base_fee_per_gas != selected_base_fee_per_gas {
+                return Err(eyre::eyre!(
+                    "flashblock post-exec base fee {} does not match {}",
+                    payload.selected_base_fee_per_gas,
+                    selected_base_fee_per_gas
+                ));
+            }
+            let recovered = tx
+                .try_into_recovered()
+                .map_err(|err| eyre::eyre!("failed to recover flashblock post-exec tx: {err}"))?
+                .into_encoded_with(raw);
+            transactions.push(recovered);
+            PostExecMode::Verify(payload)
+        } else {
+            PostExecMode::Disabled
+        };
         let tx_hashes: Vec<B256> = transactions.iter().map(|tx| *tx.tx_hash()).collect();
 
         // Get state provider and parent header context.
@@ -234,7 +274,9 @@ where
 
         // Check for resumable canonical execution state.
         let canonical_parent_hash = args.base.parent_hash;
-        let cached_prefix = if is_canonical {
+        // A PostExec payload may refund any prior transaction, so verifier replay must observe the
+        // complete transaction list and cannot resume from a prefix executed in disabled mode.
+        let cached_prefix = if is_canonical && matches!(post_exec_mode, PostExecMode::Disabled) {
             tx_cache.as_ref().and_then(|cache| {
                 cache
                     .get_resumable_state_with_execution_meta_for_parent(
@@ -375,7 +417,7 @@ where
                         &mut state,
                         parent_header,
                         args.base.clone().into(),
-                        PostExecMode::Disabled,
+                        post_exec_mode,
                         selected_base_fee_per_gas,
                     )
                     .map_err(RethError::other)?;
@@ -508,17 +550,18 @@ mod tests {
     use alloy_consensus::{SignableTransaction, TxEip1559};
     use alloy_eips::eip2718::Encodable2718;
     use alloy_network::TxSignerSync;
-    use alloy_primitives::{Address, B256, StorageKey, StorageValue, TxKind, U256};
+    use alloy_primitives::{Address, B256, Bytes, StorageKey, StorageValue, TxKind, U256};
     use alloy_signer_local::PrivateKeySigner;
+    use op_alloy_consensus::{SDMGasEntry, build_post_exec_tx};
     use op_alloy_rpc_types_engine::OpFlashblockPayloadBase;
     use op_revm::constants::L1_BLOCK_CONTRACT;
-    use reth_optimism_chainspec::OP_MAINNET;
+    use reth_optimism_chainspec::{OP_MAINNET, OpChainSpecBuilder};
     use reth_optimism_evm::OpEvmConfig;
     use reth_optimism_primitives::{OpPrimitives, OpTransactionSigned};
     use reth_primitives_traits::{AlloyBlockHeader, Recovered, SignerRecoverable};
     use reth_provider::test_utils::{ExtendedAccount, MockEthProvider};
     use reth_storage_api::BlockReaderIdExt;
-    use std::str::FromStr;
+    use std::{str::FromStr, sync::Arc};
 
     fn signed_transfer_tx(
         signer: &PrivateKeySigner,
@@ -533,6 +576,7 @@ mod tests {
             max_fee_per_gas: 2_000_000_000,
             to: TxKind::Call(recipient),
             value: U256::from(1),
+            input: Bytes::from_static(&[1]),
             ..Default::default()
         };
         let signature = signer.sign_transaction_sync(&mut tx).expect("signing tx succeeds");
@@ -566,8 +610,15 @@ mod tests {
 
     #[test]
     fn canonical_build_reuses_cached_prefix_execution() {
+        let chain_spec = Arc::new(
+            OpChainSpecBuilder::default()
+                .chain(10.into())
+                .genesis(OP_MAINNET.genesis().clone())
+                .lagoon_activated()
+                .build(),
+        );
         let provider = MockEthProvider::<OpPrimitives>::new()
-            .with_chain_spec(OP_MAINNET.clone())
+            .with_chain_spec(chain_spec.clone())
             .with_genesis_block();
 
         let recipient = Address::repeat_byte(0x22);
@@ -585,6 +636,7 @@ mod tests {
                 (StorageKey::with_last_byte(1), StorageValue::from(1_000_000_000u64)),
                 (StorageKey::with_last_byte(5), StorageValue::from(188u64)),
                 (StorageKey::with_last_byte(6), StorageValue::from(684_000u64)),
+                (StorageKey::with_last_byte(8), StorageValue::ZERO),
                 (
                     StorageKey::with_last_byte(3),
                     StorageValue::from_str(
@@ -623,7 +675,7 @@ mod tests {
         let tx_b = into_encoded_recovered(tx_b, signer);
         let tx_c = into_encoded_recovered(tx_c, signer);
 
-        let evm_config = OpEvmConfig::optimism(OP_MAINNET.clone());
+        let evm_config = OpEvmConfig::optimism(chain_spec);
         let builder = FlashBlockBuilder::new(evm_config, provider);
         let mut tx_cache = TransactionCache::<OpPrimitives>::new();
 
@@ -632,6 +684,7 @@ mod tests {
                 BuildArgs {
                     base: base.clone(),
                     transactions: vec![tx_a.clone(), tx_b.clone()],
+                    post_exec_tx: None,
                     cached_state: None,
                     last_flashblock_index: 0,
                     last_flashblock_hash: B256::repeat_byte(0xA0),
@@ -644,6 +697,9 @@ mod tests {
             .expect("first build is canonical");
 
         assert_eq!(first.pending_state.execution_outcome.result.receipts.len(), 2);
+        let first_tx_cumulative_gas = first.pending_state.execution_outcome.result.receipts[0]
+            .as_receipt()
+            .cumulative_gas_used;
         assert_eq!(
             first
                 .pending_state
@@ -691,8 +747,9 @@ mod tests {
         let second = builder
             .execute(
                 BuildArgs {
-                    base,
-                    transactions: vec![tx_a, tx_b, tx_c],
+                    base: base.clone(),
+                    transactions: vec![tx_a.clone(), tx_b.clone(), tx_c.clone()],
+                    post_exec_tx: None,
                     cached_state: None,
                     last_flashblock_index: 1,
                     last_flashblock_hash: B256::repeat_byte(0xA1),
@@ -710,6 +767,65 @@ mod tests {
         assert!(
             receipts[2].as_receipt().cumulative_gas_used >
                 receipts[1].as_receipt().cumulative_gas_used
+        );
+
+        let empty_post_exec =
+            build_post_exec_tx(base.block_number, 777, Vec::new()).encoded_2718().into();
+        let with_empty_commitment = builder
+            .execute(
+                BuildArgs {
+                    base: base.clone(),
+                    transactions: vec![tx_a.clone(), tx_b.clone(), tx_c.clone()],
+                    post_exec_tx: Some(empty_post_exec),
+                    cached_state: None,
+                    last_flashblock_index: 2,
+                    last_flashblock_hash: B256::repeat_byte(0xA2),
+                    compute_state_root: false,
+                    pending_parent: None,
+                },
+                Some(&mut tx_cache),
+            )
+            .expect("empty-commitment build succeeds")
+            .expect("empty-commitment build is canonical");
+        assert_eq!(with_empty_commitment.pending_state.execution_outcome.result.receipts.len(), 4);
+        assert_eq!(
+            with_empty_commitment.pending_state.execution_outcome.result.receipts[0]
+                .as_receipt()
+                .cumulative_gas_used,
+            first_tx_cumulative_gas,
+            "PostExec replay must bypass the tampered disabled-mode prefix cache",
+        );
+
+        let refund_post_exec = build_post_exec_tx(
+            base.block_number,
+            777,
+            vec![SDMGasEntry { index: 0, gas_refund: 1 }],
+        )
+        .encoded_2718()
+        .into();
+        let with_refund = builder
+            .execute(
+                BuildArgs {
+                    base,
+                    transactions: vec![tx_a, tx_b, tx_c],
+                    post_exec_tx: Some(refund_post_exec),
+                    cached_state: None,
+                    last_flashblock_index: 3,
+                    last_flashblock_hash: B256::repeat_byte(0xA3),
+                    compute_state_root: false,
+                    pending_parent: None,
+                },
+                Some(&mut tx_cache),
+            )
+            .expect("refund-commitment build succeeds")
+            .expect("refund-commitment build is canonical");
+        assert_eq!(with_refund.pending_state.execution_outcome.result.receipts.len(), 4);
+        assert_eq!(
+            with_refund.pending_state.execution_outcome.result.receipts[0]
+                .as_receipt()
+                .cumulative_gas_used,
+            first_tx_cumulative_gas - 1,
+            "refund targeting a formerly cached-prefix transaction must be applied",
         );
     }
 }

--- a/rust/op-reth/crates/flashblocks/src/worker.rs
+++ b/rust/op-reth/crates/flashblocks/src/worker.rs
@@ -9,12 +9,13 @@ use op_alloy_rpc_types_engine::OpFlashblockPayloadBase;
 use reth_chain_state::ExecutedBlock;
 use reth_errors::RethError;
 use reth_evm::{
-    ConfigureEvm, Evm,
+    Evm,
     execute::{
         BlockAssembler, BlockAssemblerInput, BlockBuilder, BlockBuilderOutcome, BlockExecutor,
     },
 };
 use reth_execution_types::{BlockExecutionOutput, BlockExecutionResult};
+use reth_optimism_evm::{ConfigurePostExecEvm, PostExecMode};
 use reth_optimism_primitives::OpReceipt;
 use reth_primitives_traits::{
     AlloyBlockHeader, BlockTy, HeaderTy, NodePrimitives, ReceiptTy, Recovered, RecoveredBlock,
@@ -116,7 +117,7 @@ impl<N, EvmConfig, Provider> FlashBlockBuilder<EvmConfig, Provider>
 where
     N: NodePrimitives,
     N::Receipt: FlashblockCachedReceipt,
-    EvmConfig: ConfigureEvm<Primitives = N, NextBlockEnvCtx: From<OpFlashblockPayloadBase> + Unpin>,
+    EvmConfig: ConfigurePostExecEvm<Primitives = N, NextBlockEnvCtx: From<OpFlashblockPayloadBase> + Unpin>,
     Provider: StateProviderFactory
         + BlockReaderIdExt<
             Header = HeaderTy<N>,
@@ -270,6 +271,9 @@ where
             None
         };
 
+        let selected_base_fee_per_gas = u64::try_from(args.base.base_fee_per_gas)
+            .map_err(|_| eyre::eyre!("flashblock base fee does not fit in u64"))?;
+
         // Build state with appropriate prestate
         // - Speculative builds use pending parent prestate
         // - Canonical cache-hit builds use cached prefix prestate
@@ -289,103 +293,110 @@ where
             State::builder().with_database(cached_db).with_bundle_update().build()
         };
 
-        let (execution_result, block, hashed_state, bundle) = if let Some(cached_prefix) =
-            cached_prefix
-        {
-            // Cached prefix execution model:
-            // - The cached bundle prestate already includes pre-execution state changes
-            //   (blockhash/beacon root updates, create2deployer), so we do NOT call
-            //   apply_pre_execution_changes() again.
-            // - The only pre-execution effect we need is set_state_clear_flag, which configures EVM
-            //   empty-account handling (OP Stack chains activate Spurious Dragon at genesis, so
-            //   this is always true).
-            // - Suffix transactions execute against the warm prestate.
-            // - Post-execution (finish()) runs once on the suffix executor, producing correct
-            //   results for the full block. For OP Stack post-merge, the
-            //   post_block_balance_increments are empty (no block rewards, no ommers, no
-            //   withdrawals passed), so finish() only seals execution state.
-            let attrs = args.base.clone().into();
-            let evm_env =
-                self.evm_config.next_evm_env(parent_header, &attrs).map_err(RethError::other)?;
-            let execution_ctx = self
-                .evm_config
-                .context_for_next_block(parent_header, attrs)
-                .map_err(RethError::other)?;
-
-            let evm = self.evm_config.evm_with_env(&mut state, evm_env);
-            let mut executor = self.evm_config.create_executor(evm, execution_ctx.clone());
-
-            for tx in transactions.iter().skip(cached_prefix.cached_tx_count).cloned() {
-                let _gas_used = executor.execute_transaction(tx)?;
-            }
-
-            let (evm, suffix_execution_result) = executor.finish()?;
-            let (db, evm_env) = evm.finish();
-            db.merge_transitions(BundleRetention::Reverts);
-
-            let execution_result =
-                Self::merge_cached_and_suffix_results(cached_prefix, suffix_execution_result);
-
-            let (hashed_state, state_root) = if args.compute_state_root {
-                trace!(target: "flashblocks", "Computing block state root");
-                let hashed_state = state_provider.hashed_post_state(&db.bundle_state);
-                let (state_root, _) = state_provider
-                    .state_root_with_updates(hashed_state.clone())
+        let (execution_result, block, hashed_state, bundle) =
+            if let Some(cached_prefix) = cached_prefix {
+                // Cached prefix execution model:
+                // - The cached bundle prestate already includes pre-execution state changes
+                //   (blockhash/beacon root updates, create2deployer), so we do NOT call
+                //   apply_pre_execution_changes() again.
+                // - The only pre-execution effect we need is set_state_clear_flag, which configures
+                //   EVM empty-account handling (OP Stack chains activate Spurious Dragon at
+                //   genesis, so this is always true).
+                // - Suffix transactions execute against the warm prestate.
+                // - Post-execution (finish()) runs once on the suffix executor, producing correct
+                //   results for the full block. For OP Stack post-merge, the
+                //   post_block_balance_increments are empty (no block rewards, no ommers, no
+                //   withdrawals passed), so finish() only seals execution state.
+                let attrs = args.base.clone().into();
+                let evm_env = self
+                    .evm_config
+                    .next_evm_env_with_base_fee(parent_header, &attrs, selected_base_fee_per_gas)
                     .map_err(RethError::other)?;
-                (hashed_state, state_root)
-            } else {
-                let noop_provider = NoopProvider::default();
-                let hashed_state = noop_provider.hashed_post_state(&db.bundle_state);
-                let (state_root, _) = noop_provider
-                    .state_root_with_updates(hashed_state.clone())
+                let execution_ctx = self
+                    .evm_config
+                    .context_for_next_block(parent_header, attrs)
                     .map_err(RethError::other)?;
-                (hashed_state, state_root)
-            };
-            let bundle = db.take_bundle();
 
-            let (block_transactions, senders): (Vec<_>, Vec<_>) =
-                transactions.iter().map(|tx| tx.1.clone().into_parts()).unzip();
-            let block = self
-                .evm_config
-                .block_assembler()
-                .assemble_block(BlockAssemblerInput::new(
-                    evm_env,
-                    execution_ctx,
-                    parent_header,
-                    block_transactions,
-                    &execution_result,
-                    &bundle,
-                    &state_provider,
-                    state_root,
-                    None,
-                ))
-                .map_err(RethError::other)?;
-            let block = RecoveredBlock::new_unhashed(block, senders);
+                let evm = self.evm_config.evm_with_env(&mut state, evm_env);
+                let mut executor = self.evm_config.create_executor(evm, execution_ctx.clone());
 
-            (execution_result, block, hashed_state, bundle)
-        } else {
-            let mut builder = self
-                .evm_config
-                .builder_for_next_block(&mut state, parent_header, args.base.clone().into())
-                .map_err(RethError::other)?;
+                for tx in transactions.iter().skip(cached_prefix.cached_tx_count).cloned() {
+                    let _gas_used = executor.execute_transaction(tx)?;
+                }
 
-            builder.apply_pre_execution_changes()?;
+                let (evm, suffix_execution_result) = executor.finish()?;
+                let (db, evm_env) = evm.finish();
+                db.merge_transitions(BundleRetention::Reverts);
 
-            for tx in transactions {
-                let _gas_used = builder.execute_transaction(tx)?;
-            }
+                let execution_result =
+                    Self::merge_cached_and_suffix_results(cached_prefix, suffix_execution_result);
 
-            let BlockBuilderOutcome { execution_result, block, hashed_state, .. } =
-                if args.compute_state_root {
+                let (hashed_state, state_root) = if args.compute_state_root {
                     trace!(target: "flashblocks", "Computing block state root");
-                    builder.finish(&state_provider, None)?
+                    let hashed_state = state_provider.hashed_post_state(&db.bundle_state);
+                    let (state_root, _) = state_provider
+                        .state_root_with_updates(hashed_state.clone())
+                        .map_err(RethError::other)?;
+                    (hashed_state, state_root)
                 } else {
-                    builder.finish(NoopProvider::default(), None)?
+                    let noop_provider = NoopProvider::default();
+                    let hashed_state = noop_provider.hashed_post_state(&db.bundle_state);
+                    let (state_root, _) = noop_provider
+                        .state_root_with_updates(hashed_state.clone())
+                        .map_err(RethError::other)?;
+                    (hashed_state, state_root)
                 };
-            let bundle = state.take_bundle();
+                let bundle = db.take_bundle();
 
-            (execution_result, block, hashed_state, bundle)
-        };
+                let (block_transactions, senders): (Vec<_>, Vec<_>) =
+                    transactions.iter().map(|tx| tx.1.clone().into_parts()).unzip();
+                let block = self
+                    .evm_config
+                    .block_assembler()
+                    .assemble_block(BlockAssemblerInput::new(
+                        evm_env,
+                        execution_ctx,
+                        parent_header,
+                        block_transactions,
+                        &execution_result,
+                        &bundle,
+                        &state_provider,
+                        state_root,
+                        None,
+                    ))
+                    .map_err(RethError::other)?;
+                let block = RecoveredBlock::new_unhashed(block, senders);
+
+                (execution_result, block, hashed_state, bundle)
+            } else {
+                let mut builder = self
+                    .evm_config
+                    .post_exec_builder_for_next_block(
+                        &mut state,
+                        parent_header,
+                        args.base.clone().into(),
+                        PostExecMode::Disabled,
+                        selected_base_fee_per_gas,
+                    )
+                    .map_err(RethError::other)?;
+
+                builder.apply_pre_execution_changes()?;
+
+                for tx in transactions {
+                    let _gas_used = builder.execute_transaction(tx)?;
+                }
+
+                let BlockBuilderOutcome { execution_result, block, hashed_state, .. } =
+                    if args.compute_state_root {
+                        trace!(target: "flashblocks", "Computing block state root");
+                        builder.finish(&state_provider, None)?
+                    } else {
+                        builder.finish(NoopProvider::default(), None)?
+                    };
+                let bundle = state.take_bundle();
+
+                (execution_result, block, hashed_state, bundle)
+            };
 
         // Update transaction cache if provided (only in canonical mode)
         if let Some(cache) = tx_cache &&
@@ -598,7 +609,9 @@ mod tests {
             gas_limit: 30_000_000,
             timestamp: latest.timestamp() + 2,
             extra_data: Default::default(),
-            base_fee_per_gas: U256::from(1_000_000_000u64),
+            // Deliberately differs from the parent-derived fee to prove flashblock replay uses the
+            // producer-provided value.
+            base_fee_per_gas: U256::from(777u64),
         };
         let base_parent_hash = base.parent_hash;
 
@@ -631,6 +644,15 @@ mod tests {
             .expect("first build is canonical");
 
         assert_eq!(first.pending_state.execution_outcome.result.receipts.len(), 2);
+        assert_eq!(
+            first
+                .pending_state
+                .sealed_header
+                .as_ref()
+                .expect("flashblock build seals a header")
+                .base_fee_per_gas(),
+            Some(777),
+        );
 
         let cached_hashes = vec![tx_a_hash, tx_b_hash];
         let (bundle, receipts, requests, gas_used, blob_gas_used, skip) = tx_cache

--- a/rust/op-reth/crates/flashblocks/src/worker.rs
+++ b/rust/op-reth/crates/flashblocks/src/worker.rs
@@ -60,7 +60,7 @@ impl<EvmConfig, Provider> FlashBlockBuilder<EvmConfig, Provider> {
 pub(crate) struct BuildArgs<I, N: NodePrimitives> {
     pub(crate) base: OpFlashblockPayloadBase,
     pub(crate) transactions: I,
-    /// Latest out-of-band PostExec snapshot for this sequence.
+    /// Latest out-of-band `PostExec` snapshot for this sequence.
     pub(crate) post_exec_tx: Option<Bytes>,
     pub(crate) cached_state: Option<(B256, CachedReads)>,
     pub(crate) last_flashblock_index: u64,

--- a/rust/op-reth/crates/node/src/node.rs
+++ b/rust/op-reth/crates/node/src/node.rs
@@ -7,7 +7,9 @@ use crate::{
     txpool::{OpCustomTransactionPool, OpTransactionValidator},
 };
 use alloy_primitives::Sealed;
-use op_alloy_consensus::{OpPooledTransaction, TxPostExec, interop::SafetyLevel};
+use op_alloy_consensus::{
+    OpPooledTransaction, OpTransaction as OpConsensusTransaction, TxPostExec, interop::SafetyLevel,
+};
 use reth_chainspec::{
     BaseFeeParams, ChainSpecProvider, EthChainSpec, EthereumHardforks, ForkCondition, Hardforks,
 };
@@ -40,7 +42,10 @@ use reth_optimism_forks::OpHardforks;
 use reth_optimism_payload_builder::{
     OpBuiltPayload, OpExecData, OpPayloadBuilderAttributes, OpPayloadPrimitives,
     builder::OpPayloadTransactions,
-    config::{OpBuilderConfig, OpDAConfig, OpGasLimitConfig, OperatorSdmOptIn},
+    config::{
+        BaseFeePolicy, JovianBaseFeePolicy, OpBuilderConfig, OpDAConfig, OpGasLimitConfig,
+        OperatorSdmOptIn,
+    },
 };
 use reth_optimism_primitives::{DepositReceipt, OpPrimitives};
 use reth_optimism_rpc::{
@@ -191,7 +196,7 @@ where
 }
 
 /// Type configuration for a regular Optimism node.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct OpNode {
     /// Additional Optimism args
@@ -207,6 +212,8 @@ pub struct OpNode {
     /// Used to control the gas limit of the blocks produced by the OP builder.(configured by the
     /// batcher via the `miner_` api)
     pub gas_limit_config: OpGasLimitConfig,
+    /// Producer-only base-fee policy used for normal Lagoon payloads.
+    pub base_fee_policy: Arc<dyn BaseFeePolicy>,
     /// Local operator opt-in for SDM `PostExec` production. Shared (via Arc clones) between the
     /// payload builder and the `admin_setOperatorSdmOptIn` RPC handler.
     pub operator_sdm_opt_in: OperatorSdmOptIn,
@@ -225,6 +232,12 @@ pub type OpNodeComponentBuilder<Node, Payload = OpPayloadBuilder> = ComponentsBu
     OpConsensusBuilder,
 >;
 
+impl Default for OpNode {
+    fn default() -> Self {
+        Self::new(RollupArgs::default())
+    }
+}
+
 impl OpNode {
     /// Creates a new instance of the Optimism node type.
     pub fn new(args: RollupArgs) -> Self {
@@ -234,6 +247,7 @@ impl OpNode {
             args,
             da_config: OpDAConfig::default(),
             gas_limit_config: OpGasLimitConfig::default(),
+            base_fee_policy: Arc::new(JovianBaseFeePolicy),
             operator_sdm_opt_in,
             interop_failsafe: InteropFailsafe::default(),
         }
@@ -251,6 +265,12 @@ impl OpNode {
         self
     }
 
+    /// Configure the producer-only Lagoon base-fee policy.
+    pub fn with_base_fee_policy(mut self, base_fee_policy: Arc<dyn BaseFeePolicy>) -> Self {
+        self.base_fee_policy = base_fee_policy;
+        self
+    }
+
     /// The [`OpBuilderConfig`] this node's payload builder is configured with.
     ///
     /// This is the single assembly site for the payload builder's config: [`components`] and any
@@ -264,6 +284,7 @@ impl OpNode {
         OpBuilderConfig {
             da_config: self.da_config.clone(),
             gas_limit_config: self.gas_limit_config.clone(),
+            base_fee_policy: self.base_fee_policy.clone(),
             operator_sdm_opt_in: self.operator_sdm_opt_in.clone(),
             interop_failsafe: self.interop_failsafe.clone(),
             max_uncompressed_block_size: self.args.max_uncompressed_block_size,
@@ -1518,6 +1539,13 @@ impl OpPayloadBuilder {
         self
     }
 
+    /// Configure the producer-only Lagoon base-fee policy.
+    #[must_use]
+    pub fn with_base_fee_policy(mut self, base_fee_policy: Arc<dyn BaseFeePolicy>) -> Self {
+        self.builder_config.base_fee_policy = base_fee_policy;
+        self
+    }
+
     /// Provide the shared SDM operator opt-in flag.
     #[must_use]
     pub fn with_operator_sdm_opt_in(mut self, operator_sdm_opt_in: OperatorSdmOptIn) -> Self {
@@ -1698,7 +1726,7 @@ where
     Node: FullNodeTypes<
         Types: NodeTypes<
             ChainSpec: OpHardforks,
-            Primitives: NodePrimitives<Receipt: DepositReceipt>,
+            Primitives: NodePrimitives<Receipt: DepositReceipt, SignedTx: OpConsensusTransaction>,
         >,
     >,
 {

--- a/rust/op-reth/crates/node/src/node.rs
+++ b/rust/op-reth/crates/node/src/node.rs
@@ -1464,7 +1464,7 @@ where
                     base_fee_policy.as_ref(),
                     chain_spec.as_ref(),
                     header,
-                    header.timestamp(),
+                    header.timestamp().saturating_add(12),
                 )
                 .unwrap_or_else(|err| {
                         warn!(target: "txpool", %err, "base-fee policy quote failed; using latest observed fee");

--- a/rust/op-reth/crates/node/src/node.rs
+++ b/rust/op-reth/crates/node/src/node.rs
@@ -6,6 +6,7 @@ use crate::{
     engine::OpEngineValidator,
     txpool::{OpCustomTransactionPool, OpTransactionValidator},
 };
+use alloy_consensus::BlockHeader;
 use alloy_primitives::Sealed;
 use op_alloy_consensus::{
     OpPooledTransaction, OpTransaction as OpConsensusTransaction, TxPostExec, interop::SafetyLevel,
@@ -44,7 +45,7 @@ use reth_optimism_payload_builder::{
     builder::OpPayloadTransactions,
     config::{
         BaseFeePolicy, JovianBaseFeePolicy, OpBuilderConfig, OpDAConfig, OpGasLimitConfig,
-        OperatorSdmOptIn,
+        OperatorSdmOptIn, quote_base_fee,
     },
 };
 use reth_optimism_primitives::{DepositReceipt, OpPrimitives};
@@ -66,7 +67,7 @@ use reth_rpc_api::{
     eth::{RpcTypes, helpers::config::EthConfigHandler},
 };
 use reth_rpc_server_types::RethRpcModule;
-use reth_tracing::tracing::{debug, info};
+use reth_tracing::tracing::{debug, info, warn};
 use reth_transaction_pool::{
     CoinbaseTipOrdering, EthPoolTransaction, PoolPooledTx, PoolTransaction, TransactionOrdering,
     TransactionPool, TransactionValidationTaskExecutor, TransactionValidator,
@@ -308,6 +309,7 @@ impl OpNode {
                 self.args.interop_safety_level,
             )
             .with_interop_failsafe(self.interop_failsafe.clone())
+            .with_base_fee_policy(self.base_fee_policy.clone())
     }
 
     /// Returns the payload builder stock components install.
@@ -341,6 +343,7 @@ impl OpNode {
             .with_sequencer_headers(self.args.sequencer_headers.clone())
             .with_da_config(self.da_config.clone())
             .with_gas_limit_config(self.gas_limit_config.clone())
+            .with_base_fee_policy(self.base_fee_policy.clone())
             .with_operator_sdm_opt_in(self.operator_sdm_opt_in.clone())
             .with_enable_tx_conditional(self.args.enable_tx_conditional)
             .with_min_suggested_priority_fee(self.args.min_suggested_priority_fee)
@@ -913,6 +916,8 @@ pub struct OpAddOnsBuilder<NetworkT, RpcMiddleware = Identity> {
     da_config: Option<OpDAConfig>,
     /// Gas limit configuration for the OP builder.
     gas_limit_config: Option<OpGasLimitConfig>,
+    /// Policy used by RPC to quote the next sequencer-selected base fee.
+    base_fee_policy: Option<Arc<dyn BaseFeePolicy>>,
     /// Shared SDM operator opt-in flag for the payload builder and admin RPC.
     operator_sdm_opt_in: Option<OperatorSdmOptIn>,
     /// Enable transaction conditionals.
@@ -942,6 +947,7 @@ impl<NetworkT> Default for OpAddOnsBuilder<NetworkT> {
             historical_rpc: None,
             da_config: None,
             gas_limit_config: None,
+            base_fee_policy: None,
             operator_sdm_opt_in: None,
             enable_tx_conditional: false,
             retain_forwarded_txs: false,
@@ -977,6 +983,12 @@ impl<NetworkT, RpcMiddleware> OpAddOnsBuilder<NetworkT, RpcMiddleware> {
     /// Configure the gas limit configuration for the OP payload builder.
     pub fn with_gas_limit_config(mut self, gas_limit_config: OpGasLimitConfig) -> Self {
         self.gas_limit_config = Some(gas_limit_config);
+        self
+    }
+
+    /// Configure the policy used by RPC to quote the next sequencer-selected base fee.
+    pub fn with_base_fee_policy(mut self, base_fee_policy: Arc<dyn BaseFeePolicy>) -> Self {
+        self.base_fee_policy = Some(base_fee_policy);
         self
     }
 
@@ -1028,6 +1040,7 @@ impl<NetworkT, RpcMiddleware> OpAddOnsBuilder<NetworkT, RpcMiddleware> {
             historical_rpc,
             da_config,
             gas_limit_config,
+            base_fee_policy,
             operator_sdm_opt_in,
             enable_tx_conditional,
             retain_forwarded_txs,
@@ -1044,6 +1057,7 @@ impl<NetworkT, RpcMiddleware> OpAddOnsBuilder<NetworkT, RpcMiddleware> {
             historical_rpc,
             da_config,
             gas_limit_config,
+            base_fee_policy,
             operator_sdm_opt_in,
             enable_tx_conditional,
             retain_forwarded_txs,
@@ -1086,6 +1100,7 @@ impl<NetworkT, RpcMiddleware> OpAddOnsBuilder<NetworkT, RpcMiddleware> {
             sequencer_headers,
             da_config,
             gas_limit_config,
+            base_fee_policy,
             operator_sdm_opt_in,
             enable_tx_conditional,
             retain_forwarded_txs,
@@ -1104,6 +1119,9 @@ impl<NetworkT, RpcMiddleware> OpAddOnsBuilder<NetworkT, RpcMiddleware> {
                     .with_sequencer(sequencer_url.clone())
                     .with_sequencer_headers(sequencer_headers.clone())
                     .with_min_suggested_priority_fee(min_suggested_priority_fee)
+                    .with_base_fee_policy(
+                        base_fee_policy.unwrap_or_else(|| Arc::new(JovianBaseFeePolicy)),
+                    )
                     .with_flashblocks(flashblocks_url)
                     .with_flashblock_consensus(flashblock_consensus)
                     .with_retain_forwarded_txs(retain_forwarded_txs),
@@ -1205,6 +1223,8 @@ pub struct OpPoolBuilder<
     pub interop_safety_level: SafetyLevel,
     /// Shared interop failsafe gate, passed to the interop filter client this builder constructs.
     pub interop_failsafe: InteropFailsafe,
+    /// Policy used to quote the next sequencer-selected base fee for pool classification.
+    pub base_fee_policy: Arc<dyn BaseFeePolicy>,
     /// The transaction ordering used by the pool.
     pub ordering: O,
     /// The validator wrapper applied to the built [`OpTransactionValidator`].
@@ -1222,6 +1242,7 @@ impl<T> Default for OpPoolBuilder<T> {
             interop_min_responses: None,
             interop_safety_level: SafetyLevel::CrossUnsafe,
             interop_failsafe: InteropFailsafe::default(),
+            base_fee_policy: Arc::new(JovianBaseFeePolicy),
             ordering: CoinbaseTipOrdering::default(),
             validator_wrapper: IdentityValidatorWrapper,
             _pd: Default::default(),
@@ -1238,6 +1259,7 @@ impl<T, O: Clone, W: Clone> Clone for OpPoolBuilder<T, O, W> {
             interop_min_responses: self.interop_min_responses,
             interop_safety_level: self.interop_safety_level,
             interop_failsafe: self.interop_failsafe.clone(),
+            base_fee_policy: self.base_fee_policy.clone(),
             ordering: self.ordering.clone(),
             validator_wrapper: self.validator_wrapper.clone(),
             _pd: core::marker::PhantomData,
@@ -1282,6 +1304,12 @@ impl<T, O, W> OpPoolBuilder<T, O, W> {
         self
     }
 
+    /// Sets the policy used to quote the next sequencer-selected base fee.
+    pub fn with_base_fee_policy(mut self, base_fee_policy: Arc<dyn BaseFeePolicy>) -> Self {
+        self.base_fee_policy = base_fee_policy;
+        self
+    }
+
     /// Sets a custom transaction ordering for the pool, replacing the default
     /// [`CoinbaseTipOrdering`].
     pub fn with_ordering<NewO>(self, ordering: NewO) -> OpPoolBuilder<T, NewO, W> {
@@ -1292,6 +1320,7 @@ impl<T, O, W> OpPoolBuilder<T, O, W> {
             interop_min_responses: self.interop_min_responses,
             interop_safety_level: self.interop_safety_level,
             interop_failsafe: self.interop_failsafe,
+            base_fee_policy: self.base_fee_policy,
             ordering,
             validator_wrapper: self.validator_wrapper,
             _pd: core::marker::PhantomData,
@@ -1312,6 +1341,7 @@ impl<T, O, W> OpPoolBuilder<T, O, W> {
             interop_min_responses: self.interop_min_responses,
             interop_safety_level: self.interop_safety_level,
             interop_failsafe: self.interop_failsafe,
+            base_fee_policy: self.base_fee_policy,
             ordering: self.ordering,
             validator_wrapper,
             _pd: core::marker::PhantomData,
@@ -1335,6 +1365,7 @@ where
         ctx: &BuilderContext<Node>,
         evm_config: Evm,
     ) -> eyre::Result<Self::Pool> {
+        let base_fee_policy = self.base_fee_policy.clone();
         let Self { pool_config_overrides, ordering, validator_wrapper, .. } = self;
 
         // Interop filter used for txpool validation.
@@ -1423,10 +1454,23 @@ where
             ctx.chain_spec().op_fork_activation(OpHardfork::Lagoon) != ForkCondition::Never;
         let transaction_pool = OpPool::new(inner_pool, interop_filter_enabled);
 
-        reth_node_builder::components::spawn_maintenance_tasks(
+        let chain_spec = ctx.chain_spec();
+        reth_node_builder::components::spawn_maintenance_tasks_with_base_fee(
             ctx,
             transaction_pool.clone(),
             &final_pool_config,
+            move |header| {
+                quote_base_fee(
+                    base_fee_policy.as_ref(),
+                    chain_spec.as_ref(),
+                    header,
+                    header.timestamp(),
+                )
+                .unwrap_or_else(|err| {
+                        warn!(target: "txpool", %err, "base-fee policy quote failed; using latest observed fee");
+                        header.base_fee_per_gas().unwrap_or_default()
+                    })
+            },
         )?;
 
         info!(target: "reth::cli", "Transaction pool initialized (interop filter enabled = {interop_filter_enabled})");
@@ -1782,11 +1826,17 @@ mod tests {
         let node = OpNode::new(args.clone());
 
         let pool = node.standard_pool_builder::<OpPooledTransaction>();
+        let add_ons = node.add_ons_builder::<op_alloy_network::Optimism>();
 
         assert_eq!(pool.enable_tx_conditional, args.enable_tx_conditional);
         assert_eq!(pool.interop_endpoints, args.interop_http);
         assert_eq!(pool.interop_min_responses, args.interop_min_responses);
         assert_eq!(pool.interop_safety_level, args.interop_safety_level);
+        assert!(Arc::ptr_eq(&pool.base_fee_policy, &node.base_fee_policy));
+        assert!(Arc::ptr_eq(
+            add_ons.base_fee_policy.as_ref().expect("base-fee policy must be configured"),
+            &node.base_fee_policy,
+        ));
 
         assert!(!pool.interop_failsafe.enabled(), "failsafe starts disabled");
         node.interop_failsafe.set(true);
@@ -1836,6 +1886,7 @@ mod tests {
         assert_eq!(cfg.da_config.max_da_block_size(), Some(200));
         assert!(cfg.constrained_da_config().is_some());
         assert_eq!(cfg.gas_limit_config.gas_limit(), Some(30_000_000));
+        assert!(Arc::ptr_eq(&cfg.base_fee_policy, &node.base_fee_policy));
         assert!(cfg.operator_sdm_opt_in.enabled());
         assert!(cfg.interop_failsafe.enabled());
     }

--- a/rust/op-reth/crates/node/src/node.rs
+++ b/rust/op-reth/crates/node/src/node.rs
@@ -285,6 +285,7 @@ impl OpNode {
             da_config: self.da_config.clone(),
             gas_limit_config: self.gas_limit_config.clone(),
             base_fee_policy: self.base_fee_policy.clone(),
+            base_fee_selection_cache: Default::default(),
             operator_sdm_opt_in: self.operator_sdm_opt_in.clone(),
             interop_failsafe: self.interop_failsafe.clone(),
             max_uncompressed_block_size: self.args.max_uncompressed_block_size,

--- a/rust/op-reth/crates/node/tests/it/debug_trace_post_exec.rs
+++ b/rust/op-reth/crates/node/tests/it/debug_trace_post_exec.rs
@@ -86,7 +86,7 @@ async fn test_debug_trace_block_with_post_exec_tx() -> eyre::Result<()> {
     };
     let transactions = vec![
         OpTxEnvelope::Deposit(deposit.seal_slow()),
-        OpTxEnvelope::PostExec(build_post_exec_tx(1, vec![]).seal_slow()),
+        OpTxEnvelope::PostExec(build_post_exec_tx(1, 1, vec![]).seal_slow()),
     ];
     let block = Block::new(header, BlockBody { transactions, ommers: vec![], withdrawals: None });
 

--- a/rust/op-reth/crates/node/tests/it/main.rs
+++ b/rust/op-reth/crates/node/tests/it/main.rs
@@ -18,4 +18,6 @@ mod estimate_gas_7825;
 
 mod p2p_version;
 
+mod sequencer_defined_fees;
+
 const fn main() {}

--- a/rust/op-reth/crates/node/tests/it/sequencer_defined_fees.rs
+++ b/rust/op-reth/crates/node/tests/it/sequencer_defined_fees.rs
@@ -34,6 +34,26 @@ impl BaseFeePolicy for FixedBaseFeePolicy {
     }
 }
 
+#[derive(Debug)]
+struct SimulationBaseFeePolicy;
+
+impl BaseFeePolicy for SimulationBaseFeePolicy {
+    fn select_base_fee(&self, _input: BaseFeePolicyInput<'_>) -> Result<u64, BaseFeePolicyError> {
+        Ok(SELECTED_BASE_FEE)
+    }
+
+    fn quote_base_fee(&self, input: BaseFeePolicyInput<'_>) -> Result<u64, BaseFeePolicyError> {
+        if input.next_timestamp == 100 {
+            Ok(input.next_timestamp)
+        } else {
+            Err(BaseFeePolicyError::msg(format!(
+                "unexpected simulation timestamp {}",
+                input.next_timestamp
+            )))
+        }
+    }
+}
+
 #[tokio::test]
 async fn pending_rpc_and_txpool_use_selected_base_fee() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
@@ -106,6 +126,76 @@ async fn pending_rpc_and_txpool_use_selected_base_fee() -> eyre::Result<()> {
         )
         .await?;
     assert!(estimated >= U256::from(21_000));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn simulation_quotes_effective_timestamp_only_when_needed() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let genesis: Genesis = serde_json::from_str(include_str!("../assets/genesis.json"))?;
+    let chain_spec = Arc::new(
+        OpChainSpecBuilder::optimism_sepolia().genesis(genesis).lagoon_activated().build(),
+    );
+
+    let mut network_args = NetworkArgs::default().with_unused_ports();
+    network_args.discovery.discv5_port = Some(0);
+    network_args.discovery.discv5_port_ipv6 = Some(0);
+    let node_config = NodeConfig::test()
+        .map_chain(chain_spec)
+        .with_network(network_args)
+        .with_rpc(RpcServerArgs::default().with_unused_ports().with_http());
+    let op_node = OpNode::default().with_base_fee_policy(Arc::new(SimulationBaseFeePolicy));
+
+    let NodeHandle { node, node_exit_future: _ } =
+        NodeBuilder::new(node_config).testing_node(Runtime::test()).node(op_node).launch().await?;
+    let client = node.add_ons_handle.rpc_server_handles().rpc.http_client().unwrap();
+
+    // Validation-disabled simulations do not need a sequencer fee quote.
+    let without_validation: Vec<serde_json::Value> = client
+        .request(
+            "eth_simulateV1",
+            rpc_params![json!({
+                "blockStateCalls": [{ "calls": [] }],
+                "validation": false
+            })],
+        )
+        .await?;
+    assert_eq!(without_validation.len(), 1);
+
+    // An explicit base fee also makes the policy irrelevant, even with validation enabled.
+    let explicit_fee: Vec<serde_json::Value> = client
+        .request(
+            "eth_simulateV1",
+            rpc_params![json!({
+                "blockStateCalls": [{
+                    "blockOverrides": {
+                        "time": "0x3",
+                        "baseFeePerGas": "0x2a"
+                    },
+                    "calls": []
+                }],
+                "validation": true
+            })],
+        )
+        .await?;
+    assert_eq!(explicit_fee[0]["baseFeePerGas"], json!("0x2a"));
+
+    // Without an explicit fee, the quote observes the sanitized simulation timestamp.
+    let quoted_fee: Vec<serde_json::Value> = client
+        .request(
+            "eth_simulateV1",
+            rpc_params![json!({
+                "blockStateCalls": [{
+                    "blockOverrides": { "time": "0x64" },
+                    "calls": []
+                }],
+                "validation": true
+            })],
+        )
+        .await?;
+    assert_eq!(quoted_fee[0]["baseFeePerGas"], json!("0x64"));
 
     Ok(())
 }

--- a/rust/op-reth/crates/node/tests/it/sequencer_defined_fees.rs
+++ b/rust/op-reth/crates/node/tests/it/sequencer_defined_fees.rs
@@ -1,0 +1,111 @@
+//! Pending RPC and txpool behavior with a sequencer-defined Lagoon base fee.
+
+use alloy_genesis::Genesis;
+use alloy_primitives::{Address, U256, address};
+use alloy_rpc_types_eth::FeeHistory;
+use jsonrpsee::{core::client::ClientT, rpc_params};
+use reth_node_builder::{NodeBuilder, NodeHandle};
+use reth_node_core::{
+    args::{NetworkArgs, RpcServerArgs},
+    node_config::NodeConfig,
+};
+use reth_optimism_chainspec::OpChainSpecBuilder;
+use reth_optimism_node::OpNode;
+use reth_optimism_payload_builder::config::{
+    BaseFeePolicy, BaseFeePolicyError, BaseFeePolicyInput,
+};
+use reth_rpc_eth_api::helpers::LoadPendingBlock;
+use reth_tasks::Runtime;
+use reth_transaction_pool::TransactionPool;
+use revm::context::Block;
+use serde_json::json;
+use std::sync::Arc;
+
+const SELECTED_BASE_FEE: u64 = 777;
+const SUGGESTED_PRIORITY_FEE: u64 = 1_000_000;
+const FUNDED: Address = address!("f39fd6e51aad88f6f4ce6ab8827279cfffb92266");
+
+#[derive(Debug)]
+struct FixedBaseFeePolicy;
+
+impl BaseFeePolicy for FixedBaseFeePolicy {
+    fn select_base_fee(&self, _input: BaseFeePolicyInput<'_>) -> Result<u64, BaseFeePolicyError> {
+        Ok(SELECTED_BASE_FEE)
+    }
+}
+
+#[tokio::test]
+async fn pending_rpc_and_txpool_use_selected_base_fee() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let mut genesis: Genesis = serde_json::from_str(include_str!("../assets/genesis.json"))?;
+    // Keep the latest observed fee distinct from the selected pending fee so every assertion proves
+    // that the policy hook was used rather than the canonical header value.
+    genesis.base_fee_per_gas = Some(1_000_000_000);
+    let chain_spec = Arc::new(
+        OpChainSpecBuilder::optimism_sepolia().genesis(genesis).lagoon_activated().build(),
+    );
+
+    let mut network_args = NetworkArgs::default().with_unused_ports();
+    network_args.discovery.discv5_port = Some(0);
+    network_args.discovery.discv5_port_ipv6 = Some(0);
+    let node_config = NodeConfig::test()
+        .map_chain(chain_spec)
+        .with_network(network_args)
+        .with_rpc(RpcServerArgs::default().with_unused_ports().with_http());
+    let op_node = OpNode::default().with_base_fee_policy(Arc::new(FixedBaseFeePolicy));
+
+    let NodeHandle { node, node_exit_future: _ } =
+        NodeBuilder::new(node_config).testing_node(Runtime::test()).node(op_node).launch().await?;
+    let client = node.add_ons_handle.rpc_server_handles().rpc.http_client().unwrap();
+
+    assert_eq!(node.pool.block_info().pending_basefee, SELECTED_BASE_FEE);
+    assert_eq!(
+        node.add_ons_handle.eth_api().pending_block_env_and_cfg()?.evm_env.block_env.basefee(),
+        SELECTED_BASE_FEE,
+    );
+
+    let base_fee: Option<U256> = client.request("eth_baseFee", rpc_params![]).await?;
+    assert_eq!(base_fee, Some(U256::from(SELECTED_BASE_FEE)));
+
+    let gas_price: U256 = client.request("eth_gasPrice", rpc_params![]).await?;
+    assert_eq!(gas_price, U256::from(SELECTED_BASE_FEE + SUGGESTED_PRIORITY_FEE));
+
+    let history: FeeHistory =
+        client.request("eth_feeHistory", rpc_params![1, "latest", Vec::<f64>::new()]).await?;
+    assert_eq!(history.base_fee_per_gas.last(), Some(&(SELECTED_BASE_FEE as u128)));
+
+    let filled: serde_json::Value = client
+        .request(
+            "eth_fillTransaction",
+            rpc_params![json!({
+                "from": FUNDED,
+                "to": Address::with_last_byte(1),
+                "gas": "0x5208"
+            })],
+        )
+        .await?;
+    assert_eq!(
+        filled["tx"]["maxFeePerGas"],
+        json!(format!("0x{:x}", SELECTED_BASE_FEE * 2 + SUGGESTED_PRIORITY_FEE)),
+    );
+
+    // Pending estimation must remain usable when callers price against the selected fee.
+    let estimated: U256 = client
+        .request(
+            "eth_estimateGas",
+            rpc_params![
+                json!({
+                    "from": FUNDED,
+                    "to": Address::with_last_byte(1),
+                    "maxFeePerGas": format!("0x{SELECTED_BASE_FEE:x}"),
+                    "maxPriorityFeePerGas": "0x0"
+                }),
+                "pending"
+            ],
+        )
+        .await?;
+    assert!(estimated >= U256::from(21_000));
+
+    Ok(())
+}

--- a/rust/op-reth/crates/payload/src/builder.rs
+++ b/rust/op-reth/crates/payload/src/builder.rs
@@ -759,9 +759,9 @@ pub struct ExecutionInfo {
     /// so far, in bytes. Bounds the block against the configured
     /// [`max_uncompressed_block_size`](crate::config::OpBuilderConfig::max_uncompressed_block_size).
     pub cumulative_uncompressed_bytes: u64,
-    /// Conservative space held for the mandatory trailing PostExec transaction.
+    /// Conservative space held for the mandatory trailing `PostExec` transaction.
     pub reserved_post_exec_bytes: u64,
-    /// Number of transactions included before PostExec.
+    /// Number of transactions included before `PostExec`.
     pub included_transactions: u64,
     /// Tracks fees from executed mempool transactions
     pub total_fees: U256,
@@ -781,7 +781,7 @@ impl ExecutionInfo {
         }
     }
 
-    /// Reserves conservative uncompressed block space for a mandatory trailing PostExec.
+    /// Reserves conservative uncompressed block space for a mandatory trailing `PostExec`.
     pub fn reserve_post_exec(&mut self, block_number: u64, selected_base_fee_per_gas: u64) {
         let empty_post_exec_size =
             build_post_exec_tx(block_number, selected_base_fee_per_gas, Vec::new())

--- a/rust/op-reth/crates/payload/src/builder.rs
+++ b/rust/op-reth/crates/payload/src/builder.rs
@@ -74,11 +74,15 @@ fn sdm_refund_gas(entries: &[SDMGasEntry]) -> u64 {
     entries.iter().map(|entry| entry.gas_refund).sum()
 }
 
-fn build_post_exec_recovered_tx<Tx>(block_number: u64, entries: Vec<SDMGasEntry>) -> Recovered<Tx>
+fn build_post_exec_recovered_tx<Tx>(
+    block_number: u64,
+    selected_base_fee_per_gas: u64,
+    entries: Vec<SDMGasEntry>,
+) -> Recovered<Tx>
 where
     Tx: From<Sealed<TxPostExec>>,
 {
-    let sealed = build_post_exec_tx(block_number, entries).seal_slow();
+    let sealed = build_post_exec_tx(block_number, selected_base_fee_per_gas, entries).seal_slow();
     Recovered::new_unchecked(Tx::from(sealed), Address::ZERO)
 }
 
@@ -95,6 +99,7 @@ where
 /// that no honest verifier can reproduce.
 fn try_include_post_exec_tx<Tx, Err>(
     block_number: u64,
+    selected_base_fee_per_gas: u64,
     entries: Vec<SDMGasEntry>,
     execute: impl FnOnce(Recovered<Tx>) -> Result<u64, Err>,
 ) -> Result<bool, PayloadBuilderError>
@@ -106,7 +111,8 @@ where
         return Ok(false);
     }
 
-    let post_exec_recovered = build_post_exec_recovered_tx(block_number, entries);
+    let post_exec_recovered =
+        build_post_exec_recovered_tx(block_number, selected_base_fee_per_gas, entries);
 
     execute(post_exec_recovered).map_err(|err| {
         warn!(target: "payload_builder", %err, "post-exec tx execution failed, aborting payload");
@@ -519,9 +525,10 @@ impl<Txs> OpBuilder<'_, Txs> {
         // appending would duplicate it. See `post_exec_mode`.
         let sdm_refund_gas = if produce_post_exec {
             let block_number = builder.evm_mut().block().number().saturating_to();
+            let selected_base_fee_per_gas = builder.evm_mut().block().basefee();
             let entries = builder.executor_mut().take_post_exec_entries();
             let refund_gas = self::sdm_refund_gas(&entries);
-            try_include_post_exec_tx(block_number, entries, |tx| {
+            try_include_post_exec_tx(block_number, selected_base_fee_per_gas, entries, |tx| {
                 builder.execute_transaction(tx).map(|g| g.tx_gas_used())
             })?;
             refund_gas

--- a/rust/op-reth/crates/payload/src/builder.rs
+++ b/rust/op-reth/crates/payload/src/builder.rs
@@ -499,12 +499,7 @@ impl<Txs> OpBuilder<'_, Txs> {
         let mut info = ctx.execute_sequencer_transactions(&mut builder, None)?;
         if append_post_exec {
             let block_number = builder.evm_mut().block().number().saturating_to();
-            let empty_post_exec_size =
-                build_post_exec_tx(block_number, selected_base_fee_per_gas, Vec::new())
-                    .eip2718_encoded_length() as u64;
-            info.reserved_post_exec_bytes = empty_post_exec_size.saturating_add(
-                info.included_transactions.saturating_mul(MAX_POST_EXEC_BYTES_PER_TRANSACTION),
-            );
+            info.reserve_post_exec(block_number, selected_base_fee_per_gas);
         }
 
         // 3. if mem pool transactions are requested we execute them
@@ -784,6 +779,16 @@ impl ExecutionInfo {
             included_transactions: 0,
             total_fees: U256::ZERO,
         }
+    }
+
+    /// Reserves conservative uncompressed block space for a mandatory trailing PostExec.
+    pub fn reserve_post_exec(&mut self, block_number: u64, selected_base_fee_per_gas: u64) {
+        let empty_post_exec_size =
+            build_post_exec_tx(block_number, selected_base_fee_per_gas, Vec::new())
+                .eip2718_encoded_length() as u64;
+        self.reserved_post_exec_bytes = empty_post_exec_size.saturating_add(
+            self.included_transactions.saturating_mul(MAX_POST_EXEC_BYTES_PER_TRANSACTION),
+        );
     }
 
     /// Adds a transaction's gas to both the canonical and pre-refund (real compute) counters,

--- a/rust/op-reth/crates/payload/src/builder.rs
+++ b/rust/op-reth/crates/payload/src/builder.rs
@@ -1023,7 +1023,11 @@ where
     ) -> Result<
         impl BlockBuilder<
             Primitives = Evm::Primitives,
-            Executor: PostExecExecutorExt + BlockExecutor<Result: PreRefundGasUsed>,
+            Executor: PostExecExecutorExt
+                          + BlockExecutor<
+                Evm: AlloyEvm<DB: core::ops::DerefMut<Target = State<DB>>>,
+                Result: PreRefundGasUsed,
+            >,
         > + 'a,
         PayloadBuilderError,
     > {
@@ -1041,7 +1045,11 @@ where
     ) -> Result<
         impl BlockBuilder<
             Primitives = Evm::Primitives,
-            Executor: PostExecExecutorExt + BlockExecutor<Result: PreRefundGasUsed>,
+            Executor: PostExecExecutorExt
+                          + BlockExecutor<
+                Evm: AlloyEvm<DB: core::ops::DerefMut<Target = State<DB>>>,
+                Result: PreRefundGasUsed,
+            >,
         > + 'a,
         PayloadBuilderError,
     > {

--- a/rust/op-reth/crates/payload/src/builder.rs
+++ b/rust/op-reth/crates/payload/src/builder.rs
@@ -975,11 +975,13 @@ where
 
         let selected_base_fee_per_gas = self
             .builder_config
-            .base_fee_policy
-            .select_base_fee(BaseFeePolicyInput {
-                parent: self.parent().header(),
-                next_timestamp: timestamp,
-                legacy_base_fee,
+            .base_fee_selection_cache
+            .resolve(self.payload_id(), || {
+                self.builder_config.base_fee_policy.select_base_fee(BaseFeePolicyInput {
+                    parent: self.parent().header(),
+                    next_timestamp: timestamp,
+                    legacy_base_fee,
+                })
             })
             .map_err(PayloadBuilderError::other)?;
 

--- a/rust/op-reth/crates/payload/src/builder.rs
+++ b/rust/op-reth/crates/payload/src/builder.rs
@@ -1,7 +1,9 @@
 //! Optimism payload builder implementation.
 use crate::{
-    OpAttributes, OpPayloadBuilderAttributes, OpPayloadPrimitives, config::OpBuilderConfig,
-    error::OpPayloadBuilderError, payload::OpBuiltPayload,
+    OpAttributes, OpPayloadBuilderAttributes, OpPayloadPrimitives,
+    config::{BaseFeePolicyError, BaseFeePolicyInput, OpBuilderConfig},
+    error::OpPayloadBuilderError,
+    payload::OpBuiltPayload,
 };
 use alloy_consensus::{BlockHeader, Sealable, Transaction, Typed2718, transaction::Recovered};
 use alloy_eips::eip2718::Encodable2718;
@@ -88,11 +90,8 @@ where
 
 /// Wraps refund entries in a post-exec transaction and executes it via `execute`.
 ///
-/// # Returns
-/// - `true` if a post-exec transaction was executed.
-/// - `false` if `entries` is empty.
-///
-/// The post-exec transaction MUST execute successfully: any error is surfaced as
+/// The post-exec transaction MUST execute successfully, including when `entries` is empty: any
+/// error is surfaced as
 /// `PayloadBuilderError::EvmExecutionError` so the payload build aborts. A verifier
 /// replaying this block will expect the post-exec tx to match the refunds it observes,
 /// so dropping the tx (or returning an empty block) on failure would produce a payload
@@ -107,10 +106,6 @@ where
     Tx: From<Sealed<TxPostExec>>,
     Err: core::error::Error + Send + Sync + 'static,
 {
-    if entries.is_empty() {
-        return Ok(false);
-    }
-
     let post_exec_recovered =
         build_post_exec_recovered_tx(block_number, selected_base_fee_per_gas, entries);
 
@@ -478,15 +473,16 @@ impl<Txs> OpBuilder<'_, Txs> {
         // scalar.
         db.load_cache_account(L1_BLOCK_CONTRACT).map_err(BlockExecutionError::other)?;
 
-        // Snapshot the post-exec mode once for the whole build. The opt-in flag behind
-        // `sdm_production_enabled` is mutable at runtime (admin RPC); reading it again when
-        // deciding whether to append the `0x7D` below could disagree with the mode the EVM
-        // was built in, yielding a block whose refunded state has no matching post-exec tx
-        // (or vice versa).
-        let post_exec_mode = ctx.post_exec_mode()?;
-        let produce_post_exec = matches!(post_exec_mode, PostExecMode::Produce);
+        // Resolve the fee and post-exec behavior once for the whole payload job. Both the policy
+        // and the SDM opt-in may be backed by mutable runtime state, so re-reading either after EVM
+        // construction could produce a block that no verifier can reproduce.
+        let resolved = ctx.resolve_post_exec()?;
+        let append_post_exec = resolved.append_post_exec;
+        let produce_refunds = matches!(resolved.mode, PostExecMode::Produce);
+        let selected_base_fee_per_gas = resolved.selected_base_fee_per_gas;
 
-        let mut builder = ctx.block_builder_with_mode(&mut db, post_exec_mode)?;
+        let mut builder =
+            ctx.block_builder_with_mode(&mut db, resolved.mode, selected_base_fee_per_gas)?;
 
         // 1. apply pre-execution changes
         builder.apply_pre_execution_changes().map_err(|err| {
@@ -520,13 +516,15 @@ impl<Txs> OpBuilder<'_, Txs> {
             }
         }
 
-        // Only `Produce` mode appends a post-exec tx, and only locally-sequenced blocks reach it; a
-        // derived block (force_empty) is `Verify`/`Disabled` and already carries its own `0x7D`, so
-        // appending would duplicate it. See `post_exec_mode`.
-        let sdm_refund_gas = if produce_post_exec {
+        // Normal Lagoon sequencing and deterministic fallback builds append a commitment. Derived
+        // blocks with an embedded commitment run in `Verify` mode and must not append a duplicate.
+        let sdm_refund_gas = if append_post_exec {
             let block_number = builder.evm_mut().block().number().saturating_to();
-            let selected_base_fee_per_gas = builder.evm_mut().block().basefee();
-            let entries = builder.executor_mut().take_post_exec_entries();
+            let entries = if produce_refunds {
+                builder.executor_mut().take_post_exec_entries()
+            } else {
+                Vec::new()
+            };
             let refund_gas = self::sdm_refund_gas(&entries);
             try_include_post_exec_tx(block_number, selected_base_fee_per_gas, entries, |tx| {
                 builder.execute_transaction(tx).map(|g| g.tx_gas_used())
@@ -818,6 +816,17 @@ impl ExecutionInfo {
     }
 }
 
+/// Fee and post-exec behavior resolved once for a payload job.
+#[derive(Debug, Clone)]
+pub struct ResolvedPostExec {
+    /// Execution mode controlling SDM refund production or verification.
+    pub mode: PostExecMode,
+    /// Immutable base fee used to construct the EVM environment and commitment.
+    pub selected_base_fee_per_gas: u64,
+    /// Whether the builder must append a new trailing `PostExec` transaction.
+    pub append_post_exec: bool,
+}
+
 /// Container type that holds all necessities to build a new payload.
 #[derive(derive_more::Debug)]
 pub struct OpPayloadBuilderCtx<
@@ -909,23 +918,85 @@ where
         .map_err(PayloadBuilderError::other)
     }
 
-    /// Decides this payload's SDM post-exec mode: *produce*, *verify*, or `Disabled`.
+    /// Resolves the base fee and post-exec behavior for this payload job.
     ///
-    /// The deciding factor is whether we're sequencing the block or rebuilding one
-    /// that CL already derived (`force_empty` / `no_tx_pool`):
+    /// Before Lagoon, the legacy parent-derived EIP-1559 fee remains in force and `PostExec` is
+    /// disabled. From Lagoon onward:
     ///
-    /// - **Local sequencing**: *produce* the post-exec tx when [`Self::sdm_production_enabled`],
-    ///   otherwise `Disabled`.
-    /// - **Rebuilding a derived block**: never produce — instead *verify* against the `0x7D`
-    ///   post-exec tx that CL embedded in the attributes, or `Disabled` if there is none. This
-    ///   holds regardless of the local opt-in, since the chain has already committed to it.
-    pub fn post_exec_mode(&self) -> Result<PostExecMode, PayloadBuilderError> {
-        if !self.force_empty() {
-            return Ok(self.sdm_production_enabled().into());
+    /// - normal local sequencing invokes the configured producer policy and appends `PostExec`;
+    /// - a deterministic build with an embedded `PostExec` uses and verifies its committed fee;
+    /// - a deterministic build without one carries forward the parent fee and synthesizes it.
+    pub fn resolve_post_exec(&self) -> Result<ResolvedPostExec, PayloadBuilderError> {
+        let timestamp = self.attributes().timestamp();
+        let lagoon_active =
+            reth_optimism_evm::is_sdm_active_at_timestamp(&self.chain_spec, timestamp);
+        let parsed = self.parse_embedded_post_exec()?;
+        let next_env_ctx = Evm::NextBlockEnvCtx::build_next_env(
+            self.attributes(),
+            self.parent(),
+            self.chain_spec.as_ref(),
+        )
+        .map_err(PayloadBuilderError::other)?;
+        let legacy_base_fee = self
+            .evm_config
+            .next_evm_env(self.parent(), &next_env_ctx)
+            .map_err(PayloadBuilderError::other)?
+            .block_env
+            .basefee();
+
+        if !lagoon_active {
+            return Ok(ResolvedPostExec {
+                mode: PostExecMode::Disabled,
+                selected_base_fee_per_gas: legacy_base_fee,
+                append_post_exec: false,
+            });
         }
 
-        let parsed = self.parse_embedded_post_exec()?;
-        Ok(parsed.map_or(PostExecMode::Disabled, |p| PostExecMode::Verify(p.payload)))
+        if self.force_empty() {
+            return Ok(match parsed {
+                Some(parsed) => ResolvedPostExec {
+                    selected_base_fee_per_gas: parsed.payload.selected_base_fee_per_gas,
+                    mode: PostExecMode::Verify(parsed.payload),
+                    append_post_exec: false,
+                },
+                None => ResolvedPostExec {
+                    mode: PostExecMode::Commit,
+                    selected_base_fee_per_gas: self.parent().base_fee_per_gas().unwrap_or_default(),
+                    append_post_exec: true,
+                },
+            });
+        }
+
+        if parsed.is_some() {
+            return Err(PayloadBuilderError::other(BaseFeePolicyError::msg(
+                "locally sequenced payload attributes must not contain PostExec",
+            )));
+        }
+
+        let selected_base_fee_per_gas = self
+            .builder_config
+            .base_fee_policy
+            .select_base_fee(BaseFeePolicyInput {
+                parent: self.parent().header(),
+                next_timestamp: timestamp,
+                legacy_base_fee,
+            })
+            .map_err(PayloadBuilderError::other)?;
+
+        Ok(ResolvedPostExec {
+            mode: if self.sdm_production_enabled() {
+                PostExecMode::Produce
+            } else {
+                PostExecMode::Commit
+            },
+            selected_base_fee_per_gas,
+            append_post_exec: true,
+        })
+    }
+
+    /// Decides this payload's post-exec execution mode.
+    pub fn post_exec_mode(&self) -> Result<PostExecMode, PayloadBuilderError> {
+        self.resolve_post_exec().map(|resolved| resolved.mode)
     }
 
     /// Returns the unique id for this payload job.
@@ -941,9 +1012,9 @@ where
     /// Prepares a [`BlockBuilder`] for the next block, resolving the post-exec mode from this
     /// payload's context.
     ///
-    /// Callers that also decide whether to append the trailing `0x7D` must instead resolve
-    /// [`Self::post_exec_mode`] once and pass it to [`Self::block_builder_with_mode`], so a
-    /// concurrent opt-in toggle cannot change the mode between EVM construction and the append.
+    /// Callers that also decide whether to append the trailing `0x7D` must instead call
+    /// [`Self::resolve_post_exec`] once and pass both the mode and fee to
+    /// [`Self::block_builder_with_mode`].
     pub fn block_builder<'a, DB: Database>(
         &'a self,
         db: &'a mut State<DB>,
@@ -954,15 +1025,17 @@ where
         > + 'a,
         PayloadBuilderError,
     > {
-        self.block_builder_with_mode(db, self.post_exec_mode()?)
+        let resolved = self.resolve_post_exec()?;
+        self.block_builder_with_mode(db, resolved.mode, resolved.selected_base_fee_per_gas)
     }
 
-    /// Like [`Self::block_builder`] but builds against a caller-supplied [`PostExecMode`], so a
-    /// single snapshot drives both EVM construction and any later post-exec decision.
+    /// Like [`Self::block_builder`] but builds against a caller-supplied mode and selected fee, so
+    /// a single snapshot drives EVM construction and any later post-exec decision.
     pub fn block_builder_with_mode<'a, DB: Database>(
         &'a self,
         db: &'a mut State<DB>,
         post_exec_mode: PostExecMode,
+        selected_base_fee_per_gas: u64,
     ) -> Result<
         impl BlockBuilder<
             Primitives = Evm::Primitives,
@@ -981,6 +1054,7 @@ where
                 )
                 .map_err(PayloadBuilderError::other)?,
                 post_exec_mode,
+                selected_base_fee_per_gas,
             )
             .map_err(PayloadBuilderError::other)
     }

--- a/rust/op-reth/crates/payload/src/builder.rs
+++ b/rust/op-reth/crates/payload/src/builder.rs
@@ -76,6 +76,11 @@ fn sdm_refund_gas(entries: &[SDMGasEntry]) -> u64 {
     entries.iter().map(|entry| entry.gas_refund).sum()
 }
 
+/// Conservative growth reserved for one possible maximum-width refund entry, including RLP list
+/// prefix growth. Only normal transactions can produce entries, but reserving for every included
+/// transaction keeps admission simple and safely bounds the final payload.
+const MAX_POST_EXEC_BYTES_PER_TRANSACTION: u64 = 24;
+
 fn build_post_exec_recovered_tx<Tx>(
     block_number: u64,
     selected_base_fee_per_gas: u64,
@@ -492,6 +497,15 @@ impl<Txs> OpBuilder<'_, Txs> {
 
         // 2. execute sequencer transactions
         let mut info = ctx.execute_sequencer_transactions(&mut builder, None)?;
+        if append_post_exec {
+            let block_number = builder.evm_mut().block().number().saturating_to();
+            let empty_post_exec_size =
+                build_post_exec_tx(block_number, selected_base_fee_per_gas, Vec::new())
+                    .eip2718_encoded_length() as u64;
+            info.reserved_post_exec_bytes = empty_post_exec_size.saturating_add(
+                info.included_transactions.saturating_mul(MAX_POST_EXEC_BYTES_PER_TRANSACTION),
+            );
+        }
 
         // 3. if mem pool transactions are requested we execute them
         if !ctx.attributes().no_tx_pool() {
@@ -526,9 +540,25 @@ impl<Txs> OpBuilder<'_, Txs> {
                 Vec::new()
             };
             let refund_gas = self::sdm_refund_gas(&entries);
+            let post_exec_size =
+                build_post_exec_tx(block_number, selected_base_fee_per_gas, entries.clone())
+                    .eip2718_encoded_length() as u64;
+            let total_uncompressed_bytes =
+                info.cumulative_uncompressed_bytes.saturating_add(post_exec_size);
+            if let Some(max) = ctx.builder_config.max_uncompressed_block_size &&
+                total_uncompressed_bytes > max
+            {
+                return Err(PayloadBuilderError::other(
+                    OpPayloadBuilderError::PostExecExceedsMaxBlockSize {
+                        size: total_uncompressed_bytes,
+                        max,
+                    },
+                ));
+            }
             try_include_post_exec_tx(block_number, selected_base_fee_per_gas, entries, |tx| {
                 builder.execute_transaction(tx).map(|g| g.tx_gas_used())
             })?;
+            info.cumulative_uncompressed_bytes = total_uncompressed_bytes;
             refund_gas
         } else {
             0
@@ -734,6 +764,10 @@ pub struct ExecutionInfo {
     /// so far, in bytes. Bounds the block against the configured
     /// [`max_uncompressed_block_size`](crate::config::OpBuilderConfig::max_uncompressed_block_size).
     pub cumulative_uncompressed_bytes: u64,
+    /// Conservative space held for the mandatory trailing PostExec transaction.
+    pub reserved_post_exec_bytes: u64,
+    /// Number of transactions included before PostExec.
+    pub included_transactions: u64,
     /// Tracks fees from executed mempool transactions
     pub total_fees: U256,
 }
@@ -746,6 +780,8 @@ impl ExecutionInfo {
             cumulative_evm_gas_used: 0,
             cumulative_da_bytes_used: 0,
             cumulative_uncompressed_bytes: 0,
+            reserved_post_exec_bytes: 0,
+            included_transactions: 0,
             total_fees: U256::ZERO,
         }
     }
@@ -792,8 +828,16 @@ impl ExecutionInfo {
         // exceed the configured maximum. This keeps the built payload within the size assumed by
         // consensus-layer clients.
         if let Some(max_uncompressed_block_size) = max_uncompressed_block_size {
-            let total_uncompressed_bytes =
-                self.cumulative_uncompressed_bytes.saturating_add(tx_uncompressed_size);
+            let post_exec_growth = if self.reserved_post_exec_bytes == 0 {
+                0
+            } else {
+                MAX_POST_EXEC_BYTES_PER_TRANSACTION
+            };
+            let total_uncompressed_bytes = self
+                .cumulative_uncompressed_bytes
+                .saturating_add(tx_uncompressed_size)
+                .saturating_add(self.reserved_post_exec_bytes)
+                .saturating_add(post_exec_growth);
             if total_uncompressed_bytes > max_uncompressed_block_size {
                 return true;
             }
@@ -1121,6 +1165,7 @@ where
             // Count the sequencer tx towards the block's uncompressed size so the pool-tx
             // uncompressed-size check starts from the right total.
             info.cumulative_uncompressed_bytes += sequencer_tx.encode_2718_len() as u64;
+            info.included_transactions = info.included_transactions.saturating_add(1);
 
             // Record the successfully committed transaction for callers that want per-call
             // visibility.
@@ -1281,6 +1326,12 @@ where
             info.accumulate_gas(tx_gas_used, evm_gas_used);
             info.cumulative_da_bytes_used += tx_da_size;
             info.cumulative_uncompressed_bytes += tx_uncompressed_size;
+            info.included_transactions = info.included_transactions.saturating_add(1);
+            if info.reserved_post_exec_bytes != 0 {
+                info.reserved_post_exec_bytes = info
+                    .reserved_post_exec_bytes
+                    .saturating_add(MAX_POST_EXEC_BYTES_PER_TRANSACTION);
+            }
 
             // update and add to total fees
             info.total_fees += U256::from(miner_fee) * U256::from(tx_gas_used);

--- a/rust/op-reth/crates/payload/src/builder/tests.rs
+++ b/rust/op-reth/crates/payload/src/builder/tests.rs
@@ -39,7 +39,14 @@ use reth_payload_util::PayloadTransactionsFixed;
 use reth_primitives_traits::{Account, InMemorySize, SealedHeader};
 use reth_revm::{database::StateProviderDatabase, db::State, test_utils::StateProviderTest};
 use reth_transaction_pool::PoolTransaction;
-use std::{borrow::Cow, cell::Cell, sync::Arc};
+use std::{
+    borrow::Cow,
+    cell::Cell,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+};
 
 #[derive(Debug)]
 struct TestBaseFeePolicy(Result<u64, &'static str>);
@@ -47,6 +54,15 @@ struct TestBaseFeePolicy(Result<u64, &'static str>);
 impl BaseFeePolicy for TestBaseFeePolicy {
     fn select_base_fee(&self, _input: BaseFeePolicyInput<'_>) -> Result<u64, BaseFeePolicyError> {
         self.0.map_err(BaseFeePolicyError::msg)
+    }
+}
+
+#[derive(Debug, Default)]
+struct IncrementingBaseFeePolicy(AtomicU64);
+
+impl BaseFeePolicy for IncrementingBaseFeePolicy {
+    fn select_base_fee(&self, _input: BaseFeePolicyInput<'_>) -> Result<u64, BaseFeePolicyError> {
+        Ok(700 + self.0.fetch_add(1, Ordering::Relaxed))
     }
 }
 
@@ -354,6 +370,20 @@ fn base_fee_resolution_uses_policy_commitment_and_fallback_sources() {
     assert_eq!(resolved.selected_base_fee_per_gas, 0);
     assert!(matches!(resolved.mode, PostExecMode::Commit));
     assert!(resolved.append_post_exec);
+}
+
+#[test]
+fn base_fee_selection_is_immutable_across_payload_job_retries() {
+    let mut ctx = interop_ctx(false, false, None);
+    let policy = Arc::new(IncrementingBaseFeePolicy::default());
+    ctx.builder_config.base_fee_policy = policy.clone();
+
+    let first = ctx.resolve_post_exec().expect("first attempt resolves");
+    let retry = ctx.resolve_post_exec().expect("retry resolves");
+
+    assert_eq!(first.selected_base_fee_per_gas, 700);
+    assert_eq!(retry.selected_base_fee_per_gas, 700);
+    assert_eq!(policy.0.load(Ordering::Relaxed), 1, "policy must run once per payload id");
 }
 
 #[test]

--- a/rust/op-reth/crates/payload/src/builder/tests.rs
+++ b/rust/op-reth/crates/payload/src/builder/tests.rs
@@ -2,7 +2,10 @@ use super::{
     CommittedTxGas, ExecutionInfo, OpPayloadBuilderCtx, PayloadTransactionsWithCommitHook,
     RethPayloadTransactions, build_post_exec_recovered_tx, try_include_post_exec_tx,
 };
-use crate::{OpPayloadBuilderAttributes, config::OpBuilderConfig};
+use crate::{
+    OpPayloadBuilderAttributes,
+    config::{BaseFeePolicy, BaseFeePolicyError, BaseFeePolicyInput, OpBuilderConfig},
+};
 use alloy_consensus::{
     Header, Sealable, SignableTransaction, Transaction, TxEip1559, Typed2718,
     transaction::{Recovered, TxHashRef},
@@ -37,6 +40,15 @@ use reth_primitives_traits::{Account, InMemorySize, SealedHeader};
 use reth_revm::{database::StateProviderDatabase, db::State, test_utils::StateProviderTest};
 use reth_transaction_pool::PoolTransaction;
 use std::{borrow::Cow, cell::Cell, sync::Arc};
+
+#[derive(Debug)]
+struct TestBaseFeePolicy(Result<u64, &'static str>);
+
+impl BaseFeePolicy for TestBaseFeePolicy {
+    fn select_base_fee(&self, _input: BaseFeePolicyInput<'_>) -> Result<u64, BaseFeePolicyError> {
+        self.0.map_err(BaseFeePolicyError::msg)
+    }
+}
 
 fn entries(specs: &[(u64, u64)]) -> Vec<SDMGasEntry> {
     specs.iter().map(|&(index, gas_refund)| SDMGasEntry { index, gas_refund }).collect()
@@ -303,10 +315,10 @@ fn post_exec_mode_follows_chain_regardless_of_opt_in() {
         assert_eq!(payload.gas_refund_entries, entries(&[(0, 7)]));
     }
 
-    // Follow path with no embedded 0x7D: disabled even with the opt-in on (nothing to reproduce).
+    // Deterministic Lagoon builds without an embedded commitment synthesize one without refunds.
     assert!(matches!(
         interop_ctx(true, true, None).post_exec_mode().expect("mode resolves"),
-        PostExecMode::Disabled
+        PostExecMode::Commit
     ));
 
     // Local sequencing is the only path that consults the opt-in.
@@ -316,8 +328,49 @@ fn post_exec_mode_follows_chain_regardless_of_opt_in() {
     ));
     assert!(matches!(
         interop_ctx(false, false, None).post_exec_mode().expect("mode resolves"),
-        PostExecMode::Disabled
+        PostExecMode::Commit
     ));
+}
+
+#[test]
+fn base_fee_resolution_uses_policy_commitment_and_fallback_sources() {
+    let mut local = interop_ctx(false, false, None);
+    local.builder_config.base_fee_policy = Arc::new(TestBaseFeePolicy(Ok(777)));
+    let resolved = local.resolve_post_exec().expect("policy selects fee");
+    assert_eq!(resolved.selected_base_fee_per_gas, 777);
+    assert!(matches!(resolved.mode, PostExecMode::Commit));
+    assert!(resolved.append_post_exec);
+
+    let mut derived = interop_ctx(true, false, Some(Vec::new()));
+    derived.builder_config.base_fee_policy = Arc::new(TestBaseFeePolicy(Ok(777)));
+    let resolved = derived.resolve_post_exec().expect("embedded fee resolves");
+    assert_eq!(resolved.selected_base_fee_per_gas, 1);
+    assert!(matches!(resolved.mode, PostExecMode::Verify(_)));
+    assert!(!resolved.append_post_exec);
+
+    let mut fallback = interop_ctx(true, false, None);
+    fallback.builder_config.base_fee_policy = Arc::new(TestBaseFeePolicy(Ok(777)));
+    let resolved = fallback.resolve_post_exec().expect("parent-fee fallback resolves");
+    assert_eq!(resolved.selected_base_fee_per_gas, 0);
+    assert!(matches!(resolved.mode, PostExecMode::Commit));
+    assert!(resolved.append_post_exec);
+}
+
+#[test]
+fn base_fee_policy_failure_aborts_local_sequencing() {
+    let mut ctx = interop_ctx(false, false, None);
+    ctx.builder_config.base_fee_policy = Arc::new(TestBaseFeePolicy(Err("quote unavailable")));
+    let err = ctx.resolve_post_exec().expect_err("policy failure must abort");
+    assert!(err.to_string().contains("quote unavailable"));
+}
+
+#[test]
+fn local_sequencing_rejects_embedded_post_exec() {
+    let ctx = interop_ctx(false, false, Some(Vec::new()));
+    let err = ctx.resolve_post_exec().expect_err("local attributes must reject PostExec");
+    assert!(
+        err.to_string().contains("locally sequenced payload attributes must not contain PostExec")
+    );
 }
 
 /// End-to-end regression test for the derived-attrs verify path: rebuilding a block whose
@@ -366,7 +419,7 @@ fn block_builder_with_mode_honors_snapshot_over_live_opt_in() {
         .with_bundle_update()
         .build();
     let mut builder = produce_ctx
-        .block_builder_with_mode(&mut db, PostExecMode::Produce)
+        .block_builder_with_mode(&mut db, PostExecMode::Produce, 1)
         .expect("block builder can be created");
     produce_ctx
         .execute_sequencer_transactions(&mut builder, None)
@@ -380,7 +433,7 @@ fn block_builder_with_mode_honors_snapshot_over_live_opt_in() {
         .with_bundle_update()
         .build();
     let mut builder = disabled_ctx
-        .block_builder_with_mode(&mut db, PostExecMode::Disabled)
+        .block_builder_with_mode(&mut db, PostExecMode::Disabled, 1)
         .expect("block builder can be created");
     let err = disabled_ctx
         .execute_sequencer_transactions(&mut builder, None)
@@ -646,7 +699,7 @@ fn on_commit_reports_canonical_and_pre_refund_gas_separately_under_sdm_refund() 
         .with_bundle_update()
         .build();
     let mut builder = ctx
-        .block_builder_with_mode(&mut db, PostExecMode::Verify(post_exec_payload))
+        .block_builder_with_mode(&mut db, PostExecMode::Verify(post_exec_payload), 1)
         .expect("block builder can be created");
     let mut info = ExecutionInfo::new();
 
@@ -716,21 +769,23 @@ fn build_post_exec_recovered_tx_wraps_entries_in_post_exec_tx() {
 }
 
 #[test]
-fn try_include_post_exec_tx_skips_when_no_entries() {
+fn try_include_post_exec_tx_commits_when_no_refund_entries() {
     let called = Cell::new(false);
     let result = try_include_post_exec_tx::<OpTransactionSigned, _>(1, 1, Vec::new(), |_tx| {
         called.set(true);
         Ok::<_, BlockExecutionError>(0)
     });
-    assert!(matches!(result, Ok(false)));
-    assert!(!called.get(), "execute must not run when there are no entries");
+    assert!(matches!(result, Ok(true)));
+    assert!(called.get(), "Lagoon must commit the selected fee even without refunds");
 }
 
 #[test]
 fn try_include_post_exec_tx_executes_post_exec_tx_on_happy_path() {
+    type CapturedPostExec = (u8, u64, u64, Vec<SDMGasEntry>);
+
     let block_number = 99;
     let payload_entries = entries(&[(0, 7)]);
-    let captured: Cell<Option<(u8, u64, u64, Vec<SDMGasEntry>)>> = Cell::new(None);
+    let captured: Cell<Option<CapturedPostExec>> = Cell::new(None);
 
     let result = try_include_post_exec_tx::<OpTransactionSigned, _>(
         block_number,
@@ -758,15 +813,11 @@ fn try_include_post_exec_tx_executes_post_exec_tx_on_happy_path() {
 #[test]
 fn try_include_post_exec_tx_aborts_when_execution_fails() {
     let called = Cell::new(false);
-    let result = try_include_post_exec_tx::<OpTransactionSigned, _>(
-        1,
-        1,
-        entries(&[(0, 7)]),
-        |_tx| {
+    let result =
+        try_include_post_exec_tx::<OpTransactionSigned, _>(1, 1, entries(&[(0, 7)]), |_tx| {
             called.set(true);
             Err::<u64, _>(BlockExecutionError::msg("forced post-exec tx failure"))
-        },
-    );
+        });
 
     assert!(called.get(), "execute must be invoked so its error can propagate");
     match result {

--- a/rust/op-reth/crates/payload/src/builder/tests.rs
+++ b/rust/op-reth/crates/payload/src/builder/tests.rs
@@ -49,7 +49,7 @@ fn post_exec_with_encoded(
     payload_entries: Vec<SDMGasEntry>,
 ) -> WithEncoded<OpTransactionSigned> {
     let tx =
-        OpTransactionSigned::from(build_post_exec_tx(block_number, payload_entries).seal_slow());
+        OpTransactionSigned::from(build_post_exec_tx(block_number, 1, payload_entries).seal_slow());
     let encoded = Bytes::from(tx.encoded_2718());
     WithEncoded::new(encoded, tx)
 }
@@ -110,12 +110,17 @@ fn interop_ctx(
     }
 }
 
-fn unwrap_post_exec(tx: Recovered<OpTransactionSigned>) -> (u8, u64, Vec<SDMGasEntry>) {
+fn unwrap_post_exec(tx: Recovered<OpTransactionSigned>) -> (u8, u64, u64, Vec<SDMGasEntry>) {
     let ty = tx.tx().ty();
     let OpTransactionSigned::PostExec(signed) = tx.into_inner() else {
         panic!("expected post-exec transaction");
     };
-    (ty, signed.inner().payload.block_number, signed.inner().payload.gas_refund_entries.clone())
+    (
+        ty,
+        signed.inner().payload.block_number,
+        signed.inner().payload.selected_base_fee_per_gas,
+        signed.inner().payload.gas_refund_entries.clone(),
+    )
 }
 
 fn payload_builder_ctx(
@@ -632,6 +637,7 @@ fn on_commit_reports_canonical_and_pre_refund_gas_separately_under_sdm_refund() 
     let post_exec_payload = PostExecPayload {
         version: POST_EXEC_PAYLOAD_VERSION,
         block_number: 1,
+        selected_base_fee_per_gas: 1,
         gas_refund_entries: entries(&[(0, REFUND)]),
     };
 
@@ -695,20 +701,24 @@ fn execute_best_transactions_respects_gas_limit_cap() {
 fn build_post_exec_recovered_tx_wraps_entries_in_post_exec_tx() {
     let block_number = 42;
     let payload_entries = entries(&[(3, 17), (5, 23)]);
-    let recovered =
-        build_post_exec_recovered_tx::<OpTransactionSigned>(block_number, payload_entries.clone());
+    let recovered = build_post_exec_recovered_tx::<OpTransactionSigned>(
+        block_number,
+        1,
+        payload_entries.clone(),
+    );
 
     assert_eq!(recovered.signer(), Address::ZERO);
-    let (ty, decoded_block, decoded_entries) = unwrap_post_exec(recovered);
+    let (ty, decoded_block, decoded_base_fee, decoded_entries) = unwrap_post_exec(recovered);
     assert_eq!(ty, op_alloy_consensus::POST_EXEC_TX_TYPE_ID);
     assert_eq!(decoded_block, block_number);
+    assert_eq!(decoded_base_fee, 1);
     assert_eq!(decoded_entries, payload_entries);
 }
 
 #[test]
 fn try_include_post_exec_tx_skips_when_no_entries() {
     let called = Cell::new(false);
-    let result = try_include_post_exec_tx::<OpTransactionSigned, _>(1, Vec::new(), |_tx| {
+    let result = try_include_post_exec_tx::<OpTransactionSigned, _>(1, 1, Vec::new(), |_tx| {
         called.set(true);
         Ok::<_, BlockExecutionError>(0)
     });
@@ -720,10 +730,11 @@ fn try_include_post_exec_tx_skips_when_no_entries() {
 fn try_include_post_exec_tx_executes_post_exec_tx_on_happy_path() {
     let block_number = 99;
     let payload_entries = entries(&[(0, 7)]);
-    let captured: Cell<Option<(u8, u64, Vec<SDMGasEntry>)>> = Cell::new(None);
+    let captured: Cell<Option<(u8, u64, u64, Vec<SDMGasEntry>)>> = Cell::new(None);
 
     let result = try_include_post_exec_tx::<OpTransactionSigned, _>(
         block_number,
+        1,
         payload_entries.clone(),
         |tx| {
             captured.set(Some(unwrap_post_exec(tx)));
@@ -732,9 +743,11 @@ fn try_include_post_exec_tx_executes_post_exec_tx_on_happy_path() {
     );
 
     assert!(matches!(result, Ok(true)));
-    let (ty, decoded_block, decoded_entries) = captured.take().expect("execute closure ran");
+    let (ty, decoded_block, decoded_base_fee, decoded_entries) =
+        captured.take().expect("execute closure ran");
     assert_eq!(ty, op_alloy_consensus::POST_EXEC_TX_TYPE_ID);
     assert_eq!(decoded_block, block_number);
+    assert_eq!(decoded_base_fee, 1);
     assert_eq!(decoded_entries, payload_entries);
 }
 
@@ -745,10 +758,15 @@ fn try_include_post_exec_tx_executes_post_exec_tx_on_happy_path() {
 #[test]
 fn try_include_post_exec_tx_aborts_when_execution_fails() {
     let called = Cell::new(false);
-    let result = try_include_post_exec_tx::<OpTransactionSigned, _>(1, entries(&[(0, 7)]), |_tx| {
-        called.set(true);
-        Err::<u64, _>(BlockExecutionError::msg("forced post-exec tx failure"))
-    });
+    let result = try_include_post_exec_tx::<OpTransactionSigned, _>(
+        1,
+        1,
+        entries(&[(0, 7)]),
+        |_tx| {
+            called.set(true);
+            Err::<u64, _>(BlockExecutionError::msg("forced post-exec tx failure"))
+        },
+    );
 
     assert!(called.get(), "execute must be invoked so its error can propagate");
     match result {

--- a/rust/op-reth/crates/payload/src/builder/tests.rs
+++ b/rust/op-reth/crates/payload/src/builder/tests.rs
@@ -503,6 +503,12 @@ fn is_tx_over_limits_enforces_max_uncompressed_block_size() {
 
     // One byte over the limit is rejected (100 + 51 > 150).
     assert!(info.is_tx_over_limits(0, u64::MAX, None, None, 0, None, 51, Some(150)));
+
+    // A Lagoon build reserves both the current PostExec encoding and worst-case growth for the
+    // candidate transaction before admitting it.
+    info.reserved_post_exec_bytes = 10;
+    assert!(!info.is_tx_over_limits(0, u64::MAX, None, None, 0, None, 15, Some(149)));
+    assert!(info.is_tx_over_limits(0, u64::MAX, None, None, 0, None, 16, Some(149)));
 }
 
 #[test]

--- a/rust/op-reth/crates/payload/src/config.rs
+++ b/rust/op-reth/crates/payload/src/config.rs
@@ -1,19 +1,76 @@
 //! Additional configuration for the OP builder
 
+use alloy_consensus::BlockHeader;
 use reth_optimism_txpool::interop::InteropFailsafe;
 use std::sync::{
     Arc,
     atomic::{AtomicBool, AtomicU64, Ordering},
 };
 
+/// Inputs available to a producer's base-fee policy.
+#[derive(Clone, Copy)]
+pub struct BaseFeePolicyInput<'a> {
+    /// Parent block header.
+    pub parent: &'a dyn BlockHeader,
+    /// Timestamp of the block being built.
+    pub next_timestamp: u64,
+    /// Base fee selected by the legacy Jovian EIP-1559 algorithm.
+    pub legacy_base_fee: u64,
+}
+
+impl core::fmt::Debug for BaseFeePolicyInput<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("BaseFeePolicyInput")
+            .field("parent_number", &self.parent.number())
+            .field("next_timestamp", &self.next_timestamp)
+            .field("legacy_base_fee", &self.legacy_base_fee)
+            .finish()
+    }
+}
+
+/// Error returned when a producer cannot select a base fee.
+#[derive(Debug, Clone, thiserror::Error)]
+#[error("{message}")]
+pub struct BaseFeePolicyError {
+    message: String,
+}
+
+impl BaseFeePolicyError {
+    /// Creates a policy error from a displayable message.
+    pub fn msg(message: impl Into<String>) -> Self {
+        Self { message: message.into() }
+    }
+}
+
+/// Producer-only policy for selecting the base fee of a Lagoon block.
+///
+/// Verifiers never invoke this policy. They execute with the fee committed in the block's trailing
+/// `PostExec` transaction instead.
+pub trait BaseFeePolicy: core::fmt::Debug + Send + Sync + 'static {
+    /// Selects one immutable base fee for the payload job.
+    fn select_base_fee(&self, input: BaseFeePolicyInput<'_>) -> Result<u64, BaseFeePolicyError>;
+}
+
+/// Compatibility policy that preserves the legacy Jovian EIP-1559 result at Lagoon activation.
+#[derive(Debug, Default)]
+pub struct JovianBaseFeePolicy;
+
+impl BaseFeePolicy for JovianBaseFeePolicy {
+    fn select_base_fee(&self, input: BaseFeePolicyInput<'_>) -> Result<u64, BaseFeePolicyError> {
+        Ok(input.legacy_base_fee)
+    }
+}
+
 /// Settings for the OP builder.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct OpBuilderConfig {
     /// Data availability configuration for the OP builder.
     pub da_config: OpDAConfig,
     /// Gas limit configuration for the OP builder.
     pub gas_limit_config: OpGasLimitConfig,
-    /// Local SDM `PostExec` production operator opt-in. Shared with the admin RPC.
+    /// Producer-only policy used to select the base fee for normal Lagoon payloads.
+    pub base_fee_policy: Arc<dyn BaseFeePolicy>,
+    /// Local SDM refund production operator opt-in. Shared with the admin RPC.
     pub operator_sdm_opt_in: OperatorSdmOptIn,
     /// Interop failsafe gate. Set by the interop filter client; read by the builder to exclude
     /// interop txs from blocks while it is enabled.
@@ -29,16 +86,36 @@ pub struct OpBuilderConfig {
     pub max_uncompressed_block_size: Option<u64>,
 }
 
+impl Default for OpBuilderConfig {
+    fn default() -> Self {
+        Self {
+            da_config: OpDAConfig::default(),
+            gas_limit_config: OpGasLimitConfig::default(),
+            base_fee_policy: Arc::new(JovianBaseFeePolicy),
+            operator_sdm_opt_in: OperatorSdmOptIn::default(),
+            interop_failsafe: InteropFailsafe::default(),
+            max_uncompressed_block_size: None,
+        }
+    }
+}
+
 impl OpBuilderConfig {
     /// Creates a new OP builder configuration with the given data availability configuration.
     pub fn new(da_config: OpDAConfig, gas_limit_config: OpGasLimitConfig) -> Self {
         Self {
             da_config,
             gas_limit_config,
+            base_fee_policy: Arc::new(JovianBaseFeePolicy),
             operator_sdm_opt_in: OperatorSdmOptIn::default(),
             interop_failsafe: InteropFailsafe::default(),
             max_uncompressed_block_size: None,
         }
+    }
+
+    /// Replaces the producer's base-fee policy.
+    pub fn with_base_fee_policy(mut self, policy: Arc<dyn BaseFeePolicy>) -> Self {
+        self.base_fee_policy = policy;
+        self
     }
 
     /// Returns the Data Availability configuration for the OP builder, if it has configured

--- a/rust/op-reth/crates/payload/src/config.rs
+++ b/rust/op-reth/crates/payload/src/config.rs
@@ -2,6 +2,8 @@
 
 use alloy_consensus::BlockHeader;
 use alloy_rpc_types_engine::PayloadId;
+use reth_chainspec::EthChainSpec;
+use reth_optimism_forks::OpHardforks;
 use reth_optimism_txpool::interop::InteropFailsafe;
 use std::{
     collections::VecDeque,
@@ -53,6 +55,14 @@ impl BaseFeePolicyError {
 pub trait BaseFeePolicy: core::fmt::Debug + Send + Sync + 'static {
     /// Selects one immutable base fee for the payload job.
     fn select_base_fee(&self, input: BaseFeePolicyInput<'_>) -> Result<u64, BaseFeePolicyError>;
+
+    /// Returns a provisional fee for pending transaction classification and RPC suggestions.
+    ///
+    /// Policies with stateful selection may override this to avoid consuming or mutating a payload
+    /// decision while serving a quote.
+    fn quote_base_fee(&self, input: BaseFeePolicyInput<'_>) -> Result<u64, BaseFeePolicyError> {
+        self.select_base_fee(input)
+    }
 }
 
 /// Compatibility policy that preserves the legacy Jovian EIP-1559 result at Lagoon activation.
@@ -63,6 +73,27 @@ impl BaseFeePolicy for JovianBaseFeePolicy {
     fn select_base_fee(&self, input: BaseFeePolicyInput<'_>) -> Result<u64, BaseFeePolicyError> {
         Ok(input.legacy_base_fee)
     }
+}
+
+/// Quotes the next block's fee using legacy consensus rules before Lagoon and `policy` after it.
+pub fn quote_base_fee<ChainSpec, H>(
+    policy: &dyn BaseFeePolicy,
+    chain_spec: &ChainSpec,
+    parent: &H,
+    next_timestamp: u64,
+) -> Result<u64, BaseFeePolicyError>
+where
+    ChainSpec: EthChainSpec<Header = H> + OpHardforks,
+    H: BlockHeader,
+{
+    let legacy_base_fee = chain_spec
+        .next_block_base_fee(parent, next_timestamp)
+        .unwrap_or_else(|| parent.base_fee_per_gas().unwrap_or_default());
+    if !chain_spec.is_lagoon_active_at_timestamp(next_timestamp) {
+        return Ok(legacy_base_fee);
+    }
+
+    policy.quote_base_fee(BaseFeePolicyInput { parent, next_timestamp, legacy_base_fee })
 }
 
 type BaseFeeSelections = VecDeque<(PayloadId, Result<u64, BaseFeePolicyError>)>;
@@ -284,6 +315,55 @@ impl OpGasLimitConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloy_consensus::Header;
+    use reth_optimism_chainspec::OpChainSpecBuilder;
+
+    #[derive(Debug)]
+    struct TestBaseFeePolicy;
+
+    impl BaseFeePolicy for TestBaseFeePolicy {
+        fn select_base_fee(
+            &self,
+            _input: BaseFeePolicyInput<'_>,
+        ) -> Result<u64, BaseFeePolicyError> {
+            Ok(999)
+        }
+
+        fn quote_base_fee(
+            &self,
+            _input: BaseFeePolicyInput<'_>,
+        ) -> Result<u64, BaseFeePolicyError> {
+            Ok(777)
+        }
+    }
+
+    #[test]
+    fn quote_base_fee_uses_policy_only_at_lagoon() {
+        let parent = Header {
+            timestamp: 1,
+            base_fee_per_gas: Some(100),
+            gas_limit: 30_000_000,
+            ..Default::default()
+        };
+        let pre_lagoon =
+            OpChainSpecBuilder::default().chain(10.into()).genesis(Default::default()).build();
+        let expected_legacy =
+            pre_lagoon.next_block_base_fee(&parent, parent.timestamp).unwrap_or_default();
+        assert_eq!(
+            quote_base_fee(&TestBaseFeePolicy, &pre_lagoon, &parent, parent.timestamp).unwrap(),
+            expected_legacy,
+        );
+
+        let lagoon = OpChainSpecBuilder::default()
+            .chain(10.into())
+            .genesis(Default::default())
+            .lagoon_activated()
+            .build();
+        assert_eq!(
+            quote_base_fee(&TestBaseFeePolicy, &lagoon, &parent, parent.timestamp).unwrap(),
+            777,
+        );
+    }
 
     #[test]
     fn test_da() {

--- a/rust/op-reth/crates/payload/src/config.rs
+++ b/rust/op-reth/crates/payload/src/config.rs
@@ -1,10 +1,14 @@
 //! Additional configuration for the OP builder
 
 use alloy_consensus::BlockHeader;
+use alloy_rpc_types_engine::PayloadId;
 use reth_optimism_txpool::interop::InteropFailsafe;
-use std::sync::{
-    Arc,
-    atomic::{AtomicBool, AtomicU64, Ordering},
+use std::{
+    collections::VecDeque,
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, AtomicU64, Ordering},
+    },
 };
 
 /// Inputs available to a producer's base-fee policy.
@@ -61,6 +65,37 @@ impl BaseFeePolicy for JovianBaseFeePolicy {
     }
 }
 
+type BaseFeeSelections = VecDeque<(PayloadId, Result<u64, BaseFeePolicyError>)>;
+
+/// Bounded cache that keeps a policy selection immutable across retries of one payload job.
+#[derive(Debug, Clone, Default)]
+pub struct BaseFeeSelectionCache {
+    inner: Arc<Mutex<BaseFeeSelections>>,
+}
+
+impl BaseFeeSelectionCache {
+    const CAPACITY: usize = 64;
+
+    /// Returns the selection already resolved for `payload_id`, or resolves and stores it once.
+    pub fn resolve(
+        &self,
+        payload_id: PayloadId,
+        select: impl FnOnce() -> Result<u64, BaseFeePolicyError>,
+    ) -> Result<u64, BaseFeePolicyError> {
+        let mut entries = self.inner.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        if let Some((_, selected)) = entries.iter().find(|(id, _)| *id == payload_id) {
+            return selected.clone();
+        }
+
+        let selected = select();
+        if entries.len() == Self::CAPACITY {
+            entries.pop_front();
+        }
+        entries.push_back((payload_id, selected.clone()));
+        selected
+    }
+}
+
 /// Settings for the OP builder.
 #[derive(Debug, Clone)]
 pub struct OpBuilderConfig {
@@ -70,6 +105,8 @@ pub struct OpBuilderConfig {
     pub gas_limit_config: OpGasLimitConfig,
     /// Producer-only policy used to select the base fee for normal Lagoon payloads.
     pub base_fee_policy: Arc<dyn BaseFeePolicy>,
+    /// Selections shared by retries of the same payload job.
+    pub base_fee_selection_cache: BaseFeeSelectionCache,
     /// Local SDM refund production operator opt-in. Shared with the admin RPC.
     pub operator_sdm_opt_in: OperatorSdmOptIn,
     /// Interop failsafe gate. Set by the interop filter client; read by the builder to exclude
@@ -92,6 +129,7 @@ impl Default for OpBuilderConfig {
             da_config: OpDAConfig::default(),
             gas_limit_config: OpGasLimitConfig::default(),
             base_fee_policy: Arc::new(JovianBaseFeePolicy),
+            base_fee_selection_cache: BaseFeeSelectionCache::default(),
             operator_sdm_opt_in: OperatorSdmOptIn::default(),
             interop_failsafe: InteropFailsafe::default(),
             max_uncompressed_block_size: None,
@@ -106,6 +144,7 @@ impl OpBuilderConfig {
             da_config,
             gas_limit_config,
             base_fee_policy: Arc::new(JovianBaseFeePolicy),
+            base_fee_selection_cache: BaseFeeSelectionCache::default(),
             operator_sdm_opt_in: OperatorSdmOptIn::default(),
             interop_failsafe: InteropFailsafe::default(),
             max_uncompressed_block_size: None,

--- a/rust/op-reth/crates/payload/src/error.rs
+++ b/rust/op-reth/crates/payload/src/error.rs
@@ -17,12 +17,12 @@ pub enum OpPayloadBuilderError {
     /// Thrown when force deploy of create2deployer code fails.
     #[error("failed to force create2deployer account code")]
     ForceCreate2DeployerFail,
-    /// Thrown when the mandatory PostExec transaction would exceed the configured block-size cap.
+    /// Thrown when the mandatory `PostExec` transaction would exceed the configured block-size cap.
     #[error(
         "post-exec transaction would increase uncompressed block size to {size} bytes, exceeding maximum {max}"
     )]
     PostExecExceedsMaxBlockSize {
-        /// Total EIP-2718 encoded transaction size including PostExec.
+        /// Total EIP-2718 encoded transaction size including `PostExec`.
         size: u64,
         /// Configured maximum EIP-2718 encoded transaction size.
         max: u64,

--- a/rust/op-reth/crates/payload/src/error.rs
+++ b/rust/op-reth/crates/payload/src/error.rs
@@ -17,6 +17,16 @@ pub enum OpPayloadBuilderError {
     /// Thrown when force deploy of create2deployer code fails.
     #[error("failed to force create2deployer account code")]
     ForceCreate2DeployerFail,
+    /// Thrown when the mandatory PostExec transaction would exceed the configured block-size cap.
+    #[error(
+        "post-exec transaction would increase uncompressed block size to {size} bytes, exceeding maximum {max}"
+    )]
+    PostExecExceedsMaxBlockSize {
+        /// Total EIP-2718 encoded transaction size including PostExec.
+        size: u64,
+        /// Configured maximum EIP-2718 encoded transaction size.
+        max: u64,
+    },
     /// Thrown when a blob transaction is included in a sequencer's block.
     #[error("blob transaction included in sequencer block")]
     BlobTransactionRejected,

--- a/rust/op-reth/crates/post-exec-replay/src/replay.rs
+++ b/rust/op-reth/crates/post-exec-replay/src/replay.rs
@@ -388,7 +388,7 @@ mod tests {
         let deposit: OpTransactionSigned = OpTxEnvelope::Deposit(TxDeposit::default().seal_slow());
         let user = user_tx();
         let post_exec: OpTransactionSigned =
-            OpTransactionSigned::PostExec(build_post_exec_tx(0, vec![]).seal_slow());
+            OpTransactionSigned::PostExec(build_post_exec_tx(0, 1, vec![]).seal_slow());
 
         let block = RecoveredBlock::new_unhashed(
             alloy_consensus::Block::new(
@@ -413,7 +413,7 @@ mod tests {
         let user = user_tx();
         let payload_entries = vec![op_alloy_consensus::SDMGasEntry { index: 1, gas_refund: 9 }];
         let post_exec: OpTransactionSigned = OpTransactionSigned::PostExec(
-            build_post_exec_tx(0, payload_entries.clone()).seal_slow(),
+            build_post_exec_tx(0, 1, payload_entries.clone()).seal_slow(),
         );
 
         let block = RecoveredBlock::new_unhashed(
@@ -438,7 +438,7 @@ mod tests {
     #[test]
     fn normalize_block_reuses_shared_post_exec_structure_validation() {
         let post_exec: OpTransactionSigned =
-            OpTransactionSigned::PostExec(build_post_exec_tx(0, vec![]).seal_slow());
+            OpTransactionSigned::PostExec(build_post_exec_tx(0, 1, vec![]).seal_slow());
         let user = user_tx();
 
         let block = RecoveredBlock::new_unhashed(
@@ -463,7 +463,7 @@ mod tests {
         let deposit: OpTransactionSigned = OpTxEnvelope::Deposit(TxDeposit::default().seal_slow());
         let user = user_tx();
         let post_exec: OpTransactionSigned =
-            OpTransactionSigned::PostExec(build_post_exec_tx(0, vec![]).seal_slow());
+            OpTransactionSigned::PostExec(build_post_exec_tx(0, 1, vec![]).seal_slow());
         let block = RecoveredBlock::new_unhashed(
             alloy_consensus::Block::new(
                 Header::default(),
@@ -478,6 +478,7 @@ mod tests {
         let payload = op_alloy_consensus::PostExecPayload {
             version: POST_EXEC_PAYLOAD_VERSION,
             block_number: 100,
+            selected_base_fee_per_gas: 1,
             gas_refund_entries: vec![
                 op_alloy_consensus::SDMGasEntry { index: 0, gas_refund: 1 },
                 op_alloy_consensus::SDMGasEntry { index: 2, gas_refund: 2 },

--- a/rust/op-reth/crates/post-exec-replay/src/replay.rs
+++ b/rust/op-reth/crates/post-exec-replay/src/replay.rs
@@ -194,6 +194,7 @@ fn into_replay_payload(payload: PostExecPayload) -> PostExecReplayPayload {
     PostExecReplayPayload {
         version: payload.version.into(),
         block_number: payload.block_number,
+        selected_base_fee_per_gas: payload.selected_base_fee_per_gas,
         gas_refund_entries: payload
             .gas_refund_entries
             .into_iter()
@@ -431,7 +432,9 @@ mod tests {
         let normalized = normalize_block(&block).unwrap();
         assert_eq!(normalized.post_exec_tx_index, Some(2));
         assert_eq!(normalized.original_indexes, vec![0, 1]);
-        assert_eq!(normalized.embedded_payload.unwrap().gas_refund_entries, payload_entries);
+        let embedded_payload = normalized.embedded_payload.unwrap();
+        assert_eq!(embedded_payload.selected_base_fee_per_gas, 1);
+        assert_eq!(embedded_payload.gas_refund_entries, payload_entries);
         assert_eq!(normalized.replay_block.body().transactions.len(), 2);
     }
 

--- a/rust/op-reth/crates/post-exec-replay/src/types.rs
+++ b/rust/op-reth/crates/post-exec-replay/src/types.rs
@@ -129,5 +129,6 @@ pub struct PostExecReplayPayloadEntry {
 pub struct PostExecReplayPayload {
     pub version: u64,
     pub block_number: u64,
+    pub selected_base_fee_per_gas: u64,
     pub gas_refund_entries: Vec<PostExecReplayPayloadEntry>,
 }

--- a/rust/op-reth/crates/primitives/src/transaction/signed.rs
+++ b/rust/op-reth/crates/primitives/src/transaction/signed.rs
@@ -571,6 +571,7 @@ mod tests {
                 *post_exec = TxPostExec::new(op_alloy_consensus::PostExecPayload {
                     version: 1,
                     block_number: 1,
+                    selected_base_fee_per_gas: 1,
                     gas_refund_entries: (0..16)
                         .map(|index| op_alloy_consensus::SDMGasEntry { index, gas_refund: 1 })
                         .collect(),

--- a/rust/op-reth/crates/rpc/Cargo.toml
+++ b/rust/op-reth/crates/rpc/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 # reth
 reth-basic-payload-builder.workspace = true
 reth-evm.workspace = true
+reth-errors.workspace = true
 reth-primitives-traits.workspace = true
 reth-storage-api.workspace = true
 reth-rpc-eth-api.workspace = true

--- a/rust/op-reth/crates/rpc/src/error.rs
+++ b/rust/op-reth/crates/rpc/src/error.rs
@@ -10,6 +10,7 @@ use op_alloy_consensus::PostExecPayloadValidationError;
 use op_revm::OpHaltReason;
 use reth_evm::execute::ProviderError;
 use reth_optimism_evm::OpBlockExecutionError;
+use reth_optimism_payload_builder::config::BaseFeePolicyError;
 use reth_rpc_eth_api::{AsEthApiError, EthTxEnvError, TransactionConversionError};
 use reth_rpc_eth_types::{
     EthApiError,
@@ -40,6 +41,9 @@ pub enum OpEthApiError {
     /// Invalid post-exec payload or post-exec transaction placement.
     #[error(transparent)]
     InvalidPostExecPayload(#[from] PostExecPayloadValidationError),
+    /// Base-fee policy could not provide a quote.
+    #[error(transparent)]
+    BaseFeePolicy(#[from] BaseFeePolicyError),
     /// Sequencer client error.
     #[error(transparent)]
     Sequencer(#[from] SequencerClientError),
@@ -62,7 +66,8 @@ impl From<OpEthApiError> for jsonrpsee_types::error::ErrorObject<'static> {
             OpEthApiError::Evm(_) |
             OpEthApiError::L1BlockFeeError |
             OpEthApiError::L1BlockGasError |
-            OpEthApiError::InvalidPostExecPayload(_) => internal_rpc_err(err.to_string()),
+            OpEthApiError::InvalidPostExecPayload(_) |
+            OpEthApiError::BaseFeePolicy(_) => internal_rpc_err(err.to_string()),
             OpEthApiError::Sequencer(err) => err.into(),
         }
     }

--- a/rust/op-reth/crates/rpc/src/eth/block.rs
+++ b/rust/op-reth/crates/rpc/src/eth/block.rs
@@ -1,6 +1,10 @@
 //! Loads and formats OP block RPC response.
 
-use crate::{OpEthApi, OpEthApiError, eth::RpcNodeCore};
+use crate::{
+    OpEthApi, OpEthApiError,
+    eth::{OpRpcProvider, RpcNodeCore},
+};
+use reth_optimism_evm::ConfigurePostExecEvm;
 use reth_rpc_eth_api::{
     FromEvmError, RpcConvert,
     helpers::{EthBlocks, LoadBlock},
@@ -9,6 +13,8 @@ use reth_rpc_eth_api::{
 impl<N, Rpc> EthBlocks for OpEthApi<N, Rpc>
 where
     N: RpcNodeCore,
+    N::Provider: OpRpcProvider,
+    N::Evm: ConfigurePostExecEvm,
     OpEthApiError: FromEvmError<N::Evm>,
     Rpc: RpcConvert<Primitives = N::Primitives, Error = OpEthApiError>,
 {
@@ -17,6 +23,8 @@ where
 impl<N, Rpc> LoadBlock for OpEthApi<N, Rpc>
 where
     N: RpcNodeCore,
+    N::Provider: OpRpcProvider,
+    N::Evm: ConfigurePostExecEvm,
     OpEthApiError: FromEvmError<N::Evm>,
     Rpc: RpcConvert<Primitives = N::Primitives, Error = OpEthApiError>,
 {

--- a/rust/op-reth/crates/rpc/src/eth/call.rs
+++ b/rust/op-reth/crates/rpc/src/eth/call.rs
@@ -1,4 +1,8 @@
-use crate::{OpEthApi, OpEthApiError, eth::RpcNodeCore};
+use crate::{
+    OpEthApi, OpEthApiError,
+    eth::{OpRpcProvider, RpcNodeCore},
+};
+use reth_optimism_evm::ConfigurePostExecEvm;
 use reth_rpc_eth_api::{
     FromEvmError, RpcConvert,
     helpers::{Call, EthCall, estimate::EstimateCall},
@@ -7,6 +11,8 @@ use reth_rpc_eth_api::{
 impl<N, Rpc> EthCall for OpEthApi<N, Rpc>
 where
     N: RpcNodeCore,
+    N::Provider: OpRpcProvider,
+    N::Evm: ConfigurePostExecEvm,
     OpEthApiError: FromEvmError<N::Evm>,
     Rpc: RpcConvert<Primitives = N::Primitives, Error = OpEthApiError, Evm = N::Evm>,
 {
@@ -15,6 +21,8 @@ where
 impl<N, Rpc> EstimateCall for OpEthApi<N, Rpc>
 where
     N: RpcNodeCore,
+    N::Provider: OpRpcProvider,
+    N::Evm: ConfigurePostExecEvm,
     OpEthApiError: FromEvmError<N::Evm>,
     Rpc: RpcConvert<Primitives = N::Primitives, Error = OpEthApiError, Evm = N::Evm>,
 {
@@ -23,6 +31,8 @@ where
 impl<N, Rpc> Call for OpEthApi<N, Rpc>
 where
     N: RpcNodeCore,
+    N::Provider: OpRpcProvider,
+    N::Evm: ConfigurePostExecEvm,
     OpEthApiError: FromEvmError<N::Evm>,
     Rpc: RpcConvert<Primitives = N::Primitives, Error = OpEthApiError, Evm = N::Evm>,
 {

--- a/rust/op-reth/crates/rpc/src/eth/call.rs
+++ b/rust/op-reth/crates/rpc/src/eth/call.rs
@@ -2,11 +2,14 @@ use crate::{
     OpEthApi, OpEthApiError,
     eth::{OpRpcProvider, RpcNodeCore},
 };
+use reth_evm::{EvmEnvFor, env::BlockEnvironment};
 use reth_optimism_evm::ConfigurePostExecEvm;
+use reth_primitives_traits::{HeaderTy, SealedHeader};
 use reth_rpc_eth_api::{
     FromEvmError, RpcConvert,
     helpers::{Call, EthCall, estimate::EstimateCall},
 };
+use revm::context::Block;
 
 impl<N, Rpc> EthCall for OpEthApi<N, Rpc>
 where
@@ -54,5 +57,16 @@ where
     #[inline]
     fn evm_memory_limit(&self) -> u64 {
         self.inner.eth_api.evm_memory_limit()
+    }
+
+    fn apply_simulation_evm_env_overrides(
+        &self,
+        parent: &SealedHeader<HeaderTy<Self::Primitives>>,
+        evm_env: &mut EvmEnvFor<Self::Evm>,
+    ) -> Result<(), Self::Error> {
+        let next_timestamp = evm_env.block_env.timestamp().saturating_to();
+        evm_env.block_env.inner_mut().basefee =
+            self.base_fee_quote_at_timestamp(parent.header(), next_timestamp)?;
+        Ok(())
     }
 }

--- a/rust/op-reth/crates/rpc/src/eth/mod.rs
+++ b/rust/op-reth/crates/rpc/src/eth/mod.rs
@@ -13,29 +13,32 @@ use crate::{
     OpEthApiError, SequencerClient,
     eth::{receipt::OpReceiptConverter, transaction::OpTxInfoMapper},
 };
+use alloy_consensus::BlockHeader;
 use alloy_eips::BlockNumHash;
 use alloy_primitives::U256;
-use alloy_rpc_types_eth::{Filter, Log};
+use alloy_rpc_types_eth::{BlockNumberOrTag, Filter, Log};
 use eyre::WrapErr;
 use futures::StreamExt;
 use op_alloy_network::Optimism;
 use op_alloy_rpc_types_engine::OpFlashblockPayloadBase;
 pub use receipt::{OpReceiptBuilder, OpReceiptFieldsBuilder};
 use reqwest::Url;
-use reth_chainspec::{EthereumHardforks, Hardforks};
-use reth_evm::ConfigureEvm;
+use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks, Hardforks};
 use reth_node_api::{FullNodeComponents, FullNodeTypes, HeaderTy, NodeTypes};
 use reth_node_builder::rpc::{EthApiBuilder, EthApiCtx};
+use reth_optimism_evm::ConfigurePostExecEvm;
 use reth_optimism_flashblocks::{
     FlashBlockBuildInfo, FlashBlockCompleteSequence, FlashBlockCompleteSequenceRx,
     FlashBlockConsensusClient, FlashBlockRx, FlashBlockService, FlashblockCachedReceipt,
     FlashblocksListeners, PendingBlockRx, PendingFlashBlock, WsFlashBlockStream,
 };
+use reth_optimism_forks::OpHardforks;
+use reth_optimism_payload_builder::config::{BaseFeePolicy, JovianBaseFeePolicy, quote_base_fee};
 use reth_primitives_traits::NodePrimitives;
 use reth_rpc::eth::core::EthApiInner;
 use reth_rpc_eth_api::{
-    EthApiTypes, FromEvmError, FullEthApiServer, RpcConvert, RpcConverter, RpcNodeCore,
-    RpcNodeCoreExt, RpcTypes,
+    EthApiTypes, FromEthApiError, FromEvmError, FullEthApiServer, RpcConvert, RpcConverter,
+    RpcNodeCore, RpcNodeCoreExt, RpcTypes,
     helpers::{
         EthApiSpec, EthFees, EthState, EthSubscriptions, LoadFee, LoadPendingBlock, LoadState,
         SpawnBlocking, Trace, bal::GetBlockAccessList, pending_block::BuildPendingEnv,
@@ -44,7 +47,7 @@ use reth_rpc_eth_api::{
 use reth_rpc_eth_types::{
     EthStateCache, FeeHistoryCache, GasPriceOracle, logs_utils::matching_block_logs_with_tx_hashes,
 };
-use reth_storage_api::ProviderHeader;
+use reth_storage_api::{BlockReaderIdExt, ProviderHeader};
 use reth_tasks::{
     Runtime,
     pool::{BlockingTaskGuard, BlockingTaskPool},
@@ -61,6 +64,19 @@ use tracing::info;
 
 /// Maximum duration to wait for a fresh flashblock when one is being built.
 const MAX_FLASHBLOCK_WAIT_DURATION: Duration = Duration::from_millis(50);
+
+/// Provider capabilities required by OP-specific pending-fee RPC behavior.
+pub trait OpRpcProvider:
+    ChainSpecProvider<ChainSpec: EthChainSpec<Header = ProviderHeader<Self>> + OpHardforks>
+    + BlockReaderIdExt
+{
+}
+
+impl<T> OpRpcProvider for T where
+    T: ChainSpecProvider<ChainSpec: EthChainSpec<Header = ProviderHeader<T>> + OpHardforks>
+        + BlockReaderIdExt
+{
+}
 
 /// Adapter for [`EthApiInner`], which holds all the data required to serve core `eth_` API.
 pub type EthApiNodeBackend<N, Rpc> = EthApiInner<N, Rpc>;
@@ -92,6 +108,7 @@ impl<N: RpcNodeCore, Rpc: RpcConvert> OpEthApi<N, Rpc> {
         eth_api: EthApiNodeBackend<N, Rpc>,
         sequencer_client: Option<SequencerClient>,
         min_suggested_priority_fee: U256,
+        base_fee_policy: Arc<dyn BaseFeePolicy>,
         flashblocks: Option<FlashblocksListeners<N::Primitives>>,
         retain_forwarded_txs: bool,
     ) -> Self {
@@ -99,6 +116,7 @@ impl<N: RpcNodeCore, Rpc: RpcConvert> OpEthApi<N, Rpc> {
             eth_api,
             sequencer_client,
             min_suggested_priority_fee,
+            base_fee_policy,
             flashblocks,
             retain_forwarded_txs,
         });
@@ -106,7 +124,7 @@ impl<N: RpcNodeCore, Rpc: RpcConvert> OpEthApi<N, Rpc> {
     }
 
     /// Build a [`OpEthApi`] using [`OpEthApiBuilder`].
-    pub const fn builder() -> OpEthApiBuilder<Rpc> {
+    pub fn builder() -> OpEthApiBuilder<Rpc> {
         OpEthApiBuilder::new()
     }
 
@@ -232,6 +250,42 @@ impl<N: RpcNodeCore, Rpc: RpcConvert> OpEthApi<N, Rpc> {
     }
 }
 
+impl<N, Rpc> OpEthApi<N, Rpc>
+where
+    N: RpcNodeCore,
+    N::Provider: OpRpcProvider,
+    Rpc: RpcConvert,
+{
+    /// Quotes the pending base fee from the same policy used by the payload builder.
+    fn pending_base_fee_quote(
+        &self,
+        header: &ProviderHeader<N::Provider>,
+    ) -> Result<u64, OpEthApiError> {
+        // Pending RPCs do not have payload attributes yet. The parent timestamp matches reth's
+        // existing provisional next-block quote semantics.
+        quote_base_fee(
+            self.inner.base_fee_policy.as_ref(),
+            self.inner.eth_api.provider().chain_spec().as_ref(),
+            header,
+            header.timestamp(),
+        )
+        .map_err(Into::into)
+    }
+
+    fn latest_pending_base_fee(&self) -> Result<u64, OpEthApiError> {
+        let header = self
+            .inner
+            .eth_api
+            .provider()
+            .latest_header()
+            .map_err(OpEthApiError::from_eth_err)?
+            .ok_or_else(|| {
+                reth_rpc_eth_types::EthApiError::HeaderNotFound(BlockNumberOrTag::Latest.into())
+            })?;
+        self.pending_base_fee_quote(&header)
+    }
+}
+
 impl<N, Rpc> EthApiTypes for OpEthApi<N, Rpc>
 where
     N: RpcNodeCore,
@@ -329,6 +383,8 @@ where
 impl<N, Rpc> LoadFee for OpEthApi<N, Rpc>
 where
     N: RpcNodeCore,
+    N::Provider: OpRpcProvider,
+    N::Evm: ConfigurePostExecEvm,
     OpEthApiError: FromEvmError<N::Evm>,
     Rpc: RpcConvert<Primitives = N::Primitives, Error = OpEthApiError>,
 {
@@ -340,6 +396,18 @@ where
     #[inline]
     fn fee_history_cache(&self) -> &FeeHistoryCache<ProviderHeader<N::Provider>> {
         self.inner.eth_api.fee_history_cache()
+    }
+
+    fn pending_base_fee(
+        &self,
+        header: &ProviderHeader<Self::Provider>,
+    ) -> Result<Option<u64>, Self::Error> {
+        self.pending_base_fee_quote(header).map(Some)
+    }
+
+    async fn gas_price(&self) -> Result<U256, Self::Error> {
+        Ok(U256::from(self.latest_pending_base_fee()?) +
+            LoadFee::suggested_priority_fee(self).await?)
     }
 
     async fn suggested_priority_fee(&self) -> Result<U256, Self::Error> {
@@ -355,6 +423,8 @@ where
 impl<N, Rpc> LoadState for OpEthApi<N, Rpc>
 where
     N: RpcNodeCore,
+    N::Provider: OpRpcProvider,
+    N::Evm: ConfigurePostExecEvm,
     Rpc: RpcConvert<Primitives = N::Primitives>,
     Self: LoadPendingBlock,
 {
@@ -363,6 +433,8 @@ where
 impl<N, Rpc> EthState for OpEthApi<N, Rpc>
 where
     N: RpcNodeCore,
+    N::Provider: OpRpcProvider,
+    N::Evm: ConfigurePostExecEvm,
     Rpc: RpcConvert<Primitives = N::Primitives, Error = OpEthApiError>,
     Self: LoadPendingBlock,
 {
@@ -375,6 +447,8 @@ where
 impl<N, Rpc> EthFees for OpEthApi<N, Rpc>
 where
     N: RpcNodeCore,
+    N::Provider: OpRpcProvider,
+    N::Evm: ConfigurePostExecEvm,
     OpEthApiError: FromEvmError<N::Evm>,
     Rpc: RpcConvert<Primitives = N::Primitives, Error = OpEthApiError>,
 {
@@ -390,6 +464,8 @@ where
 impl<N, Rpc> Trace for OpEthApi<N, Rpc>
 where
     N: RpcNodeCore,
+    N::Provider: OpRpcProvider,
+    N::Evm: ConfigurePostExecEvm,
     OpEthApiError: FromEvmError<N::Evm>,
     Rpc: RpcConvert<Primitives = N::Primitives, Error = OpEthApiError, Evm = N::Evm>,
 {
@@ -398,6 +474,8 @@ where
 impl<N, Rpc> GetBlockAccessList for OpEthApi<N, Rpc>
 where
     N: RpcNodeCore,
+    N::Provider: OpRpcProvider,
+    N::Evm: ConfigurePostExecEvm,
     OpEthApiError: FromEvmError<N::Evm>,
     Rpc: RpcConvert<Primitives = N::Primitives, Error = OpEthApiError, Evm = N::Evm>,
 {
@@ -420,6 +498,8 @@ pub struct OpEthApiInner<N: RpcNodeCore, Rpc: RpcConvert> {
     ///
     /// See also <https://github.com/ethereum-optimism/op-geth/blob/d4e0fe9bb0c2075a9bff269fb975464dd8498f75/eth/gasprice/optimism-gasprice.go#L38-L38>
     min_suggested_priority_fee: U256,
+    /// Policy used to quote the next sequencer-selected base fee.
+    base_fee_policy: Arc<dyn BaseFeePolicy>,
     /// Flashblocks listeners.
     ///
     /// If set, provides receivers for pending blocks, flashblock sequences, and build status.
@@ -474,6 +554,8 @@ pub struct OpEthApiBuilder<NetworkT = Optimism> {
     sequencer_headers: Vec<String>,
     /// Minimum suggested priority fee (tip)
     min_suggested_priority_fee: u64,
+    /// Policy used to quote the next sequencer-selected base fee.
+    base_fee_policy: Arc<dyn BaseFeePolicy>,
     /// A URL pointing to a secure websocket connection (wss) that streams out [flashblocks].
     ///
     /// [flashblocks]: reth_optimism_flashblocks
@@ -497,6 +579,7 @@ impl<NetworkT> Default for OpEthApiBuilder<NetworkT> {
             sequencer_url: None,
             sequencer_headers: Vec::new(),
             min_suggested_priority_fee: 1_000_000,
+            base_fee_policy: Arc::new(JovianBaseFeePolicy),
             flashblocks_url: None,
             flashblock_consensus: false,
             retain_forwarded_txs: false,
@@ -507,11 +590,12 @@ impl<NetworkT> Default for OpEthApiBuilder<NetworkT> {
 
 impl<NetworkT> OpEthApiBuilder<NetworkT> {
     /// Creates a [`OpEthApiBuilder`] instance from core components.
-    pub const fn new() -> Self {
+    pub fn new() -> Self {
         Self {
             sequencer_url: None,
             sequencer_headers: Vec::new(),
             min_suggested_priority_fee: 1_000_000,
+            base_fee_policy: Arc::new(JovianBaseFeePolicy),
             flashblocks_url: None,
             flashblock_consensus: false,
             retain_forwarded_txs: false,
@@ -534,6 +618,12 @@ impl<NetworkT> OpEthApiBuilder<NetworkT> {
     /// With minimum suggested priority fee (tip).
     pub const fn with_min_suggested_priority_fee(mut self, min: u64) -> Self {
         self.min_suggested_priority_fee = min;
+        self
+    }
+
+    /// With the policy used to quote the next sequencer-selected base fee.
+    pub fn with_base_fee_policy(mut self, base_fee_policy: Arc<dyn BaseFeePolicy>) -> Self {
+        self.base_fee_policy = base_fee_policy;
         self
     }
 
@@ -560,13 +650,13 @@ impl<NetworkT> OpEthApiBuilder<NetworkT> {
 impl<N, NetworkT> EthApiBuilder<N> for OpEthApiBuilder<NetworkT>
 where
     N: FullNodeComponents<
-            Evm: ConfigureEvm<
+            Evm: ConfigurePostExecEvm<
                 NextBlockEnvCtx: BuildPendingEnv<HeaderTy<N::Types>>
                                      + From<OpFlashblockPayloadBase>
                                      + Unpin,
             >,
             Types: NodeTypes<
-                ChainSpec: Hardforks + EthereumHardforks,
+                ChainSpec: Hardforks + EthereumHardforks + OpHardforks,
                 Payload: reth_node_api::PayloadTypes<
                     ExecutionData: for<'a> TryFrom<
                         &'a FlashBlockCompleteSequence,
@@ -588,6 +678,7 @@ where
             sequencer_url,
             sequencer_headers,
             min_suggested_priority_fee,
+            base_fee_policy,
             flashblocks_url,
             flashblock_consensus,
             retain_forwarded_txs,
@@ -652,8 +743,34 @@ where
             eth_api,
             sequencer_client,
             U256::from(min_suggested_priority_fee),
+            base_fee_policy,
             flashblocks,
             retain_forwarded_txs,
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reth_optimism_payload_builder::config::{BaseFeePolicyError, BaseFeePolicyInput};
+
+    #[derive(Debug)]
+    struct TestBaseFeePolicy;
+
+    impl BaseFeePolicy for TestBaseFeePolicy {
+        fn select_base_fee(
+            &self,
+            _input: BaseFeePolicyInput<'_>,
+        ) -> Result<u64, BaseFeePolicyError> {
+            Ok(777)
+        }
+    }
+
+    #[test]
+    fn eth_api_builder_accepts_base_fee_policy() {
+        let policy: Arc<dyn BaseFeePolicy> = Arc::new(TestBaseFeePolicy);
+        let builder = OpEthApiBuilder::<Optimism>::default().with_base_fee_policy(policy.clone());
+        assert!(Arc::ptr_eq(&builder.base_fee_policy, &policy));
     }
 }

--- a/rust/op-reth/crates/rpc/src/eth/mod.rs
+++ b/rust/op-reth/crates/rpc/src/eth/mod.rs
@@ -257,19 +257,27 @@ where
     Rpc: RpcConvert,
 {
     /// Quotes the pending base fee from the same policy used by the payload builder.
-    fn pending_base_fee_quote(
+    fn base_fee_quote_at_timestamp(
         &self,
         header: &ProviderHeader<N::Provider>,
+        next_timestamp: u64,
     ) -> Result<u64, OpEthApiError> {
-        // Pending RPCs do not have payload attributes yet. The parent timestamp matches reth's
-        // existing provisional next-block quote semantics.
         quote_base_fee(
             self.inner.base_fee_policy.as_ref(),
             self.inner.eth_api.provider().chain_spec().as_ref(),
             header,
-            header.timestamp(),
+            next_timestamp,
         )
         .map_err(Into::into)
+    }
+
+    fn pending_base_fee_quote(
+        &self,
+        header: &ProviderHeader<N::Provider>,
+    ) -> Result<u64, OpEthApiError> {
+        // Match the timestamp used by `OpNextBlockEnvAttributes::build_pending_env` so fee APIs,
+        // pending execution, and fork activation all describe the same provisional block.
+        self.base_fee_quote_at_timestamp(header, header.timestamp().saturating_add(12))
     }
 
     fn latest_pending_base_fee(&self) -> Result<u64, OpEthApiError> {

--- a/rust/op-reth/crates/rpc/src/eth/mod.rs
+++ b/rust/op-reth/crates/rpc/src/eth/mod.rs
@@ -405,6 +405,13 @@ where
         self.pending_base_fee_quote(header).map(Some)
     }
 
+    fn fill_transaction_base_fee(
+        &self,
+        header: &ProviderHeader<Self::Provider>,
+    ) -> Result<Option<u64>, Self::Error> {
+        self.pending_base_fee_quote(header).map(Some)
+    }
+
     async fn gas_price(&self) -> Result<U256, Self::Error> {
         Ok(U256::from(self.latest_pending_base_fee()?) +
             LoadFee::suggested_priority_fee(self).await?)

--- a/rust/op-reth/crates/rpc/src/eth/pending_block.rs
+++ b/rust/op-reth/crates/rpc/src/eth/pending_block.rs
@@ -1,19 +1,22 @@
 //! Loads OP pending block for a RPC response.
 
-use crate::{OpEthApi, OpEthApiError};
+use crate::{OpEthApi, OpEthApiError, eth::OpRpcProvider};
 use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::B256;
 use reth_chain_state::BlockState;
+use reth_errors::RethError;
+use reth_evm::ConfigureEvm;
+use reth_optimism_evm::ConfigurePostExecEvm;
 use reth_optimism_flashblocks::PendingFlashBlock;
 use reth_rpc_eth_api::{
     FromEvmError, RpcConvert, RpcNodeCore, RpcNodeCoreExt,
     helpers::{LoadPendingBlock, SpawnBlocking, pending_block::PendingEnvBuilder},
 };
 use reth_rpc_eth_types::{
-    EthApiError, PendingBlock, block::BlockAndReceipts, builder::config::PendingBlockKind,
-    error::FromEthApiError,
+    EthApiError, PendingBlock, PendingBlockEnv, PendingBlockEnvOrigin, block::BlockAndReceipts,
+    builder::config::PendingBlockKind, error::FromEthApiError,
 };
-use reth_storage_api::{BlockReaderIdExt, StateProviderBox, StateProviderFactory};
+use reth_storage_api::{BlockReader, BlockReaderIdExt, StateProviderBox, StateProviderFactory};
 
 #[inline]
 const fn pending_state_history_lookup_hash<N: reth_primitives_traits::NodePrimitives>(
@@ -25,9 +28,48 @@ const fn pending_state_history_lookup_hash<N: reth_primitives_traits::NodePrimit
 impl<N, Rpc> LoadPendingBlock for OpEthApi<N, Rpc>
 where
     N: RpcNodeCore,
+    N::Provider: OpRpcProvider,
+    N::Evm: ConfigurePostExecEvm,
     OpEthApiError: FromEvmError<N::Evm>,
     Rpc: RpcConvert<Primitives = N::Primitives, Error = OpEthApiError>,
 {
+    fn pending_block_env_and_cfg(&self) -> Result<PendingBlockEnv<Self::Evm>, Self::Error> {
+        if let Some((block, receipts)) =
+            self.provider().pending_block_and_receipts().map_err(Self::Error::from_eth_err)?
+        {
+            let evm_env = self
+                .evm_config()
+                .evm_env(block.header())
+                .map_err(RethError::other)
+                .map_err(Self::Error::from_eth_err)?;
+            return Ok(PendingBlockEnv::new(
+                evm_env,
+                PendingBlockEnvOrigin::ActualPending(
+                    std::sync::Arc::new(block),
+                    std::sync::Arc::new(receipts),
+                ),
+            ));
+        }
+
+        let latest = self
+            .provider()
+            .latest_header()
+            .map_err(Self::Error::from_eth_err)?
+            .ok_or(EthApiError::HeaderNotFound(BlockNumberOrTag::Latest.into()))?;
+        let attributes = self.next_env_attributes(&latest)?;
+        let evm_env = self
+            .evm_config()
+            .next_evm_env_with_base_fee(
+                latest.header(),
+                &attributes,
+                self.pending_base_fee_quote(latest.header())?,
+            )
+            .map_err(RethError::other)
+            .map_err(Self::Error::from_eth_err)?;
+
+        Ok(PendingBlockEnv::new(evm_env, PendingBlockEnvOrigin::DerivedFromLatest(latest)))
+    }
+
     #[inline]
     fn pending_block(&self) -> &tokio::sync::Mutex<Option<PendingBlock<N::Primitives>>> {
         self.inner.eth_api.pending_block()

--- a/rust/op-reth/crates/rpc/src/eth/receipt/tests.rs
+++ b/rust/op-reth/crates/rpc/src/eth/receipt/tests.rs
@@ -153,7 +153,8 @@ fn convert_receipts_extracts_post_exec_gas_refund_from_embedded_payload() {
     let tx_1 =
         OpTransactionSigned::decode_2718(&mut TX_1_OP_MAINNET_BLOCK_124665056.as_slice()).unwrap();
     let post_exec = OpTransactionSigned::PostExec(
-        build_post_exec_tx(124665056, vec![SDMGasEntry { index: 1, gas_refund: 77 }]).seal_slow(),
+        build_post_exec_tx(124665056, 1, vec![SDMGasEntry { index: 1, gas_refund: 77 }])
+            .seal_slow(),
     );
 
     let block = SealedBlock::new_unhashed(Block::<OpTransactionSigned> {
@@ -402,7 +403,7 @@ fn blob_gas_used_zero_in_post_exec_receipt_post_lagoon() {
     const DA_FOOTPRINT_GAS_SCALAR: u16 = 100;
 
     let tx: OpTransactionSigned = OpTransactionSigned::PostExec(
-        build_post_exec_tx(1, vec![SDMGasEntry { index: 1, gas_refund: 77 }]).seal_slow(),
+        build_post_exec_tx(1, 1, vec![SDMGasEntry { index: 1, gas_refund: 77 }]).seal_slow(),
     );
 
     let mut l1_block_info = op_revm::L1BlockInfo {

--- a/rust/op-revm/src/transaction.rs
+++ b/rust/op-revm/src/transaction.rs
@@ -63,7 +63,7 @@ mod tests {
     #[test]
     fn post_exec_tx_da_footprint_is_zero() {
         const SCALAR: u64 = 100;
-        let tx = build_post_exec_tx(1, vec![SDMGasEntry { index: 1, gas_refund: 77 }]);
+        let tx = build_post_exec_tx(1, 1, vec![SDMGasEntry { index: 1, gas_refund: 77 }]);
         let encoded = tx.encoded_2718();
 
         let encoded_size_footprint =


### PR DESCRIPTION
## Description

Implement Sequencer-Defined Fees (SDF) at Lagoon. The sequencer selects `baseFeePerGas` through a pluggable policy, commits that selection in the trailing `PostExec` transaction, and validators reproduce execution from the committed fee without running producer policy.

This change:

- extends the unactivated version-1 `PostExec` payload with the selected base fee
- requires a trailing Lagoon commitment, including for empty refund sets
- wires fee selection and immutable per-payload caching through op-reth payload building
- uses selected-fee quotes in txpool, pending execution, and fee-related RPC paths
- validates Lagoon commitments on Engine API block import
- reproduces fallback commitments in Kona and preserves them in output artifacts
- applies selected fees during flashblock replay and reserves block space for the mandatory commitment
- updates public documentation and acceptance-test expectations

L1 data fees, operator fees, batch formats, and payload-attribute schemas are unchanged.

## Dependencies

- Depends on ethereum-optimism/reth#8. The Rust workspace is pinned to that PR's organization-owned branch revision while it is under review.
- Specification: ethereum-optimism/specs#934.
- Premium policy integration: ethereum-optimism/optimism-premium#222.

## Validation

Completed before opening this draft:

- full Go lint and Optimism Rust lint on the initial series
- targeted op-reth/Kona tests, including 41 Kona executor tests
- no-std checks and nightly formatting
- focused checks for consensus, Kona executor/driver, flashblocks, payload builder, and RPC against the public reth revision
- regression tests for Engine API commitment validation, Kona fallback transaction persistence, flashblock selected-fee execution, and block-size reservation

Final review, broader validation after the latest fixes, and CI follow-up are still in progress.

## Review notes

Earlier independent review findings about the Engine API validation path, Kona fallback artifacts, flashblock fees, historical fee history, fill-transaction defaults, and block-size accounting were addressed before this draft was opened.

Dismissed findings:

- Cached policy failures are intentional: a payload ID has one immutable policy resolution across retries.
- A `PostExec` version 2 is unnecessary because version 1 has not activated onchain.
- Extending op-geth is out of scope because Lagoon follows the op-geth support horizon.
- No span-batch format change is required; span batches already transport the transaction bytes.
