### PR TITLE
contracts-bedrock: add Safe v1.5 module guard support to LivenessGuard

### DIFF
--- a/packages/contracts-bedrock/interfaces/safe/IModuleGuard.sol
+++ b/packages/contracts-bedrock/interfaces/safe/IModuleGuard.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+// Safe
+import { Enum } from "safe-contracts/common/Enum.sol";
+import { IERC165 } from "safe-contracts/interfaces/IERC165.sol";
+
+/// @title IModuleGuard
+/// @notice Safe v1.5.0 module guard interface (interfaceId 0x58401ed8). Vendored from
+///         safe-global/safe-smart-account v1.5.0 (contracts/base/ModuleManager.sol) because the
+///         local safe-contracts dependency does not include module-guard support. Safe v1.5.0's
+///         setModuleGuard() requires the guard to report support for this interface id via
+///         ERC-165.
+interface IModuleGuard is IERC165 {
+    /// @notice Called by the Safe (>= v1.5.0) before a module transaction is executed.
+    /// @param _to Destination address of the module transaction.
+    /// @param _value Ether value of the module transaction.
+    /// @param _data Data payload of the module transaction.
+    /// @param _operation Operation type of the module transaction.
+    /// @param _module Module executing the transaction.
+    /// @return moduleTxHash_ Hash of the module transaction, echoed back into
+    ///         checkAfterModuleExecution.
+    function checkModuleTransaction(
+        address _to,
+        uint256 _value,
+        bytes memory _data,
+        Enum.Operation _operation,
+        address _module
+    )
+        external
+        returns (bytes32 moduleTxHash_);
+
+    /// @notice Called by the Safe (>= v1.5.0) after a module transaction is executed.
+    /// @param _txHash Hash of the module transaction returned by checkModuleTransaction.
+    /// @param _success Whether the module transaction succeeded.
+    function checkAfterModuleExecution(bytes32 _txHash, bool _success) external;
+}

--- a/packages/contracts-bedrock/interfaces/safe/IUnorderedExecutionModule.sol
+++ b/packages/contracts-bedrock/interfaces/safe/IUnorderedExecutionModule.sol
@@ -1,11 +1,54 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-/// @title IUnorderedExecutionModule
-/// @notice Interface used by the LivenessGuard to read the signers of an in-flight unordered execution.
-interface IUnorderedExecutionModule {
-    /// @notice Returns the owners whose signatures were validated for the current module execution.
-    /// @dev The implementation must populate this value only after Safe.checkSignatures succeeds and clear it after
-    ///      execTransactionFromModule returns. The value must be scoped to the Safe currently executing the module call.
-    function signers() external view returns (address[] memory signers_);
+import { Safe } from "safe-contracts/Safe.sol";
+import { Enum } from "safe-contracts/common/Enum.sol";
+import { ISemver } from "interfaces/universal/ISemver.sol";
+
+interface IUnorderedExecutionModule is ISemver {
+    struct ExecTransactionParams {
+        address to;
+        uint256 value;
+        bytes data;
+        Enum.Operation operation;
+    }
+
+    error UnorderedExecutionModule_ModuleNotEnabled();
+    error UnorderedExecutionModule_HashOnceTooSmall();
+    error UnorderedExecutionModule_HashOnceAlreadyUsed();
+    error UnorderedExecutionModule_ReentrantExecution();
+    error UnorderedExecutionModule_UnsupportedSafe();
+    error UnorderedExecutionModule_ExecutionFailed(bytes data);
+
+    event TransactionExecuted(Safe indexed safe, bytes32 indexed txHash, uint256 indexed hashOnce);
+
+    function version() external view returns (string memory);
+    function __constructor__() external;
+    function executed(Safe _safe, uint256 _hashOnce) external view returns (bool executed_);
+    function signers(Safe _safe) external view returns (address[] memory signers_);
+    function deriveHashOnce(string memory _input) external pure returns (uint256 hashOnce_);
+    function encodeTransactionData(
+        Safe _safe,
+        ExecTransactionParams calldata _params,
+        uint256 _hashOnce
+    )
+        external
+        view
+        returns (bytes memory txHashData_);
+    function transactionHash(
+        Safe _safe,
+        ExecTransactionParams calldata _params,
+        uint256 _hashOnce
+    )
+        external
+        view
+        returns (bytes32 txHash_);
+    function execute(
+        Safe _safe,
+        ExecTransactionParams calldata _params,
+        uint256 _hashOnce,
+        bytes calldata _signatures
+    )
+        external
+        returns (bytes memory returnData_);
 }

--- a/packages/contracts-bedrock/interfaces/safe/IUnorderedExecutionModule.sol
+++ b/packages/contracts-bedrock/interfaces/safe/IUnorderedExecutionModule.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/// @title IUnorderedExecutionModule
+/// @notice Interface used by the LivenessGuard to read the signers of an in-flight unordered execution.
+interface IUnorderedExecutionModule {
+    /// @notice Returns the owners whose signatures were validated for the current module execution.
+    /// @dev The implementation must populate this value only after Safe.checkSignatures succeeds and clear it after
+    ///      execTransactionFromModule returns. The value must be scoped to the Safe currently executing the module call.
+    function signers() external view returns (address[] memory signers_);
+}

--- a/packages/contracts-bedrock/snapshots/abi/LivenessGuard.json
+++ b/packages/contracts-bedrock/snapshots/abi/LivenessGuard.json
@@ -5,6 +5,11 @@
         "internalType": "contract Safe",
         "name": "_safe",
         "type": "address"
+      },
+      {
+        "internalType": "contract IUnorderedExecutionModule",
+        "name": "_unorderedExecutionModule",
+        "type": "address"
       }
     ],
     "stateMutability": "nonpayable",
