### PR TITLE
contracts-bedrock: add UnorderedExecutionModule for nonceless Safe execution

### DIFF
--- a/packages/contracts-bedrock/interfaces/safe/IUnorderedExecutionModule.sol
+++ b/packages/contracts-bedrock/interfaces/safe/IUnorderedExecutionModule.sol
@@ -16,15 +16,25 @@ interface IUnorderedExecutionModule is ISemver {
     error UnorderedExecutionModule_ModuleNotEnabled();
     error UnorderedExecutionModule_HashOnceTooSmall();
     error UnorderedExecutionModule_HashOnceAlreadyUsed();
+    error UnorderedExecutionModule_ReentrantExecution();
     error UnorderedExecutionModule_UnsupportedSafe();
-    error UnorderedExecutionModule_ExecutionFailed(bytes);
+    error UnorderedExecutionModule_ExecutionFailed(bytes data);
 
     event TransactionExecuted(Safe indexed safe, bytes32 indexed txHash, uint256 indexed hashOnce);
 
     function version() external view returns (string memory);
     function __constructor__() external;
     function executed(Safe _safe, uint256 _hashOnce) external view returns (bool executed_);
+    function signers(Safe _safe) external view returns (address[] memory signers_);
     function deriveHashOnce(string memory _input) external pure returns (uint256 hashOnce_);
+    function encodeTransactionData(
+        Safe _safe,
+        ExecTransactionParams calldata _params,
+        uint256 _hashOnce
+    )
+        external
+        view
+        returns (bytes memory txHashData_);
     function transactionHash(
         Safe _safe,
         ExecTransactionParams calldata _params,

--- a/packages/contracts-bedrock/interfaces/safe/IUnorderedExecutionModule.sol
+++ b/packages/contracts-bedrock/interfaces/safe/IUnorderedExecutionModule.sol
@@ -11,32 +11,23 @@ interface IUnorderedExecutionModule is ISemver {
         uint256 value;
         bytes data;
         Enum.Operation operation;
-        uint256 safeTxGas;
-        uint256 baseGas;
-        uint256 gasPrice;
-        address gasToken;
-        address payable refundReceiver;
     }
 
-    error UnorderedExecutionModule_InvalidSafeVersion();
     error UnorderedExecutionModule_ModuleNotEnabled();
     error UnorderedExecutionModule_HashOnceTooSmall();
-    error UnorderedExecutionModule_RefundNotSupported();
-    error UnorderedExecutionModule_AlreadyExecuted();
-    error UnorderedExecutionModule_InsufficientGas();
+    error UnorderedExecutionModule_HashOnceAlreadyUsed();
+    error UnorderedExecutionModule_UnsupportedSafe();
     error UnorderedExecutionModule_ExecutionFailed(bytes);
 
-    error SemverComp_InvalidSemverParts();
-
-    event TransactionExecuted(Safe indexed safe, bytes32 indexed txHash);
+    event TransactionExecuted(Safe indexed safe, bytes32 indexed txHash, uint256 indexed hashOnce);
 
     function version() external view returns (string memory);
     function __constructor__() external;
-    function executed(Safe _safe, bytes32 _txHash) external view returns (bool executed_);
+    function executed(Safe _safe, uint256 _hashOnce) external view returns (bool executed_);
     function deriveHashOnce(string memory _input) external pure returns (uint256 hashOnce_);
     function transactionHash(
         Safe _safe,
-        ExecTransactionParams memory _params,
+        ExecTransactionParams calldata _params,
         uint256 _hashOnce
     )
         external

--- a/packages/contracts-bedrock/interfaces/safe/IUnorderedExecutionModule.sol
+++ b/packages/contracts-bedrock/interfaces/safe/IUnorderedExecutionModule.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import { Safe } from "safe-contracts/Safe.sol";
+import { Enum } from "safe-contracts/common/Enum.sol";
+import { ISemver } from "interfaces/universal/ISemver.sol";
+
+interface IUnorderedExecutionModule is ISemver {
+    struct ExecTransactionParams {
+        address to;
+        uint256 value;
+        bytes data;
+        Enum.Operation operation;
+        uint256 safeTxGas;
+        uint256 baseGas;
+        uint256 gasPrice;
+        address gasToken;
+        address payable refundReceiver;
+    }
+
+    error UnorderedExecutionModule_InvalidSafeVersion();
+    error UnorderedExecutionModule_ModuleNotEnabled();
+    error UnorderedExecutionModule_HashOnceTooSmall();
+    error UnorderedExecutionModule_RefundNotSupported();
+    error UnorderedExecutionModule_AlreadyExecuted();
+    error UnorderedExecutionModule_InsufficientGas();
+    error UnorderedExecutionModule_ExecutionFailed(bytes);
+
+    error SemverComp_InvalidSemverParts();
+
+    event TransactionExecuted(Safe indexed safe, bytes32 indexed txHash);
+
+    function version() external view returns (string memory);
+    function __constructor__() external;
+    function executed(Safe _safe, bytes32 _txHash) external view returns (bool executed_);
+    function deriveHashOnce(string memory _input) external pure returns (uint256 hashOnce_);
+    function transactionHash(
+        Safe _safe,
+        ExecTransactionParams memory _params,
+        uint256 _hashOnce
+    )
+        external
+        view
+        returns (bytes32 txHash_);
+    function execute(
+        Safe _safe,
+        ExecTransactionParams calldata _params,
+        uint256 _hashOnce,
+        bytes calldata _signatures
+    )
+        external
+        returns (bytes memory returnData_);
+}

--- a/packages/contracts-bedrock/snapshots/abi/UnorderedExecutionModule.json
+++ b/packages/contracts-bedrock/snapshots/abi/UnorderedExecutionModule.json
@@ -1,0 +1,280 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "_input",
+        "type": "string"
+      }
+    ],
+    "name": "deriveHashOnce",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "hashOnce_",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract Safe",
+        "name": "_safe",
+        "type": "address"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "to",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "value",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes",
+            "name": "data",
+            "type": "bytes"
+          },
+          {
+            "internalType": "enum Enum.Operation",
+            "name": "operation",
+            "type": "uint8"
+          },
+          {
+            "internalType": "uint256",
+            "name": "safeTxGas",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "baseGas",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "gasPrice",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "gasToken",
+            "type": "address"
+          },
+          {
+            "internalType": "address payable",
+            "name": "refundReceiver",
+            "type": "address"
+          }
+        ],
+        "internalType": "struct UnorderedExecutionModule.ExecTransactionParams",
+        "name": "_params",
+        "type": "tuple"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_hashOnce",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_signatures",
+        "type": "bytes"
+      }
+    ],
+    "name": "execute",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "returnData_",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract Safe",
+        "name": "_safe",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "_txHash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "executed",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "executed_",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract Safe",
+        "name": "_safe",
+        "type": "address"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "to",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "value",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes",
+            "name": "data",
+            "type": "bytes"
+          },
+          {
+            "internalType": "enum Enum.Operation",
+            "name": "operation",
+            "type": "uint8"
+          },
+          {
+            "internalType": "uint256",
+            "name": "safeTxGas",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "baseGas",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "gasPrice",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "gasToken",
+            "type": "address"
+          },
+          {
+            "internalType": "address payable",
+            "name": "refundReceiver",
+            "type": "address"
+          }
+        ],
+        "internalType": "struct UnorderedExecutionModule.ExecTransactionParams",
+        "name": "_params",
+        "type": "tuple"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_hashOnce",
+        "type": "uint256"
+      }
+    ],
+    "name": "transactionHash",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "txHash_",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "version",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "contract Safe",
+        "name": "safe",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "txHash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "TransactionExecuted",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "SemverComp_InvalidSemverParts",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "UnorderedExecutionModule_AlreadyExecuted",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "name": "UnorderedExecutionModule_ExecutionFailed",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "UnorderedExecutionModule_HashOnceTooSmall",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "UnorderedExecutionModule_InsufficientGas",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "UnorderedExecutionModule_InvalidSafeVersion",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "UnorderedExecutionModule_ModuleNotEnabled",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "UnorderedExecutionModule_RefundNotSupported",
+    "type": "error"
+  }
+]

--- a/packages/contracts-bedrock/snapshots/abi/UnorderedExecutionModule.json
+++ b/packages/contracts-bedrock/snapshots/abi/UnorderedExecutionModule.json
@@ -46,31 +46,6 @@
             "internalType": "enum Enum.Operation",
             "name": "operation",
             "type": "uint8"
-          },
-          {
-            "internalType": "uint256",
-            "name": "safeTxGas",
-            "type": "uint256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "baseGas",
-            "type": "uint256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "gasPrice",
-            "type": "uint256"
-          },
-          {
-            "internalType": "address",
-            "name": "gasToken",
-            "type": "address"
-          },
-          {
-            "internalType": "address payable",
-            "name": "refundReceiver",
-            "type": "address"
           }
         ],
         "internalType": "struct UnorderedExecutionModule.ExecTransactionParams",
@@ -107,9 +82,9 @@
         "type": "address"
       },
       {
-        "internalType": "bytes32",
-        "name": "_txHash",
-        "type": "bytes32"
+        "internalType": "uint256",
+        "name": "_hashOnce",
+        "type": "uint256"
       }
     ],
     "name": "executed",
@@ -151,31 +126,6 @@
             "internalType": "enum Enum.Operation",
             "name": "operation",
             "type": "uint8"
-          },
-          {
-            "internalType": "uint256",
-            "name": "safeTxGas",
-            "type": "uint256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "baseGas",
-            "type": "uint256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "gasPrice",
-            "type": "uint256"
-          },
-          {
-            "internalType": "address",
-            "name": "gasToken",
-            "type": "address"
-          },
-          {
-            "internalType": "address payable",
-            "name": "refundReceiver",
-            "type": "address"
           }
         ],
         "internalType": "struct UnorderedExecutionModule.ExecTransactionParams",
@@ -226,20 +176,16 @@
         "internalType": "bytes32",
         "name": "txHash",
         "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "hashOnce",
+        "type": "uint256"
       }
     ],
     "name": "TransactionExecuted",
     "type": "event"
-  },
-  {
-    "inputs": [],
-    "name": "SemverComp_InvalidSemverParts",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "UnorderedExecutionModule_AlreadyExecuted",
-    "type": "error"
   },
   {
     "inputs": [
@@ -254,17 +200,12 @@
   },
   {
     "inputs": [],
+    "name": "UnorderedExecutionModule_HashOnceAlreadyUsed",
+    "type": "error"
+  },
+  {
+    "inputs": [],
     "name": "UnorderedExecutionModule_HashOnceTooSmall",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "UnorderedExecutionModule_InsufficientGas",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "UnorderedExecutionModule_InvalidSafeVersion",
     "type": "error"
   },
   {
@@ -274,7 +215,7 @@
   },
   {
     "inputs": [],
-    "name": "UnorderedExecutionModule_RefundNotSupported",
+    "name": "UnorderedExecutionModule_UnsupportedSafe",
     "type": "error"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/abi/UnorderedExecutionModule.json
+++ b/packages/contracts-bedrock/snapshots/abi/UnorderedExecutionModule.json
@@ -56,6 +56,57 @@
         "internalType": "uint256",
         "name": "_hashOnce",
         "type": "uint256"
+      }
+    ],
+    "name": "encodeTransactionData",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "txHashData_",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract Safe",
+        "name": "_safe",
+        "type": "address"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "to",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "value",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes",
+            "name": "data",
+            "type": "bytes"
+          },
+          {
+            "internalType": "enum Enum.Operation",
+            "name": "operation",
+            "type": "uint8"
+          }
+        ],
+        "internalType": "struct UnorderedExecutionModule.ExecTransactionParams",
+        "name": "_params",
+        "type": "tuple"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_hashOnce",
+        "type": "uint256"
       },
       {
         "internalType": "bytes",
@@ -93,6 +144,25 @@
         "internalType": "bool",
         "name": "executed_",
         "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract Safe",
+        "name": "_safe",
+        "type": "address"
+      }
+    ],
+    "name": "signers",
+    "outputs": [
+      {
+        "internalType": "address[]",
+        "name": "signers_",
+        "type": "address[]"
       }
     ],
     "stateMutability": "view",
@@ -191,7 +261,7 @@
     "inputs": [
       {
         "internalType": "bytes",
-        "name": "",
+        "name": "data",
         "type": "bytes"
       }
     ],
@@ -211,6 +281,11 @@
   {
     "inputs": [],
     "name": "UnorderedExecutionModule_ModuleNotEnabled",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "UnorderedExecutionModule_ReentrantExecution",
     "type": "error"
   },
   {

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -215,6 +215,10 @@
     "initCodeHash": "0x841042eeab4ff85b371aae0c4ee9c17b0a0757bca04fb8ce3054cc7503df9ace",
     "sourceCodeHash": "0x426f80c0cb5e237c87326daeb2bda675ab9a54531405f108075c8b8aa4743b48"
   },