@@ -25,6 +30,63 @@
     ],
     "name": "checkAfterExecution",
     "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "name": "checkAfterModuleExecution",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      },
+      {
+        "internalType": "enum Enum.Operation",
+        "name": "",
+        "type": "uint8"
+      },
+      {
+        "internalType": "address",
+        "name": "_module",
+        "type": "address"
+      }
+    ],
+    "name": "checkModuleTransaction",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "moduleTxHash_",
+        "type": "bytes32"
+      }
+    ],
     "stateMutability": "nonpayable",
     "type": "function"
   },
@@ -134,7 +196,7 @@
     "inputs": [
       {
         "internalType": "bytes4",
-        "name": "interfaceId",
+        "name": "_interfaceId",
         "type": "bytes4"
       }
     ],
@@ -144,6 +206,19 @@
         "internalType": "bool",
         "name": "",
         "type": "bool"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "unorderedExecutionModule",
+    "outputs": [
+      {
+        "internalType": "contract IUnorderedExecutionModule",
+        "name": "module_",
+        "type": "address"
       }
     ],
     "stateMutability": "view",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -204,8 +204,8 @@
     "sourceCodeHash": "0xd15f4bb43e81a10317902cd8e27394581a59df2656b130727eb67543c985c72e"
   },
   "src/safe/LivenessGuard.sol:LivenessGuard": {
-    "initCodeHash": "0x2c55a3800e8b4934c0e8eacd61e35c4210dcc659a9cf8e3e2792e1d822096656",
-    "sourceCodeHash": "0x62e1354f04f8de3edb58aa8517faf803cd69e6b5f1ce850ac83690bf6be0d25a"
+    "initCodeHash": "0x888addbede55c87b87f5b130071b63ed5c92ab121cbca149abd9a03a7212e252",
+    "sourceCodeHash": "0x60bbaecbb7da0a84c326d13b389c01687efa343d353121e8ea1e4d9947544e12"
   },
   "src/safe/LivenessModule.sol:LivenessModule": {
     "initCodeHash": "0xf55316e85e58b74934e6075b22c85c4b77d4505e2c9e750e42865c01707e50c1",

--- a/packages/contracts-bedrock/snapshots/storageLayout/LivenessGuard.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/LivenessGuard.json
@@ -12,5 +12,12 @@
     "offset": 0,
     "slot": "1",
     "type": "struct EnumerableSet.AddressSet"
+  },
+  {
+    "bytes": "64",
+    "label": "moduleOwnersBefore",
+    "offset": 0,
+    "slot": "3",
+    "type": "struct EnumerableSet.AddressSet"
   }
 ]

--- a/packages/contracts-bedrock/src/safe/LivenessGuard.sol
+++ b/packages/contracts-bedrock/src/safe/LivenessGuard.sol
@@ -13,22 +13,8 @@ import { SafeSigners } from "src/safe/SafeSigners.sol";
 
 // Interfaces
 import { ISemver } from "interfaces/universal/ISemver.sol";
+import { IModuleGuard } from "interfaces/safe/IModuleGuard.sol";
 import { IUnorderedExecutionModule } from "interfaces/safe/IUnorderedExecutionModule.sol";
-
-/// @notice Safe v1.5.0 module guard interface (interfaceId 0x58401ed8).
-interface IModuleGuard is IERC165 {
-    function checkModuleTransaction(
-        address _to,
-        uint256 _value,
-        bytes memory _data,
-        Enum.Operation _operation,
-        address _module
-    )
-        external
-        returns (bytes32 moduleTxHash_);
-
-    function checkAfterModuleExecution(bytes32 _txHash, bool _success) external;
-}
 
 /// @title LivenessGuard
 /// @notice This Guard contract is used to track the liveness of Safe owners.
@@ -172,8 +158,9 @@ contract LivenessGuard is ISemver, BaseGuard, IModuleGuard {
     ///      module exposes the signer set it already validated via Safe.checkSignatures earlier in
     ///      this same call, so no unvalidated signatures are ever parsed here and every reported
     ///      signer is necessarily a current owner. Executions by any other module (e.g. the
-    ///      LivenessModule evicting a stale owner) record nothing and cannot be reverted by the
-    ///      recording logic, so liveness tracking can never block module execution.
+    ///      LivenessModule evicting a stale owner) perform no recording at all, so liveness
+    ///      tracking can never block third-party module execution. For the trusted module the
+    ///      signer read is a simple view call into a contract deployed alongside this guard.
     function checkModuleTransaction(
         address,
         uint256,
@@ -195,12 +182,11 @@ contract LivenessGuard is ISemver, BaseGuard, IModuleGuard {
 
         IUnorderedExecutionModule module = UNORDERED_EXECUTION_MODULE;
         if (address(module) != address(0) && _module == address(module)) {
-            try module.signers() returns (address[] memory signers) {
-                for (uint256 i = 0; i < signers.length; i++) {
-                    lastLive[signers[i]] = block.timestamp;
-                    emit OwnerRecorded(signers[i]);
-                }
-            } catch { }
+            address[] memory signers = module.signers(SAFE);
+            for (uint256 i = 0; i < signers.length; i++) {
+                lastLive[signers[i]] = block.timestamp;
+                emit OwnerRecorded(signers[i]);
+            }
         }
         return bytes32(0);
     }

--- a/packages/contracts-bedrock/src/safe/LivenessGuard.sol
+++ b/packages/contracts-bedrock/src/safe/LivenessGuard.sol
@@ -3,8 +3,9 @@ pragma solidity 0.8.15;
 
 // Safe
 import { Safe } from "safe-contracts/Safe.sol";
-import { BaseGuard } from "safe-contracts/base/GuardManager.sol";
+import { BaseGuard, Guard } from "safe-contracts/base/GuardManager.sol";
 import { Enum } from "safe-contracts/common/Enum.sol";
+import { IERC165 } from "safe-contracts/interfaces/IERC165.sol";
 
 // Libraries
 import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
@@ -12,6 +13,22 @@ import { SafeSigners } from "src/safe/SafeSigners.sol";
 
 // Interfaces
 import { ISemver } from "interfaces/universal/ISemver.sol";
+import { IUnorderedExecutionModule } from "interfaces/safe/IUnorderedExecutionModule.sol";
+
+/// @notice Safe v1.5.0 module guard interface (interfaceId 0x58401ed8).
+interface IModuleGuard is IERC165 {
+    function checkModuleTransaction(
+        address _to,
+        uint256 _value,
+        bytes memory _data,
+        Enum.Operation _operation,
+        address _module
+    )
+        external
+        returns (bytes32 moduleTxHash_);
+
+    function checkAfterModuleExecution(bytes32 _txHash, bool _success) external;
+}
 
 /// @title LivenessGuard
 /// @notice This Guard contract is used to track the liveness of Safe owners.
@@ -19,10 +36,15 @@ import { ISemver } from "interfaces/universal/ISemver.sol";
 ///      If an owner does not participate in a transaction for a certain period of time, they are considered inactive.
 ///      This Guard is intended to be used in conjunction with the LivenessModule contract, but does
 ///      not depend on it.
-///      Note: Both `checkTransaction` and `checkAfterExecution` are called once each by the Safe contract
-///      before and after the execution of a transaction. It is critical that neither function revert,
-///      otherwise the Safe contract will be unable to execute a transaction.
-contract LivenessGuard is ISemver, BaseGuard {
+///      Liveness is also recorded for executions performed through the trusted
+///      UnorderedExecutionModule (nonceless execution) via the Safe v1.5.0 module guard hooks. The
+///      module hooks use their own owner snapshot (moduleOwnersBefore) so owner-set changes are
+///      reconciled after either execution path, and so the two paths cannot corrupt each other's
+///      bookkeeping when a module execution happens inside a Safe transaction (or vice versa).
+///      Note: it is critical that none of the Safe hooks revert (beyond the onlySafe check),
+///      otherwise the Safe contract would be unable to execute a transaction — or to evict a stale
+///      owner through a module.
+contract LivenessGuard is ISemver, BaseGuard, IModuleGuard {
     using EnumerableSet for EnumerableSet.AddressSet;
 
     /// @notice Emitted when an owner is recorded.
@@ -30,11 +52,15 @@ contract LivenessGuard is ISemver, BaseGuard {
     event OwnerRecorded(address owner);
 
     /// @notice Semantic version.
-    /// @custom:semver 1.1.0
-    string public constant version = "1.1.0";
+    /// @custom:semver 1.2.0
+    string public constant version = "1.2.0";
 
     /// @notice The safe account for which this contract will be the guard.
     Safe internal immutable SAFE;
+
+    /// @notice The UnorderedExecutionModule trusted to report the signers of a nonceless (module)
+    ///         execution. May be the zero address, which disables module-path liveness recording.
+    IUnorderedExecutionModule internal immutable UNORDERED_EXECUTION_MODULE;
 
     /// @notice A mapping of the timestamp at which an owner last participated in signing a
     ///         an executed transaction, or called showLiveness.
@@ -45,10 +71,16 @@ contract LivenessGuard is ISemver, BaseGuard {
     ///         after execution.
     EnumerableSet.AddressSet internal ownersBefore;
 
+    /// @notice The owner snapshot used by the module-guard execution path.
+    EnumerableSet.AddressSet internal moduleOwnersBefore;
+
     /// @notice Constructor.
     /// @param _safe The safe account for which this contract will be the guard.
-    constructor(Safe _safe) {
+    /// @param _unorderedExecutionModule The UnorderedExecutionModule trusted for module-path
+    ///        liveness recording (zero address to disable).
+    constructor(Safe _safe, IUnorderedExecutionModule _unorderedExecutionModule) {
         SAFE = _safe;
+        UNORDERED_EXECUTION_MODULE = _unorderedExecutionModule;
         address[] memory owners = _safe.getOwners();
         for (uint256 i = 0; i < owners.length; i++) {
             address owner = owners[i];
@@ -61,6 +93,20 @@ contract LivenessGuard is ISemver, BaseGuard {
     /// @return safe_ The Safe contract instance
     function safe() public view returns (Safe safe_) {
         safe_ = SAFE;
+    }
+
+    /// @notice Getter function for the trusted UnorderedExecutionModule.
+    /// @return module_ The UnorderedExecutionModule (zero address if module recording is disabled).
+    function unorderedExecutionModule() public view returns (IUnorderedExecutionModule module_) {
+        module_ = UNORDERED_EXECUTION_MODULE;
+    }
+
+    /// @inheritdoc IERC165
+    /// @dev Safe v1.5.0 requires the guard to support the Guard interface id for setGuard (GS300)
+    ///      and the IModuleGuard interface id for setModuleGuard (GS301).
+    function supportsInterface(bytes4 _interfaceId) external pure override(BaseGuard, IERC165) returns (bool) {
+        return _interfaceId == type(Guard).interfaceId || _interfaceId == type(IModuleGuard).interfaceId
+            || _interfaceId == type(IERC165).interfaceId;
     }
 
     /// @notice Internal function to ensure that only the Safe can call certain functions.
@@ -120,6 +166,51 @@ contract LivenessGuard is ISemver, BaseGuard {
         }
     }
 
+    /// @inheritdoc IModuleGuard
+    /// @dev Called by the Safe (>= v1.5.0) before a module transaction is executed. Records
+    ///      liveness only for executions performed by the trusted UnorderedExecutionModule: that
+    ///      module exposes the signer set it already validated via Safe.checkSignatures earlier in
+    ///      this same call, so no unvalidated signatures are ever parsed here and every reported
+    ///      signer is necessarily a current owner. Executions by any other module (e.g. the
+    ///      LivenessModule evicting a stale owner) record nothing and cannot be reverted by the
+    ///      recording logic, so liveness tracking can never block module execution.
+    function checkModuleTransaction(
+        address,
+        uint256,
+        bytes memory,
+        Enum.Operation,
+        address _module
+    )
+        external
+        returns (bytes32 moduleTxHash_)
+    {
+        _requireOnlySafe();
+
+        // Cache the set of owners prior to execution.
+        // This will be used in the checkAfterModuleExecution method.
+        address[] memory owners = SAFE.getOwners();
+        for (uint256 i = 0; i < owners.length; i++) {
+            moduleOwnersBefore.add(owners[i]);
+        }
+
+        IUnorderedExecutionModule module = UNORDERED_EXECUTION_MODULE;
+        if (address(module) != address(0) && _module == address(module)) {
+            try module.signers() returns (address[] memory signers) {
+                for (uint256 i = 0; i < signers.length; i++) {
+                    lastLive[signers[i]] = block.timestamp;
+                    emit OwnerRecorded(signers[i]);
+                }
+            } catch { }
+        }
+        return bytes32(0);
+    }
+
+    /// @inheritdoc IModuleGuard
+    function checkAfterModuleExecution(bytes32, bool) external {
+        _requireOnlySafe();
+        _reconcileOwners(moduleOwnersBefore);
+    }
+
     /// @notice Update the lastLive mapping according to the set of owners before and after execution.
     /// @dev Called by the Safe contract after the execution of a transaction.
     ///      We use this post execution hook to compare the set of owners before and after.
@@ -128,6 +219,18 @@ contract LivenessGuard is ISemver, BaseGuard {
     ///      2. Delete removed owners from the lastLive mapping
     function checkAfterExecution(bytes32, bool) external {
         _requireOnlySafe();
+        _reconcileOwners(ownersBefore);
+    }
+
+    /// @notice Reconciles owner liveness after a Safe transaction may have changed the owner set.
+    function _reconcileOwners(EnumerableSet.AddressSet storage _ownersBefore) internal {
+        // An empty snapshot means this post-hook has no matching pre-hook: either a nested
+        // execution already reconciled (and drained) the snapshot, or the hook was invoked without
+        // one. Reconciling against an empty set would mark every current owner as live, so do
+        // nothing instead. Owner changes made by a nested execution are reconciled by that
+        // execution's own hook pair.
+        if (_ownersBefore.length() == 0) return;
+
         // Get the current set of owners
         address[] memory ownersAfter = SAFE.getOwners();
 
@@ -135,7 +238,7 @@ contract LivenessGuard is ISemver, BaseGuard {
         for (uint256 i = 0; i < ownersAfter.length; i++) {
             // If the value was present, remove() returns true.
             address ownerAfter = ownersAfter[i];
-            if (ownersBefore.remove(ownerAfter) == false) {
+            if (_ownersBefore.remove(ownerAfter) == false) {
                 // This address was not already an owner, add it to the lastLive mapping
                 lastLive[ownerAfter] = block.timestamp;
             }
@@ -144,11 +247,11 @@ contract LivenessGuard is ISemver, BaseGuard {
         // Now iterate over the remaining ownersBefore entries. Any remaining addresses are no longer an owner, so we
         // delete them from the lastLive mapping.
         // We cache the ownersBefore set before iterating over it, because the remove() method mutates the set.
-        address[] memory ownersBeforeCache = ownersBefore.values();
+        address[] memory ownersBeforeCache = _ownersBefore.values();
         for (uint256 i = 0; i < ownersBeforeCache.length; i++) {
             address ownerBefore = ownersBeforeCache[i];
             delete lastLive[ownerBefore];
-            ownersBefore.remove(ownerBefore);
+            _ownersBefore.remove(ownerBefore);
         }
     }
 

--- a/packages/contracts-bedrock/test/safe/LivenessGuard.t.sol
+++ b/packages/contracts-bedrock/test/safe/LivenessGuard.t.sol
@@ -8,7 +8,8 @@ import "test/safe-tools/SafeTestTools.sol";
 // Contracts
 import { Safe } from "safe-contracts/Safe.sol";
 import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
-import { LivenessGuard } from "src/safe/LivenessGuard.sol";
+import { LivenessGuard, IModuleGuard } from "src/safe/LivenessGuard.sol";
+import { IUnorderedExecutionModule } from "interfaces/safe/IUnorderedExecutionModule.sol";
 
 // Libraries
 import { OwnerManager } from "safe-contracts/base/OwnerManager.sol";
@@ -18,10 +19,33 @@ import { Enum } from "safe-contracts/common/Enum.sol";
 contract LivenessGuard_WrappedGuard_Harness is LivenessGuard {
     using EnumerableSet for EnumerableSet.AddressSet;
 
-    constructor(Safe safe) LivenessGuard(safe) { }
+    constructor(Safe safe, IUnorderedExecutionModule module) LivenessGuard(safe, module) { }
 
     function ownersBeforeLength() public view returns (uint256) {
         return ownersBefore.length();
+    }
+
+    function moduleOwnersBeforeLength() public view returns (uint256) {
+        return moduleOwnersBefore.length();
+    }
+}
+
+/// @notice Minimal stand-in for the UnorderedExecutionModule signer-reporting API.
+contract LivenessGuard_MockUnorderedExecutionModule is IUnorderedExecutionModule {
+    address[] internal currentSigners;
+    bool internal shouldRevert;
+
+    function setSigners(address[] memory _signers) external {
+        currentSigners = _signers;
+    }
+
+    function setShouldRevert(bool _shouldRevert) external {
+        shouldRevert = _shouldRevert;
+    }
+
+    function signers() external view returns (address[] memory signers_) {
+        require(!shouldRevert, "mock signer read failed");
+        signers_ = currentSigners;
     }
 }
 
@@ -33,6 +57,7 @@ abstract contract LivenessGuard_TestInit is Test, SafeTestTools {
     event OwnerRecorded(address owner);
 
     LivenessGuard_WrappedGuard_Harness livenessGuard;
+    LivenessGuard_MockUnorderedExecutionModule unorderedExecutionModule;
     SafeInstance safeInstance;
 
     // This needs to be non-zero so that the `lastLive` mapping can record non-zero timestamps
@@ -46,7 +71,10 @@ abstract contract LivenessGuard_TestInit is Test, SafeTestTools {
         vm.warp(initTime);
         (, uint256[] memory privKeys) = SafeTestLib.makeAddrsAndKeys("test-owners", ownerCount);
         safeInstance = _setupSafe(privKeys, threshold);
-        livenessGuard = new LivenessGuard_WrappedGuard_Harness(safeInstance.safe);
+        unorderedExecutionModule = new LivenessGuard_MockUnorderedExecutionModule();
+        livenessGuard = new LivenessGuard_WrappedGuard_Harness(
+            safeInstance.safe, IUnorderedExecutionModule(address(unorderedExecutionModule))
+        );
         safeInstance.setGuard(address(livenessGuard));
     }
 }
@@ -58,7 +86,9 @@ contract LivenessGuard_Constructor_Test is LivenessGuard_TestInit {
     ///         each owner.
     function test_constructor_works() external {
         address[] memory owners = safeInstance.owners;
-        livenessGuard = new LivenessGuard_WrappedGuard_Harness(safeInstance.safe);
+        livenessGuard = new LivenessGuard_WrappedGuard_Harness(
+            safeInstance.safe, IUnorderedExecutionModule(address(unorderedExecutionModule))
+        );
         for (uint256 i; i < owners.length; i++) {
             assertEq(livenessGuard.lastLive(owners[i]), initTime);
         }
@@ -71,7 +101,17 @@ contract LivenessGuard_Safe_Test is LivenessGuard_TestInit {
     /// @notice Tests that the getters return the correct values
     function test_safe_works() external view {
         assertEq(address(livenessGuard.safe()), address(safeInstance.safe));
+        assertEq(address(livenessGuard.unorderedExecutionModule()), address(unorderedExecutionModule));
         assertEq(livenessGuard.lastLive(address(0)), 0);
+    }
+
+    /// @notice Tests support for the Safe transaction-guard and v1.5.0 module-guard interfaces.
+    function test_supportsInterface_works() external view {
+        assertEq(type(IModuleGuard).interfaceId, bytes4(0x58401ed8));
+        assertTrue(livenessGuard.supportsInterface(0xe6d7a83a));
+        assertTrue(livenessGuard.supportsInterface(0x58401ed8));
+        assertTrue(livenessGuard.supportsInterface(0x01ffc9a7));
+        assertFalse(livenessGuard.supportsInterface(0xffffffff));
     }
 }
 
@@ -137,6 +177,94 @@ contract LivenessGuard_CheckAfterExecution_Test is LivenessGuard_TestInit {
     function test_checkAfterExecution_callerIsNotSafe_reverts() external {
         vm.expectRevert("LivenessGuard: only Safe can call this function");
         livenessGuard.checkAfterExecution(bytes32(0), false);
+    }
+}
+
+/// @title LivenessGuard_CheckModuleTransaction_Test
+/// @notice Tests the Safe v1.5.0 module-guard hooks.
+contract LivenessGuard_CheckModuleTransaction_Test is LivenessGuard_TestInit {
+    using SafeTestLib for SafeInstance;
+
+    function test_checkModuleTransaction_trustedModule_recordsValidatedSigners() external {
+        address[] memory signers = new address[](2);
+        signers[0] = safeInstance.owners[0];
+        signers[1] = safeInstance.owners[1];
+        unorderedExecutionModule.setSigners(signers);
+        vm.warp(block.timestamp + 100);
+
+        vm.prank(address(safeInstance.safe));
+        bytes32 moduleTxHash = livenessGuard.checkModuleTransaction(
+            address(1111), 0, hex"abba", Enum.Operation.Call, address(unorderedExecutionModule)
+        );
+
+        assertEq(moduleTxHash, bytes32(0));
+        assertEq(livenessGuard.lastLive(signers[0]), block.timestamp);
+        assertEq(livenessGuard.lastLive(signers[1]), block.timestamp);
+        for (uint256 i = 2; i < safeInstance.owners.length; i++) {
+            assertEq(livenessGuard.lastLive(safeInstance.owners[i]), initTime);
+        }
+    }
+
+    function test_checkModuleTransaction_unknownModule_doesNotRecordLiveness() external {
+        address[] memory signers = new address[](1);
+        signers[0] = safeInstance.owners[0];
+        unorderedExecutionModule.setSigners(signers);
+        vm.warp(block.timestamp + 100);
+
+        vm.prank(address(safeInstance.safe));
+        livenessGuard.checkModuleTransaction(address(0), 0, hex"", Enum.Operation.Call, makeAddr("other module"));
+
+        assertEq(livenessGuard.lastLive(signers[0]), initTime);
+    }
+
+    function test_checkModuleTransaction_unconfiguredModule_doesNotRecordLiveness() external {
+        LivenessGuard_WrappedGuard_Harness guard =
+            new LivenessGuard_WrappedGuard_Harness(safeInstance.safe, IUnorderedExecutionModule(address(0)));
+        vm.warp(block.timestamp + 100);
+
+        vm.prank(address(safeInstance.safe));
+        guard.checkModuleTransaction(address(0), 0, hex"", Enum.Operation.Call, address(unorderedExecutionModule));
+
+        for (uint256 i = 0; i < safeInstance.owners.length; i++) {
+            assertEq(guard.lastLive(safeInstance.owners[i]), initTime);
+        }
+    }
+
+    function test_checkModuleTransaction_signerReadReverts_doesNotRevert() external {
+        unorderedExecutionModule.setShouldRevert(true);
+
+        vm.prank(address(safeInstance.safe));
+        livenessGuard.checkModuleTransaction(
+            address(0), 0, hex"", Enum.Operation.Call, address(unorderedExecutionModule)
+        );
+    }
+
+    function test_checkModuleTransaction_callerIsNotSafe_reverts() external {
+        vm.expectRevert("LivenessGuard: only Safe can call this function");
+        livenessGuard.checkModuleTransaction(
+            address(0), 0, hex"", Enum.Operation.Call, address(unorderedExecutionModule)
+        );
+    }
+
+    function test_checkAfterModuleExecution_reconcilesRemovedOwner() external {
+        address ownerToRemove = safeInstance.owners[0];
+        address prevOwner = safeInstance.getPrevOwner(ownerToRemove);
+
+        vm.startPrank(address(safeInstance.safe));
+        livenessGuard.checkModuleTransaction(address(0), 0, hex"", Enum.Operation.Call, makeAddr("other module"));
+        safeInstance.safe.removeOwner(prevOwner, ownerToRemove, threshold);
+        livenessGuard.checkAfterModuleExecution(bytes32(0), true);
+        vm.stopPrank();
+
+        assertFalse(safeInstance.safe.isOwner(ownerToRemove));
+        assertEq(livenessGuard.lastLive(ownerToRemove), 0);
+        assertEq(livenessGuard.moduleOwnersBeforeLength(), 0);
+        assertEq(livenessGuard.ownersBeforeLength(), 0);
+    }
+
+    function test_checkAfterModuleExecution_callerIsNotSafe_reverts() external {
+        vm.expectRevert("LivenessGuard: only Safe can call this function");
+        livenessGuard.checkAfterModuleExecution(bytes32(0), false);
     }
 }
 
@@ -281,7 +409,9 @@ contract LivenessGuard_Uncategorized_Test is LivenessGuard_TestInit {
         saltNonce = uint256(keccak256(bytes("LIVENESS GUARD OWNER MANAGEMENT TEST")));
         // Create the new safe and register the guard.
         SafeInstance memory safeInstance = _setupSafe(ownerkeys, threshold);
-        livenessGuard = new LivenessGuard_WrappedGuard_Harness(safeInstance.safe);
+        livenessGuard = new LivenessGuard_WrappedGuard_Harness(
+            safeInstance.safe, IUnorderedExecutionModule(address(unorderedExecutionModule))
+        );
         safeInstance.setGuard(address(livenessGuard));
 
         for (uint256 i; i < changes.length; i++) {

--- a/packages/contracts-bedrock/test/safe/LivenessGuard.t.sol
+++ b/packages/contracts-bedrock/test/safe/LivenessGuard.t.sol
@@ -8,7 +8,8 @@ import "test/safe-tools/SafeTestTools.sol";
 // Contracts
 import { Safe } from "safe-contracts/Safe.sol";
 import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
-import { LivenessGuard, IModuleGuard } from "src/safe/LivenessGuard.sol";
+import { LivenessGuard } from "src/safe/LivenessGuard.sol";
+import { IModuleGuard } from "interfaces/safe/IModuleGuard.sol";
 import { IUnorderedExecutionModule } from "interfaces/safe/IUnorderedExecutionModule.sol";
 
 // Libraries
@@ -30,8 +31,10 @@ contract LivenessGuard_WrappedGuard_Harness is LivenessGuard {
     }
 }
 
-/// @notice Minimal stand-in for the UnorderedExecutionModule signer-reporting API.
-contract LivenessGuard_MockUnorderedExecutionModule is IUnorderedExecutionModule {
+/// @notice Minimal stand-in for the UnorderedExecutionModule signer-reporting API. Only the
+///         signers(Safe) getter the guard consumes is implemented, so this does not declare
+///         itself as an IUnorderedExecutionModule implementation.
+contract LivenessGuard_MockUnorderedExecutionModule_Harness {
     address[] internal currentSigners;
     bool internal shouldRevert;
 
@@ -43,8 +46,8 @@ contract LivenessGuard_MockUnorderedExecutionModule is IUnorderedExecutionModule
         shouldRevert = _shouldRevert;
     }
 
-    function signers() external view returns (address[] memory signers_) {
-        require(!shouldRevert, "mock signer read failed");
+    function signers(Safe) external view returns (address[] memory signers_) {
+        require(!shouldRevert, "LivenessGuard_MockUnorderedExecutionModule_Harness: signer read failed");
         signers_ = currentSigners;
     }
 }
@@ -57,7 +60,7 @@ abstract contract LivenessGuard_TestInit is Test, SafeTestTools {
     event OwnerRecorded(address owner);
 
     LivenessGuard_WrappedGuard_Harness livenessGuard;
-    LivenessGuard_MockUnorderedExecutionModule unorderedExecutionModule;
+    LivenessGuard_MockUnorderedExecutionModule_Harness unorderedExecutionModule;
     SafeInstance safeInstance;
 
     // This needs to be non-zero so that the `lastLive` mapping can record non-zero timestamps
@@ -71,7 +74,7 @@ abstract contract LivenessGuard_TestInit is Test, SafeTestTools {
         vm.warp(initTime);
         (, uint256[] memory privKeys) = SafeTestLib.makeAddrsAndKeys("test-owners", ownerCount);
         safeInstance = _setupSafe(privKeys, threshold);
-        unorderedExecutionModule = new LivenessGuard_MockUnorderedExecutionModule();
+        unorderedExecutionModule = new LivenessGuard_MockUnorderedExecutionModule_Harness();
         livenessGuard = new LivenessGuard_WrappedGuard_Harness(
             safeInstance.safe, IUnorderedExecutionModule(address(unorderedExecutionModule))
         );
@@ -185,7 +188,9 @@ contract LivenessGuard_CheckAfterExecution_Test is LivenessGuard_TestInit {
 contract LivenessGuard_CheckModuleTransaction_Test is LivenessGuard_TestInit {
     using SafeTestLib for SafeInstance;
 
-    function test_checkModuleTransaction_trustedModule_recordsValidatedSigners() external {
+    /// @notice Tests that an execution by the trusted module records liveness for exactly the
+    ///         signers the module reports.
+    function test_checkModuleTransaction_trustedModule_succeeds() external {
         address[] memory signers = new address[](2);
         signers[0] = safeInstance.owners[0];
         signers[1] = safeInstance.owners[1];
@@ -205,7 +210,9 @@ contract LivenessGuard_CheckModuleTransaction_Test is LivenessGuard_TestInit {
         }
     }
 
-    function test_checkModuleTransaction_unknownModule_doesNotRecordLiveness() external {
+    /// @notice Tests that an execution by an unknown module records no liveness and does not
+    ///         revert.
+    function test_checkModuleTransaction_unknownModule_succeeds() external {
         address[] memory signers = new address[](1);
         signers[0] = safeInstance.owners[0];
         unorderedExecutionModule.setSigners(signers);
@@ -217,7 +224,9 @@ contract LivenessGuard_CheckModuleTransaction_Test is LivenessGuard_TestInit {
         assertEq(livenessGuard.lastLive(signers[0]), initTime);
     }
 
-    function test_checkModuleTransaction_unconfiguredModule_doesNotRecordLiveness() external {
+    /// @notice Tests that a guard deployed without a trusted module records no liveness on the
+    ///         module path and does not revert.
+    function test_checkModuleTransaction_unconfiguredModule_succeeds() external {
         LivenessGuard_WrappedGuard_Harness guard =
             new LivenessGuard_WrappedGuard_Harness(safeInstance.safe, IUnorderedExecutionModule(address(0)));
         vm.warp(block.timestamp + 100);
@@ -230,10 +239,14 @@ contract LivenessGuard_CheckModuleTransaction_Test is LivenessGuard_TestInit {
         }
     }
 
-    function test_checkModuleTransaction_signerReadReverts_doesNotRevert() external {
+    /// @notice Tests that a revert while reading the trusted module's signers bubbles up. The
+    ///         trusted module is deployed alongside this guard, so a failure there is a bug that
+    ///         should surface loudly rather than silently skip liveness recording.
+    function test_checkModuleTransaction_signerReadReverts_reverts() external {
         unorderedExecutionModule.setShouldRevert(true);
 
         vm.prank(address(safeInstance.safe));
+        vm.expectRevert("LivenessGuard_MockUnorderedExecutionModule_Harness: signer read failed");
         livenessGuard.checkModuleTransaction(
             address(0), 0, hex"", Enum.Operation.Call, address(unorderedExecutionModule)
         );
@@ -246,7 +259,9 @@ contract LivenessGuard_CheckModuleTransaction_Test is LivenessGuard_TestInit {
         );
     }
 
-    function test_checkAfterModuleExecution_reconcilesRemovedOwner() external {
+    /// @notice Tests that the module-path post-hook reconciles an owner removed during the module
+    ///         execution, using the module-path snapshot.
+    function test_checkAfterModuleExecution_removedOwner_succeeds() external {
         address ownerToRemove = safeInstance.owners[0];
         address prevOwner = safeInstance.getPrevOwner(ownerToRemove);
 

--- a/packages/contracts-bedrock/test/safe/LivenessModule.t.sol
+++ b/packages/contracts-bedrock/test/safe/LivenessModule.t.sol
@@ -9,6 +9,7 @@ import "test/safe-tools/SafeTestTools.sol";
 import { Safe } from "safe-contracts/Safe.sol";
 import { LivenessModule } from "src/safe/LivenessModule.sol";
 import { LivenessGuard } from "src/safe/LivenessGuard.sol";
+import { IUnorderedExecutionModule } from "interfaces/safe/IUnorderedExecutionModule.sol";
 
 // Libraries
 import { OwnerManager } from "safe-contracts/base/OwnerManager.sol";
@@ -81,7 +82,7 @@ abstract contract LivenessModule_TestInit is Test, SafeTestTools {
         (, uint256[] memory keys) = SafeTestLib.makeAddrsAndKeys("moduleTest", 10);
         safeInstance = _setupSafe(keys, 8);
 
-        livenessGuard = new LivenessGuard(safeInstance.safe);
+        livenessGuard = new LivenessGuard(safeInstance.safe, IUnorderedExecutionModule(address(0)));
         fallbackOwner = makeAddr("fallbackOwner");
         livenessModule = new LivenessModule({
             _safe: safeInstance.safe,
@@ -287,7 +288,7 @@ contract LivenessModule_RemoveOwners_Test is LivenessModule_TestInit {
         (, uint256[] memory keys) = SafeTestLib.makeAddrsAndKeys("rmOwnersTest", numOwners_);
         uint256 threshold = _getRequiredThreshold(numOwners_, thresholdPercentage_);
         safeInstance = _setupSafe(keys, threshold);
-        livenessGuard = new LivenessGuard(safeInstance.safe);
+        livenessGuard = new LivenessGuard(safeInstance.safe, IUnorderedExecutionModule(address(0)));
         livenessModule = new LivenessModule({
             _safe: safeInstance.safe,
             _livenessGuard: livenessGuard,
@@ -460,7 +461,7 @@ contract LivenessModule_RemoveOwners_Test is LivenessModule_TestInit {
         address[] memory prevOwners = safeInstance.getPrevOwners(ownersToRemove);
 
         // Change the guard
-        livenessGuard = new LivenessGuard(safeInstance.safe);
+        livenessGuard = new LivenessGuard(safeInstance.safe, IUnorderedExecutionModule(address(0)));
         safeInstance.setGuard(address(livenessGuard));
 
         _warpPastLivenessInterval();


### PR DESCRIPTION
Adds Safe v1.5 module-guard support to `LivenessGuard` so owners signing nonceless transactions through `UnorderedExecutionModule` have their liveness recorded.

- Adds `checkModuleTransaction` and `checkAfterModuleExecution` (`IModuleGuard`, interfaceId `0x58401ed8`, vendored in `interfaces/safe/IModuleGuard.sol` — Safe v1.5.0 removed the ability to install guards without ERC-165 support).
- Reads the signer set already validated by the trusted `UnorderedExecutionModule` via `signers(safe)`, matching the module API in #22675. `interfaces/safe/IUnorderedExecutionModule.sol` is byte-identical with that PR so the two merge cleanly in either order.
- Restricts recording to the configured trusted module; executions by any other module (e.g. `LivenessModule` evictions) record nothing and can never be blocked by the guard.
- Reconciles owner changes using separate module-execution bookkeeping; a post-hook with an empty snapshot is a no-op, so nested executions cannot mark every owner as live.
- Adds ERC-165 support for both the transaction-guard and module-guard interfaces (required by Safe v1.5 `setGuard`/`setModuleGuard`).
- Removes redundant owner revalidation because the Safe validated the signers earlier in the same call.
- Updates constructor call sites, adds module-path tests, and regenerates snapshots (semver-lock, abi, storageLayout).

Companion PRs: module #22675, superchain-ops integration ethereum-optimism/superchain-ops#1529.

🤖 Generated with [Claude Code](https://claude.com/claude-code)