+  "src/safe/UnorderedExecutionModule.sol:UnorderedExecutionModule": {
+    "initCodeHash": "0x56016cb1008e2851e7a2fc7ee936bf874d6813f858501c32deded8b0249dee5a",
+    "sourceCodeHash": "0x76b29c7463ef6e5b5bc42a200dbab4fcb61bbeabb78d971189d36d775a28f306"
+  },
   "src/universal/OptimismMintableERC20.sol:OptimismMintableERC20": {
     "initCodeHash": "0x3c85eed0d017dca8eda6396aa842ddc12492587b061e8c756a8d32c4610a9658",
     "sourceCodeHash": "0x7023665d461f173417d932b55010b8f6c34f2bbaf56cfe4e1b15862c08cbcaac"

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -216,8 +216,8 @@
     "sourceCodeHash": "0x426f80c0cb5e237c87326daeb2bda675ab9a54531405f108075c8b8aa4743b48"
   },
   "src/safe/UnorderedExecutionModule.sol:UnorderedExecutionModule": {
-    "initCodeHash": "0xd2b5091ad328fa49f2a6aebe338d41321278df73bcb9e3dba150706b3fdfae24",
-    "sourceCodeHash": "0xd404373e3a68df607bc17a1b1b6eadbc15761a30b8232e7144f098a1a4d17e13"
+    "initCodeHash": "0x74d2de3493cd643b971df1df7c2a7b8aff0db5e567d100dace7de8b05514440f",
+    "sourceCodeHash": "0x2dcd9c2ba71ba011f50874e91fcab86a549e684e34154ce176792adb0e93f749"
   },
   "src/universal/OptimismMintableERC20.sol:OptimismMintableERC20": {
     "initCodeHash": "0x3c85eed0d017dca8eda6396aa842ddc12492587b061e8c756a8d32c4610a9658",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -216,8 +216,8 @@
     "sourceCodeHash": "0x426f80c0cb5e237c87326daeb2bda675ab9a54531405f108075c8b8aa4743b48"
   },
   "src/safe/UnorderedExecutionModule.sol:UnorderedExecutionModule": {
-    "initCodeHash": "0x14371535f9c484ce26c7f5fed13507c1e71529e2f7ec1fbe7295556773e88f0b",
-    "sourceCodeHash": "0x1d90e50fb4579bd6e3b00b3ff0a3e918f44c34de29c0b47a50d8f908856a96b8"
+    "initCodeHash": "0xd2b5091ad328fa49f2a6aebe338d41321278df73bcb9e3dba150706b3fdfae24",
+    "sourceCodeHash": "0xd404373e3a68df607bc17a1b1b6eadbc15761a30b8232e7144f098a1a4d17e13"
   },
   "src/universal/OptimismMintableERC20.sol:OptimismMintableERC20": {
     "initCodeHash": "0x3c85eed0d017dca8eda6396aa842ddc12492587b061e8c756a8d32c4610a9658",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -216,8 +216,8 @@
     "sourceCodeHash": "0x426f80c0cb5e237c87326daeb2bda675ab9a54531405f108075c8b8aa4743b48"
   },
   "src/safe/UnorderedExecutionModule.sol:UnorderedExecutionModule": {
-    "initCodeHash": "0x56016cb1008e2851e7a2fc7ee936bf874d6813f858501c32deded8b0249dee5a",
-    "sourceCodeHash": "0x76b29c7463ef6e5b5bc42a200dbab4fcb61bbeabb78d971189d36d775a28f306"
+    "initCodeHash": "0x14371535f9c484ce26c7f5fed13507c1e71529e2f7ec1fbe7295556773e88f0b",
+    "sourceCodeHash": "0x1d90e50fb4579bd6e3b00b3ff0a3e918f44c34de29c0b47a50d8f908856a96b8"
   },
   "src/universal/OptimismMintableERC20.sol:OptimismMintableERC20": {
     "initCodeHash": "0x3c85eed0d017dca8eda6396aa842ddc12492587b061e8c756a8d32c4610a9658",

--- a/packages/contracts-bedrock/snapshots/storageLayout/UnorderedExecutionModule.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/UnorderedExecutionModule.json
@@ -1,0 +1,9 @@
+[
+  {
+    "bytes": "32",
+    "label": "_executed",
+    "offset": 0,
+    "slot": "0",
+    "type": "mapping(contract Safe => mapping(bytes32 => bool))"
+  }
+]

--- a/packages/contracts-bedrock/snapshots/storageLayout/UnorderedExecutionModule.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/UnorderedExecutionModule.json
@@ -4,6 +4,6 @@
     "label": "_executed",
     "offset": 0,
     "slot": "0",
-    "type": "mapping(contract Safe => mapping(bytes32 => bool))"
+    "type": "mapping(contract Safe => mapping(uint256 => bool))"
   }
 ]

--- a/packages/contracts-bedrock/src/safe/UnorderedExecutionModule.sol
+++ b/packages/contracts-bedrock/src/safe/UnorderedExecutionModule.sol
@@ -5,6 +5,10 @@ pragma solidity 0.8.25;
 import { Safe } from "safe-contracts/Safe.sol";
 import { Enum } from "safe-contracts/common/Enum.sol";
 
+// Libraries
+import { SafeSigners } from "src/safe/SafeSigners.sol";
+import { TransientContext } from "src/libraries/TransientContext.sol";
+
 // Interfaces
 import { ISemver } from "interfaces/universal/ISemver.sol";
 
@@ -40,25 +44,42 @@ import { ISemver } from "interfaces/universal/ISemver.sol";
 ///     executed. Until a task's hash-once value has been consumed, its signatures remain valid
 ///     indefinitely; they are checked against the Safe's *current* owner set and threshold, so
 ///     rotating owners or raising the threshold also invalidates them.
+/// Liveness guard support:
+///     For the duration of the task's call, the addresses recovered from the authorizing
+///     signatures are stored and exposed via signers(), so that a module guard invoked by the
+///     Safe (checkModuleTransaction(), available from Safe 1.5.0) — e.g. a liveness guard — can
+///     read which owners approved the transaction and record their liveness. The array lives in
+///     transient storage and is cleared before execute() returns. On Safe versions before
+///     1.5.0, module transactions invoke no guard and the array simply goes unread.
 /// Security notes:
-///     - Module transactions are NOT inspected by a transaction guard on Safe versions 1.3.0 and
-///       1.4.1, so transactions executed through this module bypass any guard (e.g. a timelock
-///       guard) enabled on the Safe.
+///     - On Safe versions before 1.5.0, module transactions are NOT inspected by any guard, so
+///       transactions executed through this module bypass e.g. a timelock guard enabled on the
+///       Safe. From 1.5.0 a module guard set via setModuleGuard() inspects them.
 ///     - The relayer chooses the gas for execute(). A failed call reverts and leaves the
 ///       hash-once value unconsumed, but a target that swallows an inner failure — a nested
 ///       Safe's execTransaction(), or a multicall that allows failures — can report success on
 ///       a partial, possibly gas-starved execution and consume the hash-once value anyway. Task
 ///       authors should route calls through failure-propagating targets such as
 ///       MultiSendCallOnly.
+///     - execute() is non-reentrant per Safe, so the exposed signers always belong to the one
+///       transaction in flight for that Safe. A task must not execute another task for the same
+///       Safe from within its call.
+///     - Replay protection lives in this module's storage, so it is scoped per module instance:
+///       a Safe must never have more than one instance of this module enabled at a time, or the
+///       same signatures could execute the same transaction once through each instance.
 /// Safe compatibility:
-///     Works with Safes exposing the 1.3.0/1.4.1 interfaces this module relies on:
-///     encodeTransactionData(), getTransactionHash(), checkSignatures(bytes32,bytes,bytes),
-///     isModuleEnabled() and execTransactionFromModuleReturnData(). Rather than pinning
-///     versions, execute() verifies the single property that could otherwise diverge silently —
-///     that getTransactionHash() is the keccak256 of encodeTransactionData(). All other
-///     semantics of those functions (signature checking, domain separation) are trusted as-is,
-///     so the module should only be enabled on Safe versions known to implement them correctly;
-///     1.3.0 and 1.4.1 do. Tests exercise the vendored 1.4.1 implementation.
+///     Works with Safes exposing the interfaces this module relies on, all present in 1.3.0,
+///     1.4.1 and 1.5.0: domainSeparator(), getTransactionHash(),
+///     checkSignatures(bytes32,bytes,bytes), getThreshold(), isModuleEnabled() and
+///     execTransactionFromModuleReturnData(). The module builds the EIP-712 transaction
+///     encoding itself (Safe 1.5.0 removed encodeTransactionData()) and execute() verifies it
+///     against the Safe's getTransactionHash(), rejecting any Safe whose hashing scheme
+///     diverges. The encoding is passed to checkSignatures() as the preimage that EIP-1271
+///     owners validate on 1.3.0/1.4.1; Safe 1.5.0 ignores it and has EIP-1271 owners validate
+///     the transaction hash directly. All other semantics of those functions (signature
+///     checking, domain separation) are trusted as-is, so the module should only be enabled on
+///     Safe versions known to implement them correctly; 1.3.0, 1.4.1 and 1.5.0 do. Tests
+///     exercise the vendored 1.4.1 implementation.
 contract UnorderedExecutionModule is ISemver {
     /// @notice Parameters for the Safe transaction being executed. These are the fields
     ///         execTransactionFromModuleReturnData() consumes; the remaining fields of the
@@ -86,18 +107,35 @@ contract UnorderedExecutionModule is ISemver {
     /// @notice Error for when the hash-once value has already been consumed by an execution.
     error UnorderedExecutionModule_HashOnceAlreadyUsed();
 
+    /// @notice Error for when a task's call re-enters execute() for the same Safe.
+    error UnorderedExecutionModule_ReentrantExecution();
+
     /// @notice Error for when the Safe's transaction hashing diverges from the scheme this
     ///         module relies on.
     error UnorderedExecutionModule_UnsupportedSafe();
 
     /// @notice Error for when the transaction's call reverts, carrying the raw revert data.
-    error UnorderedExecutionModule_ExecutionFailed(bytes);
+    error UnorderedExecutionModule_ExecutionFailed(bytes data);
 
     /// @notice Emitted when a transaction is executed.
     /// @param safe The Safe the transaction was executed through.
     /// @param txHash The Safe transaction hash identifying the transaction.
     /// @param hashOnce The hash-once value consumed by the execution.
     event TransactionExecuted(Safe indexed safe, bytes32 indexed txHash, uint256 indexed hashOnce);
+
+    /// @notice EIP-712 typehash of a Safe transaction, identical across Safe 1.3.0, 1.4.1 and
+    ///         1.5.0 (0xbb8310d486368db6bd6f849402fdd73ad53d316b5a4b2644ad6efe0f941286d8).
+    bytes32 internal constant SAFE_TX_TYPEHASH = keccak256(
+        "SafeTx(address to,uint256 value,bytes data,uint8 operation,uint256 safeTxGas,uint256 baseGas,uint256 gasPrice,address gasToken,address refundReceiver,uint256 nonce)"
+    );
+
+    /// @notice Seed for the per-Safe transient storage slots holding the signers of the
+    ///         transaction currently being executed. The array length lives at the derived base
+    ///         slot and element i at base + 1 + i.
+    bytes32 internal constant SIGNERS_SLOT_SEED = keccak256("UnorderedExecutionModule.signers");
+
+    /// @notice Seed for the per-Safe transient reentrancy lock slot.
+    bytes32 internal constant LOCK_SLOT_SEED = keccak256("UnorderedExecutionModule.lock");
 
     /// @notice Hash-once values that have been consumed by an execution, keyed by Safe.
     mapping(Safe => mapping(uint256 => bool)) internal _executed;
@@ -107,27 +145,87 @@ contract UnorderedExecutionModule is ISemver {
     string public constant version = "1.0.0-beta.1";
 
     /// @notice Getter function for whether a hash-once value has been consumed.
+    ///
     /// @param _safe The Safe the hash-once value belongs to.
     /// @param _hashOnce The hash-once value.
+    ///
     /// @return executed_ Whether the hash-once value has been consumed by an execution.
     function executed(Safe _safe, uint256 _hashOnce) public view returns (bool executed_) {
         executed_ = _executed[_safe][_hashOnce];
     }
 
+    /// @notice Getter function for the signers of the transaction currently being executed.
+    ///         Non-empty only while a task's call is in flight, so that a module guard (e.g. a
+    ///         liveness guard) invoked during the call can read which owners approved it.
+    ///
+    /// @param _safe The Safe whose in-flight transaction signers to return.
+    ///
+    /// @return signers_ Addresses recovered from the authorizing signatures, or an empty array
+    ///                  when no transaction is being executed for the Safe.
+    function signers(Safe _safe) public view returns (address[] memory signers_) {
+        bytes32 slot = _signersSlot(_safe);
+        uint256 length = TransientContext.get(slot);
+        signers_ = new address[](length);
+        for (uint256 i; i < length; i++) {
+            signers_[i] = address(uint160(TransientContext.get(bytes32(uint256(slot) + 1 + i))));
+        }
+    }
+
     /// @notice Derives a canonical hash-once value from a unique string, e.g. the hashOnceInput
     ///         pinned in a superchain-ops task's configuration.
+    ///
     /// @param _input Unique string identifying the task.
+    ///
     /// @return hashOnce_ Hash-once value to use as the transaction's nonce.
     function deriveHashOnce(string memory _input) public pure returns (uint256 hashOnce_) {
         hashOnce_ = uint256(keccak256(bytes(_input)));
     }
 
-    /// @notice Computes the Safe transaction hash that owners must sign to authorize a
-    ///         transaction. Identical to the Safe's own getTransactionHash() with the hash-once
-    ///         value in the nonce slot and zeroed gas and refund fields.
+    /// @notice Computes the EIP-712 encoding of the transaction with the hash-once value in the
+    ///         nonce slot and zeroed gas and refund fields — the preimage of transactionHash().
+    ///         Built locally because Safe 1.5.0 removed encodeTransactionData(); execute()
+    ///         verifies it against the Safe's own getTransactionHash().
+    ///
     /// @param _safe The Safe the transaction is to be executed through.
     /// @param _params The parameters of the transaction.
     /// @param _hashOnce The transaction's hash-once value.
+    ///
+    /// @return txHashData_ EIP-712 encoded transaction data.
+    function encodeTransactionData(
+        Safe _safe,
+        ExecTransactionParams calldata _params,
+        uint256 _hashOnce
+    )
+        public
+        view
+        returns (bytes memory txHashData_)
+    {
+        bytes32 safeTxHash = keccak256(
+            abi.encode(
+                SAFE_TX_TYPEHASH,
+                _params.to,
+                _params.value,
+                keccak256(_params.data),
+                _params.operation,
+                uint256(0),
+                uint256(0),
+                uint256(0),
+                address(0),
+                address(0),
+                _hashOnce
+            )
+        );
+        txHashData_ = abi.encodePacked(bytes1(0x19), bytes1(0x01), _safe.domainSeparator(), safeTxHash);
+    }
+
+    /// @notice Computes the Safe transaction hash that owners must sign to authorize a
+    ///         transaction. Identical to the Safe's own getTransactionHash() with the hash-once
+    ///         value in the nonce slot and zeroed gas and refund fields.
+    ///
+    /// @param _safe The Safe the transaction is to be executed through.
+    /// @param _params The parameters of the transaction.
+    /// @param _hashOnce The transaction's hash-once value.
+    ///
     /// @return txHash_ Safe transaction hash of the transaction.
     function transactionHash(
         Safe _safe,
@@ -147,12 +245,14 @@ contract UnorderedExecutionModule is ISemver {
     ///         Callable by anyone, matching the relay model of the Safe's own execTransaction().
     ///         Reverts if the transaction's call reverts, leaving the hash-once value unconsumed
     ///         so that the transaction can be retried.
+    ///
     /// @param _safe The Safe to execute the transaction through.
     /// @param _params The parameters of the transaction.
     /// @param _hashOnce The transaction's hash-once value. Must be greater than
     ///                  type(uint128).max.
     /// @param _signatures Owner signatures over transactionHash(), in the format accepted by the
     ///                    Safe's checkSignatures() function.
+    ///
     /// @return returnData_ Return data of the transaction's call.
     function execute(
         Safe _safe,
@@ -163,6 +263,14 @@ contract UnorderedExecutionModule is ISemver {
         external
         returns (bytes memory returnData_)
     {
+        // Lock per Safe so that a task's call cannot re-enter execute() for the same Safe,
+        // which would overwrite and then clear the signers exposed for the outer transaction
+        // while it is still in flight.
+        if (TransientContext.get(_lockSlot(_safe)) != 0) {
+            revert UnorderedExecutionModule_ReentrantExecution();
+        }
+        TransientContext.set(_lockSlot(_safe), 1);
+
         // The Safe itself would reject the module call, but checking here gives a clear error.
         if (!_safe.isModuleEnabled(address(this))) {
             revert UnorderedExecutionModule_ModuleNotEnabled();
@@ -181,11 +289,12 @@ contract UnorderedExecutionModule is ISemver {
         }
 
         bytes32 txHash = transactionHash(_safe, _params, _hashOnce);
-        bytes memory txHashData = _encodeTransactionData(_safe, _params, _hashOnce);
+        bytes memory txHashData = encodeTransactionData(_safe, _params, _hashOnce);
 
-        // The digest owners sign must be the hash of the preimage passed to checkSignatures(),
-        // or EIP-1271 owners would validate different data than what was signed. This holds on
-        // Safe 1.3.0 and 1.4.1; a Safe whose hashing scheme diverges is rejected.
+        // The digest owners sign must be the hash of the locally built encoding, or the encoding
+        // passed to checkSignatures() below would not be the preimage EIP-1271 owners validate
+        // on Safe 1.3.0/1.4.1. This holds on 1.3.0, 1.4.1 and 1.5.0; a Safe whose hashing
+        // scheme diverges is rejected.
         if (keccak256(txHashData) != txHash) {
             revert UnorderedExecutionModule_UnsupportedSafe();
         }
@@ -194,14 +303,23 @@ contract UnorderedExecutionModule is ISemver {
         // threshold apply and all Safe-supported signing methods work. Reverts if invalid.
         _safe.checkSignatures(txHash, txHashData, _signatures);
 
-        // Consume the hash-once value before the external call so that the call cannot re-enter
-        // and execute the same transaction again.
+        // Consume the hash-once value before the external call so that the call cannot execute
+        // the same transaction again.
         _executed[_safe][_hashOnce] = true;
+
+        // Expose the approving signers for the duration of the call, so that a module guard
+        // (e.g. a liveness guard) invoked by the Safe can read them via signers().
+        _setSigners(_safe, SafeSigners.getNSigners(txHash, _signatures, _safe.getThreshold()));
 
         // Execute the transaction through the Safe.
         bool success;
         (success, returnData_) =
             _safe.execTransactionFromModuleReturnData(_params.to, _params.value, _params.data, _params.operation);
+
+        // Clear the exposed signers and release the lock now that the call has completed, so a
+        // later execution in the same transaction can never observe them.
+        TransientContext.set(_signersSlot(_safe), 0);
+        TransientContext.set(_lockSlot(_safe), 0);
 
         // Unlike the Safe's execTransaction(), revert if the call failed. The revert unwinds the
         // consumed hash-once value so the transaction can be retried.
@@ -212,25 +330,33 @@ contract UnorderedExecutionModule is ISemver {
         emit TransactionExecuted(_safe, txHash, _hashOnce);
     }
 
-    /// @notice Fetches the Safe's own encoding of the transaction with the hash-once value in
-    ///         the nonce slot. Kept as a helper rather than inlined into execute() because the
-    ///         ten-argument external call exceeds the stack limit of non-via-ir compilation
-    ///         there.
-    /// @param _safe The Safe the transaction is to be executed through.
-    /// @param _params The parameters of the transaction.
-    /// @param _hashOnce The transaction's hash-once value.
-    /// @return txHashData_ Encoded transaction data.
-    function _encodeTransactionData(
-        Safe _safe,
-        ExecTransactionParams calldata _params,
-        uint256 _hashOnce
-    )
-        internal
-        view
-        returns (bytes memory txHashData_)
-    {
-        txHashData_ = _safe.encodeTransactionData(
-            _params.to, _params.value, _params.data, _params.operation, 0, 0, 0, address(0), address(0), _hashOnce
-        );
+    /// @notice Derives the base transient storage slot for a Safe's exposed signers.
+    ///
+    /// @param _safe The Safe to derive the slot for.
+    ///
+    /// @return slot_ Base transient storage slot.
+    function _signersSlot(Safe _safe) internal pure returns (bytes32 slot_) {
+        slot_ = keccak256(abi.encode(SIGNERS_SLOT_SEED, _safe));
+    }
+
+    /// @notice Derives the transient storage slot for a Safe's reentrancy lock.
+    ///
+    /// @param _safe The Safe to derive the slot for.
+    ///
+    /// @return slot_ Transient storage slot of the lock.
+    function _lockSlot(Safe _safe) internal pure returns (bytes32 slot_) {
+        slot_ = keccak256(abi.encode(LOCK_SLOT_SEED, _safe));
+    }
+
+    /// @notice Writes the signers of the transaction being executed to transient storage.
+    ///
+    /// @param _safe The Safe the transaction is being executed through.
+    /// @param _txSigners Addresses recovered from the authorizing signatures.
+    function _setSigners(Safe _safe, address[] memory _txSigners) internal {
+        bytes32 slot = _signersSlot(_safe);
+        TransientContext.set(slot, _txSigners.length);
+        for (uint256 i; i < _txSigners.length; i++) {
+            TransientContext.set(bytes32(uint256(slot) + 1 + i), uint256(uint160(_txSigners[i])));
+        }
     }
 }

--- a/packages/contracts-bedrock/src/safe/UnorderedExecutionModule.sol
+++ b/packages/contracts-bedrock/src/safe/UnorderedExecutionModule.sol
@@ -141,8 +141,8 @@ contract UnorderedExecutionModule is ISemver {
     mapping(Safe => mapping(uint256 => bool)) internal _executed;
 
     /// @notice Semantic version.
-    /// @custom:semver 1.0.0-beta.1
-    string public constant version = "1.0.0-beta.1";
+    /// @custom:semver 0.1.0
+    string public constant version = "0.1.0";
 
     /// @notice Getter function for whether a hash-once value has been consumed.
     ///

--- a/packages/contracts-bedrock/src/safe/UnorderedExecutionModule.sol
+++ b/packages/contracts-bedrock/src/safe/UnorderedExecutionModule.sol
@@ -5,9 +5,6 @@ pragma solidity 0.8.25;
 import { Safe } from "safe-contracts/Safe.sol";
 import { Enum } from "safe-contracts/common/Enum.sol";
 
-// Libraries
-import { SemverComp } from "src/libraries/SemverComp.sol";
-
 // Interfaces
 import { ISemver } from "interfaces/universal/ISemver.sol";
 
@@ -21,72 +18,63 @@ import { ISemver } from "interfaces/universal/ISemver.sol";
 /// Usage:
 ///     The Safe must first enable this module via ModuleManager.enableModule(). Owners then sign
 ///     the digest returned by transactionHash() — which is exactly the Safe's own
-///     getTransactionHash() with the hash-once value as the nonce — using any method the Safe
-///     itself supports: private key signatures, Safe.approveHash(), or EIP-1271 contract
-///     signatures (including nested Safes). Existing Safe signing tooling works unchanged.
-///     Once a threshold of signatures has been collected, anyone may call execute() — the same
-///     permissionless-relay model as the Safe's own execTransaction().
+///     getTransactionHash() with the hash-once value as the nonce and the gas and refund fields
+///     (safeTxGas, baseGas, gasPrice, gasToken, refundReceiver) all zero, matching how
+///     superchain-ops tasks are signed — using any method the Safe itself supports: private key
+///     signatures, Safe.approveHash(), or EIP-1271 contract signatures (including nested Safes).
+///     Existing Safe signing tooling works unchanged. Once a threshold of signatures has been
+///     collected, anyone may call execute() — the same permissionless-relay model as the Safe's
+///     own execTransaction().
 /// Hash-once values:
 ///     The hash-once value must be unique per task and strictly greater than type(uint128).max,
 ///     so that it can never collide with the Safe's real sequential nonce. Without this floor, a
 ///     signature produced for this module could also become executable through the ordinary
-///     execTransaction() path once the Safe's nonce reached the same value. deriveHashOnce()
+///     execTransaction() path once the Safe's nonce reached the same value — a collision we
+///     realize is extremely unlikely, but the floor makes it impossible. deriveHashOnce()
 ///     computes a canonical value from a unique string.
 /// Replay protection and cancellation:
-///     Each (Safe, transaction hash) pair can be executed at most once. There is no on-chain
-///     cancellation or expiry: abandoning a signed task is handled off-chain by changing the
-///     task's hash-once input and re-signing, and the abandoned signatures simply go unused.
-///     Note that abandoned signatures remain technically executable indefinitely; signatures are
-///     verified against the Safe's *current* owner set and threshold, so rotating owners or
-///     raising the threshold invalidates them.
-/// Signature validity:
-///     Signatures are verified with the Safe's own checkSignatures() logic at execution time.
-///     The Safe's EIP-712 domain separator binds the Safe address and chain id, so a signature
-///     cannot be replayed against another Safe or chain.
+///     Each (Safe, hash-once value) pair can be executed at most once. There is no on-chain
+///     cancellation or expiry mechanism: to cancel a signed task, sign and execute a no-op
+///     transaction (e.g. a zero-value call to address(0)) using the same hash-once value. The
+///     no-op consumes the hash-once value and permanently prevents the unwanted task from being
+///     executed. Until a task's hash-once value has been consumed, its signatures remain valid
+///     indefinitely; they are checked against the Safe's *current* owner set and threshold, so
+///     rotating owners or raising the threshold also invalidates them.
 /// Security notes:
 ///     - Module transactions are NOT inspected by a transaction guard on Safe versions 1.3.0 and
 ///       1.4.1, so transactions executed through this module bypass any guard (e.g. a timelock
 ///       guard) enabled on the Safe.
-///     - The signed safeTxGas field is honored as a minimum gas commitment, so a relayer cannot
-///       cause a partial, low-gas execution that would otherwise permanently consume the
-///       transaction. Gas refund fields (gasPrice, gasToken, refundReceiver) are part of the
-///       signed payload but refunds are not paid by this module, so gasPrice must be zero.
-/// Safe Version Compatibility:
-///     Compatible with Safe versions 1.3.0 and 1.4.1, which share the encodeTransactionData(),
-///     checkSignatures(), isModuleEnabled() and execTransactionFromModuleReturnData() interfaces
-///     this module relies on.
+///     - The relayer chooses the gas for execute(). A failed call reverts and leaves the
+///       hash-once value unconsumed, but a target that swallows an inner failure — a nested
+///       Safe's execTransaction(), or a multicall that allows failures — can report success on
+///       a partial, possibly gas-starved execution and consume the hash-once value anyway. Task
+///       authors should route calls through failure-propagating targets such as
+///       MultiSendCallOnly.
+/// Safe compatibility:
+///     Works with Safes exposing the 1.3.0/1.4.1 interfaces this module relies on:
+///     encodeTransactionData(), getTransactionHash(), checkSignatures(bytes32,bytes,bytes),
+///     isModuleEnabled() and execTransactionFromModuleReturnData(). Rather than pinning
+///     versions, execute() verifies the single property that could otherwise diverge silently —
+///     that getTransactionHash() is the keccak256 of encodeTransactionData(). All other
+///     semantics of those functions (signature checking, domain separation) are trusted as-is,
+///     so the module should only be enabled on Safe versions known to implement them correctly;
+///     1.3.0 and 1.4.1 do. Tests exercise the vendored 1.4.1 implementation.
 contract UnorderedExecutionModule is ISemver {
-    /// @notice Parameters for the Safe transaction being executed, matching the fields of the
-    ///         Safe's own execTransaction() with the nonce supplied separately as the hash-once
+    /// @notice Parameters for the Safe transaction being executed. These are the fields
+    ///         execTransactionFromModuleReturnData() consumes; the remaining fields of the
+    ///         signed Safe transaction (safeTxGas, baseGas, gasPrice, gasToken, refundReceiver)
+    ///         are hard-coded to zero, and the nonce is supplied separately as the hash-once
     ///         value.
     /// @custom:field to The address of the contract to call.
     /// @custom:field value The ETH value to send with the call.
     /// @custom:field data The calldata to send with the call.
     /// @custom:field operation The operation to perform (Call or DelegateCall).
-    /// @custom:field safeTxGas Minimum gas that must be available to execute() at the point of
-    ///                         the transaction's call. The call itself receives at least 63/64 of
-    ///                         this (EIP-150), so signers should include a safety margin.
-    /// @custom:field baseGas Unused by this module, part of the signed payload for tooling
-    ///                       compatibility.
-    /// @custom:field gasPrice Must be zero: this module does not pay gas refunds.
-    /// @custom:field gasToken Unused by this module, part of the signed payload for tooling
-    ///                        compatibility.
-    /// @custom:field refundReceiver Unused by this module, part of the signed payload for tooling
-    ///                              compatibility.
     struct ExecTransactionParams {
         address to;
         uint256 value;
         bytes data;
         Enum.Operation operation;
-        uint256 safeTxGas;
-        uint256 baseGas;
-        uint256 gasPrice;
-        address gasToken;
-        address payable refundReceiver;
     }
-
-    /// @notice Error for when the Safe's version is not supported.
-    error UnorderedExecutionModule_InvalidSafeVersion();
 
     /// @notice Error for when this module is not enabled on the Safe.
     error UnorderedExecutionModule_ModuleNotEnabled();
@@ -95,15 +83,12 @@ contract UnorderedExecutionModule is ISemver {
     ///         nonce.
     error UnorderedExecutionModule_HashOnceTooSmall();
 
-    /// @notice Error for when the transaction requests a gas refund, which this module does not
-    ///         pay.
-    error UnorderedExecutionModule_RefundNotSupported();
+    /// @notice Error for when the hash-once value has already been consumed by an execution.
+    error UnorderedExecutionModule_HashOnceAlreadyUsed();
 
-    /// @notice Error for when a transaction has already been executed.
-    error UnorderedExecutionModule_AlreadyExecuted();
-
-    /// @notice Error for when less gas is available than the transaction's signed safeTxGas.
-    error UnorderedExecutionModule_InsufficientGas();
+    /// @notice Error for when the Safe's transaction hashing diverges from the scheme this
+    ///         module relies on.
+    error UnorderedExecutionModule_UnsupportedSafe();
 
     /// @notice Error for when the transaction's call reverts, carrying the raw revert data.
     error UnorderedExecutionModule_ExecutionFailed(bytes);
@@ -111,21 +96,22 @@ contract UnorderedExecutionModule is ISemver {
     /// @notice Emitted when a transaction is executed.
     /// @param safe The Safe the transaction was executed through.
     /// @param txHash The Safe transaction hash identifying the transaction.
-    event TransactionExecuted(Safe indexed safe, bytes32 indexed txHash);
+    /// @param hashOnce The hash-once value consumed by the execution.
+    event TransactionExecuted(Safe indexed safe, bytes32 indexed txHash, uint256 indexed hashOnce);
 
-    /// @notice Transactions that have been executed, keyed by Safe and Safe transaction hash.
-    mapping(Safe => mapping(bytes32 => bool)) internal _executed;
+    /// @notice Hash-once values that have been consumed by an execution, keyed by Safe.
+    mapping(Safe => mapping(uint256 => bool)) internal _executed;
 
     /// @notice Semantic version.
     /// @custom:semver 1.0.0-beta.1
     string public constant version = "1.0.0-beta.1";
 
-    /// @notice Getter function for whether a transaction has been executed.
-    /// @param _safe The Safe the transaction belongs to.
-    /// @param _txHash The Safe transaction hash identifying the transaction.
-    /// @return executed_ Whether the transaction has been executed.
-    function executed(Safe _safe, bytes32 _txHash) public view returns (bool executed_) {
-        executed_ = _executed[_safe][_txHash];
+    /// @notice Getter function for whether a hash-once value has been consumed.
+    /// @param _safe The Safe the hash-once value belongs to.
+    /// @param _hashOnce The hash-once value.
+    /// @return executed_ Whether the hash-once value has been consumed by an execution.
+    function executed(Safe _safe, uint256 _hashOnce) public view returns (bool executed_) {
+        executed_ = _executed[_safe][_hashOnce];
     }
 
     /// @notice Derives a canonical hash-once value from a unique string, e.g. the hashOnceInput
@@ -138,27 +124,29 @@ contract UnorderedExecutionModule is ISemver {
 
     /// @notice Computes the Safe transaction hash that owners must sign to authorize a
     ///         transaction. Identical to the Safe's own getTransactionHash() with the hash-once
-    ///         value in the nonce slot.
+    ///         value in the nonce slot and zeroed gas and refund fields.
     /// @param _safe The Safe the transaction is to be executed through.
     /// @param _params The parameters of the transaction.
     /// @param _hashOnce The transaction's hash-once value.
     /// @return txHash_ Safe transaction hash of the transaction.
     function transactionHash(
         Safe _safe,
-        ExecTransactionParams memory _params,
+        ExecTransactionParams calldata _params,
         uint256 _hashOnce
     )
         public
         view
         returns (bytes32 txHash_)
     {
-        txHash_ = keccak256(_encodeTransactionData(_safe, _params, _hashOnce));
+        txHash_ = _safe.getTransactionHash(
+            _params.to, _params.value, _params.data, _params.operation, 0, 0, 0, address(0), address(0), _hashOnce
+        );
     }
 
     /// @notice Executes a transaction once a threshold of owner signatures has been collected.
     ///         Callable by anyone, matching the relay model of the Safe's own execTransaction().
-    ///         Reverts if the transaction's call reverts, leaving the transaction unexecuted so
-    ///         that it can be retried.
+    ///         Reverts if the transaction's call reverts, leaving the hash-once value unconsumed
+    ///         so that the transaction can be retried.
     /// @param _safe The Safe to execute the transaction through.
     /// @param _params The parameters of the transaction.
     /// @param _hashOnce The transaction's hash-once value. Must be greater than
@@ -175,13 +163,6 @@ contract UnorderedExecutionModule is ISemver {
         external
         returns (bytes memory returnData_)
     {
-        // Only Safe versions 1.3.0 and 1.4.1 are supported. Later versions may change the
-        // transaction encoding or signature checking logic this module depends on.
-        string memory safeVersion = _safe.VERSION();
-        if (!SemverComp.eq(safeVersion, "1.3.0") && !SemverComp.eq(safeVersion, "1.4.1")) {
-            revert UnorderedExecutionModule_InvalidSafeVersion();
-        }
-
         // The Safe itself would reject the module call, but checking here gives a clear error.
         if (!_safe.isModuleEnabled(address(this))) {
             revert UnorderedExecutionModule_ModuleNotEnabled();
@@ -193,34 +174,29 @@ contract UnorderedExecutionModule is ISemver {
             revert UnorderedExecutionModule_HashOnceTooSmall();
         }
 
-        // This module never pays gas refunds, so refuse payloads that promise one.
-        if (_params.gasPrice != 0) {
-            revert UnorderedExecutionModule_RefundNotSupported();
+        // Each hash-once value can be consumed at most once. This also lets a signed task be
+        // cancelled by executing a no-op transaction with the same hash-once value.
+        if (_executed[_safe][_hashOnce]) {
+            revert UnorderedExecutionModule_HashOnceAlreadyUsed();
         }
 
-        // The transaction hash is the keccak256 of the encoded data on Safe 1.3.0 and 1.4.1,
-        // which the version gate above pins.
+        bytes32 txHash = transactionHash(_safe, _params, _hashOnce);
         bytes memory txHashData = _encodeTransactionData(_safe, _params, _hashOnce);
-        bytes32 txHash = keccak256(txHashData);
 
-        // Each transaction hash can be executed at most once.
-        if (_executed[_safe][txHash]) {
-            revert UnorderedExecutionModule_AlreadyExecuted();
+        // The digest owners sign must be the hash of the preimage passed to checkSignatures(),
+        // or EIP-1271 owners would validate different data than what was signed. This holds on
+        // Safe 1.3.0 and 1.4.1; a Safe whose hashing scheme diverges is rejected.
+        if (keccak256(txHashData) != txHash) {
+            revert UnorderedExecutionModule_UnsupportedSafe();
         }
 
         // Verify signatures using the Safe's own logic, so that the Safe's current owner set and
         // threshold apply and all Safe-supported signing methods work. Reverts if invalid.
         _safe.checkSignatures(txHash, txHashData, _signatures);
 
-        // Honor the signed gas commitment so a relayer cannot cause a partial, low-gas execution
-        // that would permanently consume the transaction.
-        if (gasleft() < _params.safeTxGas) {
-            revert UnorderedExecutionModule_InsufficientGas();
-        }
-
-        // Mark the transaction executed before the external call so that the call cannot
-        // re-enter and execute the same transaction again.
-        _executed[_safe][txHash] = true;
+        // Consume the hash-once value before the external call so that the call cannot re-enter
+        // and execute the same transaction again.
+        _executed[_safe][_hashOnce] = true;
 
         // Execute the transaction through the Safe.
         bool success;
@@ -228,23 +204,25 @@ contract UnorderedExecutionModule is ISemver {
             _safe.execTransactionFromModuleReturnData(_params.to, _params.value, _params.data, _params.operation);
 
         // Unlike the Safe's execTransaction(), revert if the call failed. The revert unwinds the
-        // executed state so the transaction can be retried.
+        // consumed hash-once value so the transaction can be retried.
         if (!success) {
             revert UnorderedExecutionModule_ExecutionFailed(returnData_);
         }
 
-        emit TransactionExecuted(_safe, txHash);
+        emit TransactionExecuted(_safe, txHash, _hashOnce);
     }
 
-    /// @notice Fetches the Safe's own EIP-712 encoding of the transaction with the hash-once
-    ///         value in the nonce slot.
+    /// @notice Fetches the Safe's own encoding of the transaction with the hash-once value in
+    ///         the nonce slot. Kept as a helper rather than inlined into execute() because the
+    ///         ten-argument external call exceeds the stack limit of non-via-ir compilation
+    ///         there.
     /// @param _safe The Safe the transaction is to be executed through.
     /// @param _params The parameters of the transaction.
     /// @param _hashOnce The transaction's hash-once value.
     /// @return txHashData_ Encoded transaction data.
     function _encodeTransactionData(
         Safe _safe,
-        ExecTransactionParams memory _params,
+        ExecTransactionParams calldata _params,
         uint256 _hashOnce
     )
         internal
@@ -252,16 +230,7 @@ contract UnorderedExecutionModule is ISemver {
         returns (bytes memory txHashData_)
     {
         txHashData_ = _safe.encodeTransactionData(
-            _params.to,
-            _params.value,
-            _params.data,
-            _params.operation,
-            _params.safeTxGas,
-            _params.baseGas,
-            _params.gasPrice,
-            _params.gasToken,
-            _params.refundReceiver,
-            _hashOnce
+            _params.to, _params.value, _params.data, _params.operation, 0, 0, 0, address(0), address(0), _hashOnce
         );
     }
 }

--- a/packages/contracts-bedrock/src/safe/UnorderedExecutionModule.sol
+++ b/packages/contracts-bedrock/src/safe/UnorderedExecutionModule.sol
@@ -1,0 +1,267 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+// Safe
+import { Safe } from "safe-contracts/Safe.sol";
+import { Enum } from "safe-contracts/common/Enum.sol";
+
+// Libraries
+import { SemverComp } from "src/libraries/SemverComp.sol";
+
+// Interfaces
+import { ISemver } from "interfaces/universal/ISemver.sol";
+
+/// @title UnorderedExecutionModule
+/// @notice Safe Module that allows a Safe's owners to authorize a transaction by signing the
+///         Safe's own transaction hash computed with a "hash-once" value in the nonce slot
+///         instead of the Safe's sequential nonce. Because the hash-once value is pinned per
+///         task (derived from a unique string in the task's configuration) and never depends on
+///         execution order, signatures remain valid regardless of the order in which tasks are
+///         executed, and reordering a queue of pending tasks never requires re-signing.
+/// Usage:
+///     The Safe must first enable this module via ModuleManager.enableModule(). Owners then sign
+///     the digest returned by transactionHash() — which is exactly the Safe's own
+///     getTransactionHash() with the hash-once value as the nonce — using any method the Safe
+///     itself supports: private key signatures, Safe.approveHash(), or EIP-1271 contract
+///     signatures (including nested Safes). Existing Safe signing tooling works unchanged.
+///     Once a threshold of signatures has been collected, anyone may call execute() — the same
+///     permissionless-relay model as the Safe's own execTransaction().
+/// Hash-once values:
+///     The hash-once value must be unique per task and strictly greater than type(uint128).max,
+///     so that it can never collide with the Safe's real sequential nonce. Without this floor, a
+///     signature produced for this module could also become executable through the ordinary
+///     execTransaction() path once the Safe's nonce reached the same value. deriveHashOnce()
+///     computes a canonical value from a unique string.
+/// Replay protection and cancellation:
+///     Each (Safe, transaction hash) pair can be executed at most once. There is no on-chain
+///     cancellation or expiry: abandoning a signed task is handled off-chain by changing the
+///     task's hash-once input and re-signing, and the abandoned signatures simply go unused.
+///     Note that abandoned signatures remain technically executable indefinitely; signatures are
+///     verified against the Safe's *current* owner set and threshold, so rotating owners or
+///     raising the threshold invalidates them.
+/// Signature validity:
+///     Signatures are verified with the Safe's own checkSignatures() logic at execution time.
+///     The Safe's EIP-712 domain separator binds the Safe address and chain id, so a signature
+///     cannot be replayed against another Safe or chain.
+/// Security notes:
+///     - Module transactions are NOT inspected by a transaction guard on Safe versions 1.3.0 and
+///       1.4.1, so transactions executed through this module bypass any guard (e.g. a timelock
+///       guard) enabled on the Safe.
+///     - The signed safeTxGas field is honored as a minimum gas commitment, so a relayer cannot
+///       cause a partial, low-gas execution that would otherwise permanently consume the
+///       transaction. Gas refund fields (gasPrice, gasToken, refundReceiver) are part of the
+///       signed payload but refunds are not paid by this module, so gasPrice must be zero.
+/// Safe Version Compatibility:
+///     Compatible with Safe versions 1.3.0 and 1.4.1, which share the encodeTransactionData(),
+///     checkSignatures(), isModuleEnabled() and execTransactionFromModuleReturnData() interfaces
+///     this module relies on.
+contract UnorderedExecutionModule is ISemver {
+    /// @notice Parameters for the Safe transaction being executed, matching the fields of the
+    ///         Safe's own execTransaction() with the nonce supplied separately as the hash-once
+    ///         value.
+    /// @custom:field to The address of the contract to call.
+    /// @custom:field value The ETH value to send with the call.
+    /// @custom:field data The calldata to send with the call.
+    /// @custom:field operation The operation to perform (Call or DelegateCall).
+    /// @custom:field safeTxGas Minimum gas that must be available to execute() at the point of
+    ///                         the transaction's call. The call itself receives at least 63/64 of
+    ///                         this (EIP-150), so signers should include a safety margin.
+    /// @custom:field baseGas Unused by this module, part of the signed payload for tooling
+    ///                       compatibility.
+    /// @custom:field gasPrice Must be zero: this module does not pay gas refunds.
+    /// @custom:field gasToken Unused by this module, part of the signed payload for tooling
+    ///                        compatibility.
+    /// @custom:field refundReceiver Unused by this module, part of the signed payload for tooling
+    ///                              compatibility.
+    struct ExecTransactionParams {
+        address to;
+        uint256 value;
+        bytes data;
+        Enum.Operation operation;
+        uint256 safeTxGas;
+        uint256 baseGas;
+        uint256 gasPrice;
+        address gasToken;
+        address payable refundReceiver;
+    }
+
+    /// @notice Error for when the Safe's version is not supported.
+    error UnorderedExecutionModule_InvalidSafeVersion();
+
+    /// @notice Error for when this module is not enabled on the Safe.
+    error UnorderedExecutionModule_ModuleNotEnabled();
+
+    /// @notice Error for when the hash-once value is small enough to collide with a real Safe
+    ///         nonce.
+    error UnorderedExecutionModule_HashOnceTooSmall();
+
+    /// @notice Error for when the transaction requests a gas refund, which this module does not
+    ///         pay.
+    error UnorderedExecutionModule_RefundNotSupported();
+
+    /// @notice Error for when a transaction has already been executed.
+    error UnorderedExecutionModule_AlreadyExecuted();
+
+    /// @notice Error for when less gas is available than the transaction's signed safeTxGas.
+    error UnorderedExecutionModule_InsufficientGas();
+
+    /// @notice Error for when the transaction's call reverts, carrying the raw revert data.
+    error UnorderedExecutionModule_ExecutionFailed(bytes);
+
+    /// @notice Emitted when a transaction is executed.
+    /// @param safe The Safe the transaction was executed through.
+    /// @param txHash The Safe transaction hash identifying the transaction.
+    event TransactionExecuted(Safe indexed safe, bytes32 indexed txHash);
+
+    /// @notice Transactions that have been executed, keyed by Safe and Safe transaction hash.
+    mapping(Safe => mapping(bytes32 => bool)) internal _executed;
+
+    /// @notice Semantic version.
+    /// @custom:semver 1.0.0-beta.1
+    string public constant version = "1.0.0-beta.1";
+
+    /// @notice Getter function for whether a transaction has been executed.
+    /// @param _safe The Safe the transaction belongs to.
+    /// @param _txHash The Safe transaction hash identifying the transaction.
+    /// @return executed_ Whether the transaction has been executed.
+    function executed(Safe _safe, bytes32 _txHash) public view returns (bool executed_) {
+        executed_ = _executed[_safe][_txHash];
+    }
+
+    /// @notice Derives a canonical hash-once value from a unique string, e.g. the hashOnceInput
+    ///         pinned in a superchain-ops task's configuration.
+    /// @param _input Unique string identifying the task.
+    /// @return hashOnce_ Hash-once value to use as the transaction's nonce.
+    function deriveHashOnce(string memory _input) public pure returns (uint256 hashOnce_) {
+        hashOnce_ = uint256(keccak256(bytes(_input)));
+    }
+
+    /// @notice Computes the Safe transaction hash that owners must sign to authorize a
+    ///         transaction. Identical to the Safe's own getTransactionHash() with the hash-once
+    ///         value in the nonce slot.
+    /// @param _safe The Safe the transaction is to be executed through.
+    /// @param _params The parameters of the transaction.
+    /// @param _hashOnce The transaction's hash-once value.
+    /// @return txHash_ Safe transaction hash of the transaction.
+    function transactionHash(
+        Safe _safe,
+        ExecTransactionParams memory _params,
+        uint256 _hashOnce
+    )
+        public
+        view
+        returns (bytes32 txHash_)
+    {
+        txHash_ = keccak256(_encodeTransactionData(_safe, _params, _hashOnce));
+    }
+
+    /// @notice Executes a transaction once a threshold of owner signatures has been collected.
+    ///         Callable by anyone, matching the relay model of the Safe's own execTransaction().
+    ///         Reverts if the transaction's call reverts, leaving the transaction unexecuted so
+    ///         that it can be retried.
+    /// @param _safe The Safe to execute the transaction through.
+    /// @param _params The parameters of the transaction.
+    /// @param _hashOnce The transaction's hash-once value. Must be greater than
+    ///                  type(uint128).max.
+    /// @param _signatures Owner signatures over transactionHash(), in the format accepted by the
+    ///                    Safe's checkSignatures() function.
+    /// @return returnData_ Return data of the transaction's call.
+    function execute(
+        Safe _safe,
+        ExecTransactionParams calldata _params,
+        uint256 _hashOnce,
+        bytes calldata _signatures
+    )
+        external
+        returns (bytes memory returnData_)
+    {
+        // Only Safe versions 1.3.0 and 1.4.1 are supported. Later versions may change the
+        // transaction encoding or signature checking logic this module depends on.
+        string memory safeVersion = _safe.VERSION();
+        if (!SemverComp.eq(safeVersion, "1.3.0") && !SemverComp.eq(safeVersion, "1.4.1")) {
+            revert UnorderedExecutionModule_InvalidSafeVersion();
+        }
+
+        // The Safe itself would reject the module call, but checking here gives a clear error.
+        if (!_safe.isModuleEnabled(address(this))) {
+            revert UnorderedExecutionModule_ModuleNotEnabled();
+        }
+
+        // A hash-once value that a sequential nonce could actually reach would let the same
+        // signatures execute both through this module and through execTransaction().
+        if (_hashOnce <= type(uint128).max) {
+            revert UnorderedExecutionModule_HashOnceTooSmall();
+        }
+
+        // This module never pays gas refunds, so refuse payloads that promise one.
+        if (_params.gasPrice != 0) {
+            revert UnorderedExecutionModule_RefundNotSupported();
+        }
+
+        // The transaction hash is the keccak256 of the encoded data on Safe 1.3.0 and 1.4.1,
+        // which the version gate above pins.
+        bytes memory txHashData = _encodeTransactionData(_safe, _params, _hashOnce);
+        bytes32 txHash = keccak256(txHashData);
+
+        // Each transaction hash can be executed at most once.
+        if (_executed[_safe][txHash]) {
+            revert UnorderedExecutionModule_AlreadyExecuted();
+        }
+
+        // Verify signatures using the Safe's own logic, so that the Safe's current owner set and
+        // threshold apply and all Safe-supported signing methods work. Reverts if invalid.
+        _safe.checkSignatures(txHash, txHashData, _signatures);
+
+        // Honor the signed gas commitment so a relayer cannot cause a partial, low-gas execution
+        // that would permanently consume the transaction.
+        if (gasleft() < _params.safeTxGas) {
+            revert UnorderedExecutionModule_InsufficientGas();
+        }
+
+        // Mark the transaction executed before the external call so that the call cannot
+        // re-enter and execute the same transaction again.
+        _executed[_safe][txHash] = true;
+
+        // Execute the transaction through the Safe.
+        bool success;
+        (success, returnData_) =
+            _safe.execTransactionFromModuleReturnData(_params.to, _params.value, _params.data, _params.operation);
+
+        // Unlike the Safe's execTransaction(), revert if the call failed. The revert unwinds the
+        // executed state so the transaction can be retried.
+        if (!success) {
+            revert UnorderedExecutionModule_ExecutionFailed(returnData_);
+        }
+
+        emit TransactionExecuted(_safe, txHash);
+    }
+
+    /// @notice Fetches the Safe's own EIP-712 encoding of the transaction with the hash-once
+    ///         value in the nonce slot.
+    /// @param _safe The Safe the transaction is to be executed through.
+    /// @param _params The parameters of the transaction.
+    /// @param _hashOnce The transaction's hash-once value.
+    /// @return txHashData_ Encoded transaction data.
+    function _encodeTransactionData(
+        Safe _safe,
+        ExecTransactionParams memory _params,
+        uint256 _hashOnce
+    )
+        internal
+        view
+        returns (bytes memory txHashData_)
+    {
+        txHashData_ = _safe.encodeTransactionData(
+            _params.to,
+            _params.value,
+            _params.data,
+            _params.operation,
+            _params.safeTxGas,
+            _params.baseGas,
+            _params.gasPrice,
+            _params.gasToken,
+            _params.refundReceiver,
+            _hashOnce
+        );
+    }
+}

--- a/packages/contracts-bedrock/test/safe/UnorderedExecutionModule.t.sol
+++ b/packages/contracts-bedrock/test/safe/UnorderedExecutionModule.t.sol
@@ -47,6 +47,57 @@ contract UnorderedExecutionModule_Emitter_Harness {
     }
 }
 
+/// @notice Reads the module's exposed signers during a task's call, standing in for a module
+///         guard such as the liveness guard.
+contract UnorderedExecutionModule_SignersReader_Harness {
+    IUnorderedExecutionModule internal module;
+    Safe internal safe;
+    address[] public seenSigners;
+
+    constructor(IUnorderedExecutionModule _module, Safe _safe) {
+        module = _module;
+        safe = _safe;
+    }
+
+    function record() external {
+        address[] memory signers = module.signers(safe);
+        for (uint256 i; i < signers.length; i++) {
+            seenSigners.push(signers[i]);
+        }
+    }
+
+    function seenSignersLength() external view returns (uint256) {
+        return seenSigners.length;
+    }
+}
+
+/// @notice Attempts to re-enter execute() for the same Safe from within a task's call and
+///         records the inner revert reason.
+contract UnorderedExecutionModule_Reenterer_Harness {
+    IUnorderedExecutionModule internal module;
+    Safe internal safe;
+    bytes4 public innerRevertSelector;
+
+    constructor(IUnorderedExecutionModule _module, Safe _safe) {
+        module = _module;
+        safe = _safe;
+    }
+
+    function reenter(
+        IUnorderedExecutionModule.ExecTransactionParams calldata _params,
+        uint256 _hashOnce,
+        bytes calldata _signatures
+    )
+        external
+    {
+        try module.execute(safe, _params, _hashOnce, _signatures) returns (bytes memory) {
+            innerRevertSelector = 0xffffffff;
+        } catch (bytes memory err) {
+            innerRevertSelector = bytes4(err);
+        }
+    }
+}
+
 /// @title UnorderedExecutionModule_TestInit
 /// @notice Reusable test initialization for `UnorderedExecutionModule` tests.
 abstract contract UnorderedExecutionModule_TestInit is Test, SafeTestTools {
@@ -208,16 +259,15 @@ contract UnorderedExecutionModule_Execute_Test is UnorderedExecutionModule_TestI
 
     /// @notice Transactions can carry ETH value from the Safe.
     function test_execute_withValue_succeeds() external {
-        address recipient = makeAddr("recipient");
-        IUnorderedExecutionModule.ExecTransactionParams memory params = _makeParams(0);
-        params.to = recipient;
+        IUnorderedExecutionModule.ExecTransactionParams memory params = _makeParams(8);
         params.value = 1 ether;
-        params.data = "";
         bytes memory sigs = _signTx(params, HASH_ONCE);
 
         module.execute(safe, params, HASH_ONCE, sigs);
 
-        assertEq(recipient.balance, 1 ether);
+        assertEq(target.value(), 8);
+        assertEq(target.lastMsgValue(), 1 ether);
+        assertEq(address(target).balance, 1 ether);
         assertEq(address(safe).balance, SAFE_BALANCE - 1 ether);
     }
 
@@ -286,10 +336,7 @@ contract UnorderedExecutionModule_Execute_Test is UnorderedExecutionModule_TestI
         IUnorderedExecutionModule.ExecTransactionParams memory params = _makeParams(21);
 
         // The child Safe signs the parent Safe's encoded transaction data as a Safe message.
-        bytes memory txHashData = parentSafe.encodeTransactionData(
-            params.to, params.value, params.data, params.operation, 0, 0, 0, address(0), address(0), HASH_ONCE
-        );
-        SafeTestLib.EIP1271Sign(childInstance, txHashData);
+        SafeTestLib.EIP1271Sign(childInstance, module.encodeTransactionData(parentSafe, params, HASH_ONCE));
 
         // Contract signature: r = child Safe address, s = offset of the (empty) dynamic part,
         // v = 0.
@@ -300,6 +347,28 @@ contract UnorderedExecutionModule_Execute_Test is UnorderedExecutionModule_TestI
         module.execute(parentSafe, params, HASH_ONCE, sigs);
         assertEq(target.value(), 21);
         assertEq(target.lastSender(), address(parentSafe));
+    }
+
+    /// @notice The approving signers are exposed via signers() during the task's call — as a
+    ///         module guard like the liveness guard would read them — and cleared afterwards.
+    function test_execute_signersExposedDuringCall_succeeds() external {
+        UnorderedExecutionModule_SignersReader_Harness reader =
+            new UnorderedExecutionModule_SignersReader_Harness(module, safe);
+
+        IUnorderedExecutionModule.ExecTransactionParams memory params = _makeParams(0);
+        params.to = address(reader);
+        params.data = abi.encodeCall(UnorderedExecutionModule_SignersReader_Harness.record, ());
+        module.execute(safe, params, HASH_ONCE, _signTx(params, HASH_ONCE));
+
+        // The reader saw exactly the threshold of signers that authorized the task, in the
+        // ascending owner order the signatures were supplied in.
+        assertEq(reader.seenSignersLength(), THRESHOLD);
+        for (uint256 i; i < THRESHOLD; i++) {
+            assertEq(reader.seenSigners(i), safeInstance.owners[i]);
+        }
+
+        // The exposed signers are cleared once execution completes.
+        assertEq(module.signers(safe).length, 0);
     }
 
     /// @notice The smallest allowed hash-once value is accepted.
@@ -361,6 +430,38 @@ contract UnorderedExecutionModule_Execute_Test is UnorderedExecutionModule_TestI
         vm.expectRevert(IUnorderedExecutionModule.UnorderedExecutionModule_HashOnceAlreadyUsed.selector);
         module.execute(safe, params, HASH_ONCE, sigs);
         assertEq(target.value(), 0);
+    }
+
+    /// @notice A task's call cannot re-enter execute() for the same Safe, so the signers
+    ///         exposed for the outer transaction survive its whole call.
+    function test_execute_reentrantExecution_reverts() external {
+        UnorderedExecutionModule_Reenterer_Harness reenterer =
+            new UnorderedExecutionModule_Reenterer_Harness(module, safe);
+
+        // The inner task the outer task will attempt to execute reentrantly.
+        IUnorderedExecutionModule.ExecTransactionParams memory innerParams = _makeParams(5);
+        uint256 innerHashOnce = uint256(keccak256("task: inner"));
+        bytes memory innerSigs = _signTx(innerParams, innerHashOnce);
+
+        // The outer task calls the reenterer, which attempts the inner execution.
+        IUnorderedExecutionModule.ExecTransactionParams memory params = _makeParams(0);
+        params.to = address(reenterer);
+        params.data =
+            abi.encodeCall(UnorderedExecutionModule_Reenterer_Harness.reenter, (innerParams, innerHashOnce, innerSigs));
+        module.execute(safe, params, HASH_ONCE, _signTx(params, HASH_ONCE));
+
+        // The inner execution reverted with ReentrantExecution and consumed nothing.
+        assertEq(
+            reenterer.innerRevertSelector(),
+            IUnorderedExecutionModule.UnorderedExecutionModule_ReentrantExecution.selector
+        );
+        assertTrue(module.executed(safe, HASH_ONCE));
+        assertFalse(module.executed(safe, innerHashOnce));
+        assertEq(target.value(), 0);
+
+        // The inner task executes normally once the outer transaction has completed.
+        module.execute(safe, innerParams, innerHashOnce, innerSigs);
+        assertEq(target.value(), 5);
     }
 
     /// @notice A hash-once value small enough to collide with a real Safe nonce is rejected, so
@@ -498,6 +599,21 @@ contract UnorderedExecutionModule_TransactionHash_Test is UnorderedExecutionModu
         );
     }
 
+    /// @notice The module's locally built EIP-712 encoding matches the Safe's own
+    ///         encodeTransactionData() (present through 1.4.1, removed in 1.5.0) and hashes to
+    ///         transactionHash().
+    function test_encodeTransactionData_matchesSafe_works() external view {
+        IUnorderedExecutionModule.ExecTransactionParams memory params = _makeParams(1);
+        bytes memory txHashData = module.encodeTransactionData(safe, params, HASH_ONCE);
+        assertEq(
+            txHashData,
+            safe.encodeTransactionData(
+                params.to, params.value, params.data, params.operation, 0, 0, 0, address(0), address(0), HASH_ONCE
+            )
+        );
+        assertEq(keccak256(txHashData), module.transactionHash(safe, params, HASH_ONCE));
+    }
+
     /// @notice The transaction hash binds the Safe address.
     function test_transactionHash_bindsSafe_works() external {
         SafeInstance memory otherInstance = _setupExtraSafe(safeInstance.ownerPKs, THRESHOLD, 105);
@@ -531,5 +647,10 @@ contract UnorderedExecutionModule_Uncategorized_Test is UnorderedExecutionModule
     /// @notice Unknown hash-once values are unconsumed.
     function test_executed_default_works() external view {
         assertFalse(module.executed(safe, uint256(123)));
+    }
+
+    /// @notice No signers are exposed outside of an execution.
+    function test_signers_default_works() external view {
+        assertEq(module.signers(safe).length, 0);
     }
 }

--- a/packages/contracts-bedrock/test/safe/UnorderedExecutionModule.t.sol
+++ b/packages/contracts-bedrock/test/safe/UnorderedExecutionModule.t.sol
@@ -1,0 +1,578 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+// Testing
+import { Test } from "test/setup/Test.sol";
+import "test/safe-tools/SafeTestTools.sol";
+
+// Safe
+import { Safe } from "safe-contracts/Safe.sol";
+import { Enum } from "safe-contracts/common/Enum.sol";
+
+// Libraries
+import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
+
+// Interfaces
+import { IUnorderedExecutionModule } from "interfaces/safe/IUnorderedExecutionModule.sol";
+
+/// @notice Simple call target for module execution tests.
+contract UnorderedExecutionModule_Target_Harness {
+    uint256 public value;
+    address public lastSender;
+    uint256 public lastMsgValue;
+    bool public shouldRevert;
+
+    function setValue(uint256 _value) external payable {
+        value = _value;
+        lastSender = msg.sender;
+        lastMsgValue = msg.value;
+    }
+
+    function setShouldRevert(bool _shouldRevert) external {
+        shouldRevert = _shouldRevert;
+    }
+
+    function conditionalRevert() external view {
+        require(!shouldRevert, "Target: forced revert");
+    }
+}
+
+/// @notice Emits an event bound to address(this), so a delegatecall from the Safe emits from the
+///         Safe's own address.
+contract UnorderedExecutionModule_Emitter_Harness {
+    event Emitted(address self);
+
+    function emitEvent() external {
+        emit Emitted(address(this));
+    }
+}
+
+/// @title UnorderedExecutionModule_TestInit
+/// @notice Reusable test initialization for `UnorderedExecutionModule` tests.
+abstract contract UnorderedExecutionModule_TestInit is Test, SafeTestTools {
+    using SafeTestLib for SafeInstance;
+
+    event TransactionExecuted(address indexed safe, bytes32 indexed txHash);
+    event Emitted(address self);
+
+    uint256 internal constant INIT_TIME = 1_000_000;
+    uint256 internal constant NUM_OWNERS = 3;
+    uint256 internal constant THRESHOLD = 2;
+    uint256 internal constant SAFE_BALANCE = 100 ether;
+
+    /// @notice Default hash-once value, as derived from a superchain-ops hashOnceInput string.
+    uint256 internal constant HASH_ONCE = uint256(keccak256("task: default"));
+
+    IUnorderedExecutionModule module;
+    SafeInstance safeInstance;
+    Safe safe;
+    UnorderedExecutionModule_Target_Harness target;
+
+    function setUp() public virtual {
+        vm.warp(INIT_TIME);
+
+        module = IUnorderedExecutionModule(
+            DeployUtils.create1({
+                _name: "UnorderedExecutionModule",
+                _args: DeployUtils.encodeConstructor(abi.encodeCall(IUnorderedExecutionModule.__constructor__, ()))
+            })
+        );
+
+        (, uint256[] memory keys) = SafeTestLib.makeAddrsAndKeys("UnorderedExecutionModule_test_", NUM_OWNERS);
+        safeInstance = _setupSafe(keys, THRESHOLD, SAFE_BALANCE);
+        safe = Safe(payable(address(safeInstance.safe)));
+        safeInstance.enableModule(address(module));
+
+        target = new UnorderedExecutionModule_Target_Harness();
+    }
+
+    /// @notice Sets up an additional Safe with the given owners and a unique CREATE2 salt.
+    function _setupExtraSafe(
+        uint256[] memory _keys,
+        uint256 _threshold,
+        uint256 _salt
+    )
+        internal
+        returns (SafeInstance memory)
+    {
+        saltNonce = _salt;
+        return _setupSafe(_keys, _threshold, SAFE_BALANCE);
+    }
+
+    /// @notice Returns transaction params calling target.setValue(_value).
+    function _makeParams(uint256 _value)
+        internal
+        view
+        returns (IUnorderedExecutionModule.ExecTransactionParams memory)
+    {
+        return IUnorderedExecutionModule.ExecTransactionParams({
+            to: address(target),
+            value: 0,
+            data: abi.encodeCall(UnorderedExecutionModule_Target_Harness.setValue, (_value)),
+            operation: Enum.Operation.Call,
+            safeTxGas: 0,
+            baseGas: 0,
+            gasPrice: 0,
+            gasToken: address(0),
+            refundReceiver: payable(address(0))
+        });
+    }
+
+    /// @notice Signs the transaction's hash with the first _numSigs owner keys of _instance, in
+    ///         the ascending-owner-address order required by the Safe's checkSignatures().
+    function _signTx(
+        SafeInstance memory _instance,
+        IUnorderedExecutionModule.ExecTransactionParams memory _params,
+        uint256 _hashOnce,
+        uint256 _numSigs
+    )
+        internal
+        view
+        returns (bytes memory sigs_)
+    {
+        bytes32 digest = module.transactionHash(Safe(payable(address(_instance.safe))), _params, _hashOnce);
+        for (uint256 i; i < _numSigs; i++) {
+            (uint8 v, bytes32 r, bytes32 s) = vm.sign(_instance.ownerPKs[i], digest);
+            sigs_ = bytes.concat(sigs_, abi.encodePacked(r, s, v));
+        }
+    }
+
+    /// @notice Signs a transaction with a threshold of the default Safe's owners.
+    function _signTx(
+        IUnorderedExecutionModule.ExecTransactionParams memory _params,
+        uint256 _hashOnce
+    )
+        internal
+        view
+        returns (bytes memory)
+    {
+        return _signTx(safeInstance, _params, _hashOnce, THRESHOLD);
+    }
+}
+
+/// @title UnorderedExecutionModule_Execute_Test
+/// @notice Tests for the `execute` function.
+contract UnorderedExecutionModule_Execute_Test is UnorderedExecutionModule_TestInit {
+    using SafeTestLib for SafeInstance;
+
+    /// @notice A signed transaction executes the call, is marked executed, and emits
+    ///         TransactionExecuted.
+    function test_execute_succeeds() external {
+        IUnorderedExecutionModule.ExecTransactionParams memory params = _makeParams(42);
+        bytes memory sigs = _signTx(params, HASH_ONCE);
+        bytes32 txHash = module.transactionHash(safe, params, HASH_ONCE);
+
+        vm.expectEmit(address(module));
+        emit TransactionExecuted(address(safe), txHash);
+        module.execute(safe, params, HASH_ONCE, sigs);
+
+        assertEq(target.value(), 42);
+        assertEq(target.lastSender(), address(safe));
+        assertTrue(module.executed(safe, txHash));
+    }
+
+    /// @notice Transactions execute in any order relative to the order they were signed in, and
+    ///         the Safe's nonce is never consumed.
+    function test_execute_outOfOrder_succeeds() external {
+        IUnorderedExecutionModule.ExecTransactionParams memory params1 = _makeParams(1);
+        IUnorderedExecutionModule.ExecTransactionParams memory params2 = _makeParams(2);
+        uint256 hashOnce1 = uint256(keccak256("task: one"));
+        uint256 hashOnce2 = uint256(keccak256("task: two"));
+        bytes memory sigs1 = _signTx(params1, hashOnce1);
+        bytes memory sigs2 = _signTx(params2, hashOnce2);
+
+        uint256 nonceBefore = safe.nonce();
+
+        // Execute in the reverse of signing order.
+        module.execute(safe, params2, hashOnce2, sigs2);
+        assertEq(target.value(), 2);
+        module.execute(safe, params1, hashOnce1, sigs1);
+        assertEq(target.value(), 1);
+
+        assertEq(safe.nonce(), nonceBefore);
+    }
+
+    /// @notice The transaction hash does not depend on the Safe's nonce: signatures collected
+    ///         before other (nonce-based) transactions execute remain valid afterwards.
+    function test_execute_nonceIndependent_succeeds() external {
+        IUnorderedExecutionModule.ExecTransactionParams memory params = _makeParams(7);
+        bytes32 hashBefore = module.transactionHash(safe, params, HASH_ONCE);
+        bytes memory sigs = _signTx(params, HASH_ONCE);
+
+        // Execute an ordinary nonce-based Safe transaction in the meantime.
+        safeInstance.execTransaction(
+            address(target), 0, abi.encodeCall(UnorderedExecutionModule_Target_Harness.setValue, (999))
+        );
+        assertEq(target.value(), 999);
+
+        // The transaction hash is unchanged and the old signatures still execute.
+        assertEq(module.transactionHash(safe, params, HASH_ONCE), hashBefore);
+        module.execute(safe, params, HASH_ONCE, sigs);
+        assertEq(target.value(), 7);
+    }
+
+    /// @notice Transactions can carry ETH value from the Safe.
+    function test_execute_withValue_succeeds() external {
+        address recipient = makeAddr("recipient");
+        IUnorderedExecutionModule.ExecTransactionParams memory params = _makeParams(0);
+        params.to = recipient;
+        params.value = 1 ether;
+        params.data = "";
+        bytes memory sigs = _signTx(params, HASH_ONCE);
+
+        module.execute(safe, params, HASH_ONCE, sigs);
+
+        assertEq(recipient.balance, 1 ether);
+        assertEq(address(safe).balance, SAFE_BALANCE - 1 ether);
+    }
+
+    /// @notice Delegatecall transactions run in the Safe's own context.
+    function test_execute_delegatecall_succeeds() external {
+        UnorderedExecutionModule_Emitter_Harness emitter = new UnorderedExecutionModule_Emitter_Harness();
+        IUnorderedExecutionModule.ExecTransactionParams memory params = _makeParams(0);
+        params.to = address(emitter);
+        params.data = abi.encodeCall(UnorderedExecutionModule_Emitter_Harness.emitEvent, ());
+        params.operation = Enum.Operation.DelegateCall;
+        bytes memory sigs = _signTx(params, HASH_ONCE);
+
+        vm.expectEmit(address(safe));
+        emit Emitted(address(safe));
+        module.execute(safe, params, HASH_ONCE, sigs);
+    }
+
+    /// @notice The same call can be authorized and executed twice using distinct hash-once
+    ///         values.
+    function test_execute_sameParamsDifferentHashOnce_succeeds() external {
+        IUnorderedExecutionModule.ExecTransactionParams memory params = _makeParams(5);
+        uint256 hashOnce1 = uint256(keccak256("task: first run"));
+        uint256 hashOnce2 = uint256(keccak256("task: second run"));
+
+        assertTrue(module.transactionHash(safe, params, hashOnce1) != module.transactionHash(safe, params, hashOnce2));
+
+        module.execute(safe, params, hashOnce1, _signTx(params, hashOnce1));
+        module.execute(safe, params, hashOnce2, _signTx(params, hashOnce2));
+        assertEq(target.value(), 5);
+    }
+
+    /// @notice Owners can authorize a transaction with Safe.approveHash() instead of an ECDSA
+    ///         signature.
+    function test_execute_approvedHash_succeeds() external {
+        IUnorderedExecutionModule.ExecTransactionParams memory params = _makeParams(11);
+        bytes32 txHash = module.transactionHash(safe, params, HASH_ONCE);
+
+        // Owners are sorted ascending, matching the order checkSignatures() requires.
+        bytes memory sigs;
+        for (uint256 i; i < THRESHOLD; i++) {
+            address owner = safeInstance.owners[i];
+            vm.prank(owner);
+            safe.approveHash(txHash);
+            sigs = bytes.concat(sigs, abi.encodePacked(bytes32(uint256(uint160(owner))), bytes32(0), uint8(1)));
+        }
+
+        module.execute(safe, params, HASH_ONCE, sigs);
+        assertEq(target.value(), 11);
+    }
+
+    /// @notice A nested Safe owner can authorize a transaction with an EIP-1271 contract
+    ///         signature over the Safe's encoded transaction data.
+    function test_execute_contractSignature_succeeds() external {
+        // Child Safe that will act as the sole owner of a parent Safe, as with a nested Safe
+        // setup like the L1PAO.
+        (, uint256[] memory childKeys) = SafeTestLib.makeAddrsAndKeys("UnorderedExecutionModule_child_", 2);
+        SafeInstance memory childInstance = _setupExtraSafe(childKeys, 2, 100);
+
+        uint256[] memory parentPKs = new uint256[](1);
+        parentPKs[0] = SafeTestLib.encodeSmartContractWalletAsPK(address(childInstance.safe));
+        SafeInstance memory parentInstance = _setupExtraSafe(parentPKs, 1, 101);
+        Safe parentSafe = Safe(payable(address(parentInstance.safe)));
+        // SafeTestLib's execTransaction cannot auto-sign for contract owners, so enable the
+        // module by impersonating the Safe itself.
+        vm.prank(address(parentSafe));
+        parentSafe.enableModule(address(module));
+
+        IUnorderedExecutionModule.ExecTransactionParams memory params = _makeParams(21);
+
+        // The child Safe signs the parent Safe's encoded transaction data as a Safe message.
+        bytes memory txHashData = parentSafe.encodeTransactionData(
+            params.to,
+            params.value,
+            params.data,
+            params.operation,
+            params.safeTxGas,
+            params.baseGas,
+            params.gasPrice,
+            params.gasToken,
+            params.refundReceiver,
+            HASH_ONCE
+        );
+        SafeTestLib.EIP1271Sign(childInstance, txHashData);
+
+        // Contract signature: r = child Safe address, s = offset of the (empty) dynamic part,
+        // v = 0.
+        bytes memory sigs = abi.encodePacked(
+            bytes32(uint256(uint160(address(childInstance.safe)))), bytes32(uint256(65)), uint8(0), uint256(0)
+        );
+
+        module.execute(parentSafe, params, HASH_ONCE, sigs);
+        assertEq(target.value(), 21);
+        assertEq(target.lastSender(), address(parentSafe));
+    }
+
+    /// @notice A Safe reporting version 1.3.0 is accepted.
+    function test_execute_safeVersion130_succeeds() external {
+        // nosemgrep: sol-style-use-abi-encodecall
+        vm.mockCall(address(safe), abi.encodeWithSignature("VERSION()"), abi.encode("1.3.0"));
+        IUnorderedExecutionModule.ExecTransactionParams memory params = _makeParams(9);
+        module.execute(safe, params, HASH_ONCE, _signTx(params, HASH_ONCE));
+        assertEq(target.value(), 9);
+    }
+
+    /// @notice The smallest allowed hash-once value is accepted.
+    function test_execute_hashOnceAtBoundary_succeeds() external {
+        uint256 hashOnce = uint256(type(uint128).max) + 1;
+        IUnorderedExecutionModule.ExecTransactionParams memory params = _makeParams(4);
+        module.execute(safe, params, hashOnce, _signTx(params, hashOnce));
+        assertEq(target.value(), 4);
+    }
+
+    /// @notice A transaction with a signed safeTxGas executes when enough gas is supplied.
+    function test_execute_safeTxGasSatisfied_succeeds() external {
+        IUnorderedExecutionModule.ExecTransactionParams memory params = _makeParams(13);
+        params.safeTxGas = 100_000;
+        module.execute(safe, params, HASH_ONCE, _signTx(params, HASH_ONCE));
+        assertEq(target.value(), 13);
+    }
+
+    /// @notice A failed transaction reverts, remains unexecuted, and can be retried.
+    function test_execute_retryAfterFailure_succeeds() external {
+        IUnorderedExecutionModule.ExecTransactionParams memory params = _makeParams(0);
+        params.data = abi.encodeCall(UnorderedExecutionModule_Target_Harness.conditionalRevert, ());
+        bytes memory sigs = _signTx(params, HASH_ONCE);
+        bytes32 txHash = module.transactionHash(safe, params, HASH_ONCE);
+
+        target.setShouldRevert(true);
+        vm.expectPartialRevert(IUnorderedExecutionModule.UnorderedExecutionModule_ExecutionFailed.selector);
+        module.execute(safe, params, HASH_ONCE, sigs);
+
+        // The failed execution left the transaction unexecuted.
+        assertFalse(module.executed(safe, txHash));
+
+        // The same signatures work once the call can succeed.
+        target.setShouldRevert(false);
+        module.execute(safe, params, HASH_ONCE, sigs);
+        assertTrue(module.executed(safe, txHash));
+    }
+
+    /// @notice A transaction cannot be executed twice with the same signatures.
+    function test_execute_replay_reverts() external {
+        IUnorderedExecutionModule.ExecTransactionParams memory params = _makeParams(1);
+        bytes memory sigs = _signTx(params, HASH_ONCE);
+
+        module.execute(safe, params, HASH_ONCE, sigs);
+
+        vm.expectRevert(IUnorderedExecutionModule.UnorderedExecutionModule_AlreadyExecuted.selector);
+        module.execute(safe, params, HASH_ONCE, sigs);
+    }
+
+    /// @notice A hash-once value small enough to collide with a real Safe nonce is rejected, so
+    ///         the same signatures can never execute through both this module and
+    ///         execTransaction().
+    function test_execute_hashOnceTooSmall_reverts() external {
+        uint256 hashOnce = uint256(type(uint128).max);
+        IUnorderedExecutionModule.ExecTransactionParams memory params = _makeParams(1);
+        bytes memory sigs = _signTx(params, hashOnce);
+
+        vm.expectRevert(IUnorderedExecutionModule.UnorderedExecutionModule_HashOnceTooSmall.selector);
+        module.execute(safe, params, hashOnce, sigs);
+    }
+
+    /// @notice A transaction promising a gas refund is rejected, since the module pays none.
+    function test_execute_refundNotSupported_reverts() external {
+        IUnorderedExecutionModule.ExecTransactionParams memory params = _makeParams(1);
+        params.gasPrice = 1;
+        bytes memory sigs = _signTx(params, HASH_ONCE);
+
+        vm.expectRevert(IUnorderedExecutionModule.UnorderedExecutionModule_RefundNotSupported.selector);
+        module.execute(safe, params, HASH_ONCE, sigs);
+    }
+
+    /// @notice A transaction cannot be executed with less gas available than its signed
+    ///         safeTxGas, so a relayer cannot consume the transaction with a partial, low-gas
+    ///         execution.
+    function test_execute_insufficientGas_reverts() external {
+        IUnorderedExecutionModule.ExecTransactionParams memory params = _makeParams(13);
+        params.safeTxGas = 30_000_000;
+        bytes memory sigs = _signTx(params, HASH_ONCE);
+        bytes32 txHash = module.transactionHash(safe, params, HASH_ONCE);
+
+        vm.expectRevert(IUnorderedExecutionModule.UnorderedExecutionModule_InsufficientGas.selector);
+        module.execute{ gas: 1_000_000 }(safe, params, HASH_ONCE, sigs);
+
+        // The transaction remains executable with sufficient gas.
+        assertFalse(module.executed(safe, txHash));
+    }
+
+    /// @notice Fewer signatures than the Safe's threshold are rejected.
+    function test_execute_insufficientSignatures_reverts() external {
+        IUnorderedExecutionModule.ExecTransactionParams memory params = _makeParams(1);
+        bytes memory sigs = _signTx(safeInstance, params, HASH_ONCE, THRESHOLD - 1);
+
+        vm.expectRevert(bytes("GS020"));
+        module.execute(safe, params, HASH_ONCE, sigs);
+    }
+
+    /// @notice Signatures from non-owners are rejected.
+    function test_execute_invalidSigner_reverts() external {
+        IUnorderedExecutionModule.ExecTransactionParams memory params = _makeParams(1);
+        bytes32 digest = module.transactionHash(safe, params, HASH_ONCE);
+
+        (, uint256 badKey) = makeAddrAndKey("notAnOwner");
+        (uint8 v1, bytes32 r1, bytes32 s1) = vm.sign(badKey, digest);
+        (uint8 v2, bytes32 r2, bytes32 s2) = vm.sign(safeInstance.ownerPKs[0], digest);
+        bytes memory sigs = abi.encodePacked(r1, s1, v1, r2, s2, v2);
+
+        vm.expectRevert(bytes("GS026"));
+        module.execute(safe, params, HASH_ONCE, sigs);
+    }
+
+    /// @notice Signatures do not carry over to modified transaction params or a modified
+    ///         hash-once value.
+    function test_execute_tamperedParams_reverts() external {
+        IUnorderedExecutionModule.ExecTransactionParams memory params = _makeParams(1);
+        bytes memory sigs = _signTx(params, HASH_ONCE);
+
+        params.value = 1 ether;
+        vm.expectRevert(bytes("GS026"));
+        module.execute(safe, params, HASH_ONCE, sigs);
+
+        params.value = 0;
+        vm.expectRevert(bytes("GS026"));
+        module.execute(safe, params, uint256(keccak256("task: other")), sigs);
+    }
+
+    /// @notice A signature for one Safe cannot be replayed against another Safe with the same
+    ///         owners.
+    function test_execute_wrongSafe_reverts() external {
+        SafeInstance memory otherInstance = _setupExtraSafe(safeInstance.ownerPKs, THRESHOLD, 102);
+        Safe otherSafe = Safe(payable(address(otherInstance.safe)));
+        otherInstance.enableModule(address(module));
+
+        IUnorderedExecutionModule.ExecTransactionParams memory params = _makeParams(1);
+        // Signed for `safe`, executed against `otherSafe`.
+        bytes memory sigs = _signTx(safeInstance, params, HASH_ONCE, THRESHOLD);
+
+        vm.expectRevert(bytes("GS026"));
+        module.execute(otherSafe, params, HASH_ONCE, sigs);
+    }
+
+    /// @notice Signatures are checked against the Safe's current threshold, not the threshold at
+    ///         signing time.
+    function test_execute_thresholdRaisedAfterSigning_reverts() external {
+        IUnorderedExecutionModule.ExecTransactionParams memory params = _makeParams(1);
+        bytes memory sigs = _signTx(params, HASH_ONCE);
+
+        safeInstance.changeThreshold(THRESHOLD + 1);
+
+        vm.expectRevert(bytes("GS020"));
+        module.execute(safe, params, HASH_ONCE, sigs);
+    }
+
+    /// @notice Execution requires the module to be enabled on the Safe.
+    function test_execute_moduleNotEnabled_reverts() external {
+        (, uint256[] memory keys) = SafeTestLib.makeAddrsAndKeys("UnorderedExecutionModule_noModule_", 2);
+        SafeInstance memory otherInstance = _setupExtraSafe(keys, 2, 103);
+        Safe otherSafe = Safe(payable(address(otherInstance.safe)));
+
+        IUnorderedExecutionModule.ExecTransactionParams memory params = _makeParams(1);
+        bytes memory sigs = _signTx(otherInstance, params, HASH_ONCE, 2);
+
+        vm.expectRevert(IUnorderedExecutionModule.UnorderedExecutionModule_ModuleNotEnabled.selector);
+        module.execute(otherSafe, params, HASH_ONCE, sigs);
+    }
+
+    /// @notice Safes with unsupported versions are rejected.
+    function test_execute_invalidSafeVersion_reverts() external {
+        // nosemgrep: sol-style-use-abi-encodecall
+        vm.mockCall(address(safe), abi.encodeWithSignature("VERSION()"), abi.encode("1.5.0"));
+
+        IUnorderedExecutionModule.ExecTransactionParams memory params = _makeParams(1);
+        bytes memory sigs = _signTx(params, HASH_ONCE);
+
+        vm.expectRevert(IUnorderedExecutionModule.UnorderedExecutionModule_InvalidSafeVersion.selector);
+        module.execute(safe, params, HASH_ONCE, sigs);
+    }
+
+    /// @notice Any signed transaction with valid parameters executes.
+    function testFuzz_execute_succeeds(uint256 _value, uint256 _hashOnce) external {
+        _hashOnce = bound(_hashOnce, uint256(type(uint128).max) + 1, type(uint256).max);
+
+        IUnorderedExecutionModule.ExecTransactionParams memory params = _makeParams(_value);
+        bytes memory sigs = _signTx(params, _hashOnce);
+        bytes32 txHash = module.transactionHash(safe, params, _hashOnce);
+
+        module.execute(safe, params, _hashOnce, sigs);
+
+        assertEq(target.value(), _value);
+        assertTrue(module.executed(safe, txHash));
+    }
+}
+
+/// @title UnorderedExecutionModule_TransactionHash_Test
+/// @notice Tests for the `transactionHash` function.
+contract UnorderedExecutionModule_TransactionHash_Test is UnorderedExecutionModule_TestInit {
+    /// @notice transactionHash() is exactly the Safe's own getTransactionHash() with the
+    ///         hash-once value in the nonce slot, so existing signing tooling works unchanged.
+    function test_transactionHash_matchesSafe_works() external view {
+        IUnorderedExecutionModule.ExecTransactionParams memory params = _makeParams(1);
+        assertEq(
+            module.transactionHash(safe, params, HASH_ONCE),
+            safe.getTransactionHash(
+                params.to,
+                params.value,
+                params.data,
+                params.operation,
+                params.safeTxGas,
+                params.baseGas,
+                params.gasPrice,
+                params.gasToken,
+                params.refundReceiver,
+                HASH_ONCE
+            )
+        );
+    }
+
+    /// @notice The transaction hash binds the Safe address.
+    function test_transactionHash_bindsSafe_works() external {
+        SafeInstance memory otherInstance = _setupExtraSafe(safeInstance.ownerPKs, THRESHOLD, 105);
+        Safe otherSafe = Safe(payable(address(otherInstance.safe)));
+
+        IUnorderedExecutionModule.ExecTransactionParams memory params = _makeParams(1);
+        assertTrue(
+            module.transactionHash(safe, params, HASH_ONCE) != module.transactionHash(otherSafe, params, HASH_ONCE)
+        );
+    }
+
+    /// @notice The transaction hash binds the hash-once value.
+    function testFuzz_transactionHash_bindsHashOnce_works(uint256 _hashOnce1, uint256 _hashOnce2) external view {
+        vm.assume(_hashOnce1 != _hashOnce2);
+        IUnorderedExecutionModule.ExecTransactionParams memory params = _makeParams(1);
+        assertTrue(module.transactionHash(safe, params, _hashOnce1) != module.transactionHash(safe, params, _hashOnce2));
+    }
+}
+
+/// @title UnorderedExecutionModule_Uncategorized_Test
+/// @notice Tests for simple getters.
+contract UnorderedExecutionModule_Uncategorized_Test is UnorderedExecutionModule_TestInit {
+    /// @notice deriveHashOnce() is the keccak256 of the input string, always above the hash-once
+    ///         floor for realistic inputs.
+    function test_deriveHashOnce_works() external view {
+        string memory input = "eip/upgrade-99: totally unique string";
+        assertEq(module.deriveHashOnce(input), uint256(keccak256(bytes(input))));
+        assertTrue(module.deriveHashOnce(input) > uint256(type(uint128).max));
+    }
+
+    /// @notice Unknown transaction hashes are unexecuted.
+    function test_executed_default_works() external view {
+        assertFalse(module.executed(safe, bytes32(uint256(123))));
+    }
+}

--- a/packages/contracts-bedrock/test/safe/UnorderedExecutionModule.t.sol
+++ b/packages/contracts-bedrock/test/safe/UnorderedExecutionModule.t.sol
@@ -52,7 +52,7 @@ contract UnorderedExecutionModule_Emitter_Harness {
 abstract contract UnorderedExecutionModule_TestInit is Test, SafeTestTools {
     using SafeTestLib for SafeInstance;
 
-    event TransactionExecuted(address indexed safe, bytes32 indexed txHash);
+    event TransactionExecuted(address indexed safe, bytes32 indexed txHash, uint256 indexed hashOnce);
     event Emitted(address self);
 
     uint256 internal constant INIT_TIME = 1_000_000;
@@ -109,12 +109,7 @@ abstract contract UnorderedExecutionModule_TestInit is Test, SafeTestTools {
             to: address(target),
             value: 0,
             data: abi.encodeCall(UnorderedExecutionModule_Target_Harness.setValue, (_value)),
-            operation: Enum.Operation.Call,
-            safeTxGas: 0,
-            baseGas: 0,
-            gasPrice: 0,
-            gasToken: address(0),
-            refundReceiver: payable(address(0))
+            operation: Enum.Operation.Call
         });
     }
 
@@ -155,7 +150,7 @@ abstract contract UnorderedExecutionModule_TestInit is Test, SafeTestTools {
 contract UnorderedExecutionModule_Execute_Test is UnorderedExecutionModule_TestInit {
     using SafeTestLib for SafeInstance;
 
-    /// @notice A signed transaction executes the call, is marked executed, and emits
+    /// @notice A signed transaction executes the call, consumes the hash-once value, and emits
     ///         TransactionExecuted.
     function test_execute_succeeds() external {
         IUnorderedExecutionModule.ExecTransactionParams memory params = _makeParams(42);
@@ -163,12 +158,12 @@ contract UnorderedExecutionModule_Execute_Test is UnorderedExecutionModule_TestI
         bytes32 txHash = module.transactionHash(safe, params, HASH_ONCE);
 
         vm.expectEmit(address(module));
-        emit TransactionExecuted(address(safe), txHash);
+        emit TransactionExecuted(address(safe), txHash, HASH_ONCE);
         module.execute(safe, params, HASH_ONCE, sigs);
 
         assertEq(target.value(), 42);
         assertEq(target.lastSender(), address(safe));
-        assertTrue(module.executed(safe, txHash));
+        assertTrue(module.executed(safe, HASH_ONCE));
     }
 
     /// @notice Transactions execute in any order relative to the order they were signed in, and
@@ -247,8 +242,6 @@ contract UnorderedExecutionModule_Execute_Test is UnorderedExecutionModule_TestI
         uint256 hashOnce1 = uint256(keccak256("task: first run"));
         uint256 hashOnce2 = uint256(keccak256("task: second run"));
 
-        assertTrue(module.transactionHash(safe, params, hashOnce1) != module.transactionHash(safe, params, hashOnce2));
-
         module.execute(safe, params, hashOnce1, _signTx(params, hashOnce1));
         module.execute(safe, params, hashOnce2, _signTx(params, hashOnce2));
         assertEq(target.value(), 5);
@@ -294,16 +287,7 @@ contract UnorderedExecutionModule_Execute_Test is UnorderedExecutionModule_TestI
 
         // The child Safe signs the parent Safe's encoded transaction data as a Safe message.
         bytes memory txHashData = parentSafe.encodeTransactionData(
-            params.to,
-            params.value,
-            params.data,
-            params.operation,
-            params.safeTxGas,
-            params.baseGas,
-            params.gasPrice,
-            params.gasToken,
-            params.refundReceiver,
-            HASH_ONCE
+            params.to, params.value, params.data, params.operation, 0, 0, 0, address(0), address(0), HASH_ONCE
         );
         SafeTestLib.EIP1271Sign(childInstance, txHashData);
 
@@ -318,15 +302,6 @@ contract UnorderedExecutionModule_Execute_Test is UnorderedExecutionModule_TestI
         assertEq(target.lastSender(), address(parentSafe));
     }
 
-    /// @notice A Safe reporting version 1.3.0 is accepted.
-    function test_execute_safeVersion130_succeeds() external {
-        // nosemgrep: sol-style-use-abi-encodecall
-        vm.mockCall(address(safe), abi.encodeWithSignature("VERSION()"), abi.encode("1.3.0"));
-        IUnorderedExecutionModule.ExecTransactionParams memory params = _makeParams(9);
-        module.execute(safe, params, HASH_ONCE, _signTx(params, HASH_ONCE));
-        assertEq(target.value(), 9);
-    }
-
     /// @notice The smallest allowed hash-once value is accepted.
     function test_execute_hashOnceAtBoundary_succeeds() external {
         uint256 hashOnce = uint256(type(uint128).max) + 1;
@@ -335,32 +310,24 @@ contract UnorderedExecutionModule_Execute_Test is UnorderedExecutionModule_TestI
         assertEq(target.value(), 4);
     }
 
-    /// @notice A transaction with a signed safeTxGas executes when enough gas is supplied.
-    function test_execute_safeTxGasSatisfied_succeeds() external {
-        IUnorderedExecutionModule.ExecTransactionParams memory params = _makeParams(13);
-        params.safeTxGas = 100_000;
-        module.execute(safe, params, HASH_ONCE, _signTx(params, HASH_ONCE));
-        assertEq(target.value(), 13);
-    }
-
-    /// @notice A failed transaction reverts, remains unexecuted, and can be retried.
+    /// @notice A failed transaction reverts, leaves the hash-once value unconsumed, and can be
+    ///         retried.
     function test_execute_retryAfterFailure_succeeds() external {
         IUnorderedExecutionModule.ExecTransactionParams memory params = _makeParams(0);
         params.data = abi.encodeCall(UnorderedExecutionModule_Target_Harness.conditionalRevert, ());
         bytes memory sigs = _signTx(params, HASH_ONCE);
-        bytes32 txHash = module.transactionHash(safe, params, HASH_ONCE);
 
         target.setShouldRevert(true);
         vm.expectPartialRevert(IUnorderedExecutionModule.UnorderedExecutionModule_ExecutionFailed.selector);
         module.execute(safe, params, HASH_ONCE, sigs);
 
-        // The failed execution left the transaction unexecuted.
-        assertFalse(module.executed(safe, txHash));
+        // The failed execution left the hash-once value unconsumed.
+        assertFalse(module.executed(safe, HASH_ONCE));
 
         // The same signatures work once the call can succeed.
         target.setShouldRevert(false);
         module.execute(safe, params, HASH_ONCE, sigs);
-        assertTrue(module.executed(safe, txHash));
+        assertTrue(module.executed(safe, HASH_ONCE));
     }
 
     /// @notice A transaction cannot be executed twice with the same signatures.
@@ -370,8 +337,30 @@ contract UnorderedExecutionModule_Execute_Test is UnorderedExecutionModule_TestI
 
         module.execute(safe, params, HASH_ONCE, sigs);
 
-        vm.expectRevert(IUnorderedExecutionModule.UnorderedExecutionModule_AlreadyExecuted.selector);
+        vm.expectRevert(IUnorderedExecutionModule.UnorderedExecutionModule_HashOnceAlreadyUsed.selector);
         module.execute(safe, params, HASH_ONCE, sigs);
+    }
+
+    /// @notice A signed task is cancelled by executing a no-op transaction with the same
+    ///         hash-once value, which consumes it and blocks the unwanted task forever.
+    function test_execute_cancelledByNoOp_reverts() external {
+        // The unwanted task.
+        IUnorderedExecutionModule.ExecTransactionParams memory params = _makeParams(666);
+        bytes memory sigs = _signTx(params, HASH_ONCE);
+
+        // The no-op cancellation task, signed with the same hash-once value.
+        IUnorderedExecutionModule.ExecTransactionParams memory noOp = IUnorderedExecutionModule.ExecTransactionParams({
+            to: address(0),
+            value: 0,
+            data: "",
+            operation: Enum.Operation.Call
+        });
+        module.execute(safe, noOp, HASH_ONCE, _signTx(noOp, HASH_ONCE));
+
+        // The unwanted task can no longer be executed.
+        vm.expectRevert(IUnorderedExecutionModule.UnorderedExecutionModule_HashOnceAlreadyUsed.selector);
+        module.execute(safe, params, HASH_ONCE, sigs);
+        assertEq(target.value(), 0);
     }
 
     /// @notice A hash-once value small enough to collide with a real Safe nonce is rejected, so
@@ -386,30 +375,19 @@ contract UnorderedExecutionModule_Execute_Test is UnorderedExecutionModule_TestI
         module.execute(safe, params, hashOnce, sigs);
     }
 
-    /// @notice A transaction promising a gas refund is rejected, since the module pays none.
-    function test_execute_refundNotSupported_reverts() external {
+    /// @notice A Safe whose getTransactionHash() diverges from the keccak256 of its
+    ///         encodeTransactionData() is rejected.
+    function test_execute_hashSchemeMismatch_reverts() external {
         IUnorderedExecutionModule.ExecTransactionParams memory params = _makeParams(1);
-        params.gasPrice = 1;
         bytes memory sigs = _signTx(params, HASH_ONCE);
 
-        vm.expectRevert(IUnorderedExecutionModule.UnorderedExecutionModule_RefundNotSupported.selector);
+        // nosemgrep: sol-style-use-abi-encodecall
+        vm.mockCall(
+            address(safe), abi.encodeWithSelector(safe.getTransactionHash.selector), abi.encode(bytes32(uint256(1)))
+        );
+
+        vm.expectRevert(IUnorderedExecutionModule.UnorderedExecutionModule_UnsupportedSafe.selector);
         module.execute(safe, params, HASH_ONCE, sigs);
-    }
-
-    /// @notice A transaction cannot be executed with less gas available than its signed
-    ///         safeTxGas, so a relayer cannot consume the transaction with a partial, low-gas
-    ///         execution.
-    function test_execute_insufficientGas_reverts() external {
-        IUnorderedExecutionModule.ExecTransactionParams memory params = _makeParams(13);
-        params.safeTxGas = 30_000_000;
-        bytes memory sigs = _signTx(params, HASH_ONCE);
-        bytes32 txHash = module.transactionHash(safe, params, HASH_ONCE);
-
-        vm.expectRevert(IUnorderedExecutionModule.UnorderedExecutionModule_InsufficientGas.selector);
-        module.execute{ gas: 1_000_000 }(safe, params, HASH_ONCE, sigs);
-
-        // The transaction remains executable with sufficient gas.
-        assertFalse(module.executed(safe, txHash));
     }
 
     /// @notice Fewer signatures than the Safe's threshold are rejected.
@@ -490,30 +468,17 @@ contract UnorderedExecutionModule_Execute_Test is UnorderedExecutionModule_TestI
         module.execute(otherSafe, params, HASH_ONCE, sigs);
     }
 
-    /// @notice Safes with unsupported versions are rejected.
-    function test_execute_invalidSafeVersion_reverts() external {
-        // nosemgrep: sol-style-use-abi-encodecall
-        vm.mockCall(address(safe), abi.encodeWithSignature("VERSION()"), abi.encode("1.5.0"));
-
-        IUnorderedExecutionModule.ExecTransactionParams memory params = _makeParams(1);
-        bytes memory sigs = _signTx(params, HASH_ONCE);
-
-        vm.expectRevert(IUnorderedExecutionModule.UnorderedExecutionModule_InvalidSafeVersion.selector);
-        module.execute(safe, params, HASH_ONCE, sigs);
-    }
-
     /// @notice Any signed transaction with valid parameters executes.
     function testFuzz_execute_succeeds(uint256 _value, uint256 _hashOnce) external {
         _hashOnce = bound(_hashOnce, uint256(type(uint128).max) + 1, type(uint256).max);
 
         IUnorderedExecutionModule.ExecTransactionParams memory params = _makeParams(_value);
         bytes memory sigs = _signTx(params, _hashOnce);
-        bytes32 txHash = module.transactionHash(safe, params, _hashOnce);
 
         module.execute(safe, params, _hashOnce, sigs);
 
         assertEq(target.value(), _value);
-        assertTrue(module.executed(safe, txHash));
+        assertTrue(module.executed(safe, _hashOnce));
     }
 }
 
@@ -521,22 +486,14 @@ contract UnorderedExecutionModule_Execute_Test is UnorderedExecutionModule_TestI
 /// @notice Tests for the `transactionHash` function.
 contract UnorderedExecutionModule_TransactionHash_Test is UnorderedExecutionModule_TestInit {
     /// @notice transactionHash() is exactly the Safe's own getTransactionHash() with the
-    ///         hash-once value in the nonce slot, so existing signing tooling works unchanged.
+    ///         hash-once value in the nonce slot and zeroed gas and refund fields, so existing
+    ///         signing tooling works unchanged.
     function test_transactionHash_matchesSafe_works() external view {
         IUnorderedExecutionModule.ExecTransactionParams memory params = _makeParams(1);
         assertEq(
             module.transactionHash(safe, params, HASH_ONCE),
             safe.getTransactionHash(
-                params.to,
-                params.value,
-                params.data,
-                params.operation,
-                params.safeTxGas,
-                params.baseGas,
-                params.gasPrice,
-                params.gasToken,
-                params.refundReceiver,
-                HASH_ONCE
+                params.to, params.value, params.data, params.operation, 0, 0, 0, address(0), address(0), HASH_ONCE
             )
         );
     }
@@ -571,8 +528,8 @@ contract UnorderedExecutionModule_Uncategorized_Test is UnorderedExecutionModule
         assertTrue(module.deriveHashOnce(input) > uint256(type(uint128).max));
     }
 
-    /// @notice Unknown transaction hashes are unexecuted.
+    /// @notice Unknown hash-once values are unconsumed.
     function test_executed_default_works() external view {
-        assertFalse(module.executed(safe, bytes32(uint256(123))));
+        assertFalse(module.executed(safe, uint256(123)));
     }
 }


### PR DESCRIPTION
## Summary

Adds `UnorderedExecutionModule`, a Safe module enabling nonceless (hash-once) execution for superchain-ops tasks: owners sign the Safe's own transaction hash computed with a per-task hash-once value (keccak of a unique string pinned in the task config) in the nonce slot instead of the sequential nonce. Signatures stay valid regardless of task ordering, so reordering pending tasks never forces re-signing.

Design points:
- Replay protection is a per-`(safe, hashOnce)` consumed-once mapping; hash-once values must exceed `type(uint128).max` so they can never collide with a real nonce.
- No cancellation/expiry mechanism: cancel by consuming the hash-once value with a no-op, or rotate the task's `hashOnceInput`.
- No ordering support (no dependency chaining): tasks that need ordering use the existing nonce flow.
- Signature verification uses the Safe's `checkSignatures`, so approveHash, EIP-1271 and EOA signatures all work; the EIP-712 encoding is built locally so Safe 1.5.0 (which removed `encodeTransactionData`) is supported alongside 1.3.0/1.4.1.
- Approver addresses are exposed via `signers()` in transient storage for future module guards (liveness); nothing but the replay mapping persists.

Deployed and source-verified on Sepolia at `0xADcbCff796a47D468fE8C0252FBe8d856d4e63D7`, enabled on Safe 1.5.0 and 1.4.1 instances, and exercised end-to-end (single and nested safes) by superchain-ops test tasks — see companion superchain-ops PR.

Part of the San Diego hackathon nonceless (hash-once) Safe execution project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)