### PR TITLE
contracts-bedrock: throttle ERC20 and ETH withdrawals

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -2954,6 +2954,9 @@ workflows:
                 - CUSTOM_GAS_TOKEN
                 - OPTIMISM_PORTAL_INTEROP
                 - ZK_DISPUTE_GAME
+                - WITHDRAWAL_THROTTLE
+                - WITHDRAWAL_THROTTLE,OPTIMISM_PORTAL_INTEROP
+                - WITHDRAWAL_THROTTLE,CUSTOM_GAS_TOKEN
           context:
             - circleci-repo-readonly-authenticated-github-token
             - slack
@@ -3109,18 +3112,30 @@ workflows:
             - contracts-bedrock-tests CUSTOM_GAS_TOKEN: terminal
             - contracts-bedrock-tests OPTIMISM_PORTAL_INTEROP: terminal
             - contracts-bedrock-tests ZK_DISPUTE_GAME: terminal
+            - contracts-bedrock-tests WITHDRAWAL_THROTTLE: terminal
+            - contracts-bedrock-tests WITHDRAWAL_THROTTLE,OPTIMISM_PORTAL_INTEROP: terminal
+            - contracts-bedrock-tests WITHDRAWAL_THROTTLE,CUSTOM_GAS_TOKEN: terminal
             - contracts-bedrock-tests-heavy-fuzz-modified main: terminal
             - contracts-bedrock-tests-heavy-fuzz-modified CUSTOM_GAS_TOKEN: terminal
             - contracts-bedrock-tests-heavy-fuzz-modified OPTIMISM_PORTAL_INTEROP: terminal
             - contracts-bedrock-tests-heavy-fuzz-modified ZK_DISPUTE_GAME: terminal
+            - contracts-bedrock-tests-heavy-fuzz-modified WITHDRAWAL_THROTTLE: terminal
+            - contracts-bedrock-tests-heavy-fuzz-modified WITHDRAWAL_THROTTLE,OPTIMISM_PORTAL_INTEROP: terminal
+            - contracts-bedrock-tests-heavy-fuzz-modified WITHDRAWAL_THROTTLE,CUSTOM_GAS_TOKEN: terminal
             - contracts-bedrock-coverage main: terminal
             - contracts-bedrock-coverage CUSTOM_GAS_TOKEN: terminal
             - contracts-bedrock-coverage OPTIMISM_PORTAL_INTEROP: terminal
             - contracts-bedrock-coverage ZK_DISPUTE_GAME: terminal
+            - contracts-bedrock-coverage WITHDRAWAL_THROTTLE: terminal
+            - contracts-bedrock-coverage WITHDRAWAL_THROTTLE,OPTIMISM_PORTAL_INTEROP: terminal
+            - contracts-bedrock-coverage WITHDRAWAL_THROTTLE,CUSTOM_GAS_TOKEN: terminal
             - contracts-bedrock-tests-upgrade op-mainnet main: terminal
             - contracts-bedrock-tests-upgrade op-mainnet CUSTOM_GAS_TOKEN: terminal
             - contracts-bedrock-tests-upgrade op-mainnet OPTIMISM_PORTAL_INTEROP: terminal
             - contracts-bedrock-tests-upgrade op-mainnet ZK_DISPUTE_GAME: terminal
+            - contracts-bedrock-tests-upgrade op-mainnet WITHDRAWAL_THROTTLE: terminal
+            - contracts-bedrock-tests-upgrade op-mainnet WITHDRAWAL_THROTTLE,OPTIMISM_PORTAL_INTEROP: terminal
+            - contracts-bedrock-tests-upgrade op-mainnet WITHDRAWAL_THROTTLE,CUSTOM_GAS_TOKEN: terminal
             - contracts-bedrock-tests-upgrade op-mainnet: terminal
             - contracts-bedrock-tests-upgrade ink-mainnet: terminal
             - contracts-bedrock-tests-upgrade unichain-mainnet: terminal

--- a/docs/ai/devfeatures.md
+++ b/docs/ai/devfeatures.md
@@ -19,7 +19,7 @@ Active flags:
 | `DeployV2DisputeGames` | Legacy, no longer used; constant kept for historical reasons |
 | `ZKDisputeGame` | ZK dispute game system |
 | `SuperRootGamesMigration` | Super-root games migration path in OPCM upgrade — **enabled by default** |
-
+| `WithdrawalThrottle` | Withdrawal throttle configuration through OPCM upgrade and migration instructions |
 
 The predicate is a bitwise AND (`(bitmap & flag) == flag && flag != 0`) — except that `IsDevFeatureEnabled` short-circuits to `true` for `SuperRootGamesMigration`, which is enabled by default on both the Go and Solidity sides. The bitmap no longer acts as a circuit breaker for it; removal is tracked in #21662.
 
@@ -67,8 +67,11 @@ A separate, **test-only** assembler exists for Foundry tests and fork scripts. I
 
 - `DEV_FEATURE__OPTIMISM_PORTAL_INTEROP`
 - `DEV_FEATURE__ZK_DISPUTE_GAME`
+- `DEV_FEATURE__WITHDRAWAL_THROTTLE`
 
-Interop and ZK are read via `vm.envOr(..., false)` in `packages/contracts-bedrock/scripts/libraries/Config.sol`; `devFeatureSuperRootGamesMigration()` returns `true` unconditionally. The only callers are under `test/`:
+Interop, ZK, and withdrawal throttling are read via `vm.envOr(..., false)` in
+`packages/contracts-bedrock/scripts/libraries/Config.sol`; `devFeatureSuperRootGamesMigration()`
+returns `true` unconditionally. The only callers are under `test/`:
 
 - `test/setup/FeatureFlags.sol` — `resolveFeaturesFromEnv()` OR-s each enabled flag into `devFeatureBitmap`
 - `test/setup/CommonTest.sol`, `test/setup/ForkL1Live.s.sol`, `test/setup/ForkL2Live.s.sol` — branch on individual `Config.devFeature*` returns
@@ -101,6 +104,12 @@ It does **not** flow to op-node, op-program, or kona at runtime. They learn abou
 
 ## E. Activation — who reads it and what they gate
 
+**On L1 (Solidity)**, `OPContractsManagerV2` and `OPContractsManagerMigrator` read the immutable
+bitmap in their contracts container. `WithdrawalThrottle` permits the one-off
+`WithdrawalThrottleConfig` upgrade/migration instruction; it does not gate the owner-only throttle
+setters themselves. A predeployed OPCM cannot gain this bit from a later intent override, so the
+OPCM deployment must already include the feature.
+
 **On L2 (Solidity)**, readers consult either the in-memory bitmap (during deploy scripts) or the `L2DevFeatureFlags` predeploy (at runtime):
 
 - `Predeploys.isSupportedPredeploy(...)` in `src/libraries/Predeploys.sol` takes the bitmap as a parameter. Gates whether the interop predeploys (`CrossL2Inbox`, `L2ToL2CrossDomainMessenger`, `SuperchainETHBridge`, `ETHLiquidity`, all under `OptimismPortalInterop`) are considered "real" predeploys.
@@ -120,7 +129,13 @@ It does **not** flow to op-node, op-program, or kona at runtime. They learn abou
 
 ## F. Hardfork interaction
 
-Interop and ZK use the bitmap as their per-chain provisioning switch and have no parallel hardfork timestamp. Super-root migration also has no parallel hardfork timestamp, but it is default-on in the predicate, so its bitmap bit no longer acts as a circuit breaker. Network-wide activation timing is a separate mechanism: the hardfork timestamps mapped by the developer toggles in `op-node/rollup/toggles.go` (see section B), e.g. `IsL2CM(time)` decides **when** L2ContractsManager upgrade transactions execute across the network.
+Interop, ZK, and withdrawal throttling use the bitmap as provisioning switches and have no parallel
+hardfork timestamp. Withdrawal throttling gates one-off L1 OPCM instructions; it does not install a
+runtime L2 flag consumer. Super-root migration also has no parallel hardfork timestamp, but it is
+default-on in the predicate, so its bitmap bit no longer acts as a circuit breaker. Network-wide
+activation timing is a separate mechanism: the hardfork timestamps mapped by the developer toggles
+in `op-node/rollup/toggles.go` (see section B), e.g. `IsL2CM(time)` decides **when**
+L2ContractsManager upgrade transactions execute across the network.
 
 ## G. Lifecycle direction
 

--- a/op-core/devfeatures/devfeatures.go
+++ b/op-core/devfeatures/devfeatures.go
@@ -30,6 +30,9 @@ var (
 
 	// SuperRootGamesMigrationFlag enables the super root games migration path in OPCM upgrade.
 	SuperRootGamesMigrationFlag = common.HexToHash("0x0000000000000000000000000000000000000000000000000000000010000000")
+
+	// WithdrawalThrottleFlag enables withdrawal throttle configuration through OPCM.
+	WithdrawalThrottleFlag = common.HexToHash("0x0000000000000000000000000000000000000000000000000000001000000000")
 )
 
 // IsDevFeatureEnabled checks if a specific development feature is enabled in a feature bitmap.

--- a/op-deployer/pkg/deployer/manage/migrate.go
+++ b/op-deployer/pkg/deployer/manage/migrate.go
@@ -11,18 +11,27 @@ import (
 )
 
 // ScriptInput represents the input struct that is actually passed to the script.
-// It contains the prank address, OPCM address, and ABI-encoded migrate input.
+// It contains the prank address, OPCM address, ABI-encoded migrate input, and optional
+// ABI-encoded extra instructions.
 type ScriptInput struct {
-	Prank        common.Address `evm:"prank"`
-	Opcm         common.Address `evm:"opcm"`
-	MigrateInput []byte         `evm:"migrateInput"`
+	Prank             common.Address `evm:"prank"`
+	Opcm              common.Address `evm:"opcm"`
+	MigrateInput      []byte         `evm:"migrateInput"`
+	ExtraInstructions []byte         `evm:"extraInstructions"`
 }
 
 // InteropMigrationInput represents the struct that is read from the config file.
 type InteropMigrationInput struct {
-	Prank          common.Address  `json:"prank"`
-	Opcm           common.Address  `json:"opcm"`
-	MigrateInputV2 *MigrateInputV2 `json:"migrateInputV2,omitempty"`
+	Prank             common.Address     `json:"prank"`
+	Opcm              common.Address     `json:"opcm"`
+	MigrateInputV2    *MigrateInputV2    `json:"migrateInputV2,omitempty"`
+	ExtraInstructions []ExtraInstruction `json:"extraInstructions,omitempty"`
+}
+
+// ExtraInstruction represents a one-off OPCM migration instruction.
+type ExtraInstruction struct {
+	Key  string `json:"key"`
+	Data []byte `json:"data"`
 }
 
 // MigrateInputV2 represents the migrate input format for OPCM v2 (>= 7.0.0).
@@ -59,6 +68,11 @@ var migrateInputV2Encoder = w3.MustNewFunc(
 	"",
 )
 
+var extraInstructionsEncoder = w3.MustNewFunc(
+	"dummy((string key,bytes data)[])",
+	"",
+)
+
 func (i *InteropMigrationInput) EncodedMigrateInputV2() ([]byte, error) {
 	if i.MigrateInputV2 == nil {
 		return nil, fmt.Errorf("MigrateInputV2 is nil")
@@ -76,6 +90,22 @@ func (i *InteropMigrationInput) EncodedMigrateInputV2() ([]byte, error) {
 	return data[4:], nil
 }
 
+func (i *InteropMigrationInput) EncodedExtraInstructions() ([]byte, error) {
+	if len(i.ExtraInstructions) == 0 {
+		return nil, nil
+	}
+
+	data, err := extraInstructionsEncoder.EncodeArgs(i.ExtraInstructions)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode extra instructions: %w", err)
+	}
+	if len(data) < 4 {
+		return nil, fmt.Errorf("failed to encode extra instructions: data is too short")
+	}
+
+	return data[4:], nil
+}
+
 func (output *InteropMigrationOutput) CheckOutput(input common.Address) error {
 	return nil
 }
@@ -89,11 +119,16 @@ func Migrate(host *script.Host, input InteropMigrationInput) (InteropMigrationOu
 	if err != nil {
 		return InteropMigrationOutput{}, err
 	}
+	encodedExtraInstructions, err := input.EncodedExtraInstructions()
+	if err != nil {
+		return InteropMigrationOutput{}, err
+	}
 
 	scriptInput := ScriptInput{
-		Prank:        input.Prank,
-		Opcm:         input.Opcm,
-		MigrateInput: encodedMigrateInput,
+		Prank:             input.Prank,
+		Opcm:              input.Opcm,
+		MigrateInput:      encodedMigrateInput,
+		ExtraInstructions: encodedExtraInstructions,
 	}
 	return opcm.RunScriptSingle[ScriptInput, InteropMigrationOutput](host, scriptInput, "InteropMigration.s.sol", "InteropMigration")
 }

--- a/op-deployer/pkg/deployer/manage/migrate_test.go
+++ b/op-deployer/pkg/deployer/manage/migrate_test.go
@@ -50,6 +50,7 @@ func TestInteropMigration(t *testing.T) {
 	intent, st := shared.NewIntent(t, l1ChainID, dk, l2ChainID, loc, loc, 30_000_000)
 
 	devBitmap := devfeatures.EnableDevFeature(common.Hash{}, devfeatures.OptimismPortalInteropFlag)
+	devBitmap = devfeatures.EnableDevFeature(devBitmap, devfeatures.WithdrawalThrottleFlag)
 	intent.GlobalDeployOverrides = map[string]any{
 		"devFeatureBitmap": devBitmap,
 	}
@@ -107,6 +108,20 @@ func TestInteropMigration(t *testing.T) {
 	testPrestate := common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000abc")
 	gameArgs, err := abi.Arguments{{Type: bytes32Type}}.Pack(testPrestate)
 	require.NoError(t, err)
+	withdrawalThrottleType, err := abi.NewType("tuple[]", "", []abi.ArgumentMarshaling{
+		{Name: "token", Type: "address"},
+		{Name: "maxBps", Type: "uint16"},
+		{Name: "refillPeriod", Type: "uint64"},
+	})
+	require.NoError(t, err)
+	withdrawalThrottleData, err := abi.Arguments{{Type: withdrawalThrottleType}}.Pack([]struct {
+		Token        common.Address
+		MaxBps       uint16
+		RefillPeriod uint64
+	}{
+		{MaxBps: 1000, RefillPeriod: 100},
+	})
+	require.NoError(t, err)
 
 	// Define game type constants matching Solidity GameTypes library.
 	const GameTypeSuperCannonKona = uint32(9)
@@ -132,6 +147,9 @@ func TestInteropMigration(t *testing.T) {
 			},
 			StartingRespectedGameType: GameTypeSuperCannonKona,
 		},
+		ExtraInstructions: []ExtraInstruction{
+			{Key: "WithdrawalThrottleConfig", Data: withdrawalThrottleData},
+		},
 	}
 
 	// Execute Migration
@@ -144,6 +162,9 @@ func TestInteropMigration(t *testing.T) {
 	require.Len(t, dump, 1, "Should have one transaction (migration)")
 	require.True(t, dump[0].Value.ToInt().Cmp(common.Big0) == 0, "Transaction value should be zero")
 	require.Equal(t, l1ProxyAdminOwner, *dump[0].To, "Transaction should be sent to prank address")
+	require.GreaterOrEqual(t, len(dump[0].Data), 4)
+	require.Equal(t, common.FromHex("c73d1bb8"), []byte(dump[0].Data[:4]),
+		"transaction should call migrateWithInstructions")
 }
 
 func TestCommandsDoNotIncludeMigrate(t *testing.T) {
@@ -205,4 +226,35 @@ func TestEncodedMigrateInputV2(t *testing.T) {
 		"aa00000000000000000000000000000000000000000000000000000000000000" // gameArgs data (prestate)
 
 	require.Equal(t, expected, hex.EncodeToString(data))
+}
+
+func TestEncodedExtraInstructions(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		data, err := (&InteropMigrationInput{}).EncodedExtraInstructions()
+		require.NoError(t, err)
+		require.Nil(t, data)
+	})
+
+	t.Run("encodes instructions", func(t *testing.T) {
+		input := &InteropMigrationInput{
+			ExtraInstructions: []ExtraInstruction{
+				{Key: "test-key", Data: []byte{0x04, 0x05, 0x06}},
+			},
+		}
+
+		data, err := input.EncodedExtraInstructions()
+		require.NoError(t, err)
+
+		expected := "0000000000000000000000000000000000000000000000000000000000000020" + // offset to instructions
+			"0000000000000000000000000000000000000000000000000000000000000001" + // instructions.length
+			"0000000000000000000000000000000000000000000000000000000000000020" + // offset to instructions[0]
+			"0000000000000000000000000000000000000000000000000000000000000040" + // offset to key
+			"0000000000000000000000000000000000000000000000000000000000000080" + // offset to data
+			"0000000000000000000000000000000000000000000000000000000000000008" + // key.length
+			"746573742d6b6579000000000000000000000000000000000000000000000000" + // key data
+			"0000000000000000000000000000000000000000000000000000000000000003" + // data.length
+			"0405060000000000000000000000000000000000000000000000000000000000" // data
+
+		require.Equal(t, expected, hex.EncodeToString(data))
+	})
 }

--- a/packages/contracts-bedrock/interfaces/L1/IETHLockbox.sol
+++ b/packages/contracts-bedrock/interfaces/L1/IETHLockbox.sol
@@ -14,6 +14,22 @@ interface IETHLockbox is IProxyAdminOwnedBase, ISemver, IReinitializableBase {
     error ETHLockbox_InsufficientBalance();
     error ETHLockbox_NoWithdrawalTransactions();
     error ETHLockbox_DifferentSuperchainConfig();
+    error ETHLockbox_InvalidWithdrawalThrottleBps();
+    error ETHLockbox_InvalidWithdrawalThrottlePeriod();
+    error ETHLockbox_WithdrawalThrottleNotEnabled();
+    error ETHLockbox_WithdrawalThrottled(
+        uint256 requestedAmount, uint256 availableCapacity, uint256 totalCapacity
+    );
+
+    struct WithdrawalThrottleConfig {
+        uint256 capacity;
+        uint256 available;
+        uint64 refillPeriod;
+        uint64 lastUpdated;
+        uint64 refillRemainder;
+        uint16 maxBps;
+        bool enabled;
+    }
 
     event Initialized(uint8 version);
     event ETHLocked(IOptimismPortal2 indexed portal, uint256 amount);
@@ -22,6 +38,17 @@ interface IETHLockbox is IProxyAdminOwnedBase, ISemver, IReinitializableBase {
     event LockboxAuthorized(IETHLockbox indexed lockbox);
     event LiquidityMigrated(IETHLockbox indexed lockbox, uint256 amount);
     event LiquidityReceived(IETHLockbox indexed lockbox, uint256 amount);
+    event WithdrawalThrottleConfigured(
+        uint16 maxBps,
+        uint64 refillPeriod,
+        uint256 stockSnapshot,
+        uint256 capacity,
+        uint256 available
+    );
+    event WithdrawalThrottleRefreshed(uint256 stockSnapshot, uint256 capacity, uint256 available);
+    event WithdrawalThrottleDisabled();
+    event WithdrawalThrottleCapacityConsumed(uint256 amount, uint256 remaining);
+    event WithdrawalThrottleCapacityExhausted();
 
     function initialize(ISystemConfig _systemConfig, IOptimismPortal2[] calldata _portals) external;
     function systemConfig() external view returns (ISystemConfig);
@@ -35,6 +62,11 @@ interface IETHLockbox is IProxyAdminOwnedBase, ISemver, IReinitializableBase {
     function authorizeLockbox(IETHLockbox _lockbox) external;
     function migrateLiquidity(IETHLockbox _lockbox) external;
     function superchainConfig() external view returns (ISuperchainConfig);
+    function setWithdrawalThrottle(uint16 _maxBps, uint64 _refillPeriod) external;
+    function refreshWithdrawalThrottle() external;
+    function disableWithdrawalThrottle() external;
+    function withdrawalThrottle() external view returns (WithdrawalThrottleConfig memory);
+    function availableWithdrawalCapacity() external view returns (uint256);
 
     function __constructor__() external;
 }

--- a/packages/contracts-bedrock/interfaces/L1/IETHLockbox.sol
+++ b/packages/contracts-bedrock/interfaces/L1/IETHLockbox.sol
@@ -9,6 +9,7 @@ import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 import { IReinitializableBase } from "interfaces/universal/IReinitializableBase.sol";
 
 interface IETHLockbox is IProxyAdminOwnedBase, ISemver, IReinitializableBase {
+    error WithdrawalThrottle_TimestampOverflow();
     error ETHLockbox_Unauthorized();
     error ETHLockbox_Paused();
     error ETHLockbox_InsufficientBalance();
@@ -21,6 +22,7 @@ interface IETHLockbox is IProxyAdminOwnedBase, ISemver, IReinitializableBase {
         uint256 requestedAmount, uint256 availableCapacity, uint256 totalCapacity
     );
 
+    /// @notice Stored withdrawal throttle state before pending refill is materialized.
     struct WithdrawalThrottleConfig {
         uint256 capacity;
         uint256 available;

--- a/packages/contracts-bedrock/interfaces/L1/IL1StandardBridge.sol
+++ b/packages/contracts-bedrock/interfaces/L1/IL1StandardBridge.sol
@@ -9,6 +9,27 @@ import { IProxyAdminOwnedBase } from "interfaces/universal/IProxyAdminOwnedBase.
 
 interface IL1StandardBridge is IStandardBridge, IProxyAdminOwnedBase {
     error ReinitializableBase_ZeroInitVersion();
+    error L1StandardBridge_InvalidWithdrawalThrottleToken();
+    error L1StandardBridge_InvalidWithdrawalThrottleBps();
+    error L1StandardBridge_UnsupportedWithdrawalThrottleToken();
+    error L1StandardBridge_InvalidWithdrawalThrottlePeriod();
+    error L1StandardBridge_WithdrawalThrottleNotEnabled();
+    error L1StandardBridge_WithdrawalThrottled(
+        address token,
+        uint256 requestedAmount,
+        uint256 availableCapacity,
+        uint256 totalCapacity
+    );
+
+    struct WithdrawalThrottleConfig {
+        uint256 capacity;
+        uint256 available;
+        uint64 refillPeriod;
+        uint64 lastUpdated;
+        uint64 refillRemainder;
+        uint16 maxBps;
+        bool enabled;
+    }
 
     event ERC20DepositInitiated(
         address indexed l1Token,
@@ -28,6 +49,20 @@ interface IL1StandardBridge is IStandardBridge, IProxyAdminOwnedBase {
     );
     event ETHDepositInitiated(address indexed from, address indexed to, uint256 amount, bytes extraData);
     event ETHWithdrawalFinalized(address indexed from, address indexed to, uint256 amount, bytes extraData);
+    event WithdrawalThrottleConfigured(
+        address indexed token,
+        uint16 maxBps,
+        uint64 refillPeriod,
+        uint256 stockSnapshot,
+        uint256 capacity,
+        uint256 available
+    );
+    event WithdrawalThrottleRefreshed(
+        address indexed token, uint256 stockSnapshot, uint256 capacity, uint256 available
+    );
+    event WithdrawalThrottleDisabled(address indexed token);
+    event WithdrawalThrottleCapacityConsumed(address indexed token, uint256 amount, uint256 remaining);
+    event WithdrawalThrottleCapacityExhausted(address indexed token);
 
     function initVersion() external view returns (uint8);
     function depositERC20(
@@ -68,6 +103,11 @@ interface IL1StandardBridge is IStandardBridge, IProxyAdminOwnedBase {
         payable;
     function initialize(ICrossDomainMessenger _messenger, ISystemConfig _systemConfig) external;
     function l2TokenBridge() external view returns (address);
+    function setWithdrawalThrottle(address _token, uint16 _maxBps, uint64 _refillPeriod) external;
+    function refreshWithdrawalThrottle(address _token) external;
+    function disableWithdrawalThrottle(address _token) external;
+    function withdrawalThrottle(address _token) external view returns (WithdrawalThrottleConfig memory);
+    function availableWithdrawalCapacity(address _token) external view returns (uint256);
     function systemConfig() external view returns (ISystemConfig);
     function version() external view returns (string memory);
     function superchainConfig() external view returns (ISuperchainConfig);

--- a/packages/contracts-bedrock/interfaces/L1/IL1StandardBridge.sol
+++ b/packages/contracts-bedrock/interfaces/L1/IL1StandardBridge.sol
@@ -8,6 +8,7 @@ import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 import { IProxyAdminOwnedBase } from "interfaces/universal/IProxyAdminOwnedBase.sol";
 
 interface IL1StandardBridge is IStandardBridge, IProxyAdminOwnedBase {
+    error WithdrawalThrottle_TimestampOverflow();
     error ReinitializableBase_ZeroInitVersion();
     error L1StandardBridge_InvalidWithdrawalThrottleToken();
     error L1StandardBridge_InvalidWithdrawalThrottleBps();
@@ -21,6 +22,7 @@ interface IL1StandardBridge is IStandardBridge, IProxyAdminOwnedBase {
         uint256 totalCapacity
     );
 
+    /// @notice Stored withdrawal throttle state before pending refill is materialized.
     struct WithdrawalThrottleConfig {
         uint256 capacity;
         uint256 available;

--- a/packages/contracts-bedrock/interfaces/L1/IOptimismPortal2.sol
+++ b/packages/contracts-bedrock/interfaces/L1/IOptimismPortal2.sol
@@ -12,6 +12,17 @@ import { IProxyAdminOwnedBase } from "interfaces/universal/IProxyAdminOwnedBase.
 import { IETHLockbox } from "interfaces/L1/IETHLockbox.sol";
 
 interface IOptimismPortal2 is IProxyAdminOwnedBase {
+    /// @notice Withdrawal throttle state for ETH held directly by the portal.
+    struct WithdrawalThrottleConfig {
+        uint256 capacity;
+        uint256 available;
+        uint64 refillPeriod;
+        uint64 lastUpdated;
+        uint64 refillRemainder;
+        uint16 maxBps;
+        bool enabled;
+    }
+
     error ContentLengthMismatch();
     error EmptyItem();
     error InvalidDataRemainder();
@@ -69,6 +80,7 @@ interface IOptimismPortal2 is IProxyAdminOwnedBase {
         uint256 capacity,
         uint256 available
     );
+    event WithdrawalThrottleRefreshed(uint256 stockSnapshot, uint256 capacity, uint256 available);
     event WithdrawalThrottleDisabled();
     event WithdrawalThrottleCapacityConsumed(uint256 amount, uint256 remaining);
     event WithdrawalThrottleCapacityExhausted();
@@ -113,6 +125,7 @@ interface IOptimismPortal2 is IProxyAdminOwnedBase {
     function proofSubmitters(bytes32, uint256) external view returns (address);
     function setWithdrawalThrottle(uint16 _maxBps, uint64 _refillPeriod) external;
     function disableWithdrawalThrottle() external;
+    function withdrawalThrottle() external view returns (WithdrawalThrottleConfig memory);
     function availableWithdrawalCapacity() external view returns (uint256);
     function proveWithdrawalTransaction(
         Types.WithdrawalTransaction memory _tx,

--- a/packages/contracts-bedrock/interfaces/L1/IOptimismPortal2.sol
+++ b/packages/contracts-bedrock/interfaces/L1/IOptimismPortal2.sol
@@ -39,6 +39,13 @@ interface IOptimismPortal2 is IProxyAdminOwnedBase {
     error OptimismPortal_InvalidLockboxState();
     error OptimismPortal_ZeroAddress();
     error OptimismPortal_LockboxNotAuthorizedForPortal();
+    error OptimismPortal_InvalidWithdrawalThrottleBps();
+    error OptimismPortal_InvalidWithdrawalThrottlePeriod();
+    error OptimismPortal_WithdrawalThrottleNotEnabled();
+    error OptimismPortal_WithdrawalThrottleManagedByLockbox();
+    error OptimismPortal_WithdrawalThrottled(
+        uint256 requestedAmount, uint256 availableCapacity, uint256 totalCapacity
+    );
     error OutOfGas();
     error UnexpectedList();
     error UnexpectedString();
@@ -55,6 +62,16 @@ interface IOptimismPortal2 is IProxyAdminOwnedBase {
     event WithdrawalFinalized(bytes32 indexed withdrawalHash, bool success);
     event WithdrawalProven(bytes32 indexed withdrawalHash, address indexed from, address indexed to);
     event WithdrawalProvenExtension1(bytes32 indexed withdrawalHash, address indexed proofSubmitter);
+    event WithdrawalThrottleConfigured(
+        uint16 maxBps,
+        uint64 refillPeriod,
+        uint256 stockSnapshot,
+        uint256 capacity,
+        uint256 available
+    );
+    event WithdrawalThrottleDisabled();
+    event WithdrawalThrottleCapacityConsumed(uint256 amount, uint256 remaining);
+    event WithdrawalThrottleCapacityExhausted();
 
     receive() external payable;
 
@@ -94,6 +111,9 @@ interface IOptimismPortal2 is IProxyAdminOwnedBase {
     function paused() external view returns (bool);
     function proofMaturityDelaySeconds() external view returns (uint256);
     function proofSubmitters(bytes32, uint256) external view returns (address);
+    function setWithdrawalThrottle(uint16 _maxBps, uint64 _refillPeriod) external;
+    function disableWithdrawalThrottle() external;
+    function availableWithdrawalCapacity() external view returns (uint256);
     function proveWithdrawalTransaction(
         Types.WithdrawalTransaction memory _tx,
         uint256 _disputeGameIndex,

--- a/packages/contracts-bedrock/interfaces/L1/IOptimismPortal2.sol
+++ b/packages/contracts-bedrock/interfaces/L1/IOptimismPortal2.sol
@@ -12,7 +12,7 @@ import { IProxyAdminOwnedBase } from "interfaces/universal/IProxyAdminOwnedBase.
 import { IETHLockbox } from "interfaces/L1/IETHLockbox.sol";
 
 interface IOptimismPortal2 is IProxyAdminOwnedBase {
-    /// @notice Withdrawal throttle state for ETH held directly by the portal.
+    /// @notice Stored withdrawal throttle state for ETH held directly by the portal before pending refill.
     struct WithdrawalThrottleConfig {
         uint256 capacity;
         uint256 available;
@@ -23,6 +23,7 @@ interface IOptimismPortal2 is IProxyAdminOwnedBase {
         bool enabled;
     }
 
+    error WithdrawalThrottle_TimestampOverflow();
     error ContentLengthMismatch();
     error EmptyItem();
     error InvalidDataRemainder();

--- a/packages/contracts-bedrock/interfaces/L1/opcm/IOPContractsManagerMigrator.sol
+++ b/packages/contracts-bedrock/interfaces/L1/opcm/IOPContractsManagerMigrator.sol
@@ -67,6 +67,12 @@ interface IOPContractsManagerMigrator {
     ///         it is given, so a disabled config would be registered anyway.
     error OPContractsManagerMigrator_DisputeGameNotEnabled();
 
+    /// @notice Thrown when a migration instruction is not permitted.
+    error OPContractsManagerMigrator_InvalidMigrationInstruction(string _key);
+
+    /// @notice Thrown when shared lockbox throttle configuration is not exactly one ETH entry.
+    error OPContractsManagerMigrator_InvalidWithdrawalThrottleConfig();
+
     /// @notice Returns the container of blueprint and implementation contract addresses.
     function contractsContainer() external view returns (IOPContractsManagerContainer);
 
@@ -77,6 +83,13 @@ interface IOPContractsManagerMigrator {
     ///         dispute game contracts.
     /// @param _input The input parameters for the migration.
     function migrate(MigrateInput calldata _input) external;
+
+    /// @notice Migrates chains and applies permitted one-off migration instructions.
+    function migrateWithInstructions(
+        MigrateInput calldata _input,
+        IOPContractsManagerUtils.ExtraInstruction[] calldata _extraInstructions
+    )
+        external;
 
     function __constructor__(IOPContractsManagerUtils _utils) external;
 }

--- a/packages/contracts-bedrock/interfaces/L1/opcm/IOPContractsManagerUtils.sol
+++ b/packages/contracts-bedrock/interfaces/L1/opcm/IOPContractsManagerUtils.sol
@@ -23,6 +23,16 @@ interface IOPContractsManagerUtils {
         bytes data;
     }
 
+    /// @notice Parameters for configuring one asset's withdrawal throttle.
+    /// @param token        L1 token address, or address(0) for ETH.
+    /// @param maxBps       Maximum withdrawable stock in basis points.
+    /// @param refillPeriod Time in seconds for the bucket to refill from empty to full.
+    struct WithdrawalThrottleConfig {
+        address token;
+        uint16 maxBps;
+        uint64 refillPeriod;
+    }
+
     /// @notice Configuration struct for the FaultDisputeGame.
     struct FaultDisputeGameConfig {
         Claim absolutePrestate;

--- a/packages/contracts-bedrock/interfaces/L1/opcm/IOPContractsManagerV2.sol
+++ b/packages/contracts-bedrock/interfaces/L1/opcm/IOPContractsManagerV2.sol
@@ -82,6 +82,9 @@ interface IOPContractsManagerV2 {
     error OPContractsManagerV2_SuperchainConfigNeedsUpgrade();
     error OPContractsManagerV2_InvalidUpgradeInstruction(string _key);
     error OPContractsManagerV2_DuplicateUpgradeInstruction(string _key);
+    error OPContractsManagerV2_InvalidWithdrawalThrottleConfig();
+    error OPContractsManagerV2_DuplicateWithdrawalThrottleToken(address _token);
+    error OPContractsManagerV2_WithdrawalThrottleConfigConflict(address _token);
     error OPContractsManagerV2_OnlyDelegateCall();
     error OPContractsManagerV2_CannotUpgradeToCustomGasToken();
     error OPContractsManagerV2_InvalidUpgradeSequence(string _lastVersion, string _thisVersion);
@@ -131,6 +134,13 @@ interface IOPContractsManagerV2 {
     /// @notice Migrates one or more OP Stack chains to use the Super Root dispute games and shared
     ///         dispute game contracts.
     function migrate(IOPContractsManagerMigrator.MigrateInput calldata _input) external;
+
+    /// @notice Migrates chains and applies permitted one-off migration instructions.
+    function migrateWithInstructions(
+        IOPContractsManagerMigrator.MigrateInput calldata _input,
+        IOPContractsManagerUtils.ExtraInstruction[] calldata _extraInstructions
+    )
+        external;
 
     /// @notice Returns whether a development feature is enabled.
     function isDevFeatureEnabled(bytes32 _feature) external view returns (bool);

--- a/packages/contracts-bedrock/scripts/deploy/InteropMigration.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/InteropMigration.s.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.15;
 import { Script } from "forge-std/Script.sol";
 import { BaseDeployIO } from "scripts/deploy/BaseDeployIO.sol";
 import { IOPContractsManagerMigrator } from "interfaces/L1/opcm/IOPContractsManagerMigrator.sol";
+import { IOPContractsManagerUtils } from "interfaces/L1/opcm/IOPContractsManagerUtils.sol";
 import { ISemver } from "interfaces/universal/ISemver.sol";
 import { SemverComp } from "src/libraries/SemverComp.sol";
 import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
@@ -16,6 +17,8 @@ contract InteropMigrationInput is BaseDeployIO {
     address internal _opcm;
     /// @notice The migrate input is stored as opaque bytes to allow storing both OPCM v1 and v2 migrate inputs.
     bytes internal _migrateInput;
+    /// @notice Optional one-off migration instructions.
+    bytes internal _extraInstructions;
 
     function set(bytes4 _sel, address _value) public {
         require(address(_value) != address(0), "InteropMigrationInput: cannot set zero address");
@@ -33,6 +36,12 @@ contract InteropMigrationInput is BaseDeployIO {
         else revert("InteropMigrationInput: unknown selector");
     }
 
+    /// @notice Sets one-off OPCM migration instructions.
+    function set(bytes4 _sel, IOPContractsManagerUtils.ExtraInstruction[] memory _value) public {
+        if (_sel == this.extraInstructions.selector) _extraInstructions = abi.encode(_value);
+        else revert("InteropMigrationInput: unknown selector");
+    }
+
     function prank() public view returns (address) {
         require(address(_prank) != address(0), "InteropMigrationInput: prank not set");
         return _prank;
@@ -46,6 +55,10 @@ contract InteropMigrationInput is BaseDeployIO {
     function migrateInput() public view returns (bytes memory) {
         require(_migrateInput.length > 0, "InteropMigrationInput: migrateInput not set");
         return _migrateInput;
+    }
+
+    function extraInstructions() public view returns (bytes memory) {
+        return _extraInstructions;
     }
 }
 
@@ -72,6 +85,13 @@ contract InteropMigration is Script {
             SemverComp.gte(ISemver(opcm).version(), "7.0.0"),
             "InteropMigration: OPCM must be v7.0.0 or later (OPCMv2). OPCMv1 is no longer supported."
         );
+        bytes memory encodedInstructions = _imi.extraInstructions();
+        if (encodedInstructions.length != 0) {
+            require(
+                SemverComp.gte(ISemver(opcm).version(), "8.0.4"),
+                "InteropMigration: OPCM must be v8.0.4 or later when using extra instructions."
+            );
+        }
 
         // Etch DummyCaller contract. This contract is used to mimic the contract that is used
         // as the source of the delegatecall to the OPCM. In practice this will be the governance
@@ -85,9 +105,15 @@ contract InteropMigration is Script {
         // Call into the DummyCaller. This will perform the delegatecall under the hood.
         // The DummyCaller uses a fallback that reverts on failure, so no need to check success.
         vm.startBroadcast(msg.sender);
-        IOPContractsManagerMigrator(prank).migrate(
-            abi.decode(_imi.migrateInput(), (IOPContractsManagerMigrator.MigrateInput))
-        );
+        IOPContractsManagerMigrator.MigrateInput memory migrateInput =
+            abi.decode(_imi.migrateInput(), (IOPContractsManagerMigrator.MigrateInput));
+        if (encodedInstructions.length == 0) {
+            IOPContractsManagerMigrator(prank).migrate(migrateInput);
+        } else {
+            IOPContractsManagerMigrator(prank).migrateWithInstructions(
+                migrateInput, abi.decode(encodedInstructions, (IOPContractsManagerUtils.ExtraInstruction[]))
+            );
+        }
         vm.stopBroadcast();
 
         // After migration all portals will have the same DGF

--- a/packages/contracts-bedrock/scripts/libraries/Config.sol
+++ b/packages/contracts-bedrock/scripts/libraries/Config.sol
@@ -342,6 +342,11 @@ library Config {
         return true;
     }
 
+    /// @notice Returns true if withdrawal throttle configuration through OPCM is enabled.
+    function devFeatureWithdrawalThrottle() internal view returns (bool) {
+        return vm.envOr("DEV_FEATURE__WITHDRAWAL_THROTTLE", false);
+    }
+
     /// @notice Returns true if the system feature custom_gas_token is enabled.
     function sysFeatureCustomGasToken() internal view returns (bool) {
         return vm.envOr("SYS_FEATURE__CUSTOM_GAS_TOKEN", false);

--- a/packages/contracts-bedrock/snapshots/WithdrawalFinalizationGas.json
+++ b/packages/contracts-bedrock/snapshots/WithdrawalFinalizationGas.json
@@ -1,0 +1,10 @@
+{
+  "eth-lockbox-shared-throttled": "214324",
+  "eth-lockbox-shared-unthrottled": "199484",
+  "eth-lockbox-throttled": "77021",
+  "eth-lockbox-unthrottled": "62181",
+  "l1-standard-bridge-throttled": "124119",
+  "l1-standard-bridge-unthrottled": "106877",
+  "optimism-portal-throttled": "171335",
+  "optimism-portal-unthrottled": "156495"
+}

--- a/packages/contracts-bedrock/snapshots/WithdrawalFinalizationGas.json
+++ b/packages/contracts-bedrock/snapshots/WithdrawalFinalizationGas.json
@@ -1,10 +1,10 @@
 {
-  "eth-lockbox-shared-throttled": "214324",
+  "eth-lockbox-shared-throttled": "214379",
   "eth-lockbox-shared-unthrottled": "199484",
-  "eth-lockbox-throttled": "77021",
+  "eth-lockbox-throttled": "77076",
   "eth-lockbox-unthrottled": "62181",
-  "l1-standard-bridge-throttled": "124119",
+  "l1-standard-bridge-throttled": "124177",
   "l1-standard-bridge-unthrottled": "106877",
-  "optimism-portal-throttled": "171335",
+  "optimism-portal-throttled": "171390",
   "optimism-portal-unthrottled": "156495"
 }

--- a/packages/contracts-bedrock/snapshots/abi/ETHLockbox.json
+++ b/packages/contracts-bedrock/snapshots/abi/ETHLockbox.json
@@ -615,5 +615,10 @@
     "inputs": [],
     "name": "ReinitializableBase_ZeroInitVersion",
     "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "WithdrawalThrottle_TimestampOverflow",
+    "type": "error"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/abi/ETHLockbox.json
+++ b/packages/contracts-bedrock/snapshots/abi/ETHLockbox.json
@@ -70,6 +70,26 @@
   },
   {
     "inputs": [],
+    "name": "availableWithdrawalCapacity",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "disableWithdrawalThrottle",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
     "name": "initVersion",
     "outputs": [
       {
@@ -167,6 +187,31 @@
   },
   {
     "inputs": [],
+    "name": "refreshWithdrawalThrottle",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint16",
+        "name": "_maxBps",
+        "type": "uint16"
+      },
+      {
+        "internalType": "uint64",
+        "name": "_refillPeriod",
+        "type": "uint64"
+      }
+    ],
+    "name": "setWithdrawalThrottle",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
     "name": "superchainConfig",
     "outputs": [
       {
@@ -212,6 +257,56 @@
         "internalType": "string",
         "name": "",
         "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "withdrawalThrottle",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "capacity",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "available",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint64",
+            "name": "refillPeriod",
+            "type": "uint64"
+          },
+          {
+            "internalType": "uint64",
+            "name": "lastUpdated",
+            "type": "uint64"
+          },
+          {
+            "internalType": "uint64",
+            "name": "refillRemainder",
+            "type": "uint64"
+          },
+          {
+            "internalType": "uint16",
+            "name": "maxBps",
+            "type": "uint16"
+          },
+          {
+            "internalType": "bool",
+            "name": "enabled",
+            "type": "bool"
+          }
+        ],
+        "internalType": "struct ETHLockbox.WithdrawalThrottleConfig",
+        "name": "",
+        "type": "tuple"
       }
     ],
     "stateMutability": "view",
@@ -333,6 +428,99 @@
     "type": "event"
   },
   {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "remaining",
+        "type": "uint256"
+      }
+    ],
+    "name": "WithdrawalThrottleCapacityConsumed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [],
+    "name": "WithdrawalThrottleCapacityExhausted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint16",
+        "name": "maxBps",
+        "type": "uint16"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "refillPeriod",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "stockSnapshot",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "capacity",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "available",
+        "type": "uint256"
+      }
+    ],
+    "name": "WithdrawalThrottleConfigured",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [],
+    "name": "WithdrawalThrottleDisabled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "stockSnapshot",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "capacity",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "available",
+        "type": "uint256"
+      }
+    ],
+    "name": "WithdrawalThrottleRefreshed",
+    "type": "event"
+  },
+  {
     "inputs": [],
     "name": "ETHLockbox_DifferentSuperchainConfig",
     "type": "error"
@@ -340,6 +528,16 @@
   {
     "inputs": [],
     "name": "ETHLockbox_InsufficientBalance",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ETHLockbox_InvalidWithdrawalThrottleBps",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ETHLockbox_InvalidWithdrawalThrottlePeriod",
     "type": "error"
   },
   {
@@ -355,6 +553,32 @@
   {
     "inputs": [],
     "name": "ETHLockbox_Unauthorized",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ETHLockbox_WithdrawalThrottleNotEnabled",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "requestedAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "availableCapacity",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "totalCapacity",
+        "type": "uint256"
+      }
+    ],
+    "name": "ETHLockbox_WithdrawalThrottled",
     "type": "error"
   },
   {

--- a/packages/contracts-bedrock/snapshots/abi/L1StandardBridge.json
+++ b/packages/contracts-bedrock/snapshots/abi/L1StandardBridge.json
@@ -38,6 +38,25 @@
     "inputs": [
       {
         "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      }
+    ],
+    "name": "availableWithdrawalCapacity",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
         "name": "_localToken",
         "type": "address"
       },
@@ -286,6 +305,19 @@
     "inputs": [
       {
         "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      }
+    ],
+    "name": "disableWithdrawalThrottle",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
         "name": "_localToken",
         "type": "address"
       },
@@ -524,6 +556,42 @@
     "type": "function"
   },
   {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      }
+    ],
+    "name": "refreshWithdrawalThrottle",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      },
+      {
+        "internalType": "uint16",
+        "name": "_maxBps",
+        "type": "uint16"
+      },
+      {
+        "internalType": "uint64",
+        "name": "_refillPeriod",
+        "type": "uint64"
+      }
+    ],
+    "name": "setWithdrawalThrottle",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
     "inputs": [],
     "name": "superchainConfig",
     "outputs": [
@@ -557,6 +625,62 @@
         "internalType": "string",
         "name": "",
         "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      }
+    ],
+    "name": "withdrawalThrottle",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "capacity",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "available",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint64",
+            "name": "refillPeriod",
+            "type": "uint64"
+          },
+          {
+            "internalType": "uint64",
+            "name": "lastUpdated",
+            "type": "uint64"
+          },
+          {
+            "internalType": "uint64",
+            "name": "refillRemainder",
+            "type": "uint64"
+          },
+          {
+            "internalType": "uint16",
+            "name": "maxBps",
+            "type": "uint16"
+          },
+          {
+            "internalType": "bool",
+            "name": "enabled",
+            "type": "bool"
+          }
+        ],
+        "internalType": "struct L1StandardBridge.WithdrawalThrottleConfig",
+        "name": "",
+        "type": "tuple"
       }
     ],
     "stateMutability": "view",
@@ -870,6 +994,182 @@
     ],
     "name": "Initialized",
     "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "remaining",
+        "type": "uint256"
+      }
+    ],
+    "name": "WithdrawalThrottleCapacityConsumed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      }
+    ],
+    "name": "WithdrawalThrottleCapacityExhausted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint16",
+        "name": "maxBps",
+        "type": "uint16"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "refillPeriod",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "stockSnapshot",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "capacity",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "available",
+        "type": "uint256"
+      }
+    ],
+    "name": "WithdrawalThrottleConfigured",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      }
+    ],
+    "name": "WithdrawalThrottleDisabled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "stockSnapshot",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "capacity",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "available",
+        "type": "uint256"
+      }
+    ],
+    "name": "WithdrawalThrottleRefreshed",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "L1StandardBridge_InvalidWithdrawalThrottleBps",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "L1StandardBridge_InvalidWithdrawalThrottlePeriod",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "L1StandardBridge_InvalidWithdrawalThrottleToken",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "L1StandardBridge_UnsupportedWithdrawalThrottleToken",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "L1StandardBridge_WithdrawalThrottleNotEnabled",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "requestedAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "availableCapacity",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "totalCapacity",
+        "type": "uint256"
+      }
+    ],
+    "name": "L1StandardBridge_WithdrawalThrottled",
+    "type": "error"
   },
   {
     "inputs": [],

--- a/packages/contracts-bedrock/snapshots/abi/L1StandardBridge.json
+++ b/packages/contracts-bedrock/snapshots/abi/L1StandardBridge.json
@@ -1205,5 +1205,10 @@
     "inputs": [],
     "name": "ReinitializableBase_ZeroInitVersion",
     "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "WithdrawalThrottle_TimestampOverflow",
+    "type": "error"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/abi/OPContractsManagerMigrator.json
+++ b/packages/contracts-bedrock/snapshots/abi/OPContractsManagerMigrator.json
@@ -93,6 +93,92 @@
     "type": "function"
   },
   {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "contract ISystemConfig[]",
+            "name": "chainSystemConfigs",
+            "type": "address[]"
+          },
+          {
+            "components": [
+              {
+                "internalType": "bool",
+                "name": "enabled",
+                "type": "bool"
+              },
+              {
+                "internalType": "uint256",
+                "name": "initBond",
+                "type": "uint256"
+              },
+              {
+                "internalType": "GameType",
+                "name": "gameType",
+                "type": "uint32"
+              },
+              {
+                "internalType": "bytes",
+                "name": "gameArgs",
+                "type": "bytes"
+              }
+            ],
+            "internalType": "struct IOPContractsManagerUtils.DisputeGameConfig[]",
+            "name": "disputeGameConfigs",
+            "type": "tuple[]"
+          },
+          {
+            "components": [
+              {
+                "internalType": "Hash",
+                "name": "root",
+                "type": "bytes32"
+              },
+              {
+                "internalType": "uint256",
+                "name": "l2SequenceNumber",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct Proposal",
+            "name": "startingAnchorRoot",
+            "type": "tuple"
+          },
+          {
+            "internalType": "GameType",
+            "name": "startingRespectedGameType",
+            "type": "uint32"
+          }
+        ],
+        "internalType": "struct OPContractsManagerMigrator.MigrateInput",
+        "name": "_input",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          {
+            "internalType": "string",
+            "name": "key",
+            "type": "string"
+          },
+          {
+            "internalType": "bytes",
+            "name": "data",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct IOPContractsManagerUtils.ExtraInstruction[]",
+        "name": "_extraInstructions",
+        "type": "tuple[]"
+      }
+    ],
+    "name": "migrateWithInstructions",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
     "inputs": [],
     "name": "opcmUtils",
     "outputs": [
@@ -146,8 +232,24 @@
     "type": "error"
   },
   {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "_key",
+        "type": "string"
+      }
+    ],
+    "name": "OPContractsManagerMigrator_InvalidMigrationInstruction",
+    "type": "error"
+  },
+  {
     "inputs": [],
     "name": "OPContractsManagerMigrator_InvalidStartingRespectedGameType",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "OPContractsManagerMigrator_InvalidWithdrawalThrottleConfig",
     "type": "error"
   },
   {

--- a/packages/contracts-bedrock/snapshots/abi/OPContractsManagerV2.json
+++ b/packages/contracts-bedrock/snapshots/abi/OPContractsManagerV2.json
@@ -528,6 +528,92 @@
     "type": "function"
   },
   {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "contract ISystemConfig[]",
+            "name": "chainSystemConfigs",
+            "type": "address[]"
+          },
+          {
+            "components": [
+              {
+                "internalType": "bool",
+                "name": "enabled",
+                "type": "bool"
+              },
+              {
+                "internalType": "uint256",
+                "name": "initBond",
+                "type": "uint256"
+              },
+              {
+                "internalType": "GameType",
+                "name": "gameType",
+                "type": "uint32"
+              },
+              {
+                "internalType": "bytes",
+                "name": "gameArgs",
+                "type": "bytes"
+              }
+            ],
+            "internalType": "struct IOPContractsManagerUtils.DisputeGameConfig[]",
+            "name": "disputeGameConfigs",
+            "type": "tuple[]"
+          },
+          {
+            "components": [
+              {
+                "internalType": "Hash",
+                "name": "root",
+                "type": "bytes32"
+              },
+              {
+                "internalType": "uint256",
+                "name": "l2SequenceNumber",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct Proposal",
+            "name": "startingAnchorRoot",
+            "type": "tuple"
+          },
+          {
+            "internalType": "GameType",
+            "name": "startingRespectedGameType",
+            "type": "uint32"
+          }
+        ],
+        "internalType": "struct IOPContractsManagerMigrator.MigrateInput",
+        "name": "_input",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          {
+            "internalType": "string",
+            "name": "key",
+            "type": "string"
+          },
+          {
+            "internalType": "bytes",
+            "name": "data",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct IOPContractsManagerUtils.ExtraInstruction[]",
+        "name": "_extraInstructions",
+        "type": "tuple[]"
+      }
+    ],
+    "name": "migrateWithInstructions",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
     "inputs": [],
     "name": "opcmMigrator",
     "outputs": [
@@ -816,6 +902,17 @@
     "type": "error"
   },
   {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      }
+    ],
+    "name": "OPContractsManagerV2_DuplicateWithdrawalThrottleToken",
+    "type": "error"
+  },
+  {
     "inputs": [],
     "name": "OPContractsManagerV2_InvalidEthLockbox",
     "type": "error"
@@ -859,12 +956,28 @@
   },
   {
     "inputs": [],
+    "name": "OPContractsManagerV2_InvalidWithdrawalThrottleConfig",
+    "type": "error"
+  },
+  {
+    "inputs": [],
     "name": "OPContractsManagerV2_OnlyDelegateCall",
     "type": "error"
   },
   {
     "inputs": [],
     "name": "OPContractsManagerV2_SuperchainConfigNeedsUpgrade",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      }
+    ],
+    "name": "OPContractsManagerV2_WithdrawalThrottleConfigConflict",
     "type": "error"
   },
   {

--- a/packages/contracts-bedrock/snapshots/abi/OptimismPortal2.json
+++ b/packages/contracts-bedrock/snapshots/abi/OptimismPortal2.json
@@ -28,6 +28,19 @@
     "type": "function"
   },
   {
+    "inputs": [],
+    "name": "availableWithdrawalCapacity",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [
       {
         "internalType": "bytes32",
@@ -76,6 +89,13 @@
     "name": "depositTransaction",
     "outputs": [],
     "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "disableWithdrawalThrottle",
+    "outputs": [],
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
@@ -619,6 +639,24 @@
     "type": "function"
   },
   {
+    "inputs": [
+      {
+        "internalType": "uint16",
+        "name": "_maxBps",
+        "type": "uint16"
+      },
+      {
+        "internalType": "uint64",
+        "name": "_refillPeriod",
+        "type": "uint64"
+      }
+    ],
+    "name": "setWithdrawalThrottle",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
     "inputs": [],
     "name": "superchainConfig",
     "outputs": [
@@ -815,6 +853,74 @@
     "type": "event"
   },
   {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "remaining",
+        "type": "uint256"
+      }
+    ],
+    "name": "WithdrawalThrottleCapacityConsumed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [],
+    "name": "WithdrawalThrottleCapacityExhausted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint16",
+        "name": "maxBps",
+        "type": "uint16"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "refillPeriod",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "stockSnapshot",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "capacity",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "available",
+        "type": "uint256"
+      }
+    ],
+    "name": "WithdrawalThrottleConfigured",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [],
+    "name": "WithdrawalThrottleDisabled",
+    "type": "event"
+  },
+  {
     "inputs": [],
     "name": "ContentLengthMismatch",
     "type": "error"
@@ -906,6 +1012,16 @@
   },
   {
     "inputs": [],
+    "name": "OptimismPortal_InvalidWithdrawalThrottleBps",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "OptimismPortal_InvalidWithdrawalThrottlePeriod",
+    "type": "error"
+  },
+  {
+    "inputs": [],
     "name": "OptimismPortal_LockboxNotAuthorizedForPortal",
     "type": "error"
   },
@@ -937,6 +1053,37 @@
   {
     "inputs": [],
     "name": "OptimismPortal_Unproven",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "OptimismPortal_WithdrawalThrottleManagedByLockbox",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "OptimismPortal_WithdrawalThrottleNotEnabled",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "requestedAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "availableCapacity",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "totalCapacity",
+        "type": "uint256"
+      }
+    ],
+    "name": "OptimismPortal_WithdrawalThrottled",
     "type": "error"
   },
   {

--- a/packages/contracts-bedrock/snapshots/abi/OptimismPortal2.json
+++ b/packages/contracts-bedrock/snapshots/abi/OptimismPortal2.json
@@ -696,6 +696,56 @@
     "type": "function"
   },
   {
+    "inputs": [],
+    "name": "withdrawalThrottle",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "capacity",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "available",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint64",
+            "name": "refillPeriod",
+            "type": "uint64"
+          },
+          {
+            "internalType": "uint64",
+            "name": "lastUpdated",
+            "type": "uint64"
+          },
+          {
+            "internalType": "uint64",
+            "name": "refillRemainder",
+            "type": "uint64"
+          },
+          {
+            "internalType": "uint16",
+            "name": "maxBps",
+            "type": "uint16"
+          },
+          {
+            "internalType": "bool",
+            "name": "enabled",
+            "type": "bool"
+          }
+        ],
+        "internalType": "struct OptimismPortal2.WithdrawalThrottleConfig",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "anonymous": false,
     "inputs": [
       {
@@ -918,6 +968,31 @@
     "anonymous": false,
     "inputs": [],
     "name": "WithdrawalThrottleDisabled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "stockSnapshot",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "capacity",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "available",
+        "type": "uint256"
+      }
+    ],
+    "name": "WithdrawalThrottleRefreshed",
     "type": "event"
   },
   {

--- a/packages/contracts-bedrock/snapshots/abi/OptimismPortal2.json
+++ b/packages/contracts-bedrock/snapshots/abi/OptimismPortal2.json
@@ -1215,5 +1215,10 @@
     "inputs": [],
     "name": "UnexpectedString",
     "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "WithdrawalThrottle_TimestampOverflow",
+    "type": "error"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -4,8 +4,8 @@
     "sourceCodeHash": "0x97888fc27c562c1ee77050e76c81249f4dc41c519c0a7f663740ff582df09045"
   },
   "src/L1/ETHLockbox.sol:ETHLockbox": {
-    "initCodeHash": "0xb2ff8426ab2eb36352f790748963c8e1f7a91caf16bee6a035c2c41bac532836",
-    "sourceCodeHash": "0x870004d5acc24a704277680f09ccca51a020a512e6c6d48cca583a23a0de43a2"
+    "initCodeHash": "0x5cf5c6aa45540014324870cbce88d54785208d1620a00eefa2349dce982f5e97",
+    "sourceCodeHash": "0x4c994fe9e09f4fc773f81d404867ee250b7c6e027d9ad90388e672ae658ed124"
   },
   "src/L1/L1CrossDomainMessenger.sol:L1CrossDomainMessenger": {
     "initCodeHash": "0xc1ec4cfb082f933ed4a705a6d6de874c0fe167683e1f8fcf792fdcfeb767ea0d",
@@ -16,16 +16,16 @@
     "sourceCodeHash": "0xfd4d13c09f30072475e2286457a35abaa122223c26ae40398524ad77d5dbb9e1"
   },
   "src/L1/L1StandardBridge.sol:L1StandardBridge": {
-    "initCodeHash": "0x75b07cd638ef34349da3478aeab051472c1cba8c8074d3df48af3d7fbd97fd49",
-    "sourceCodeHash": "0x0ef8461e8bc55314e61e60924465574db17bdf30bbbfe9739b52cac623bba2db"
+    "initCodeHash": "0x0c6d8af60e637210307212e682b849e92ba2b7ab04c37542419c69137fa47c8f",
+    "sourceCodeHash": "0x5c42f4b876f6305d7433a1ab4af4f6417b18646da2e666ddc8ccdcb2b0faed55"
   },
   "src/L1/OPContractsManagerStandardValidator.sol:OPContractsManagerStandardValidator": {
     "initCodeHash": "0xbe11f1f682870fef423354ea210151a91f82703e5524dbe2f9a3221bedbe5ed7",
     "sourceCodeHash": "0x983f90f2198b5116b5498081a909ce1c6a88019a0005bbad2e462c10cd83fcbb"
   },
   "src/L1/OptimismPortal2.sol:OptimismPortal2": {
-    "initCodeHash": "0x67bbf6c9b344870cdbd7b041ddad6fb69057a4b48ec6dd96876af55d14fc1943",
-    "sourceCodeHash": "0x6f754eee67b9e8b9a8a46db304f695d381b63fdf2c48b540fd0cb39aed9daaa9"
+    "initCodeHash": "0x6e108a549fbeb91651874b56398ede13ee7ba885d0232750b85b76ca60574e68",
+    "sourceCodeHash": "0x6b6db66014b6da30718b52e1d258aef6e371f5437ccce5a2328d5f25dbd94057"
   },
   "src/L1/SuperchainConfig.sol:SuperchainConfig": {
     "initCodeHash": "0x68f3fa110e1509bd841932feab438df5b5995ee222fc69a4dd6fcd48428e06f5",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -4,8 +4,8 @@
     "sourceCodeHash": "0x97888fc27c562c1ee77050e76c81249f4dc41c519c0a7f663740ff582df09045"
   },
   "src/L1/ETHLockbox.sol:ETHLockbox": {
-    "initCodeHash": "0xc32502953cf6f1833be63f6e8d8f4ca513890af9cfc5125902d36393deea6b6c",
-    "sourceCodeHash": "0xc11312db2c796bd8904ecb94bb6a5c53259f19799686978ac1a90374c75b694c"
+    "initCodeHash": "0x5b71fd06a6fbf1469cdd1e03b555b27fab4005142309393dbb1aee6e6d118223",
+    "sourceCodeHash": "0xe7f110ac34c83d36e88267cd3ae342e0259a700099e3e98b6d55b42801847f6b"
   },
   "src/L1/L1CrossDomainMessenger.sol:L1CrossDomainMessenger": {
     "initCodeHash": "0xc1ec4cfb082f933ed4a705a6d6de874c0fe167683e1f8fcf792fdcfeb767ea0d",
@@ -16,16 +16,16 @@
     "sourceCodeHash": "0xfd4d13c09f30072475e2286457a35abaa122223c26ae40398524ad77d5dbb9e1"
   },
   "src/L1/L1StandardBridge.sol:L1StandardBridge": {
-    "initCodeHash": "0xd066492150b153552cdc3701c904d4e2310ec209686a46e8d847030b79675e2f",
-    "sourceCodeHash": "0xed338f5b345d57009c56905587911b32521ece1a74329691442fe21505d72334"
+    "initCodeHash": "0x0db2b1014942c279ebb87fad4359293cf6143aac428a77648730eaf7c5aa908e",
+    "sourceCodeHash": "0x415a9829a2c7ca0e2e81761d0f2b6fadcd4e6987814a1401f9625707d4854ca0"
   },
   "src/L1/OPContractsManagerStandardValidator.sol:OPContractsManagerStandardValidator": {
     "initCodeHash": "0xbe11f1f682870fef423354ea210151a91f82703e5524dbe2f9a3221bedbe5ed7",
     "sourceCodeHash": "0x983f90f2198b5116b5498081a909ce1c6a88019a0005bbad2e462c10cd83fcbb"
   },
   "src/L1/OptimismPortal2.sol:OptimismPortal2": {
-    "initCodeHash": "0x6199fb981f95fcf8d07f4be3da15ccd578398717e7f493fe9edb5e9414e9611d",
-    "sourceCodeHash": "0x9db8b1f5326838d54534d60261deb07a9f4f0504b22cf9d1aa859531e21dc7b0"
+    "initCodeHash": "0x84ec2149d775d67058f327e636dfb84a56d55cd83edd1f74bcadcf93394f624b",
+    "sourceCodeHash": "0x4b319bc264943eac22b2bde84f8a6509bf55665404a8da807f1b32551b51ddd9"
   },
   "src/L1/SuperchainConfig.sol:SuperchainConfig": {
     "initCodeHash": "0x68f3fa110e1509bd841932feab438df5b5995ee222fc69a4dd6fcd48428e06f5",
@@ -36,7 +36,7 @@
     "sourceCodeHash": "0xceeedf69dcb6c05b88fd1569c53606dec02195b4d393a6491876b6d2f0c2ff1f"
   },
   "src/L1/opcm/OPContractsManagerV2.sol:OPContractsManagerV2": {
-    "initCodeHash": "0x7daf216ff2eb417724c3a8178014e8937f4cca6b95fa05b105bd55c1553181e0",
+    "initCodeHash": "0x99cff2c298fa2cbbcb9d57e1c3b3d882169e7dabfc46926310f23fee3487a6e7",
     "sourceCodeHash": "0x94ec09a253d7975a299afc5830cf03c43e66685f9254fa23b19a34fbfb6a3e63"
   },
   "src/L2/BaseFeeVault.sol:BaseFeeVault": {

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -4,8 +4,8 @@
     "sourceCodeHash": "0x97888fc27c562c1ee77050e76c81249f4dc41c519c0a7f663740ff582df09045"
   },
   "src/L1/ETHLockbox.sol:ETHLockbox": {
-    "initCodeHash": "0x5b71fd06a6fbf1469cdd1e03b555b27fab4005142309393dbb1aee6e6d118223",
-    "sourceCodeHash": "0xe7f110ac34c83d36e88267cd3ae342e0259a700099e3e98b6d55b42801847f6b"
+    "initCodeHash": "0xcd9c2580c61197ae1a82ddc6575481f1db1bf96405d04010866f25c706f2a06e",
+    "sourceCodeHash": "0xf31e87cf05c4027e2f1ab40ecada66e99bc7f698c31fe361062acae40c7b2832"
   },
   "src/L1/L1CrossDomainMessenger.sol:L1CrossDomainMessenger": {
     "initCodeHash": "0xc1ec4cfb082f933ed4a705a6d6de874c0fe167683e1f8fcf792fdcfeb767ea0d",
@@ -16,16 +16,16 @@
     "sourceCodeHash": "0xfd4d13c09f30072475e2286457a35abaa122223c26ae40398524ad77d5dbb9e1"
   },
   "src/L1/L1StandardBridge.sol:L1StandardBridge": {
-    "initCodeHash": "0x0db2b1014942c279ebb87fad4359293cf6143aac428a77648730eaf7c5aa908e",
-    "sourceCodeHash": "0x415a9829a2c7ca0e2e81761d0f2b6fadcd4e6987814a1401f9625707d4854ca0"
+    "initCodeHash": "0x50adc4c2d0354b432a01791f2b4c58bdb12b2cb4d6e6415ddbc3baae6ec04af8",
+    "sourceCodeHash": "0x73cb7dfabc4fedf34f68090921cd0fe1818a7e735ba517cb27e3b8aaf8eabdff"
   },
   "src/L1/OPContractsManagerStandardValidator.sol:OPContractsManagerStandardValidator": {
     "initCodeHash": "0xbe11f1f682870fef423354ea210151a91f82703e5524dbe2f9a3221bedbe5ed7",
     "sourceCodeHash": "0x983f90f2198b5116b5498081a909ce1c6a88019a0005bbad2e462c10cd83fcbb"
   },
   "src/L1/OptimismPortal2.sol:OptimismPortal2": {
-    "initCodeHash": "0x84ec2149d775d67058f327e636dfb84a56d55cd83edd1f74bcadcf93394f624b",
-    "sourceCodeHash": "0x4b319bc264943eac22b2bde84f8a6509bf55665404a8da807f1b32551b51ddd9"
+    "initCodeHash": "0x470ae55605db43a72048cdfca86ef466a8e8fdc02a7ecfa9c6fda24d5c24e916",
+    "sourceCodeHash": "0x3cd9c2541575b128a470a9e562546ee60f5aa7bb931d0800748bb12fd9b4ab96"
   },
   "src/L1/SuperchainConfig.sol:SuperchainConfig": {
     "initCodeHash": "0x68f3fa110e1509bd841932feab438df5b5995ee222fc69a4dd6fcd48428e06f5",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -4,8 +4,8 @@
     "sourceCodeHash": "0x97888fc27c562c1ee77050e76c81249f4dc41c519c0a7f663740ff582df09045"
   },
   "src/L1/ETHLockbox.sol:ETHLockbox": {
-    "initCodeHash": "0x5cf5c6aa45540014324870cbce88d54785208d1620a00eefa2349dce982f5e97",
-    "sourceCodeHash": "0x4c994fe9e09f4fc773f81d404867ee250b7c6e027d9ad90388e672ae658ed124"
+    "initCodeHash": "0xc32502953cf6f1833be63f6e8d8f4ca513890af9cfc5125902d36393deea6b6c",
+    "sourceCodeHash": "0xc11312db2c796bd8904ecb94bb6a5c53259f19799686978ac1a90374c75b694c"
   },
   "src/L1/L1CrossDomainMessenger.sol:L1CrossDomainMessenger": {
     "initCodeHash": "0xc1ec4cfb082f933ed4a705a6d6de874c0fe167683e1f8fcf792fdcfeb767ea0d",
@@ -16,16 +16,16 @@
     "sourceCodeHash": "0xfd4d13c09f30072475e2286457a35abaa122223c26ae40398524ad77d5dbb9e1"
   },
   "src/L1/L1StandardBridge.sol:L1StandardBridge": {
-    "initCodeHash": "0x0c6d8af60e637210307212e682b849e92ba2b7ab04c37542419c69137fa47c8f",
-    "sourceCodeHash": "0x5c42f4b876f6305d7433a1ab4af4f6417b18646da2e666ddc8ccdcb2b0faed55"
+    "initCodeHash": "0xd066492150b153552cdc3701c904d4e2310ec209686a46e8d847030b79675e2f",
+    "sourceCodeHash": "0xed338f5b345d57009c56905587911b32521ece1a74329691442fe21505d72334"
   },
   "src/L1/OPContractsManagerStandardValidator.sol:OPContractsManagerStandardValidator": {
     "initCodeHash": "0xbe11f1f682870fef423354ea210151a91f82703e5524dbe2f9a3221bedbe5ed7",
     "sourceCodeHash": "0x983f90f2198b5116b5498081a909ce1c6a88019a0005bbad2e462c10cd83fcbb"
   },
   "src/L1/OptimismPortal2.sol:OptimismPortal2": {
-    "initCodeHash": "0x6e108a549fbeb91651874b56398ede13ee7ba885d0232750b85b76ca60574e68",
-    "sourceCodeHash": "0x6b6db66014b6da30718b52e1d258aef6e371f5437ccce5a2328d5f25dbd94057"
+    "initCodeHash": "0x6199fb981f95fcf8d07f4be3da15ccd578398717e7f493fe9edb5e9414e9611d",
+    "sourceCodeHash": "0x9db8b1f5326838d54534d60261deb07a9f4f0504b22cf9d1aa859531e21dc7b0"
   },
   "src/L1/SuperchainConfig.sol:SuperchainConfig": {
     "initCodeHash": "0x68f3fa110e1509bd841932feab438df5b5995ee222fc69a4dd6fcd48428e06f5",
@@ -36,8 +36,8 @@
     "sourceCodeHash": "0xceeedf69dcb6c05b88fd1569c53606dec02195b4d393a6491876b6d2f0c2ff1f"
   },
   "src/L1/opcm/OPContractsManagerV2.sol:OPContractsManagerV2": {
-    "initCodeHash": "0x81553faee6dfead8f15319088db35dde88ddb8196a99c4df9f7eb7569b72b86f",
-    "sourceCodeHash": "0x55e34a11ced7e8b135e01d3a661276ab94173a6d92255c092c2ba44d25afc31d"
+    "initCodeHash": "0x7daf216ff2eb417724c3a8178014e8937f4cca6b95fa05b105bd55c1553181e0",
+    "sourceCodeHash": "0x94ec09a253d7975a299afc5830cf03c43e66685f9254fa23b19a34fbfb6a3e63"
   },
   "src/L2/BaseFeeVault.sol:BaseFeeVault": {
     "initCodeHash": "0x18650c65fa6f23fefc6f0c5fff605f12be99fce0bfbcbc0644403138e4c8bb12",

--- a/packages/contracts-bedrock/snapshots/storageLayout/ETHLockbox.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/ETHLockbox.json
@@ -35,10 +35,10 @@
     "type": "mapping(contract IETHLockbox => bool)"
   },
   {
-    "bytes": "96",
+    "bytes": "64",
     "label": "_withdrawalThrottle",
     "offset": 0,
     "slot": "3",
-    "type": "struct ETHLockbox.WithdrawalThrottleConfig"
+    "type": "struct ETHLockbox.WithdrawalThrottleState"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/ETHLockbox.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/ETHLockbox.json
@@ -39,6 +39,6 @@
     "label": "_withdrawalThrottle",
     "offset": 0,
     "slot": "3",
-    "type": "struct ETHLockbox.WithdrawalThrottleState"
+    "type": "struct WithdrawalThrottle.State"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/ETHLockbox.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/ETHLockbox.json
@@ -33,5 +33,12 @@
     "offset": 0,
     "slot": "2",
     "type": "mapping(contract IETHLockbox => bool)"
+  },
+  {
+    "bytes": "96",
+    "label": "_withdrawalThrottle",
+    "offset": 0,
+    "slot": "3",
+    "type": "struct ETHLockbox.WithdrawalThrottleConfig"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/L1StandardBridge.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/L1StandardBridge.json
@@ -81,6 +81,6 @@
     "label": "_withdrawalThrottles",
     "offset": 0,
     "slot": "53",
-    "type": "mapping(address => struct L1StandardBridge.WithdrawalThrottleState)"
+    "type": "mapping(address => struct WithdrawalThrottle.State)"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/L1StandardBridge.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/L1StandardBridge.json
@@ -81,6 +81,6 @@
     "label": "_withdrawalThrottles",
     "offset": 0,
     "slot": "53",
-    "type": "mapping(address => struct L1StandardBridge.WithdrawalThrottleConfig)"
+    "type": "mapping(address => struct L1StandardBridge.WithdrawalThrottleState)"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/L1StandardBridge.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/L1StandardBridge.json
@@ -75,5 +75,12 @@
     "offset": 0,
     "slot": "52",
     "type": "contract ISystemConfig"
+  },
+  {
+    "bytes": "32",
+    "label": "_withdrawalThrottles",
+    "offset": 0,
+    "slot": "53",
+    "type": "mapping(address => struct L1StandardBridge.WithdrawalThrottleConfig)"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/OptimismPortal2.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/OptimismPortal2.json
@@ -151,6 +151,6 @@
     "label": "_withdrawalThrottle",
     "offset": 0,
     "slot": "64",
-    "type": "struct OptimismPortal2.WithdrawalThrottleState"
+    "type": "struct WithdrawalThrottle.State"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/OptimismPortal2.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/OptimismPortal2.json
@@ -147,10 +147,10 @@
     "type": "bool"
   },
   {
-    "bytes": "96",
+    "bytes": "64",
     "label": "_withdrawalThrottle",
     "offset": 0,
     "slot": "64",
-    "type": "struct OptimismPortal2.WithdrawalThrottleConfig"
+    "type": "struct OptimismPortal2.WithdrawalThrottleState"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/OptimismPortal2.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/OptimismPortal2.json
@@ -145,5 +145,12 @@
     "offset": 20,
     "slot": "63",
     "type": "bool"
+  },
+  {
+    "bytes": "96",
+    "label": "_withdrawalThrottle",
+    "offset": 0,
+    "slot": "64",
+    "type": "struct OptimismPortal2.WithdrawalThrottleConfig"
   }
 ]

--- a/packages/contracts-bedrock/src/L1/ETHLockbox.sol
+++ b/packages/contracts-bedrock/src/L1/ETHLockbox.sol
@@ -8,6 +8,7 @@ import { ReinitializableBase } from "src/universal/ReinitializableBase.sol";
 
 // Libraries
 import { Constants } from "src/libraries/Constants.sol";
+import { WithdrawalThrottle } from "src/libraries/WithdrawalThrottle.sol";
 
 // Interfaces
 import { ISemver } from "interfaces/universal/ISemver.sol";
@@ -36,6 +37,29 @@ contract ETHLockbox is ProxyAdminOwnedBase, Initializable, ReinitializableBase, 
     /// @notice Thrown when any authorized portal has a different SuperchainConfig.
     error ETHLockbox_DifferentSuperchainConfig();
 
+    /// @notice Thrown when a withdrawal throttle basis point value is zero or exceeds 100%.
+    error ETHLockbox_InvalidWithdrawalThrottleBps();
+
+    /// @notice Thrown when a withdrawal throttle refill period is zero.
+    error ETHLockbox_InvalidWithdrawalThrottlePeriod();
+
+    /// @notice Thrown when the withdrawal throttle is not enabled.
+    error ETHLockbox_WithdrawalThrottleNotEnabled();
+
+    /// @notice Thrown when an ETH withdrawal exceeds the available withdrawal capacity.
+    error ETHLockbox_WithdrawalThrottled(uint256 requestedAmount, uint256 availableCapacity, uint256 totalCapacity);
+
+    /// @notice Withdrawal throttle state for ETH held by the lockbox.
+    struct WithdrawalThrottleConfig {
+        uint256 capacity;
+        uint256 available;
+        uint64 refillPeriod;
+        uint64 lastUpdated;
+        uint64 refillRemainder;
+        uint16 maxBps;
+        bool enabled;
+    }
+
     /// @notice Emitted when ETH is locked in the lockbox by an authorized portal.
     /// @param portal The address of the portal that locked the ETH.
     /// @param amount The amount of ETH locked.
@@ -63,6 +87,23 @@ contract ETHLockbox is ProxyAdminOwnedBase, Initializable, ReinitializableBase, 
     /// @param amount The amount of ETH received.
     event LiquidityReceived(IETHLockbox indexed lockbox, uint256 amount);
 
+    /// @notice Emitted when the ETH withdrawal throttle is configured.
+    event WithdrawalThrottleConfigured(
+        uint16 maxBps, uint64 refillPeriod, uint256 stockSnapshot, uint256 capacity, uint256 available
+    );
+
+    /// @notice Emitted when the ETH withdrawal throttle stock snapshot is refreshed.
+    event WithdrawalThrottleRefreshed(uint256 stockSnapshot, uint256 capacity, uint256 available);
+
+    /// @notice Emitted when the ETH withdrawal throttle is disabled.
+    event WithdrawalThrottleDisabled();
+
+    /// @notice Emitted when ETH withdrawal capacity is consumed.
+    event WithdrawalThrottleCapacityConsumed(uint256 amount, uint256 remaining);
+
+    /// @notice Emitted when all currently available ETH withdrawal capacity is consumed.
+    event WithdrawalThrottleCapacityExhausted();
+
     /// @notice The address of the SystemConfig contract.
     ISystemConfig public systemConfig;
 
@@ -72,10 +113,13 @@ contract ETHLockbox is ProxyAdminOwnedBase, Initializable, ReinitializableBase, 
     /// @notice Mapping of authorized lockboxes.
     mapping(IETHLockbox => bool) public authorizedLockboxes;
 
+    /// @notice Withdrawal throttle state for ETH held by the lockbox.
+    WithdrawalThrottleConfig internal _withdrawalThrottle;
+
     /// @notice Semantic version.
-    /// @custom:semver 1.3.1
+    /// @custom:semver 2.0.0
     function version() public view virtual returns (string memory) {
-        return "1.3.1";
+        return "2.0.0";
     }
 
     /// @notice Constructs the ETHLockbox contract.
@@ -116,6 +160,81 @@ contract ETHLockbox is ProxyAdminOwnedBase, Initializable, ReinitializableBase, 
     /// @return ISuperchainConfig The SuperchainConfig contract.
     function superchainConfig() public view returns (ISuperchainConfig) {
         return systemConfig.superchainConfig();
+    }
+
+    /// @notice Configures ETH withdrawal capacity as a percentage of the current lockbox balance.
+    ///         Reconfiguration preserves accrued capacity and clamps it to the new maximum.
+    /// @param _maxBps       Maximum withdrawable stock in basis points.
+    /// @param _refillPeriod Time in seconds for the bucket to refill from empty to full.
+    function setWithdrawalThrottle(uint16 _maxBps, uint64 _refillPeriod) external {
+        _assertOnlyProxyAdminOwner();
+
+        if (_maxBps == 0 || _maxBps > WithdrawalThrottle.MAX_BPS) {
+            revert ETHLockbox_InvalidWithdrawalThrottleBps();
+        }
+        if (_refillPeriod == 0) revert ETHLockbox_InvalidWithdrawalThrottlePeriod();
+
+        WithdrawalThrottleConfig storage throttle = _withdrawalThrottle;
+        uint256 available;
+        if (throttle.enabled) (available,) = _availableWithdrawalCapacity();
+        else available = type(uint256).max;
+        uint256 stockSnapshot = address(this).balance;
+        uint256 capacity = WithdrawalThrottle.capacity(stockSnapshot, _maxBps);
+        if (available > capacity) available = capacity;
+
+        throttle.capacity = capacity;
+        throttle.available = available;
+        throttle.refillPeriod = _refillPeriod;
+        throttle.lastUpdated = uint64(block.timestamp);
+        throttle.refillRemainder = 0;
+        throttle.maxBps = _maxBps;
+        throttle.enabled = true;
+
+        emit WithdrawalThrottleConfigured(_maxBps, _refillPeriod, stockSnapshot, capacity, available);
+    }
+
+    /// @notice Recomputes ETH withdrawal capacity from the current lockbox balance without refilling it.
+    function refreshWithdrawalThrottle() external {
+        _assertOnlyProxyAdminOwner();
+
+        WithdrawalThrottleConfig storage throttle = _withdrawalThrottle;
+        if (!throttle.enabled) revert ETHLockbox_WithdrawalThrottleNotEnabled();
+
+        (uint256 available,) = _availableWithdrawalCapacity();
+        uint256 stockSnapshot = address(this).balance;
+        uint256 capacity = WithdrawalThrottle.capacity(stockSnapshot, throttle.maxBps);
+        if (available > capacity) available = capacity;
+
+        throttle.capacity = capacity;
+        throttle.available = available;
+        throttle.lastUpdated = uint64(block.timestamp);
+        throttle.refillRemainder = 0;
+
+        emit WithdrawalThrottleRefreshed(stockSnapshot, capacity, available);
+    }
+
+    /// @notice Disables the ETH withdrawal throttle.
+    function disableWithdrawalThrottle() external {
+        _assertOnlyProxyAdminOwner();
+
+        if (!_withdrawalThrottle.enabled) revert ETHLockbox_WithdrawalThrottleNotEnabled();
+        delete _withdrawalThrottle;
+
+        emit WithdrawalThrottleDisabled();
+    }
+
+    /// @notice Returns the stored ETH withdrawal throttle state before pending refill is materialized.
+    /// @return Withdrawal throttle state.
+    function withdrawalThrottle() external view returns (WithdrawalThrottleConfig memory) {
+        return _withdrawalThrottle;
+    }
+
+    /// @notice Returns currently available ETH withdrawal capacity.
+    /// @return Available capacity, or the maximum uint256 value when throttling is disabled.
+    function availableWithdrawalCapacity() external view returns (uint256) {
+        if (!_withdrawalThrottle.enabled) return type(uint256).max;
+        (uint256 available,) = _availableWithdrawalCapacity();
+        return available;
     }
 
     /// @notice Authorizes a portal to lock and unlock ETH.
@@ -168,6 +287,8 @@ contract ETHLockbox is ProxyAdminOwnedBase, Initializable, ReinitializableBase, 
         if (sender.l2Sender() != Constants.DEFAULT_L2_SENDER) {
             revert ETHLockbox_NoWithdrawalTransactions();
         }
+
+        _consumeWithdrawalCapacity(_value);
 
         // Using donateETH to avoid triggering a deposit.
         sender.donateETH{ value: _value }();
@@ -228,5 +349,40 @@ contract ETHLockbox is ProxyAdminOwnedBase, Initializable, ReinitializableBase, 
 
         // Emit the event.
         emit PortalAuthorized(_portal);
+    }
+
+    /// @notice Consumes available ETH withdrawal capacity when the throttle is enabled.
+    /// @param _amount Amount of ETH to withdraw.
+    function _consumeWithdrawalCapacity(uint256 _amount) internal {
+        WithdrawalThrottleConfig storage throttle = _withdrawalThrottle;
+        if (!throttle.enabled || _amount == 0) return;
+
+        (uint256 available, uint64 refillRemainder) = _availableWithdrawalCapacity();
+        if (_amount > available) {
+            revert ETHLockbox_WithdrawalThrottled(_amount, available, throttle.capacity);
+        }
+
+        uint256 remaining = available - _amount;
+        throttle.available = remaining;
+        throttle.lastUpdated = uint64(block.timestamp);
+        throttle.refillRemainder = refillRemainder;
+
+        emit WithdrawalThrottleCapacityConsumed(_amount, remaining);
+        if (remaining == 0) emit WithdrawalThrottleCapacityExhausted();
+    }
+
+    /// @notice Computes available ETH withdrawal capacity after its pending linear refill.
+    /// @return available_ Available capacity at the current timestamp.
+    /// @return remainder_ Fractional refill numerator to preserve when materializing the refill.
+    function _availableWithdrawalCapacity() internal view returns (uint256 available_, uint64 remainder_) {
+        WithdrawalThrottleConfig storage throttle = _withdrawalThrottle;
+        return WithdrawalThrottle.available(
+            throttle.capacity,
+            throttle.available,
+            throttle.refillRemainder,
+            throttle.refillPeriod,
+            throttle.lastUpdated,
+            block.timestamp
+        );
     }
 }

--- a/packages/contracts-bedrock/src/L1/ETHLockbox.sol
+++ b/packages/contracts-bedrock/src/L1/ETHLockbox.sol
@@ -200,15 +200,18 @@ contract ETHLockbox is ProxyAdminOwnedBase, Initializable, ReinitializableBase, 
         WithdrawalThrottleConfig storage throttle = _withdrawalThrottle;
         if (!throttle.enabled) revert ETHLockbox_WithdrawalThrottleNotEnabled();
 
-        (uint256 available,) = _availableWithdrawalCapacity();
+        (uint256 available, uint64 refillRemainder) = _availableWithdrawalCapacity();
         uint256 stockSnapshot = address(this).balance;
         uint256 capacity = WithdrawalThrottle.capacity(stockSnapshot, throttle.maxBps);
-        if (available > capacity) available = capacity;
+        if (available >= capacity) {
+            available = capacity;
+            refillRemainder = 0;
+        }
 
         throttle.capacity = capacity;
         throttle.available = available;
         throttle.lastUpdated = uint64(block.timestamp);
-        throttle.refillRemainder = 0;
+        throttle.refillRemainder = refillRemainder;
 
         emit WithdrawalThrottleRefreshed(stockSnapshot, capacity, available);
     }
@@ -233,7 +236,7 @@ contract ETHLockbox is ProxyAdminOwnedBase, Initializable, ReinitializableBase, 
     /// @return Available capacity, or the maximum uint256 value when throttling is disabled.
     function availableWithdrawalCapacity() external view returns (uint256) {
         if (!_withdrawalThrottle.enabled) return type(uint256).max;
-        (uint256 available,) = _availableWithdrawalCapacity();
+        (,, uint256 available,) = _syncedWithdrawalCapacity();
         return available;
     }
 
@@ -357,16 +360,20 @@ contract ETHLockbox is ProxyAdminOwnedBase, Initializable, ReinitializableBase, 
         WithdrawalThrottleConfig storage throttle = _withdrawalThrottle;
         if (!throttle.enabled || _amount == 0) return;
 
-        (uint256 available, uint64 refillRemainder) = _availableWithdrawalCapacity();
+        (uint256 stockSnapshot, uint256 capacity, uint256 available, uint64 refillRemainder) =
+            _syncedWithdrawalCapacity();
         if (_amount > available) {
-            revert ETHLockbox_WithdrawalThrottled(_amount, available, throttle.capacity);
+            revert ETHLockbox_WithdrawalThrottled(_amount, available, capacity);
         }
 
         uint256 remaining = available - _amount;
+        bool capacityChanged = capacity != throttle.capacity;
+        throttle.capacity = capacity;
         throttle.available = remaining;
         throttle.lastUpdated = uint64(block.timestamp);
         throttle.refillRemainder = refillRemainder;
 
+        if (capacityChanged) emit WithdrawalThrottleRefreshed(stockSnapshot, capacity, available);
         emit WithdrawalThrottleCapacityConsumed(_amount, remaining);
         if (remaining == 0) emit WithdrawalThrottleCapacityExhausted();
     }
@@ -384,5 +391,25 @@ contract ETHLockbox is ProxyAdminOwnedBase, Initializable, ReinitializableBase, 
             throttle.lastUpdated,
             block.timestamp
         );
+    }
+
+    /// @notice Computes the effective bucket state against the lockbox's current ETH stock.
+    /// @return stock_ Current lockbox balance.
+    /// @return capacity_ Capacity derived from the current stock.
+    /// @return available_ Available capacity after refill and stock synchronization.
+    /// @return remainder_ Fractional refill numerator to preserve when materializing the refill.
+    function _syncedWithdrawalCapacity()
+        internal
+        view
+        returns (uint256 stock_, uint256 capacity_, uint256 available_, uint64 remainder_)
+    {
+        WithdrawalThrottleConfig storage throttle = _withdrawalThrottle;
+        (available_, remainder_) = _availableWithdrawalCapacity();
+        stock_ = address(this).balance;
+        capacity_ = WithdrawalThrottle.capacity(stock_, throttle.maxBps);
+        if (available_ >= capacity_) {
+            available_ = capacity_;
+            remainder_ = 0;
+        }
     }
 }

--- a/packages/contracts-bedrock/src/L1/ETHLockbox.sol
+++ b/packages/contracts-bedrock/src/L1/ETHLockbox.sol
@@ -49,7 +49,7 @@ contract ETHLockbox is ProxyAdminOwnedBase, Initializable, ReinitializableBase, 
     /// @notice Thrown when an ETH withdrawal exceeds the available withdrawal capacity.
     error ETHLockbox_WithdrawalThrottled(uint256 requestedAmount, uint256 availableCapacity, uint256 totalCapacity);
 
-    /// @notice Withdrawal throttle state for ETH held by the lockbox.
+    /// @notice Logical withdrawal throttle state for ETH held by the lockbox.
     struct WithdrawalThrottleConfig {
         uint256 capacity;
         uint256 available;
@@ -58,6 +58,12 @@ contract ETHLockbox is ProxyAdminOwnedBase, Initializable, ReinitializableBase, 
         uint64 refillRemainder;
         uint16 maxBps;
         bool enabled;
+    }
+
+    /// @notice Packed withdrawal throttle storage for ETH held by the lockbox.
+    struct WithdrawalThrottleState {
+        uint256 config;
+        uint256 bucket;
     }
 
     /// @notice Emitted when ETH is locked in the lockbox by an authorized portal.
@@ -114,7 +120,7 @@ contract ETHLockbox is ProxyAdminOwnedBase, Initializable, ReinitializableBase, 
     mapping(IETHLockbox => bool) public authorizedLockboxes;
 
     /// @notice Withdrawal throttle state for ETH held by the lockbox.
-    WithdrawalThrottleConfig internal _withdrawalThrottle;
+    WithdrawalThrottleState internal _withdrawalThrottle;
 
     /// @notice Semantic version.
     /// @custom:semver 2.0.0
@@ -163,7 +169,8 @@ contract ETHLockbox is ProxyAdminOwnedBase, Initializable, ReinitializableBase, 
     }
 
     /// @notice Configures ETH withdrawal capacity as a percentage of the current lockbox balance.
-    ///         Reconfiguration preserves accrued capacity and clamps it to the new maximum.
+    ///         Reconfiguration preserves accrued whole-unit capacity, resets the fractional
+    ///         remainder, and clamps availability to the new maximum.
     /// @param _maxBps       Maximum withdrawable stock in basis points.
     /// @param _refillPeriod Time in seconds for the bucket to refill from empty to full.
     function setWithdrawalThrottle(uint16 _maxBps, uint64 _refillPeriod) external {
@@ -174,21 +181,28 @@ contract ETHLockbox is ProxyAdminOwnedBase, Initializable, ReinitializableBase, 
         }
         if (_refillPeriod == 0) revert ETHLockbox_InvalidWithdrawalThrottlePeriod();
 
-        WithdrawalThrottleConfig storage throttle = _withdrawalThrottle;
-        uint256 available;
-        if (throttle.enabled) (available,) = _availableWithdrawalCapacity();
-        else available = type(uint256).max;
+        WithdrawalThrottleState storage throttle = _withdrawalThrottle;
+        uint256 oldConfig = throttle.config;
         uint256 stockSnapshot = address(this).balance;
-        uint256 capacity = WithdrawalThrottle.capacity(stockSnapshot, _maxBps);
+        uint128 available;
+        if (WithdrawalThrottle.enabled(oldConfig)) {
+            uint128 liveOldCapacity = WithdrawalThrottle.capacity(stockSnapshot, WithdrawalThrottle.maxBps(oldConfig));
+            (available,) = WithdrawalThrottle.sync(
+                WithdrawalThrottle.capacity(oldConfig),
+                throttle.bucket,
+                WithdrawalThrottle.refillPeriod(oldConfig),
+                liveOldCapacity,
+                block.timestamp
+            );
+        } else {
+            available = type(uint128).max;
+        }
+        uint128 capacity = WithdrawalThrottle.capacity(stockSnapshot, _maxBps);
         if (available > capacity) available = capacity;
 
-        throttle.capacity = capacity;
-        throttle.available = available;
-        throttle.refillPeriod = _refillPeriod;
-        throttle.lastUpdated = uint64(block.timestamp);
-        throttle.refillRemainder = 0;
-        throttle.maxBps = _maxBps;
-        throttle.enabled = true;
+        uint64 timestamp = WithdrawalThrottle.timestamp(block.timestamp);
+        throttle.config = WithdrawalThrottle.config(capacity, _refillPeriod, _maxBps, true);
+        throttle.bucket = WithdrawalThrottle.bucket(available, timestamp, 0);
 
         emit WithdrawalThrottleConfigured(_maxBps, _refillPeriod, stockSnapshot, capacity, available);
     }
@@ -197,21 +211,22 @@ contract ETHLockbox is ProxyAdminOwnedBase, Initializable, ReinitializableBase, 
     function refreshWithdrawalThrottle() external {
         _assertOnlyProxyAdminOwner();
 
-        WithdrawalThrottleConfig storage throttle = _withdrawalThrottle;
-        if (!throttle.enabled) revert ETHLockbox_WithdrawalThrottleNotEnabled();
+        WithdrawalThrottleState storage throttle = _withdrawalThrottle;
+        uint256 oldConfig = throttle.config;
+        if (!WithdrawalThrottle.enabled(oldConfig)) revert ETHLockbox_WithdrawalThrottleNotEnabled();
 
-        (uint256 available, uint64 refillRemainder) = _availableWithdrawalCapacity();
         uint256 stockSnapshot = address(this).balance;
-        uint256 capacity = WithdrawalThrottle.capacity(stockSnapshot, throttle.maxBps);
-        if (available >= capacity) {
-            available = capacity;
-            refillRemainder = 0;
+        uint16 maxBps = WithdrawalThrottle.maxBps(oldConfig);
+        uint64 refillPeriod = WithdrawalThrottle.refillPeriod(oldConfig);
+        uint128 capacity = WithdrawalThrottle.capacity(stockSnapshot, maxBps);
+        (uint128 available, uint64 remainder) = WithdrawalThrottle.sync(
+            WithdrawalThrottle.capacity(oldConfig), throttle.bucket, refillPeriod, capacity, block.timestamp
+        );
+        uint64 timestamp = WithdrawalThrottle.timestamp(block.timestamp);
+        if (capacity != WithdrawalThrottle.capacity(oldConfig)) {
+            throttle.config = WithdrawalThrottle.config(capacity, refillPeriod, maxBps, true);
         }
-
-        throttle.capacity = capacity;
-        throttle.available = available;
-        throttle.lastUpdated = uint64(block.timestamp);
-        throttle.refillRemainder = refillRemainder;
+        throttle.bucket = WithdrawalThrottle.bucket(available, timestamp, remainder);
 
         emit WithdrawalThrottleRefreshed(stockSnapshot, capacity, available);
     }
@@ -220,7 +235,9 @@ contract ETHLockbox is ProxyAdminOwnedBase, Initializable, ReinitializableBase, 
     function disableWithdrawalThrottle() external {
         _assertOnlyProxyAdminOwner();
 
-        if (!_withdrawalThrottle.enabled) revert ETHLockbox_WithdrawalThrottleNotEnabled();
+        if (!WithdrawalThrottle.enabled(_withdrawalThrottle.config)) {
+            revert ETHLockbox_WithdrawalThrottleNotEnabled();
+        }
         delete _withdrawalThrottle;
 
         emit WithdrawalThrottleDisabled();
@@ -229,14 +246,26 @@ contract ETHLockbox is ProxyAdminOwnedBase, Initializable, ReinitializableBase, 
     /// @notice Returns the stored ETH withdrawal throttle state before pending refill is materialized.
     /// @return Withdrawal throttle state.
     function withdrawalThrottle() external view returns (WithdrawalThrottleConfig memory) {
-        return _withdrawalThrottle;
+        WithdrawalThrottleState storage throttle = _withdrawalThrottle;
+        uint256 config_ = throttle.config;
+        uint256 bucket_ = throttle.bucket;
+        return WithdrawalThrottleConfig({
+            capacity: WithdrawalThrottle.capacity(config_),
+            available: WithdrawalThrottle.storedAvailable(bucket_),
+            refillPeriod: WithdrawalThrottle.refillPeriod(config_),
+            lastUpdated: WithdrawalThrottle.lastUpdated(bucket_),
+            refillRemainder: WithdrawalThrottle.refillRemainder(bucket_),
+            maxBps: WithdrawalThrottle.maxBps(config_),
+            enabled: WithdrawalThrottle.enabled(config_)
+        });
     }
 
     /// @notice Returns currently available ETH withdrawal capacity.
     /// @return Available capacity, or the maximum uint256 value when throttling is disabled.
     function availableWithdrawalCapacity() external view returns (uint256) {
-        if (!_withdrawalThrottle.enabled) return type(uint256).max;
-        (,, uint256 available,) = _syncedWithdrawalCapacity();
+        uint256 config_ = _withdrawalThrottle.config;
+        if (!WithdrawalThrottle.enabled(config_)) return type(uint256).max;
+        (,, uint128 available,) = _syncedWithdrawalCapacity(config_);
         return available;
     }
 
@@ -357,40 +386,32 @@ contract ETHLockbox is ProxyAdminOwnedBase, Initializable, ReinitializableBase, 
     /// @notice Consumes available ETH withdrawal capacity when the throttle is enabled.
     /// @param _amount Amount of ETH to withdraw.
     function _consumeWithdrawalCapacity(uint256 _amount) internal {
-        WithdrawalThrottleConfig storage throttle = _withdrawalThrottle;
-        if (!throttle.enabled || _amount == 0) return;
+        WithdrawalThrottleState storage throttle = _withdrawalThrottle;
+        uint256 config_ = throttle.config;
+        if (!WithdrawalThrottle.enabled(config_) || _amount == 0) return;
 
-        (uint256 stockSnapshot, uint256 capacity, uint256 available, uint64 refillRemainder) =
-            _syncedWithdrawalCapacity();
+        (uint256 stockSnapshot, uint128 capacity, uint128 available, uint64 remainder) =
+            _syncedWithdrawalCapacity(config_);
         if (_amount > available) {
             revert ETHLockbox_WithdrawalThrottled(_amount, available, capacity);
         }
 
-        uint256 remaining = available - _amount;
-        bool capacityChanged = capacity != throttle.capacity;
-        throttle.capacity = capacity;
-        throttle.available = remaining;
-        throttle.lastUpdated = uint64(block.timestamp);
-        throttle.refillRemainder = refillRemainder;
+        uint256 remainingValue = uint256(available) - _amount;
+        assert(remainingValue <= type(uint128).max);
+        uint128 remaining = uint128(remainingValue);
+        uint128 oldCapacity = WithdrawalThrottle.capacity(config_);
+        bool capacityChanged = capacity != oldCapacity;
+        uint64 timestamp = WithdrawalThrottle.timestamp(block.timestamp);
+        if (capacityChanged) {
+            throttle.config = WithdrawalThrottle.config(
+                capacity, WithdrawalThrottle.refillPeriod(config_), WithdrawalThrottle.maxBps(config_), true
+            );
+        }
+        throttle.bucket = WithdrawalThrottle.bucket(remaining, timestamp, remainder);
 
         if (capacityChanged) emit WithdrawalThrottleRefreshed(stockSnapshot, capacity, available);
         emit WithdrawalThrottleCapacityConsumed(_amount, remaining);
         if (remaining == 0) emit WithdrawalThrottleCapacityExhausted();
-    }
-
-    /// @notice Computes available ETH withdrawal capacity after its pending linear refill.
-    /// @return available_ Available capacity at the current timestamp.
-    /// @return remainder_ Fractional refill numerator to preserve when materializing the refill.
-    function _availableWithdrawalCapacity() internal view returns (uint256 available_, uint64 remainder_) {
-        WithdrawalThrottleConfig storage throttle = _withdrawalThrottle;
-        return WithdrawalThrottle.available(
-            throttle.capacity,
-            throttle.available,
-            throttle.refillRemainder,
-            throttle.refillPeriod,
-            throttle.lastUpdated,
-            block.timestamp
-        );
     }
 
     /// @notice Computes the effective bucket state against the lockbox's current ETH stock.
@@ -398,18 +419,20 @@ contract ETHLockbox is ProxyAdminOwnedBase, Initializable, ReinitializableBase, 
     /// @return capacity_ Capacity derived from the current stock.
     /// @return available_ Available capacity after refill and stock synchronization.
     /// @return remainder_ Fractional refill numerator to preserve when materializing the refill.
-    function _syncedWithdrawalCapacity()
+    function _syncedWithdrawalCapacity(uint256 _config)
         internal
         view
-        returns (uint256 stock_, uint256 capacity_, uint256 available_, uint64 remainder_)
+        returns (uint256 stock_, uint128 capacity_, uint128 available_, uint64 remainder_)
     {
-        WithdrawalThrottleConfig storage throttle = _withdrawalThrottle;
-        (available_, remainder_) = _availableWithdrawalCapacity();
+        WithdrawalThrottleState storage throttle = _withdrawalThrottle;
         stock_ = address(this).balance;
-        capacity_ = WithdrawalThrottle.capacity(stock_, throttle.maxBps);
-        if (available_ >= capacity_) {
-            available_ = capacity_;
-            remainder_ = 0;
-        }
+        capacity_ = WithdrawalThrottle.capacity(stock_, WithdrawalThrottle.maxBps(_config));
+        (available_, remainder_) = WithdrawalThrottle.sync(
+            WithdrawalThrottle.capacity(_config),
+            throttle.bucket,
+            WithdrawalThrottle.refillPeriod(_config),
+            capacity_,
+            block.timestamp
+        );
     }
 }

--- a/packages/contracts-bedrock/src/L1/ETHLockbox.sol
+++ b/packages/contracts-bedrock/src/L1/ETHLockbox.sol
@@ -22,6 +22,8 @@ import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
 /// @notice Manages ETH liquidity locking and unlocking for authorized OptimismPortals, enabling unified ETH liquidity
 ///         management across chains in the superchain cluster.
 contract ETHLockbox is ProxyAdminOwnedBase, Initializable, ReinitializableBase, ISemver {
+    using WithdrawalThrottle for WithdrawalThrottle.State;
+
     /// @notice Thrown when the lockbox is paused.
     error ETHLockbox_Paused();
 
@@ -58,12 +60,6 @@ contract ETHLockbox is ProxyAdminOwnedBase, Initializable, ReinitializableBase, 
         uint64 refillRemainder;
         uint16 maxBps;
         bool enabled;
-    }
-
-    /// @notice Packed withdrawal throttle storage for ETH held by the lockbox.
-    struct WithdrawalThrottleState {
-        uint256 config;
-        uint256 bucket;
     }
 
     /// @notice Emitted when ETH is locked in the lockbox by an authorized portal.
@@ -120,12 +116,12 @@ contract ETHLockbox is ProxyAdminOwnedBase, Initializable, ReinitializableBase, 
     mapping(IETHLockbox => bool) public authorizedLockboxes;
 
     /// @notice Withdrawal throttle state for ETH held by the lockbox.
-    WithdrawalThrottleState internal _withdrawalThrottle;
+    WithdrawalThrottle.State internal _withdrawalThrottle;
 
     /// @notice Semantic version.
-    /// @custom:semver 2.0.0
+    /// @custom:semver 2.1.0
     function version() public view virtual returns (string memory) {
-        return "2.0.0";
+        return "2.1.0";
     }
 
     /// @notice Constructs the ETHLockbox contract.
@@ -181,28 +177,10 @@ contract ETHLockbox is ProxyAdminOwnedBase, Initializable, ReinitializableBase, 
         }
         if (_refillPeriod == 0) revert ETHLockbox_InvalidWithdrawalThrottlePeriod();
 
-        WithdrawalThrottleState storage throttle = _withdrawalThrottle;
-        uint256 oldConfig = throttle.config;
+        WithdrawalThrottle.State storage throttle = _withdrawalThrottle;
         uint256 stockSnapshot = address(this).balance;
-        uint128 available;
-        if (WithdrawalThrottle.enabled(oldConfig)) {
-            uint128 liveOldCapacity = WithdrawalThrottle.capacity(stockSnapshot, WithdrawalThrottle.maxBps(oldConfig));
-            (available,) = WithdrawalThrottle.sync(
-                WithdrawalThrottle.capacity(oldConfig),
-                throttle.bucket,
-                WithdrawalThrottle.refillPeriod(oldConfig),
-                liveOldCapacity,
-                block.timestamp
-            );
-        } else {
-            available = type(uint128).max;
-        }
-        uint128 capacity = WithdrawalThrottle.capacity(stockSnapshot, _maxBps);
-        if (available > capacity) available = capacity;
-
-        uint64 timestamp = WithdrawalThrottle.timestamp(block.timestamp);
-        throttle.config = WithdrawalThrottle.config(capacity, _refillPeriod, _maxBps, true);
-        throttle.bucket = WithdrawalThrottle.bucket(available, timestamp, 0);
+        (uint128 capacity, uint128 available) =
+            throttle.configure(stockSnapshot, _maxBps, _refillPeriod, block.timestamp);
 
         emit WithdrawalThrottleConfigured(_maxBps, _refillPeriod, stockSnapshot, capacity, available);
     }
@@ -211,22 +189,12 @@ contract ETHLockbox is ProxyAdminOwnedBase, Initializable, ReinitializableBase, 
     function refreshWithdrawalThrottle() external {
         _assertOnlyProxyAdminOwner();
 
-        WithdrawalThrottleState storage throttle = _withdrawalThrottle;
-        uint256 oldConfig = throttle.config;
-        if (!WithdrawalThrottle.enabled(oldConfig)) revert ETHLockbox_WithdrawalThrottleNotEnabled();
+        WithdrawalThrottle.State storage throttle = _withdrawalThrottle;
+        uint256 config_ = throttle.config;
+        if (!WithdrawalThrottle.enabled(config_)) revert ETHLockbox_WithdrawalThrottleNotEnabled();
 
         uint256 stockSnapshot = address(this).balance;
-        uint16 maxBps = WithdrawalThrottle.maxBps(oldConfig);
-        uint64 refillPeriod = WithdrawalThrottle.refillPeriod(oldConfig);
-        uint128 capacity = WithdrawalThrottle.capacity(stockSnapshot, maxBps);
-        (uint128 available, uint64 remainder) = WithdrawalThrottle.sync(
-            WithdrawalThrottle.capacity(oldConfig), throttle.bucket, refillPeriod, capacity, block.timestamp
-        );
-        uint64 timestamp = WithdrawalThrottle.timestamp(block.timestamp);
-        if (capacity != WithdrawalThrottle.capacity(oldConfig)) {
-            throttle.config = WithdrawalThrottle.config(capacity, refillPeriod, maxBps, true);
-        }
-        throttle.bucket = WithdrawalThrottle.bucket(available, timestamp, remainder);
+        (uint128 capacity, uint128 available) = throttle.refresh(config_, stockSnapshot, block.timestamp);
 
         emit WithdrawalThrottleRefreshed(stockSnapshot, capacity, available);
     }
@@ -235,10 +203,8 @@ contract ETHLockbox is ProxyAdminOwnedBase, Initializable, ReinitializableBase, 
     function disableWithdrawalThrottle() external {
         _assertOnlyProxyAdminOwner();
 
-        if (!WithdrawalThrottle.enabled(_withdrawalThrottle.config)) {
-            revert ETHLockbox_WithdrawalThrottleNotEnabled();
-        }
-        delete _withdrawalThrottle;
+        if (!WithdrawalThrottle.enabled(_withdrawalThrottle.config)) revert ETHLockbox_WithdrawalThrottleNotEnabled();
+        _withdrawalThrottle.disable();
 
         emit WithdrawalThrottleDisabled();
     }
@@ -246,17 +212,15 @@ contract ETHLockbox is ProxyAdminOwnedBase, Initializable, ReinitializableBase, 
     /// @notice Returns the stored ETH withdrawal throttle state before pending refill is materialized.
     /// @return Withdrawal throttle state.
     function withdrawalThrottle() external view returns (WithdrawalThrottleConfig memory) {
-        WithdrawalThrottleState storage throttle = _withdrawalThrottle;
-        uint256 config_ = throttle.config;
-        uint256 bucket_ = throttle.bucket;
+        WithdrawalThrottle.Snapshot memory throttle = _withdrawalThrottle.snapshot();
         return WithdrawalThrottleConfig({
-            capacity: WithdrawalThrottle.capacity(config_),
-            available: WithdrawalThrottle.storedAvailable(bucket_),
-            refillPeriod: WithdrawalThrottle.refillPeriod(config_),
-            lastUpdated: WithdrawalThrottle.lastUpdated(bucket_),
-            refillRemainder: WithdrawalThrottle.refillRemainder(bucket_),
-            maxBps: WithdrawalThrottle.maxBps(config_),
-            enabled: WithdrawalThrottle.enabled(config_)
+            capacity: throttle.capacity,
+            available: throttle.available,
+            refillPeriod: throttle.refillPeriod,
+            lastUpdated: throttle.lastUpdated,
+            refillRemainder: throttle.refillRemainder,
+            maxBps: throttle.maxBps,
+            enabled: throttle.enabled
         });
     }
 
@@ -265,8 +229,7 @@ contract ETHLockbox is ProxyAdminOwnedBase, Initializable, ReinitializableBase, 
     function availableWithdrawalCapacity() external view returns (uint256) {
         uint256 config_ = _withdrawalThrottle.config;
         if (!WithdrawalThrottle.enabled(config_)) return type(uint256).max;
-        (,, uint128 available,) = _syncedWithdrawalCapacity(config_);
-        return available;
+        return _withdrawalThrottle.availableCapacity(config_, address(this).balance, block.timestamp);
     }
 
     /// @notice Authorizes a portal to lock and unlock ETH.
@@ -386,53 +349,19 @@ contract ETHLockbox is ProxyAdminOwnedBase, Initializable, ReinitializableBase, 
     /// @notice Consumes available ETH withdrawal capacity when the throttle is enabled.
     /// @param _amount Amount of ETH to withdraw.
     function _consumeWithdrawalCapacity(uint256 _amount) internal {
-        WithdrawalThrottleState storage throttle = _withdrawalThrottle;
+        WithdrawalThrottle.State storage throttle = _withdrawalThrottle;
         uint256 config_ = throttle.config;
         if (!WithdrawalThrottle.enabled(config_) || _amount == 0) return;
 
-        (uint256 stockSnapshot, uint128 capacity, uint128 available, uint64 remainder) =
-            _syncedWithdrawalCapacity(config_);
+        uint256 stockSnapshot = address(this).balance;
+        (uint128 capacity, uint128 available, uint128 remaining, bool capacityChanged) =
+            throttle.consume(config_, stockSnapshot, _amount, block.timestamp);
         if (_amount > available) {
             revert ETHLockbox_WithdrawalThrottled(_amount, available, capacity);
         }
 
-        uint256 remainingValue = uint256(available) - _amount;
-        assert(remainingValue <= type(uint128).max);
-        uint128 remaining = uint128(remainingValue);
-        uint128 oldCapacity = WithdrawalThrottle.capacity(config_);
-        bool capacityChanged = capacity != oldCapacity;
-        uint64 timestamp = WithdrawalThrottle.timestamp(block.timestamp);
-        if (capacityChanged) {
-            throttle.config = WithdrawalThrottle.config(
-                capacity, WithdrawalThrottle.refillPeriod(config_), WithdrawalThrottle.maxBps(config_), true
-            );
-        }
-        throttle.bucket = WithdrawalThrottle.bucket(remaining, timestamp, remainder);
-
         if (capacityChanged) emit WithdrawalThrottleRefreshed(stockSnapshot, capacity, available);
         emit WithdrawalThrottleCapacityConsumed(_amount, remaining);
         if (remaining == 0) emit WithdrawalThrottleCapacityExhausted();
-    }
-
-    /// @notice Computes the effective bucket state against the lockbox's current ETH stock.
-    /// @return stock_ Current lockbox balance.
-    /// @return capacity_ Capacity derived from the current stock.
-    /// @return available_ Available capacity after refill and stock synchronization.
-    /// @return remainder_ Fractional refill numerator to preserve when materializing the refill.
-    function _syncedWithdrawalCapacity(uint256 _config)
-        internal
-        view
-        returns (uint256 stock_, uint128 capacity_, uint128 available_, uint64 remainder_)
-    {
-        WithdrawalThrottleState storage throttle = _withdrawalThrottle;
-        stock_ = address(this).balance;
-        capacity_ = WithdrawalThrottle.capacity(stock_, WithdrawalThrottle.maxBps(_config));
-        (available_, remainder_) = WithdrawalThrottle.sync(
-            WithdrawalThrottle.capacity(_config),
-            throttle.bucket,
-            WithdrawalThrottle.refillPeriod(_config),
-            capacity_,
-            block.timestamp
-        );
     }
 }

--- a/packages/contracts-bedrock/src/L1/L1StandardBridge.sol
+++ b/packages/contracts-bedrock/src/L1/L1StandardBridge.sol
@@ -48,7 +48,7 @@ contract L1StandardBridge is StandardBridge, ProxyAdminOwnedBase, Reinitializabl
         address token, uint256 requestedAmount, uint256 availableCapacity, uint256 totalCapacity
     );
 
-    /// @notice Withdrawal throttle state for an L1 token.
+    /// @notice Logical withdrawal throttle state for an L1 token.
     struct WithdrawalThrottleConfig {
         uint256 capacity;
         uint256 available;
@@ -57,6 +57,12 @@ contract L1StandardBridge is StandardBridge, ProxyAdminOwnedBase, Reinitializabl
         uint64 refillRemainder;
         uint16 maxBps;
         bool enabled;
+    }
+
+    /// @notice Packed withdrawal throttle storage for an L1 token.
+    struct WithdrawalThrottleState {
+        uint256 config;
+        uint256 bucket;
     }
 
     /// @notice Emitted when a withdrawal throttle is configured for a token.
@@ -151,7 +157,7 @@ contract L1StandardBridge is StandardBridge, ProxyAdminOwnedBase, Reinitializabl
     ISystemConfig public systemConfig;
 
     /// @notice Withdrawal throttle state keyed by L1 token address.
-    mapping(address => WithdrawalThrottleConfig) internal _withdrawalThrottles;
+    mapping(address => WithdrawalThrottleState) internal _withdrawalThrottles;
 
     /// @notice Constructs the L1StandardBridge contract.
     constructor() StandardBridge() ReinitializableBase(3) {
@@ -191,7 +197,8 @@ contract L1StandardBridge is StandardBridge, ProxyAdminOwnedBase, Reinitializabl
     }
 
     /// @notice Configures a token's withdrawal capacity as a percentage of its current bridge stock.
-    ///         Reconfiguration preserves accrued capacity and clamps it to the new maximum.
+    ///         Reconfiguration preserves accrued whole-unit capacity, resets the fractional
+    ///         remainder, and clamps availability to the new maximum.
     /// @param _token        Address of the L1 token to throttle.
     /// @param _maxBps       Maximum withdrawable stock in basis points.
     /// @param _refillPeriod Time in seconds for the bucket to refill from empty to full.
@@ -205,21 +212,28 @@ contract L1StandardBridge is StandardBridge, ProxyAdminOwnedBase, Reinitializabl
         }
         if (_refillPeriod == 0) revert L1StandardBridge_InvalidWithdrawalThrottlePeriod();
 
-        WithdrawalThrottleConfig storage throttle = _withdrawalThrottles[_token];
-        uint256 available;
-        if (throttle.enabled) (available,) = _availableWithdrawalCapacity(throttle);
-        else available = type(uint256).max;
+        WithdrawalThrottleState storage throttle = _withdrawalThrottles[_token];
+        uint256 oldConfig = throttle.config;
         uint256 stockSnapshot = IERC20(_token).balanceOf(address(this));
-        uint256 capacity = WithdrawalThrottle.capacity(stockSnapshot, _maxBps);
+        uint128 available;
+        if (WithdrawalThrottle.enabled(oldConfig)) {
+            uint128 liveOldCapacity = WithdrawalThrottle.capacity(stockSnapshot, WithdrawalThrottle.maxBps(oldConfig));
+            (available,) = WithdrawalThrottle.sync(
+                WithdrawalThrottle.capacity(oldConfig),
+                throttle.bucket,
+                WithdrawalThrottle.refillPeriod(oldConfig),
+                liveOldCapacity,
+                block.timestamp
+            );
+        } else {
+            available = type(uint128).max;
+        }
+        uint128 capacity = WithdrawalThrottle.capacity(stockSnapshot, _maxBps);
         if (available > capacity) available = capacity;
 
-        throttle.capacity = capacity;
-        throttle.available = available;
-        throttle.refillPeriod = _refillPeriod;
-        throttle.lastUpdated = uint64(block.timestamp);
-        throttle.refillRemainder = 0;
-        throttle.maxBps = _maxBps;
-        throttle.enabled = true;
+        uint64 timestamp = WithdrawalThrottle.timestamp(block.timestamp);
+        throttle.config = WithdrawalThrottle.config(capacity, _refillPeriod, _maxBps, true);
+        throttle.bucket = WithdrawalThrottle.bucket(available, timestamp, 0);
 
         emit WithdrawalThrottleConfigured(_token, _maxBps, _refillPeriod, stockSnapshot, capacity, available);
     }
@@ -229,21 +243,22 @@ contract L1StandardBridge is StandardBridge, ProxyAdminOwnedBase, Reinitializabl
     function refreshWithdrawalThrottle(address _token) external {
         _assertOnlyProxyAdminOwner();
 
-        WithdrawalThrottleConfig storage throttle = _withdrawalThrottles[_token];
-        if (!throttle.enabled) revert L1StandardBridge_WithdrawalThrottleNotEnabled();
+        WithdrawalThrottleState storage throttle = _withdrawalThrottles[_token];
+        uint256 oldConfig = throttle.config;
+        if (!WithdrawalThrottle.enabled(oldConfig)) revert L1StandardBridge_WithdrawalThrottleNotEnabled();
 
-        (uint256 available, uint64 refillRemainder) = _availableWithdrawalCapacity(throttle);
         uint256 stockSnapshot = IERC20(_token).balanceOf(address(this));
-        uint256 capacity = WithdrawalThrottle.capacity(stockSnapshot, throttle.maxBps);
-        if (available >= capacity) {
-            available = capacity;
-            refillRemainder = 0;
+        uint16 maxBps = WithdrawalThrottle.maxBps(oldConfig);
+        uint64 refillPeriod = WithdrawalThrottle.refillPeriod(oldConfig);
+        uint128 capacity = WithdrawalThrottle.capacity(stockSnapshot, maxBps);
+        (uint128 available, uint64 remainder) = WithdrawalThrottle.sync(
+            WithdrawalThrottle.capacity(oldConfig), throttle.bucket, refillPeriod, capacity, block.timestamp
+        );
+        uint64 timestamp = WithdrawalThrottle.timestamp(block.timestamp);
+        if (capacity != WithdrawalThrottle.capacity(oldConfig)) {
+            throttle.config = WithdrawalThrottle.config(capacity, refillPeriod, maxBps, true);
         }
-
-        throttle.capacity = capacity;
-        throttle.available = available;
-        throttle.lastUpdated = uint64(block.timestamp);
-        throttle.refillRemainder = refillRemainder;
+        throttle.bucket = WithdrawalThrottle.bucket(available, timestamp, remainder);
 
         emit WithdrawalThrottleRefreshed(_token, stockSnapshot, capacity, available);
     }
@@ -253,7 +268,7 @@ contract L1StandardBridge is StandardBridge, ProxyAdminOwnedBase, Reinitializabl
     function disableWithdrawalThrottle(address _token) external {
         _assertOnlyProxyAdminOwner();
 
-        if (!_withdrawalThrottles[_token].enabled) {
+        if (!WithdrawalThrottle.enabled(_withdrawalThrottles[_token].config)) {
             revert L1StandardBridge_WithdrawalThrottleNotEnabled();
         }
         delete _withdrawalThrottles[_token];
@@ -261,20 +276,32 @@ contract L1StandardBridge is StandardBridge, ProxyAdminOwnedBase, Reinitializabl
         emit WithdrawalThrottleDisabled(_token);
     }
 
-    /// @notice Returns the stored withdrawal throttle state for a token.
+    /// @notice Returns the stored withdrawal throttle state for a token before pending refill is materialized.
     /// @param _token Address of the L1 token.
-    /// @return Withdrawal throttle state before any pending refill is materialized.
+    /// @return Withdrawal throttle state.
     function withdrawalThrottle(address _token) external view returns (WithdrawalThrottleConfig memory) {
-        return _withdrawalThrottles[_token];
+        WithdrawalThrottleState storage throttle = _withdrawalThrottles[_token];
+        uint256 config_ = throttle.config;
+        uint256 bucket_ = throttle.bucket;
+        return WithdrawalThrottleConfig({
+            capacity: WithdrawalThrottle.capacity(config_),
+            available: WithdrawalThrottle.storedAvailable(bucket_),
+            refillPeriod: WithdrawalThrottle.refillPeriod(config_),
+            lastUpdated: WithdrawalThrottle.lastUpdated(bucket_),
+            refillRemainder: WithdrawalThrottle.refillRemainder(bucket_),
+            maxBps: WithdrawalThrottle.maxBps(config_),
+            enabled: WithdrawalThrottle.enabled(config_)
+        });
     }
 
     /// @notice Returns the currently available withdrawal capacity for a token.
     /// @param _token Address of the L1 token.
     /// @return Available capacity, or the maximum uint256 value when throttling is disabled.
     function availableWithdrawalCapacity(address _token) external view returns (uint256) {
-        WithdrawalThrottleConfig storage throttle = _withdrawalThrottles[_token];
-        if (!throttle.enabled) return type(uint256).max;
-        (,, uint256 available,) = _syncedWithdrawalCapacity(_token, throttle);
+        WithdrawalThrottleState storage throttle = _withdrawalThrottles[_token];
+        uint256 config_ = throttle.config;
+        if (!WithdrawalThrottle.enabled(config_)) return type(uint256).max;
+        (,, uint128 available,) = _syncedWithdrawalCapacity(_token, throttle, config_);
         return available;
     }
 
@@ -434,44 +461,32 @@ contract L1StandardBridge is StandardBridge, ProxyAdminOwnedBase, Reinitializabl
 
     /// @inheritdoc StandardBridge
     function _beforeFinalizeBridgeERC20(address _localToken, uint256 _amount) internal override {
-        WithdrawalThrottleConfig storage throttle = _withdrawalThrottles[_localToken];
-        if (!throttle.enabled || _amount == 0) return;
+        WithdrawalThrottleState storage throttle = _withdrawalThrottles[_localToken];
+        uint256 config_ = throttle.config;
+        if (!WithdrawalThrottle.enabled(config_) || _amount == 0) return;
 
-        (uint256 stockSnapshot, uint256 capacity, uint256 available, uint64 refillRemainder) =
-            _syncedWithdrawalCapacity(_localToken, throttle);
+        (uint256 stockSnapshot, uint128 capacity, uint128 available, uint64 remainder) =
+            _syncedWithdrawalCapacity(_localToken, throttle, config_);
         if (_amount > available) {
             revert L1StandardBridge_WithdrawalThrottled(_localToken, _amount, available, capacity);
         }
 
-        uint256 remaining = available - _amount;
-        bool capacityChanged = capacity != throttle.capacity;
-        throttle.capacity = capacity;
-        throttle.available = remaining;
-        throttle.lastUpdated = uint64(block.timestamp);
-        throttle.refillRemainder = refillRemainder;
+        uint256 remainingValue = uint256(available) - _amount;
+        assert(remainingValue <= type(uint128).max);
+        uint128 remaining = uint128(remainingValue);
+        uint128 oldCapacity = WithdrawalThrottle.capacity(config_);
+        bool capacityChanged = capacity != oldCapacity;
+        uint64 timestamp = WithdrawalThrottle.timestamp(block.timestamp);
+        if (capacityChanged) {
+            throttle.config = WithdrawalThrottle.config(
+                capacity, WithdrawalThrottle.refillPeriod(config_), WithdrawalThrottle.maxBps(config_), true
+            );
+        }
+        throttle.bucket = WithdrawalThrottle.bucket(remaining, timestamp, remainder);
 
         if (capacityChanged) emit WithdrawalThrottleRefreshed(_localToken, stockSnapshot, capacity, available);
         emit WithdrawalThrottleCapacityConsumed(_localToken, _amount, remaining);
         if (remaining == 0) emit WithdrawalThrottleCapacityExhausted(_localToken);
-    }
-
-    /// @notice Computes a throttle's available capacity after its pending linear refill.
-    /// @param _throttle Withdrawal throttle state.
-    /// @return available_ Available capacity at the current timestamp.
-    /// @return remainder_ Fractional refill numerator to preserve when materializing the refill.
-    function _availableWithdrawalCapacity(WithdrawalThrottleConfig storage _throttle)
-        internal
-        view
-        returns (uint256 available_, uint64 remainder_)
-    {
-        return WithdrawalThrottle.available(
-            _throttle.capacity,
-            _throttle.available,
-            _throttle.refillRemainder,
-            _throttle.refillPeriod,
-            _throttle.lastUpdated,
-            block.timestamp
-        );
     }
 
     /// @notice Computes the effective bucket state against the token's current bridge stock.
@@ -483,19 +498,22 @@ contract L1StandardBridge is StandardBridge, ProxyAdminOwnedBase, Reinitializabl
     /// @return remainder_ Fractional refill numerator to preserve when materializing the refill.
     function _syncedWithdrawalCapacity(
         address _token,
-        WithdrawalThrottleConfig storage _throttle
+        WithdrawalThrottleState storage _throttle,
+        uint256 _config
     )
         internal
         view
-        returns (uint256 stock_, uint256 capacity_, uint256 available_, uint64 remainder_)
+        returns (uint256 stock_, uint128 capacity_, uint128 available_, uint64 remainder_)
     {
-        (available_, remainder_) = _availableWithdrawalCapacity(_throttle);
         stock_ = IERC20(_token).balanceOf(address(this));
-        capacity_ = WithdrawalThrottle.capacity(stock_, _throttle.maxBps);
-        if (available_ >= capacity_) {
-            available_ = capacity_;
-            remainder_ = 0;
-        }
+        capacity_ = WithdrawalThrottle.capacity(stock_, WithdrawalThrottle.maxBps(_config));
+        (available_, remainder_) = WithdrawalThrottle.sync(
+            WithdrawalThrottle.capacity(_config),
+            _throttle.bucket,
+            WithdrawalThrottle.refillPeriod(_config),
+            capacity_,
+            block.timestamp
+        );
     }
 
     /// @inheritdoc StandardBridge

--- a/packages/contracts-bedrock/src/L1/L1StandardBridge.sol
+++ b/packages/contracts-bedrock/src/L1/L1StandardBridge.sol
@@ -232,15 +232,18 @@ contract L1StandardBridge is StandardBridge, ProxyAdminOwnedBase, Reinitializabl
         WithdrawalThrottleConfig storage throttle = _withdrawalThrottles[_token];
         if (!throttle.enabled) revert L1StandardBridge_WithdrawalThrottleNotEnabled();
 
-        (uint256 available,) = _availableWithdrawalCapacity(throttle);
+        (uint256 available, uint64 refillRemainder) = _availableWithdrawalCapacity(throttle);
         uint256 stockSnapshot = IERC20(_token).balanceOf(address(this));
         uint256 capacity = WithdrawalThrottle.capacity(stockSnapshot, throttle.maxBps);
-        if (available > capacity) available = capacity;
+        if (available >= capacity) {
+            available = capacity;
+            refillRemainder = 0;
+        }
 
         throttle.capacity = capacity;
         throttle.available = available;
         throttle.lastUpdated = uint64(block.timestamp);
-        throttle.refillRemainder = 0;
+        throttle.refillRemainder = refillRemainder;
 
         emit WithdrawalThrottleRefreshed(_token, stockSnapshot, capacity, available);
     }
@@ -271,7 +274,7 @@ contract L1StandardBridge is StandardBridge, ProxyAdminOwnedBase, Reinitializabl
     function availableWithdrawalCapacity(address _token) external view returns (uint256) {
         WithdrawalThrottleConfig storage throttle = _withdrawalThrottles[_token];
         if (!throttle.enabled) return type(uint256).max;
-        (uint256 available,) = _availableWithdrawalCapacity(throttle);
+        (,, uint256 available,) = _syncedWithdrawalCapacity(_token, throttle);
         return available;
     }
 
@@ -434,16 +437,20 @@ contract L1StandardBridge is StandardBridge, ProxyAdminOwnedBase, Reinitializabl
         WithdrawalThrottleConfig storage throttle = _withdrawalThrottles[_localToken];
         if (!throttle.enabled || _amount == 0) return;
 
-        (uint256 available, uint64 refillRemainder) = _availableWithdrawalCapacity(throttle);
+        (uint256 stockSnapshot, uint256 capacity, uint256 available, uint64 refillRemainder) =
+            _syncedWithdrawalCapacity(_localToken, throttle);
         if (_amount > available) {
-            revert L1StandardBridge_WithdrawalThrottled(_localToken, _amount, available, throttle.capacity);
+            revert L1StandardBridge_WithdrawalThrottled(_localToken, _amount, available, capacity);
         }
 
         uint256 remaining = available - _amount;
+        bool capacityChanged = capacity != throttle.capacity;
+        throttle.capacity = capacity;
         throttle.available = remaining;
         throttle.lastUpdated = uint64(block.timestamp);
         throttle.refillRemainder = refillRemainder;
 
+        if (capacityChanged) emit WithdrawalThrottleRefreshed(_localToken, stockSnapshot, capacity, available);
         emit WithdrawalThrottleCapacityConsumed(_localToken, _amount, remaining);
         if (remaining == 0) emit WithdrawalThrottleCapacityExhausted(_localToken);
     }
@@ -465,6 +472,30 @@ contract L1StandardBridge is StandardBridge, ProxyAdminOwnedBase, Reinitializabl
             _throttle.lastUpdated,
             block.timestamp
         );
+    }
+
+    /// @notice Computes the effective bucket state against the token's current bridge stock.
+    /// @param _token Token whose bridge stock should be read.
+    /// @param _throttle Withdrawal throttle state.
+    /// @return stock_ Current bridge stock.
+    /// @return capacity_ Capacity derived from the current stock.
+    /// @return available_ Available capacity after refill and stock synchronization.
+    /// @return remainder_ Fractional refill numerator to preserve when materializing the refill.
+    function _syncedWithdrawalCapacity(
+        address _token,
+        WithdrawalThrottleConfig storage _throttle
+    )
+        internal
+        view
+        returns (uint256 stock_, uint256 capacity_, uint256 available_, uint64 remainder_)
+    {
+        (available_, remainder_) = _availableWithdrawalCapacity(_throttle);
+        stock_ = IERC20(_token).balanceOf(address(this));
+        capacity_ = WithdrawalThrottle.capacity(stock_, _throttle.maxBps);
+        if (available_ >= capacity_) {
+            available_ = capacity_;
+            remainder_ = 0;
+        }
     }
 
     /// @inheritdoc StandardBridge

--- a/packages/contracts-bedrock/src/L1/L1StandardBridge.sol
+++ b/packages/contracts-bedrock/src/L1/L1StandardBridge.sol
@@ -8,8 +8,10 @@ import { StandardBridge } from "src/universal/StandardBridge.sol";
 
 // Libraries
 import { Predeploys } from "src/libraries/Predeploys.sol";
+import { WithdrawalThrottle } from "src/libraries/WithdrawalThrottle.sol";
 
 // Interfaces
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { ISemver } from "interfaces/universal/ISemver.sol";
 import { ICrossDomainMessenger } from "interfaces/universal/ICrossDomainMessenger.sol";
 import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
@@ -26,6 +28,61 @@ import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 ///         of some token types that may not be properly supported by this contract include, but are
 ///         not limited to: tokens with transfer fees, rebasing tokens, and tokens with blocklists.
 contract L1StandardBridge is StandardBridge, ProxyAdminOwnedBase, ReinitializableBase, ISemver {
+    /// @notice Thrown when a withdrawal throttle is configured for the zero address.
+    error L1StandardBridge_InvalidWithdrawalThrottleToken();
+
+    /// @notice Thrown when a withdrawal throttle basis point value is zero or exceeds 100%.
+    error L1StandardBridge_InvalidWithdrawalThrottleBps();
+
+    /// @notice Thrown when a withdrawal throttle is configured for a non-escrowed token.
+    error L1StandardBridge_UnsupportedWithdrawalThrottleToken();
+
+    /// @notice Thrown when a withdrawal throttle refill period is zero.
+    error L1StandardBridge_InvalidWithdrawalThrottlePeriod();
+
+    /// @notice Thrown when a withdrawal throttle is not enabled for a token.
+    error L1StandardBridge_WithdrawalThrottleNotEnabled();
+
+    /// @notice Thrown when a withdrawal exceeds the token's available withdrawal capacity.
+    error L1StandardBridge_WithdrawalThrottled(
+        address token, uint256 requestedAmount, uint256 availableCapacity, uint256 totalCapacity
+    );
+
+    /// @notice Withdrawal throttle state for an L1 token.
+    struct WithdrawalThrottleConfig {
+        uint256 capacity;
+        uint256 available;
+        uint64 refillPeriod;
+        uint64 lastUpdated;
+        uint64 refillRemainder;
+        uint16 maxBps;
+        bool enabled;
+    }
+
+    /// @notice Emitted when a withdrawal throttle is configured for a token.
+    event WithdrawalThrottleConfigured(
+        address indexed token,
+        uint16 maxBps,
+        uint64 refillPeriod,
+        uint256 stockSnapshot,
+        uint256 capacity,
+        uint256 available
+    );
+
+    /// @notice Emitted when a withdrawal throttle's stock snapshot is refreshed.
+    event WithdrawalThrottleRefreshed(
+        address indexed token, uint256 stockSnapshot, uint256 capacity, uint256 available
+    );
+
+    /// @notice Emitted when a withdrawal throttle is disabled for a token.
+    event WithdrawalThrottleDisabled(address indexed token);
+
+    /// @notice Emitted when withdrawal capacity is consumed.
+    event WithdrawalThrottleCapacityConsumed(address indexed token, uint256 amount, uint256 remaining);
+
+    /// @notice Emitted when all currently available withdrawal capacity is consumed.
+    event WithdrawalThrottleCapacityExhausted(address indexed token);
+
     /// @custom:legacy
     /// @notice Emitted whenever a deposit of ETH from L1 into L2 is initiated.
     /// @param from      Address of the depositor.
@@ -77,8 +134,8 @@ contract L1StandardBridge is StandardBridge, ProxyAdminOwnedBase, Reinitializabl
     );
 
     /// @notice Semantic version.
-    /// @custom:semver 2.8.2
-    string public constant version = "2.8.2";
+    /// @custom:semver 3.0.0
+    string public constant version = "3.0.0";
 
     /// @custom:legacy
     /// @custom:spacer superchainConfig
@@ -92,6 +149,9 @@ contract L1StandardBridge is StandardBridge, ProxyAdminOwnedBase, Reinitializabl
 
     /// @notice Address of the SystemConfig contract.
     ISystemConfig public systemConfig;
+
+    /// @notice Withdrawal throttle state keyed by L1 token address.
+    mapping(address => WithdrawalThrottleConfig) internal _withdrawalThrottles;
 
     /// @notice Constructs the L1StandardBridge contract.
     constructor() StandardBridge() ReinitializableBase(3) {
@@ -128,6 +188,91 @@ contract L1StandardBridge is StandardBridge, ProxyAdminOwnedBase, Reinitializabl
     /// @return ISuperchainConfig The SuperchainConfig contract.
     function superchainConfig() public view returns (ISuperchainConfig) {
         return systemConfig.superchainConfig();
+    }
+
+    /// @notice Configures a token's withdrawal capacity as a percentage of its current bridge stock.
+    ///         Reconfiguration preserves accrued capacity and clamps it to the new maximum.
+    /// @param _token        Address of the L1 token to throttle.
+    /// @param _maxBps       Maximum withdrawable stock in basis points.
+    /// @param _refillPeriod Time in seconds for the bucket to refill from empty to full.
+    function setWithdrawalThrottle(address _token, uint16 _maxBps, uint64 _refillPeriod) external {
+        _assertOnlyProxyAdminOwner();
+
+        if (_token == address(0)) revert L1StandardBridge_InvalidWithdrawalThrottleToken();
+        if (_isOptimismMintableERC20(_token)) revert L1StandardBridge_UnsupportedWithdrawalThrottleToken();
+        if (_maxBps == 0 || _maxBps > WithdrawalThrottle.MAX_BPS) {
+            revert L1StandardBridge_InvalidWithdrawalThrottleBps();
+        }
+        if (_refillPeriod == 0) revert L1StandardBridge_InvalidWithdrawalThrottlePeriod();
+
+        WithdrawalThrottleConfig storage throttle = _withdrawalThrottles[_token];
+        uint256 available;
+        if (throttle.enabled) (available,) = _availableWithdrawalCapacity(throttle);
+        else available = type(uint256).max;
+        uint256 stockSnapshot = IERC20(_token).balanceOf(address(this));
+        uint256 capacity = WithdrawalThrottle.capacity(stockSnapshot, _maxBps);
+        if (available > capacity) available = capacity;
+
+        throttle.capacity = capacity;
+        throttle.available = available;
+        throttle.refillPeriod = _refillPeriod;
+        throttle.lastUpdated = uint64(block.timestamp);
+        throttle.refillRemainder = 0;
+        throttle.maxBps = _maxBps;
+        throttle.enabled = true;
+
+        emit WithdrawalThrottleConfigured(_token, _maxBps, _refillPeriod, stockSnapshot, capacity, available);
+    }
+
+    /// @notice Recomputes a token's capacity from its current bridge stock without refilling it.
+    /// @param _token Address of the L1 token whose stock snapshot should be refreshed.
+    function refreshWithdrawalThrottle(address _token) external {
+        _assertOnlyProxyAdminOwner();
+
+        WithdrawalThrottleConfig storage throttle = _withdrawalThrottles[_token];
+        if (!throttle.enabled) revert L1StandardBridge_WithdrawalThrottleNotEnabled();
+
+        (uint256 available,) = _availableWithdrawalCapacity(throttle);
+        uint256 stockSnapshot = IERC20(_token).balanceOf(address(this));
+        uint256 capacity = WithdrawalThrottle.capacity(stockSnapshot, throttle.maxBps);
+        if (available > capacity) available = capacity;
+
+        throttle.capacity = capacity;
+        throttle.available = available;
+        throttle.lastUpdated = uint64(block.timestamp);
+        throttle.refillRemainder = 0;
+
+        emit WithdrawalThrottleRefreshed(_token, stockSnapshot, capacity, available);
+    }
+
+    /// @notice Disables a token's withdrawal throttle.
+    /// @param _token Address of the L1 token whose throttle should be disabled.
+    function disableWithdrawalThrottle(address _token) external {
+        _assertOnlyProxyAdminOwner();
+
+        if (!_withdrawalThrottles[_token].enabled) {
+            revert L1StandardBridge_WithdrawalThrottleNotEnabled();
+        }
+        delete _withdrawalThrottles[_token];
+
+        emit WithdrawalThrottleDisabled(_token);
+    }
+
+    /// @notice Returns the stored withdrawal throttle state for a token.
+    /// @param _token Address of the L1 token.
+    /// @return Withdrawal throttle state before any pending refill is materialized.
+    function withdrawalThrottle(address _token) external view returns (WithdrawalThrottleConfig memory) {
+        return _withdrawalThrottles[_token];
+    }
+
+    /// @notice Returns the currently available withdrawal capacity for a token.
+    /// @param _token Address of the L1 token.
+    /// @return Available capacity, or the maximum uint256 value when throttling is disabled.
+    function availableWithdrawalCapacity(address _token) external view returns (uint256) {
+        WithdrawalThrottleConfig storage throttle = _withdrawalThrottles[_token];
+        if (!throttle.enabled) return type(uint256).max;
+        (uint256 available,) = _availableWithdrawalCapacity(throttle);
+        return available;
     }
 
     /// @notice Allows EOAs to bridge ETH by sending directly to the bridge.
@@ -282,6 +427,44 @@ contract L1StandardBridge is StandardBridge, ProxyAdminOwnedBase, Reinitializabl
         internal
     {
         _initiateBridgeERC20(_l1Token, _l2Token, _from, _to, _amount, _minGasLimit, _extraData);
+    }
+
+    /// @inheritdoc StandardBridge
+    function _beforeFinalizeBridgeERC20(address _localToken, uint256 _amount) internal override {
+        WithdrawalThrottleConfig storage throttle = _withdrawalThrottles[_localToken];
+        if (!throttle.enabled || _amount == 0) return;
+
+        (uint256 available, uint64 refillRemainder) = _availableWithdrawalCapacity(throttle);
+        if (_amount > available) {
+            revert L1StandardBridge_WithdrawalThrottled(_localToken, _amount, available, throttle.capacity);
+        }
+
+        uint256 remaining = available - _amount;
+        throttle.available = remaining;
+        throttle.lastUpdated = uint64(block.timestamp);
+        throttle.refillRemainder = refillRemainder;
+
+        emit WithdrawalThrottleCapacityConsumed(_localToken, _amount, remaining);
+        if (remaining == 0) emit WithdrawalThrottleCapacityExhausted(_localToken);
+    }
+
+    /// @notice Computes a throttle's available capacity after its pending linear refill.
+    /// @param _throttle Withdrawal throttle state.
+    /// @return available_ Available capacity at the current timestamp.
+    /// @return remainder_ Fractional refill numerator to preserve when materializing the refill.
+    function _availableWithdrawalCapacity(WithdrawalThrottleConfig storage _throttle)
+        internal
+        view
+        returns (uint256 available_, uint64 remainder_)
+    {
+        return WithdrawalThrottle.available(
+            _throttle.capacity,
+            _throttle.available,
+            _throttle.refillRemainder,
+            _throttle.refillPeriod,
+            _throttle.lastUpdated,
+            block.timestamp
+        );
     }
 
     /// @inheritdoc StandardBridge

--- a/packages/contracts-bedrock/src/L1/L1StandardBridge.sol
+++ b/packages/contracts-bedrock/src/L1/L1StandardBridge.sol
@@ -28,6 +28,8 @@ import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 ///         of some token types that may not be properly supported by this contract include, but are
 ///         not limited to: tokens with transfer fees, rebasing tokens, and tokens with blocklists.
 contract L1StandardBridge is StandardBridge, ProxyAdminOwnedBase, ReinitializableBase, ISemver {
+    using WithdrawalThrottle for WithdrawalThrottle.State;
+
     /// @notice Thrown when a withdrawal throttle is configured for the zero address.
     error L1StandardBridge_InvalidWithdrawalThrottleToken();
 
@@ -57,12 +59,6 @@ contract L1StandardBridge is StandardBridge, ProxyAdminOwnedBase, Reinitializabl
         uint64 refillRemainder;
         uint16 maxBps;
         bool enabled;
-    }
-
-    /// @notice Packed withdrawal throttle storage for an L1 token.
-    struct WithdrawalThrottleState {
-        uint256 config;
-        uint256 bucket;
     }
 
     /// @notice Emitted when a withdrawal throttle is configured for a token.
@@ -140,8 +136,8 @@ contract L1StandardBridge is StandardBridge, ProxyAdminOwnedBase, Reinitializabl
     );
 
     /// @notice Semantic version.
-    /// @custom:semver 3.0.0
-    string public constant version = "3.0.0";
+    /// @custom:semver 3.1.0
+    string public constant version = "3.1.0";
 
     /// @custom:legacy
     /// @custom:spacer superchainConfig
@@ -157,7 +153,7 @@ contract L1StandardBridge is StandardBridge, ProxyAdminOwnedBase, Reinitializabl
     ISystemConfig public systemConfig;
 
     /// @notice Withdrawal throttle state keyed by L1 token address.
-    mapping(address => WithdrawalThrottleState) internal _withdrawalThrottles;
+    mapping(address => WithdrawalThrottle.State) internal _withdrawalThrottles;
 
     /// @notice Constructs the L1StandardBridge contract.
     constructor() StandardBridge() ReinitializableBase(3) {
@@ -212,28 +208,10 @@ contract L1StandardBridge is StandardBridge, ProxyAdminOwnedBase, Reinitializabl
         }
         if (_refillPeriod == 0) revert L1StandardBridge_InvalidWithdrawalThrottlePeriod();
 
-        WithdrawalThrottleState storage throttle = _withdrawalThrottles[_token];
-        uint256 oldConfig = throttle.config;
+        WithdrawalThrottle.State storage throttle = _withdrawalThrottles[_token];
         uint256 stockSnapshot = IERC20(_token).balanceOf(address(this));
-        uint128 available;
-        if (WithdrawalThrottle.enabled(oldConfig)) {
-            uint128 liveOldCapacity = WithdrawalThrottle.capacity(stockSnapshot, WithdrawalThrottle.maxBps(oldConfig));
-            (available,) = WithdrawalThrottle.sync(
-                WithdrawalThrottle.capacity(oldConfig),
-                throttle.bucket,
-                WithdrawalThrottle.refillPeriod(oldConfig),
-                liveOldCapacity,
-                block.timestamp
-            );
-        } else {
-            available = type(uint128).max;
-        }
-        uint128 capacity = WithdrawalThrottle.capacity(stockSnapshot, _maxBps);
-        if (available > capacity) available = capacity;
-
-        uint64 timestamp = WithdrawalThrottle.timestamp(block.timestamp);
-        throttle.config = WithdrawalThrottle.config(capacity, _refillPeriod, _maxBps, true);
-        throttle.bucket = WithdrawalThrottle.bucket(available, timestamp, 0);
+        (uint128 capacity, uint128 available) =
+            throttle.configure(stockSnapshot, _maxBps, _refillPeriod, block.timestamp);
 
         emit WithdrawalThrottleConfigured(_token, _maxBps, _refillPeriod, stockSnapshot, capacity, available);
     }
@@ -243,22 +221,12 @@ contract L1StandardBridge is StandardBridge, ProxyAdminOwnedBase, Reinitializabl
     function refreshWithdrawalThrottle(address _token) external {
         _assertOnlyProxyAdminOwner();
 
-        WithdrawalThrottleState storage throttle = _withdrawalThrottles[_token];
-        uint256 oldConfig = throttle.config;
-        if (!WithdrawalThrottle.enabled(oldConfig)) revert L1StandardBridge_WithdrawalThrottleNotEnabled();
+        WithdrawalThrottle.State storage throttle = _withdrawalThrottles[_token];
+        uint256 config_ = throttle.config;
+        if (!WithdrawalThrottle.enabled(config_)) revert L1StandardBridge_WithdrawalThrottleNotEnabled();
 
         uint256 stockSnapshot = IERC20(_token).balanceOf(address(this));
-        uint16 maxBps = WithdrawalThrottle.maxBps(oldConfig);
-        uint64 refillPeriod = WithdrawalThrottle.refillPeriod(oldConfig);
-        uint128 capacity = WithdrawalThrottle.capacity(stockSnapshot, maxBps);
-        (uint128 available, uint64 remainder) = WithdrawalThrottle.sync(
-            WithdrawalThrottle.capacity(oldConfig), throttle.bucket, refillPeriod, capacity, block.timestamp
-        );
-        uint64 timestamp = WithdrawalThrottle.timestamp(block.timestamp);
-        if (capacity != WithdrawalThrottle.capacity(oldConfig)) {
-            throttle.config = WithdrawalThrottle.config(capacity, refillPeriod, maxBps, true);
-        }
-        throttle.bucket = WithdrawalThrottle.bucket(available, timestamp, remainder);
+        (uint128 capacity, uint128 available) = throttle.refresh(config_, stockSnapshot, block.timestamp);
 
         emit WithdrawalThrottleRefreshed(_token, stockSnapshot, capacity, available);
     }
@@ -268,10 +236,9 @@ contract L1StandardBridge is StandardBridge, ProxyAdminOwnedBase, Reinitializabl
     function disableWithdrawalThrottle(address _token) external {
         _assertOnlyProxyAdminOwner();
 
-        if (!WithdrawalThrottle.enabled(_withdrawalThrottles[_token].config)) {
-            revert L1StandardBridge_WithdrawalThrottleNotEnabled();
-        }
-        delete _withdrawalThrottles[_token];
+        WithdrawalThrottle.State storage throttle = _withdrawalThrottles[_token];
+        if (!WithdrawalThrottle.enabled(throttle.config)) revert L1StandardBridge_WithdrawalThrottleNotEnabled();
+        throttle.disable();
 
         emit WithdrawalThrottleDisabled(_token);
     }
@@ -280,17 +247,15 @@ contract L1StandardBridge is StandardBridge, ProxyAdminOwnedBase, Reinitializabl
     /// @param _token Address of the L1 token.
     /// @return Withdrawal throttle state.
     function withdrawalThrottle(address _token) external view returns (WithdrawalThrottleConfig memory) {
-        WithdrawalThrottleState storage throttle = _withdrawalThrottles[_token];
-        uint256 config_ = throttle.config;
-        uint256 bucket_ = throttle.bucket;
+        WithdrawalThrottle.Snapshot memory throttle = _withdrawalThrottles[_token].snapshot();
         return WithdrawalThrottleConfig({
-            capacity: WithdrawalThrottle.capacity(config_),
-            available: WithdrawalThrottle.storedAvailable(bucket_),
-            refillPeriod: WithdrawalThrottle.refillPeriod(config_),
-            lastUpdated: WithdrawalThrottle.lastUpdated(bucket_),
-            refillRemainder: WithdrawalThrottle.refillRemainder(bucket_),
-            maxBps: WithdrawalThrottle.maxBps(config_),
-            enabled: WithdrawalThrottle.enabled(config_)
+            capacity: throttle.capacity,
+            available: throttle.available,
+            refillPeriod: throttle.refillPeriod,
+            lastUpdated: throttle.lastUpdated,
+            refillRemainder: throttle.refillRemainder,
+            maxBps: throttle.maxBps,
+            enabled: throttle.enabled
         });
     }
 
@@ -298,11 +263,10 @@ contract L1StandardBridge is StandardBridge, ProxyAdminOwnedBase, Reinitializabl
     /// @param _token Address of the L1 token.
     /// @return Available capacity, or the maximum uint256 value when throttling is disabled.
     function availableWithdrawalCapacity(address _token) external view returns (uint256) {
-        WithdrawalThrottleState storage throttle = _withdrawalThrottles[_token];
+        WithdrawalThrottle.State storage throttle = _withdrawalThrottles[_token];
         uint256 config_ = throttle.config;
         if (!WithdrawalThrottle.enabled(config_)) return type(uint256).max;
-        (,, uint128 available,) = _syncedWithdrawalCapacity(_token, throttle, config_);
-        return available;
+        return throttle.availableCapacity(config_, IERC20(_token).balanceOf(address(this)), block.timestamp);
     }
 
     /// @notice Allows EOAs to bridge ETH by sending directly to the bridge.
@@ -461,59 +425,20 @@ contract L1StandardBridge is StandardBridge, ProxyAdminOwnedBase, Reinitializabl
 
     /// @inheritdoc StandardBridge
     function _beforeFinalizeBridgeERC20(address _localToken, uint256 _amount) internal override {
-        WithdrawalThrottleState storage throttle = _withdrawalThrottles[_localToken];
+        WithdrawalThrottle.State storage throttle = _withdrawalThrottles[_localToken];
         uint256 config_ = throttle.config;
         if (!WithdrawalThrottle.enabled(config_) || _amount == 0) return;
 
-        (uint256 stockSnapshot, uint128 capacity, uint128 available, uint64 remainder) =
-            _syncedWithdrawalCapacity(_localToken, throttle, config_);
+        uint256 stockSnapshot = IERC20(_localToken).balanceOf(address(this));
+        (uint128 capacity, uint128 available, uint128 remaining, bool capacityChanged) =
+            throttle.consume(config_, stockSnapshot, _amount, block.timestamp);
         if (_amount > available) {
             revert L1StandardBridge_WithdrawalThrottled(_localToken, _amount, available, capacity);
         }
 
-        uint256 remainingValue = uint256(available) - _amount;
-        assert(remainingValue <= type(uint128).max);
-        uint128 remaining = uint128(remainingValue);
-        uint128 oldCapacity = WithdrawalThrottle.capacity(config_);
-        bool capacityChanged = capacity != oldCapacity;
-        uint64 timestamp = WithdrawalThrottle.timestamp(block.timestamp);
-        if (capacityChanged) {
-            throttle.config = WithdrawalThrottle.config(
-                capacity, WithdrawalThrottle.refillPeriod(config_), WithdrawalThrottle.maxBps(config_), true
-            );
-        }
-        throttle.bucket = WithdrawalThrottle.bucket(remaining, timestamp, remainder);
-
         if (capacityChanged) emit WithdrawalThrottleRefreshed(_localToken, stockSnapshot, capacity, available);
         emit WithdrawalThrottleCapacityConsumed(_localToken, _amount, remaining);
         if (remaining == 0) emit WithdrawalThrottleCapacityExhausted(_localToken);
-    }
-
-    /// @notice Computes the effective bucket state against the token's current bridge stock.
-    /// @param _token Token whose bridge stock should be read.
-    /// @param _throttle Withdrawal throttle state.
-    /// @return stock_ Current bridge stock.
-    /// @return capacity_ Capacity derived from the current stock.
-    /// @return available_ Available capacity after refill and stock synchronization.
-    /// @return remainder_ Fractional refill numerator to preserve when materializing the refill.
-    function _syncedWithdrawalCapacity(
-        address _token,
-        WithdrawalThrottleState storage _throttle,
-        uint256 _config
-    )
-        internal
-        view
-        returns (uint256 stock_, uint128 capacity_, uint128 available_, uint64 remainder_)
-    {
-        stock_ = IERC20(_token).balanceOf(address(this));
-        capacity_ = WithdrawalThrottle.capacity(stock_, WithdrawalThrottle.maxBps(_config));
-        (available_, remainder_) = WithdrawalThrottle.sync(
-            WithdrawalThrottle.capacity(_config),
-            _throttle.bucket,
-            WithdrawalThrottle.refillPeriod(_config),
-            capacity_,
-            block.timestamp
-        );
     }
 
     /// @inheritdoc StandardBridge

--- a/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
+++ b/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
@@ -44,7 +44,7 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
         uint64 timestamp;
     }
 
-    /// @notice Withdrawal throttle state for ETH held directly by the portal.
+    /// @notice Logical withdrawal throttle state for ETH held directly by the portal.
     struct WithdrawalThrottleConfig {
         uint256 capacity;
         uint256 available;
@@ -53,6 +53,12 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
         uint64 refillRemainder;
         uint16 maxBps;
         bool enabled;
+    }
+
+    /// @notice Packed withdrawal throttle storage for ETH held directly by the portal.
+    struct WithdrawalThrottleState {
+        uint256 config;
+        uint256 bucket;
     }
 
     /// @notice The delay between when a withdrawal is proven and when it may be finalized.
@@ -144,7 +150,7 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
     bool private spacer_63_20_1;
 
     /// @notice Withdrawal throttle state for ETH held directly by the portal.
-    WithdrawalThrottleConfig internal _withdrawalThrottle;
+    WithdrawalThrottleState internal _withdrawalThrottle;
 
     /// @notice Emitted when the Portal is migrated.
     /// @param oldLockbox The lockbox before the migration
@@ -357,7 +363,8 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
 
     /// @notice Configures ETH withdrawal capacity as a percentage of the current portal balance.
     ///         Only applies when ETH is held directly by the portal. Reconfiguration preserves
-    ///         accrued capacity and clamps it to the new maximum.
+    ///         accrued whole-unit capacity, resets the fractional remainder, and clamps
+    ///         availability to the new maximum.
     /// @param _maxBps       Maximum withdrawable stock in basis points.
     /// @param _refillPeriod Time in seconds for the bucket to refill from empty to full.
     function setWithdrawalThrottle(uint16 _maxBps, uint64 _refillPeriod) external {
@@ -369,21 +376,28 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
         }
         if (_refillPeriod == 0) revert OptimismPortal_InvalidWithdrawalThrottlePeriod();
 
-        WithdrawalThrottleConfig storage throttle = _withdrawalThrottle;
-        uint256 available;
-        if (throttle.enabled) (available,) = _availableWithdrawalCapacity();
-        else available = type(uint256).max;
+        WithdrawalThrottleState storage throttle = _withdrawalThrottle;
+        uint256 oldConfig = throttle.config;
         uint256 stockSnapshot = address(this).balance;
-        uint256 capacity = WithdrawalThrottle.capacity(stockSnapshot, _maxBps);
+        uint128 available;
+        if (WithdrawalThrottle.enabled(oldConfig)) {
+            uint128 liveOldCapacity = WithdrawalThrottle.capacity(stockSnapshot, WithdrawalThrottle.maxBps(oldConfig));
+            (available,) = WithdrawalThrottle.sync(
+                WithdrawalThrottle.capacity(oldConfig),
+                throttle.bucket,
+                WithdrawalThrottle.refillPeriod(oldConfig),
+                liveOldCapacity,
+                block.timestamp
+            );
+        } else {
+            available = type(uint128).max;
+        }
+        uint128 capacity = WithdrawalThrottle.capacity(stockSnapshot, _maxBps);
         if (available > capacity) available = capacity;
 
-        throttle.capacity = capacity;
-        throttle.available = available;
-        throttle.refillPeriod = _refillPeriod;
-        throttle.lastUpdated = uint64(block.timestamp);
-        throttle.refillRemainder = 0;
-        throttle.maxBps = _maxBps;
-        throttle.enabled = true;
+        uint64 timestamp = WithdrawalThrottle.timestamp(block.timestamp);
+        throttle.config = WithdrawalThrottle.config(capacity, _refillPeriod, _maxBps, true);
+        throttle.bucket = WithdrawalThrottle.bucket(available, timestamp, 0);
 
         emit WithdrawalThrottleConfigured(_maxBps, _refillPeriod, stockSnapshot, capacity, available);
     }
@@ -392,7 +406,9 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
     function disableWithdrawalThrottle() external {
         _assertOnlyProxyAdminOwner();
 
-        if (!_withdrawalThrottle.enabled) revert OptimismPortal_WithdrawalThrottleNotEnabled();
+        if (!WithdrawalThrottle.enabled(_withdrawalThrottle.config)) {
+            revert OptimismPortal_WithdrawalThrottleNotEnabled();
+        }
         delete _withdrawalThrottle;
 
         emit WithdrawalThrottleDisabled();
@@ -401,14 +417,26 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
     /// @notice Returns the stored portal ETH withdrawal throttle state before pending refill is materialized.
     /// @return Withdrawal throttle state.
     function withdrawalThrottle() external view returns (WithdrawalThrottleConfig memory) {
-        return _withdrawalThrottle;
+        WithdrawalThrottleState storage throttle = _withdrawalThrottle;
+        uint256 config_ = throttle.config;
+        uint256 bucket_ = throttle.bucket;
+        return WithdrawalThrottleConfig({
+            capacity: WithdrawalThrottle.capacity(config_),
+            available: WithdrawalThrottle.storedAvailable(bucket_),
+            refillPeriod: WithdrawalThrottle.refillPeriod(config_),
+            lastUpdated: WithdrawalThrottle.lastUpdated(bucket_),
+            refillRemainder: WithdrawalThrottle.refillRemainder(bucket_),
+            maxBps: WithdrawalThrottle.maxBps(config_),
+            enabled: WithdrawalThrottle.enabled(config_)
+        });
     }
 
     /// @notice Returns currently available portal ETH withdrawal capacity.
     /// @return Available capacity, or the maximum uint256 value when throttling is disabled.
     function availableWithdrawalCapacity() external view returns (uint256) {
-        if (!_withdrawalThrottle.enabled) return type(uint256).max;
-        (,, uint256 available,) = _syncedWithdrawalCapacity();
+        uint256 config_ = _withdrawalThrottle.config;
+        if (!WithdrawalThrottle.enabled(config_)) return type(uint256).max;
+        (,, uint128 available,) = _syncedWithdrawalCapacity(config_);
         return available;
     }
 
@@ -862,40 +890,32 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
     /// @notice Consumes available ETH withdrawal capacity when the throttle is enabled.
     /// @param _amount Amount of ETH to withdraw.
     function _consumeWithdrawalCapacity(uint256 _amount) internal {
-        WithdrawalThrottleConfig storage throttle = _withdrawalThrottle;
-        if (!throttle.enabled || _amount == 0) return;
+        WithdrawalThrottleState storage throttle = _withdrawalThrottle;
+        uint256 config_ = throttle.config;
+        if (!WithdrawalThrottle.enabled(config_) || _amount == 0) return;
 
-        (uint256 stockSnapshot, uint256 capacity, uint256 available, uint64 refillRemainder) =
-            _syncedWithdrawalCapacity();
+        (uint256 stockSnapshot, uint128 capacity, uint128 available, uint64 remainder) =
+            _syncedWithdrawalCapacity(config_);
         if (_amount > available) {
             revert OptimismPortal_WithdrawalThrottled(_amount, available, capacity);
         }
 
-        uint256 remaining = available - _amount;
-        bool capacityChanged = capacity != throttle.capacity;
-        throttle.capacity = capacity;
-        throttle.available = remaining;
-        throttle.lastUpdated = uint64(block.timestamp);
-        throttle.refillRemainder = refillRemainder;
+        uint256 remainingValue = uint256(available) - _amount;
+        assert(remainingValue <= type(uint128).max);
+        uint128 remaining = uint128(remainingValue);
+        uint128 oldCapacity = WithdrawalThrottle.capacity(config_);
+        bool capacityChanged = capacity != oldCapacity;
+        uint64 timestamp = WithdrawalThrottle.timestamp(block.timestamp);
+        if (capacityChanged) {
+            throttle.config = WithdrawalThrottle.config(
+                capacity, WithdrawalThrottle.refillPeriod(config_), WithdrawalThrottle.maxBps(config_), true
+            );
+        }
+        throttle.bucket = WithdrawalThrottle.bucket(remaining, timestamp, remainder);
 
         if (capacityChanged) emit WithdrawalThrottleRefreshed(stockSnapshot, capacity, available);
         emit WithdrawalThrottleCapacityConsumed(_amount, remaining);
         if (remaining == 0) emit WithdrawalThrottleCapacityExhausted();
-    }
-
-    /// @notice Computes available ETH withdrawal capacity after its pending linear refill.
-    /// @return available_ Available capacity at the current timestamp.
-    /// @return remainder_ Fractional refill numerator to preserve when materializing the refill.
-    function _availableWithdrawalCapacity() internal view returns (uint256 available_, uint64 remainder_) {
-        WithdrawalThrottleConfig storage throttle = _withdrawalThrottle;
-        return WithdrawalThrottle.available(
-            throttle.capacity,
-            throttle.available,
-            throttle.refillRemainder,
-            throttle.refillPeriod,
-            throttle.lastUpdated,
-            block.timestamp
-        );
     }
 
     /// @notice Computes the effective bucket state against the portal's current ETH stock.
@@ -903,19 +923,21 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
     /// @return capacity_ Capacity derived from the current stock.
     /// @return available_ Available capacity after refill and stock synchronization.
     /// @return remainder_ Fractional refill numerator to preserve when materializing the refill.
-    function _syncedWithdrawalCapacity()
+    function _syncedWithdrawalCapacity(uint256 _config)
         internal
         view
-        returns (uint256 stock_, uint256 capacity_, uint256 available_, uint64 remainder_)
+        returns (uint256 stock_, uint128 capacity_, uint128 available_, uint64 remainder_)
     {
-        WithdrawalThrottleConfig storage throttle = _withdrawalThrottle;
-        (available_, remainder_) = _availableWithdrawalCapacity();
+        WithdrawalThrottleState storage throttle = _withdrawalThrottle;
         stock_ = address(this).balance;
-        capacity_ = WithdrawalThrottle.capacity(stock_, throttle.maxBps);
-        if (available_ >= capacity_) {
-            available_ = capacity_;
-            remainder_ = 0;
-        }
+        capacity_ = WithdrawalThrottle.capacity(stock_, WithdrawalThrottle.maxBps(_config));
+        (available_, remainder_) = WithdrawalThrottle.sync(
+            WithdrawalThrottle.capacity(_config),
+            throttle.bucket,
+            WithdrawalThrottle.refillPeriod(_config),
+            capacity_,
+            block.timestamp
+        );
     }
 
     /// @notice Checks if the Interop feature is enabled.

--- a/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
+++ b/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
@@ -36,6 +36,8 @@ import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 ///         and L2. Messages sent directly to the OptimismPortal have no form of replayability.
 ///         Users are encouraged to use the L1CrossDomainMessenger for a higher-level interface.
 contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase, ProxyAdminOwnedBase, ISemver {
+    using WithdrawalThrottle for WithdrawalThrottle.State;
+
     /// @notice Represents a proven withdrawal.
     /// @custom:field disputeGameProxy Game that the withdrawal was proven against.
     /// @custom:field timestamp        Timestamp at which the withdrawal was proven.
@@ -53,12 +55,6 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
         uint64 refillRemainder;
         uint16 maxBps;
         bool enabled;
-    }
-
-    /// @notice Packed withdrawal throttle storage for ETH held directly by the portal.
-    struct WithdrawalThrottleState {
-        uint256 config;
-        uint256 bucket;
     }
 
     /// @notice The delay between when a withdrawal is proven and when it may be finalized.
@@ -150,7 +146,7 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
     bool private spacer_63_20_1;
 
     /// @notice Withdrawal throttle state for ETH held directly by the portal.
-    WithdrawalThrottleState internal _withdrawalThrottle;
+    WithdrawalThrottle.State internal _withdrawalThrottle;
 
     /// @notice Emitted when the Portal is migrated.
     /// @param oldLockbox The lockbox before the migration
@@ -294,9 +290,9 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
     event WithdrawalThrottleCapacityExhausted();
 
     /// @notice Semantic version.
-    /// @custom:semver 6.0.0
+    /// @custom:semver 6.1.0
     function version() public pure virtual returns (string memory) {
-        return "6.0.0";
+        return "6.1.0";
     }
 
     /// @param _proofMaturityDelaySeconds The proof maturity delay in seconds.
@@ -376,28 +372,10 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
         }
         if (_refillPeriod == 0) revert OptimismPortal_InvalidWithdrawalThrottlePeriod();
 
-        WithdrawalThrottleState storage throttle = _withdrawalThrottle;
-        uint256 oldConfig = throttle.config;
+        WithdrawalThrottle.State storage throttle = _withdrawalThrottle;
         uint256 stockSnapshot = address(this).balance;
-        uint128 available;
-        if (WithdrawalThrottle.enabled(oldConfig)) {
-            uint128 liveOldCapacity = WithdrawalThrottle.capacity(stockSnapshot, WithdrawalThrottle.maxBps(oldConfig));
-            (available,) = WithdrawalThrottle.sync(
-                WithdrawalThrottle.capacity(oldConfig),
-                throttle.bucket,
-                WithdrawalThrottle.refillPeriod(oldConfig),
-                liveOldCapacity,
-                block.timestamp
-            );
-        } else {
-            available = type(uint128).max;
-        }
-        uint128 capacity = WithdrawalThrottle.capacity(stockSnapshot, _maxBps);
-        if (available > capacity) available = capacity;
-
-        uint64 timestamp = WithdrawalThrottle.timestamp(block.timestamp);
-        throttle.config = WithdrawalThrottle.config(capacity, _refillPeriod, _maxBps, true);
-        throttle.bucket = WithdrawalThrottle.bucket(available, timestamp, 0);
+        (uint128 capacity, uint128 available) =
+            throttle.configure(stockSnapshot, _maxBps, _refillPeriod, block.timestamp);
 
         emit WithdrawalThrottleConfigured(_maxBps, _refillPeriod, stockSnapshot, capacity, available);
     }
@@ -409,7 +387,7 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
         if (!WithdrawalThrottle.enabled(_withdrawalThrottle.config)) {
             revert OptimismPortal_WithdrawalThrottleNotEnabled();
         }
-        delete _withdrawalThrottle;
+        _withdrawalThrottle.disable();
 
         emit WithdrawalThrottleDisabled();
     }
@@ -417,17 +395,15 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
     /// @notice Returns the stored portal ETH withdrawal throttle state before pending refill is materialized.
     /// @return Withdrawal throttle state.
     function withdrawalThrottle() external view returns (WithdrawalThrottleConfig memory) {
-        WithdrawalThrottleState storage throttle = _withdrawalThrottle;
-        uint256 config_ = throttle.config;
-        uint256 bucket_ = throttle.bucket;
+        WithdrawalThrottle.Snapshot memory throttle = _withdrawalThrottle.snapshot();
         return WithdrawalThrottleConfig({
-            capacity: WithdrawalThrottle.capacity(config_),
-            available: WithdrawalThrottle.storedAvailable(bucket_),
-            refillPeriod: WithdrawalThrottle.refillPeriod(config_),
-            lastUpdated: WithdrawalThrottle.lastUpdated(bucket_),
-            refillRemainder: WithdrawalThrottle.refillRemainder(bucket_),
-            maxBps: WithdrawalThrottle.maxBps(config_),
-            enabled: WithdrawalThrottle.enabled(config_)
+            capacity: throttle.capacity,
+            available: throttle.available,
+            refillPeriod: throttle.refillPeriod,
+            lastUpdated: throttle.lastUpdated,
+            refillRemainder: throttle.refillRemainder,
+            maxBps: throttle.maxBps,
+            enabled: throttle.enabled
         });
     }
 
@@ -436,8 +412,7 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
     function availableWithdrawalCapacity() external view returns (uint256) {
         uint256 config_ = _withdrawalThrottle.config;
         if (!WithdrawalThrottle.enabled(config_)) return type(uint256).max;
-        (,, uint128 available,) = _syncedWithdrawalCapacity(config_);
-        return available;
+        return _withdrawalThrottle.availableCapacity(config_, address(this).balance, block.timestamp);
     }
 
     /// @custom:legacy
@@ -890,54 +865,20 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
     /// @notice Consumes available ETH withdrawal capacity when the throttle is enabled.
     /// @param _amount Amount of ETH to withdraw.
     function _consumeWithdrawalCapacity(uint256 _amount) internal {
-        WithdrawalThrottleState storage throttle = _withdrawalThrottle;
+        WithdrawalThrottle.State storage throttle = _withdrawalThrottle;
         uint256 config_ = throttle.config;
         if (!WithdrawalThrottle.enabled(config_) || _amount == 0) return;
 
-        (uint256 stockSnapshot, uint128 capacity, uint128 available, uint64 remainder) =
-            _syncedWithdrawalCapacity(config_);
+        uint256 stockSnapshot = address(this).balance;
+        (uint128 capacity, uint128 available, uint128 remaining, bool capacityChanged) =
+            throttle.consume(config_, stockSnapshot, _amount, block.timestamp);
         if (_amount > available) {
             revert OptimismPortal_WithdrawalThrottled(_amount, available, capacity);
         }
 
-        uint256 remainingValue = uint256(available) - _amount;
-        assert(remainingValue <= type(uint128).max);
-        uint128 remaining = uint128(remainingValue);
-        uint128 oldCapacity = WithdrawalThrottle.capacity(config_);
-        bool capacityChanged = capacity != oldCapacity;
-        uint64 timestamp = WithdrawalThrottle.timestamp(block.timestamp);
-        if (capacityChanged) {
-            throttle.config = WithdrawalThrottle.config(
-                capacity, WithdrawalThrottle.refillPeriod(config_), WithdrawalThrottle.maxBps(config_), true
-            );
-        }
-        throttle.bucket = WithdrawalThrottle.bucket(remaining, timestamp, remainder);
-
         if (capacityChanged) emit WithdrawalThrottleRefreshed(stockSnapshot, capacity, available);
         emit WithdrawalThrottleCapacityConsumed(_amount, remaining);
         if (remaining == 0) emit WithdrawalThrottleCapacityExhausted();
-    }
-
-    /// @notice Computes the effective bucket state against the portal's current ETH stock.
-    /// @return stock_ Current portal balance.
-    /// @return capacity_ Capacity derived from the current stock.
-    /// @return available_ Available capacity after refill and stock synchronization.
-    /// @return remainder_ Fractional refill numerator to preserve when materializing the refill.
-    function _syncedWithdrawalCapacity(uint256 _config)
-        internal
-        view
-        returns (uint256 stock_, uint128 capacity_, uint128 available_, uint64 remainder_)
-    {
-        WithdrawalThrottleState storage throttle = _withdrawalThrottle;
-        stock_ = address(this).balance;
-        capacity_ = WithdrawalThrottle.capacity(stock_, WithdrawalThrottle.maxBps(_config));
-        (available_, remainder_) = WithdrawalThrottle.sync(
-            WithdrawalThrottle.capacity(_config),
-            throttle.bucket,
-            WithdrawalThrottle.refillPeriod(_config),
-            capacity_,
-            block.timestamp
-        );
     }
 
     /// @notice Checks if the Interop feature is enabled.

--- a/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
+++ b/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
@@ -275,6 +275,9 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
         uint16 maxBps, uint64 refillPeriod, uint256 stockSnapshot, uint256 capacity, uint256 available
     );
 
+    /// @notice Emitted when the portal ETH withdrawal throttle synchronizes to a new stock level.
+    event WithdrawalThrottleRefreshed(uint256 stockSnapshot, uint256 capacity, uint256 available);
+
     /// @notice Emitted when the ETH withdrawal throttle is disabled.
     event WithdrawalThrottleDisabled();
 
@@ -395,11 +398,17 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
         emit WithdrawalThrottleDisabled();
     }
 
+    /// @notice Returns the stored portal ETH withdrawal throttle state before pending refill is materialized.
+    /// @return Withdrawal throttle state.
+    function withdrawalThrottle() external view returns (WithdrawalThrottleConfig memory) {
+        return _withdrawalThrottle;
+    }
+
     /// @notice Returns currently available portal ETH withdrawal capacity.
     /// @return Available capacity, or the maximum uint256 value when throttling is disabled.
     function availableWithdrawalCapacity() external view returns (uint256) {
         if (!_withdrawalThrottle.enabled) return type(uint256).max;
-        (uint256 available,) = _availableWithdrawalCapacity();
+        (,, uint256 available,) = _syncedWithdrawalCapacity();
         return available;
     }
 
@@ -856,16 +865,20 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
         WithdrawalThrottleConfig storage throttle = _withdrawalThrottle;
         if (!throttle.enabled || _amount == 0) return;
 
-        (uint256 available, uint64 refillRemainder) = _availableWithdrawalCapacity();
+        (uint256 stockSnapshot, uint256 capacity, uint256 available, uint64 refillRemainder) =
+            _syncedWithdrawalCapacity();
         if (_amount > available) {
-            revert OptimismPortal_WithdrawalThrottled(_amount, available, throttle.capacity);
+            revert OptimismPortal_WithdrawalThrottled(_amount, available, capacity);
         }
 
         uint256 remaining = available - _amount;
+        bool capacityChanged = capacity != throttle.capacity;
+        throttle.capacity = capacity;
         throttle.available = remaining;
         throttle.lastUpdated = uint64(block.timestamp);
         throttle.refillRemainder = refillRemainder;
 
+        if (capacityChanged) emit WithdrawalThrottleRefreshed(stockSnapshot, capacity, available);
         emit WithdrawalThrottleCapacityConsumed(_amount, remaining);
         if (remaining == 0) emit WithdrawalThrottleCapacityExhausted();
     }
@@ -883,6 +896,26 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
             throttle.lastUpdated,
             block.timestamp
         );
+    }
+
+    /// @notice Computes the effective bucket state against the portal's current ETH stock.
+    /// @return stock_ Current portal balance.
+    /// @return capacity_ Capacity derived from the current stock.
+    /// @return available_ Available capacity after refill and stock synchronization.
+    /// @return remainder_ Fractional refill numerator to preserve when materializing the refill.
+    function _syncedWithdrawalCapacity()
+        internal
+        view
+        returns (uint256 stock_, uint256 capacity_, uint256 available_, uint64 remainder_)
+    {
+        WithdrawalThrottleConfig storage throttle = _withdrawalThrottle;
+        (available_, remainder_) = _availableWithdrawalCapacity();
+        stock_ = address(this).balance;
+        capacity_ = WithdrawalThrottle.capacity(stock_, throttle.maxBps);
+        if (available_ >= capacity_) {
+            available_ = capacity_;
+            remainder_ = 0;
+        }
     }
 
     /// @notice Checks if the Interop feature is enabled.

--- a/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
+++ b/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
@@ -17,6 +17,7 @@ import { SecureMerkleTrie } from "src/libraries/trie/SecureMerkleTrie.sol";
 import { AddressAliasHelper } from "src/vendor/AddressAliasHelper.sol";
 import { Claim, GameStatus, GameType, GameTypes } from "src/dispute/lib/Types.sol";
 import { Features } from "src/libraries/Features.sol";
+import { WithdrawalThrottle } from "src/libraries/WithdrawalThrottle.sol";
 
 // Interfaces
 import { ISemver } from "interfaces/universal/ISemver.sol";
@@ -41,6 +42,17 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
     struct ProvenWithdrawal {
         IDisputeGame disputeGameProxy;
         uint64 timestamp;
+    }
+
+    /// @notice Withdrawal throttle state for ETH held directly by the portal.
+    struct WithdrawalThrottleConfig {
+        uint256 capacity;
+        uint256 available;
+        uint64 refillPeriod;
+        uint64 lastUpdated;
+        uint64 refillRemainder;
+        uint16 maxBps;
+        bool enabled;
     }
 
     /// @notice The delay between when a withdrawal is proven and when it may be finalized.
@@ -130,6 +142,9 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
     /// @custom:legacy
     /// @custom:spacer superRootsActive
     bool private spacer_63_20_1;
+
+    /// @notice Withdrawal throttle state for ETH held directly by the portal.
+    WithdrawalThrottleConfig internal _withdrawalThrottle;
 
     /// @notice Emitted when the Portal is migrated.
     /// @param oldLockbox The lockbox before the migration
@@ -240,10 +255,39 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
     /// @notice Thrown when the new lockbox has not authorized this portal.
     error OptimismPortal_LockboxNotAuthorizedForPortal();
 
+    /// @notice Thrown when a withdrawal throttle basis point value is zero or exceeds 100%.
+    error OptimismPortal_InvalidWithdrawalThrottleBps();
+
+    /// @notice Thrown when a withdrawal throttle refill period is zero.
+    error OptimismPortal_InvalidWithdrawalThrottlePeriod();
+
+    /// @notice Thrown when the withdrawal throttle is not enabled.
+    error OptimismPortal_WithdrawalThrottleNotEnabled();
+
+    /// @notice Thrown when the shared ETHLockbox must manage withdrawal throttling.
+    error OptimismPortal_WithdrawalThrottleManagedByLockbox();
+
+    /// @notice Thrown when an ETH withdrawal exceeds the available withdrawal capacity.
+    error OptimismPortal_WithdrawalThrottled(uint256 requestedAmount, uint256 availableCapacity, uint256 totalCapacity);
+
+    /// @notice Emitted when the ETH withdrawal throttle is configured.
+    event WithdrawalThrottleConfigured(
+        uint16 maxBps, uint64 refillPeriod, uint256 stockSnapshot, uint256 capacity, uint256 available
+    );
+
+    /// @notice Emitted when the ETH withdrawal throttle is disabled.
+    event WithdrawalThrottleDisabled();
+
+    /// @notice Emitted when ETH withdrawal capacity is consumed.
+    event WithdrawalThrottleCapacityConsumed(uint256 amount, uint256 remaining);
+
+    /// @notice Emitted when all currently available ETH withdrawal capacity is consumed.
+    event WithdrawalThrottleCapacityExhausted();
+
     /// @notice Semantic version.
-    /// @custom:semver 5.8.0
+    /// @custom:semver 6.0.0
     function version() public pure virtual returns (string memory) {
-        return "5.8.0";
+        return "6.0.0";
     }
 
     /// @param _proofMaturityDelaySeconds The proof maturity delay in seconds.
@@ -306,6 +350,57 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
     /// @return ISuperchainConfig The SuperchainConfig contract.
     function superchainConfig() external view returns (ISuperchainConfig) {
         return systemConfig.superchainConfig();
+    }
+
+    /// @notice Configures ETH withdrawal capacity as a percentage of the current portal balance.
+    ///         Only applies when ETH is held directly by the portal. Reconfiguration preserves
+    ///         accrued capacity and clamps it to the new maximum.
+    /// @param _maxBps       Maximum withdrawable stock in basis points.
+    /// @param _refillPeriod Time in seconds for the bucket to refill from empty to full.
+    function setWithdrawalThrottle(uint16 _maxBps, uint64 _refillPeriod) external {
+        _assertOnlyProxyAdminOwner();
+
+        if (_isUsingLockbox()) revert OptimismPortal_WithdrawalThrottleManagedByLockbox();
+        if (_maxBps == 0 || _maxBps > WithdrawalThrottle.MAX_BPS) {
+            revert OptimismPortal_InvalidWithdrawalThrottleBps();
+        }
+        if (_refillPeriod == 0) revert OptimismPortal_InvalidWithdrawalThrottlePeriod();
+
+        WithdrawalThrottleConfig storage throttle = _withdrawalThrottle;
+        uint256 available;
+        if (throttle.enabled) (available,) = _availableWithdrawalCapacity();
+        else available = type(uint256).max;
+        uint256 stockSnapshot = address(this).balance;
+        uint256 capacity = WithdrawalThrottle.capacity(stockSnapshot, _maxBps);
+        if (available > capacity) available = capacity;
+
+        throttle.capacity = capacity;
+        throttle.available = available;
+        throttle.refillPeriod = _refillPeriod;
+        throttle.lastUpdated = uint64(block.timestamp);
+        throttle.refillRemainder = 0;
+        throttle.maxBps = _maxBps;
+        throttle.enabled = true;
+
+        emit WithdrawalThrottleConfigured(_maxBps, _refillPeriod, stockSnapshot, capacity, available);
+    }
+
+    /// @notice Disables the portal's ETH withdrawal throttle.
+    function disableWithdrawalThrottle() external {
+        _assertOnlyProxyAdminOwner();
+
+        if (!_withdrawalThrottle.enabled) revert OptimismPortal_WithdrawalThrottleNotEnabled();
+        delete _withdrawalThrottle;
+
+        emit WithdrawalThrottleDisabled();
+    }
+
+    /// @notice Returns currently available portal ETH withdrawal capacity.
+    /// @return Available capacity, or the maximum uint256 value when throttling is disabled.
+    function availableWithdrawalCapacity() external view returns (uint256) {
+        if (!_withdrawalThrottle.enabled) return type(uint256).max;
+        (uint256 available,) = _availableWithdrawalCapacity();
+        return available;
     }
 
     /// @custom:legacy
@@ -588,11 +683,16 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
         // Check that the withdrawal can be finalized.
         checkWithdrawal(withdrawalHash, _proofSubmitter);
 
+        // Consume the portal's ETH withdrawal capacity when ETH is not held by a lockbox.
+        // Capacity measures finalized withdrawal attempts, including target calls that later fail.
+        bool usingLockbox = _isUsingLockbox();
+        if (!usingLockbox) _consumeWithdrawalCapacity(_tx.value);
+
         // Mark the withdrawal as finalized so it can't be replayed.
         finalizedWithdrawals[withdrawalHash] = true;
 
         // If using ETHLockbox, unlock the ETH from the ETHLockbox.
-        if (_isUsingLockbox()) {
+        if (usingLockbox) {
             if (_tx.value > 0) ethLockbox.unlockETH(_tx.value);
         }
 
@@ -617,7 +717,7 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
 
         // If using ETHLockbox, send ETH back to the Lockbox in the case of a failed transaction or
         // it'll get stuck here and would need to be moved back via admin action.
-        if (_isUsingLockbox()) {
+        if (usingLockbox) {
             if (!success && _tx.value > 0) {
                 ethLockbox.lockETH{ value: _tx.value }();
             }
@@ -748,6 +848,41 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
     /// @return bool True if the ETHLockbox feature is enabled.
     function _isUsingLockbox() internal view returns (bool) {
         return systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX) && address(ethLockbox) != address(0);
+    }
+
+    /// @notice Consumes available ETH withdrawal capacity when the throttle is enabled.
+    /// @param _amount Amount of ETH to withdraw.
+    function _consumeWithdrawalCapacity(uint256 _amount) internal {
+        WithdrawalThrottleConfig storage throttle = _withdrawalThrottle;
+        if (!throttle.enabled || _amount == 0) return;
+
+        (uint256 available, uint64 refillRemainder) = _availableWithdrawalCapacity();
+        if (_amount > available) {
+            revert OptimismPortal_WithdrawalThrottled(_amount, available, throttle.capacity);
+        }
+
+        uint256 remaining = available - _amount;
+        throttle.available = remaining;
+        throttle.lastUpdated = uint64(block.timestamp);
+        throttle.refillRemainder = refillRemainder;
+
+        emit WithdrawalThrottleCapacityConsumed(_amount, remaining);
+        if (remaining == 0) emit WithdrawalThrottleCapacityExhausted();
+    }
+
+    /// @notice Computes available ETH withdrawal capacity after its pending linear refill.
+    /// @return available_ Available capacity at the current timestamp.
+    /// @return remainder_ Fractional refill numerator to preserve when materializing the refill.
+    function _availableWithdrawalCapacity() internal view returns (uint256 available_, uint64 remainder_) {
+        WithdrawalThrottleConfig storage throttle = _withdrawalThrottle;
+        return WithdrawalThrottle.available(
+            throttle.capacity,
+            throttle.available,
+            throttle.refillRemainder,
+            throttle.refillPeriod,
+            throttle.lastUpdated,
+            block.timestamp
+        );
     }
 
     /// @notice Checks if the Interop feature is enabled.

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerMigrator.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerMigrator.sol
@@ -84,6 +84,12 @@ contract OPContractsManagerMigrator is OPContractsManagerUtilsCaller {
     ///         it is given, so a disabled config would be registered anyway.
     error OPContractsManagerMigrator_DisputeGameNotEnabled();
 
+    /// @notice Thrown when a migration instruction is not permitted.
+    error OPContractsManagerMigrator_InvalidMigrationInstruction(string _key);
+
+    /// @notice Thrown when shared lockbox throttle configuration is not exactly one ETH entry.
+    error OPContractsManagerMigrator_InvalidWithdrawalThrottleConfig();
+
     /// @param _utils The utility functions for the OPContractsManager.
     constructor(IOPContractsManagerUtils _utils) OPContractsManagerUtilsCaller(_utils) { }
 
@@ -115,6 +121,32 @@ contract OPContractsManagerMigrator is OPContractsManagerUtilsCaller {
     ///      portal to the shared dispute game contracts.
     /// @param _input The input parameters for the migration.
     function migrate(MigrateInput calldata _input) public {
+        IOPContractsManagerUtils.ExtraInstruction[] memory extraInstructions =
+            new IOPContractsManagerUtils.ExtraInstruction[](0);
+        _migrate(_input, extraInstructions);
+    }
+
+    /// @notice Migrates chains and applies permitted one-off migration instructions.
+    /// @param _input The input parameters for the migration.
+    /// @param _extraInstructions One-off migration instructions.
+    function migrateWithInstructions(
+        MigrateInput calldata _input,
+        IOPContractsManagerUtils.ExtraInstruction[] calldata _extraInstructions
+    )
+        public
+    {
+        _migrate(_input, _extraInstructions);
+    }
+
+    /// @notice Executes the interop migration with optional one-off instructions.
+    /// @param _input The input parameters for the migration.
+    /// @param _extraInstructions One-off migration instructions.
+    function _migrate(
+        MigrateInput calldata _input,
+        IOPContractsManagerUtils.ExtraInstruction[] memory _extraInstructions
+    )
+        internal
+    {
         // Check that at least one chain is being migrated.
         if (_input.chainSystemConfigs.length == 0) {
             revert OPContractsManagerMigrator_NoChains();
@@ -124,6 +156,8 @@ contract OPContractsManagerMigrator is OPContractsManagerUtilsCaller {
         if (!contractsContainer().isDevFeatureEnabled(DevFeatures.OPTIMISM_PORTAL_INTEROP)) {
             revert OPContractsManagerMigrator_InteropNotEnabled();
         }
+
+        _validateMigrationInstructions(_extraInstructions);
 
         // Check that the starting respected game type is a valid super game type.
         // SUPER_CANNON is retired in favor of SUPER_CANNON_KONA.
@@ -249,15 +283,72 @@ contract OPContractsManagerMigrator is OPContractsManagerUtilsCaller {
             }
         }
 
-        // Set up the dispute games in the new DisputeGameFactory. Configs are validated by
-        // _validateDisputeGameConfigs above.
-        for (uint256 i = 0; i < _input.disputeGameConfigs.length; i++) {
-            disputeGameFactory.setImplementation(
-                _input.disputeGameConfigs[i].gameType,
-                _getGameImpl(_input.disputeGameConfigs[i].gameType),
-                _makeGameArgs(0, anchorStateRegistry, delayedWETH, _input.disputeGameConfigs[i])
+        // Configure the shared ETH bucket only after every portal and old lockbox has contributed
+        // its liquidity, so the percentage is calculated from the aggregate stock.
+        _configureSharedETHWithdrawalThrottle(ethLockbox, _extraInstructions);
+
+        _configureDisputeGames(disputeGameFactory, anchorStateRegistry, delayedWETH, _input.disputeGameConfigs);
+    }
+
+    /// @notice Validates one-off migration instructions.
+    /// @param _extraInstructions Instructions supplied by the operator.
+    function _validateMigrationInstructions(IOPContractsManagerUtils.ExtraInstruction[] memory _extraInstructions)
+        internal
+        view
+    {
+        if (_extraInstructions.length > 1) {
+            revert OPContractsManagerMigrator_InvalidMigrationInstruction(_extraInstructions[1].key);
+        }
+        if (_extraInstructions.length == 0) return;
+
+        if (
+            !contractsContainer().isDevFeatureEnabled(DevFeatures.WITHDRAWAL_THROTTLE)
+                || !_isMatchingInstructionByKey(_extraInstructions[0], Constants.WITHDRAWAL_THROTTLE_CONFIG_KEY)
+        ) {
+            revert OPContractsManagerMigrator_InvalidMigrationInstruction(_extraInstructions[0].key);
+        }
+    }
+
+    /// @notice Configures the aggregate shared ETH withdrawal bucket after liquidity migration.
+    /// @param _ethLockbox The newly deployed shared ETH lockbox.
+    /// @param _extraInstructions Instructions supplied by the operator.
+    function _configureSharedETHWithdrawalThrottle(
+        IETHLockbox _ethLockbox,
+        IOPContractsManagerUtils.ExtraInstruction[] memory _extraInstructions
+    )
+        internal
+    {
+        if (_extraInstructions.length == 0) return;
+
+        IOPContractsManagerUtils.WithdrawalThrottleConfig[] memory configs =
+            abi.decode(_extraInstructions[0].data, (IOPContractsManagerUtils.WithdrawalThrottleConfig[]));
+        if (configs.length != 1 || configs[0].token != address(0)) {
+            revert OPContractsManagerMigrator_InvalidWithdrawalThrottleConfig();
+        }
+
+        _ethLockbox.setWithdrawalThrottle(configs[0].maxBps, configs[0].refillPeriod);
+    }
+
+    /// @notice Configures the shared dispute game factory after migration.
+    /// @param _disputeGameFactory The shared dispute game factory.
+    /// @param _anchorStateRegistry The shared anchor state registry.
+    /// @param _delayedWETH The shared delayed WETH contract.
+    /// @param _configs Validated dispute game configurations.
+    function _configureDisputeGames(
+        IDisputeGameFactory _disputeGameFactory,
+        IAnchorStateRegistry _anchorStateRegistry,
+        IDelayedWETH _delayedWETH,
+        IOPContractsManagerUtils.DisputeGameConfig[] calldata _configs
+    )
+        internal
+    {
+        for (uint256 i = 0; i < _configs.length; i++) {
+            _disputeGameFactory.setImplementation(
+                _configs[i].gameType,
+                _getGameImpl(_configs[i].gameType),
+                _makeGameArgs(0, _anchorStateRegistry, _delayedWETH, _configs[i])
             );
-            disputeGameFactory.setInitBond(_input.disputeGameConfigs[i].gameType, _input.disputeGameConfigs[i].initBond);
+            _disputeGameFactory.setInitBond(_configs[i].gameType, _configs[i].initBond);
         }
     }
 

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
@@ -131,6 +131,15 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
     /// @notice Thrown when duplicate upgrade instruction keys are provided.
     error OPContractsManagerV2_DuplicateUpgradeInstruction(string _key);
 
+    /// @notice Thrown when a withdrawal throttle instruction contains no asset configurations.
+    error OPContractsManagerV2_InvalidWithdrawalThrottleConfig();
+
+    /// @notice Thrown when a withdrawal throttle instruction configures an asset more than once.
+    error OPContractsManagerV2_DuplicateWithdrawalThrottleToken(address _token);
+
+    /// @notice Thrown when an asset already has a different withdrawal throttle configuration.
+    error OPContractsManagerV2_WithdrawalThrottleConfigConflict(address _token);
+
     /// @notice Thrown when a function that must be delegatecalled is called directly.
     error OPContractsManagerV2_OnlyDelegateCall();
 
@@ -158,9 +167,9 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
     ///         - Major bump: New required sequential upgrade
     ///         - Minor bump: Replacement OPCM for same upgrade
     ///         - Patch bump: Development changes (expected for normal dev work)
-    /// @custom:semver 8.0.3
+    /// @custom:semver 8.0.4
     function version() public pure returns (string memory) {
-        return "8.0.3";
+        return "8.0.4";
     }
 
     /// @param _standardValidator The standard validator for this OPCM release.
@@ -265,7 +274,12 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
         FullConfig memory cfg = _loadFullConfig(_inp, cts);
 
         // Execute the upgrade.
-        return _apply(cfg, cts, false);
+        cts = _apply(cfg, cts, false);
+
+        // Apply any one-off withdrawal throttle configuration after the implementations are live.
+        _configureWithdrawalThrottles(cts, _inp.extraInstructions);
+
+        return cts;
     }
 
     /// @notice Migrates one or more OP Stack chains to use the Super Root dispute games and shared
@@ -289,6 +303,27 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
         // Delegatecall to the migrator contract.
         (bool success, bytes memory result) =
             address(opcmMigrator).delegatecall(abi.encodeCall(IOPContractsManagerMigrator.migrate, (_input)));
+        if (!success) {
+            assembly {
+                revert(add(result, 0x20), mload(result))
+            }
+        }
+    }
+
+    /// @notice Migrates chains and applies permitted one-off migration instructions.
+    /// @param _input The input parameters for the migration.
+    /// @param _extraInstructions One-off migration instructions.
+    function migrateWithInstructions(
+        IOPContractsManagerMigrator.MigrateInput calldata _input,
+        IOPContractsManagerUtils.ExtraInstruction[] calldata _extraInstructions
+    )
+        public
+    {
+        _onlyDelegateCall();
+
+        (bool success, bytes memory result) = address(opcmMigrator).delegatecall(
+            abi.encodeCall(IOPContractsManagerMigrator.migrateWithInstructions, (_input, _extraInstructions))
+        );
         if (!success) {
             assembly {
                 revert(add(result, 0x20), mload(result))
@@ -346,6 +381,10 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
             if (isDevFeatureEnabled(DevFeatures.SUPER_ROOT_GAMES_MIGRATION)) {
                 if (_isMatchingInstructionByKey(_instruction, "overrides.cfg.startingAnchorRoot")) return true;
             }
+
+            if (isDevFeatureEnabled(DevFeatures.WITHDRAWAL_THROTTLE)) {
+                if (_isMatchingInstructionByKey(_instruction, Constants.WITHDRAWAL_THROTTLE_CONFIG_KEY)) return true;
+            }
         }
 
         // Allow overriding the starting respected game type during upgrades. This is needed when
@@ -357,6 +396,66 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
 
         // Always return false by default.
         return false;
+    }
+
+    /// @notice Applies the one-off withdrawal throttle instruction after a chain upgrade.
+    /// @param _cts The upgraded chain contracts.
+    /// @param _instructions The upgrade instructions supplied by the operator.
+    function _configureWithdrawalThrottles(
+        ChainContracts memory _cts,
+        IOPContractsManagerUtils.ExtraInstruction[] memory _instructions
+    )
+        internal
+    {
+        for (uint256 i = 0; i < _instructions.length; i++) {
+            if (!_isMatchingInstructionByKey(_instructions[i], Constants.WITHDRAWAL_THROTTLE_CONFIG_KEY)) continue;
+
+            IOPContractsManagerUtils.WithdrawalThrottleConfig[] memory configs =
+                abi.decode(_instructions[i].data, (IOPContractsManagerUtils.WithdrawalThrottleConfig[]));
+            if (configs.length == 0) revert OPContractsManagerV2_InvalidWithdrawalThrottleConfig();
+
+            for (uint256 j = 0; j < configs.length; j++) {
+                for (uint256 k = j + 1; k < configs.length; k++) {
+                    if (configs[j].token == configs[k].token) {
+                        revert OPContractsManagerV2_DuplicateWithdrawalThrottleToken(configs[j].token);
+                    }
+                }
+
+                IOPContractsManagerUtils.WithdrawalThrottleConfig memory config = configs[j];
+                if (config.token == address(0)) {
+                    if (_cts.systemConfig.isCustomGasToken()) {
+                        revert OPContractsManagerV2_InvalidWithdrawalThrottleConfig();
+                    }
+
+                    if (_cts.systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX)) {
+                        IETHLockbox.WithdrawalThrottleConfig memory throttle = _cts.ethLockbox.withdrawalThrottle();
+                        if (!throttle.enabled) {
+                            _cts.ethLockbox.setWithdrawalThrottle(config.maxBps, config.refillPeriod);
+                        } else if (throttle.maxBps != config.maxBps || throttle.refillPeriod != config.refillPeriod) {
+                            revert OPContractsManagerV2_WithdrawalThrottleConfigConflict(config.token);
+                        }
+                    } else {
+                        IOptimismPortal.WithdrawalThrottleConfig memory throttle =
+                            _cts.optimismPortal.withdrawalThrottle();
+                        if (!throttle.enabled) {
+                            _cts.optimismPortal.setWithdrawalThrottle(config.maxBps, config.refillPeriod);
+                        } else if (throttle.maxBps != config.maxBps || throttle.refillPeriod != config.refillPeriod) {
+                            revert OPContractsManagerV2_WithdrawalThrottleConfigConflict(config.token);
+                        }
+                    }
+                } else {
+                    IL1StandardBridge.WithdrawalThrottleConfig memory throttle =
+                        _cts.l1StandardBridge.withdrawalThrottle(config.token);
+                    if (!throttle.enabled) {
+                        _cts.l1StandardBridge.setWithdrawalThrottle(config.token, config.maxBps, config.refillPeriod);
+                    } else if (throttle.maxBps != config.maxBps || throttle.refillPeriod != config.refillPeriod) {
+                        revert OPContractsManagerV2_WithdrawalThrottleConfigConflict(config.token);
+                    }
+                }
+            }
+
+            return;
+        }
     }
 
     /// @notice Loads (or builds) the chain contracts from whatever exists.

--- a/packages/contracts-bedrock/src/libraries/Constants.sol
+++ b/packages/contracts-bedrock/src/libraries/Constants.sol
@@ -50,6 +50,9 @@ library Constants {
     /// @notice Special constant key for the PermittedProxyDeployment instruction.
     string internal constant PERMITTED_PROXY_DEPLOYMENT_KEY = "PermittedProxyDeployment";
 
+    /// @notice One-off OPCM instruction key for withdrawal throttle configuration.
+    string internal constant WITHDRAWAL_THROTTLE_CONFIG_KEY = "WithdrawalThrottleConfig";
+
     /// @notice Special constant value for the PermittedProxyDeployment instruction to permit all
     ///         contracts to be deployed. Used for both initial deployments and migrations.
     bytes internal constant PERMIT_ALL_CONTRACTS_INSTRUCTION = bytes("ALL");

--- a/packages/contracts-bedrock/src/libraries/DevFeatures.sol
+++ b/packages/contracts-bedrock/src/libraries/DevFeatures.sol
@@ -46,6 +46,10 @@ library DevFeatures {
     bytes32 public constant SUPER_ROOT_GAMES_MIGRATION =
         bytes32(0x0000000000000000000000000000000000000000000000000000000010000000);
 
+    /// @notice The feature that enables withdrawal throttle configuration through OPCM.
+    bytes32 public constant WITHDRAWAL_THROTTLE =
+        bytes32(0x0000000000000000000000000000000000000000000000000000001000000000);
+
     /// @notice Checks if a feature is enabled in a bitmap. Note that this function does not check
     ///         that the input feature represents a single feature and the bitwise AND operation
     ///         allows for multiple features to be enabled at once. Users should generally check

--- a/packages/contracts-bedrock/src/libraries/WithdrawalThrottle.sol
+++ b/packages/contracts-bedrock/src/libraries/WithdrawalThrottle.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+/// @title WithdrawalThrottle
+/// @notice Arithmetic helpers for percentage-based withdrawal token buckets.
+library WithdrawalThrottle {
+    /// @notice Denominator used for basis point values.
+    uint256 internal constant MAX_BPS = 10_000;
+
+    /// @notice Computes bucket capacity as a percentage of an asset stock.
+    /// @param _stock  Current stock of the asset.
+    /// @param _maxBps Maximum withdrawable stock in basis points.
+    /// @return Bucket capacity.
+    function capacity(uint256 _stock, uint16 _maxBps) internal pure returns (uint256) {
+        return (_stock / MAX_BPS) * _maxBps + ((_stock % MAX_BPS) * _maxBps) / MAX_BPS;
+    }
+
+    /// @notice Computes available capacity after a pending linear refill.
+    /// @param _capacity        Maximum bucket capacity.
+    /// @param _available       Stored available capacity.
+    /// @param _refillRemainder Stored fractional refill numerator.
+    /// @param _refillPeriod    Time for the bucket to refill from empty to full.
+    /// @param _lastUpdated     Timestamp of the last materialized refill.
+    /// @param _timestamp       Timestamp at which to compute availability.
+    /// @return available_ Available capacity at `_timestamp`.
+    /// @return remainder_ Fractional refill numerator to preserve when materializing the refill.
+    function available(
+        uint256 _capacity,
+        uint256 _available,
+        uint64 _refillRemainder,
+        uint64 _refillPeriod,
+        uint64 _lastUpdated,
+        uint256 _timestamp
+    )
+        internal
+        pure
+        returns (uint256 available_, uint64 remainder_)
+    {
+        if (_available >= _capacity) return (_capacity, 0);
+
+        uint256 elapsed = _timestamp - _lastUpdated;
+        if (elapsed >= _refillPeriod) return (_capacity, 0);
+
+        uint256 numerator = (_capacity % _refillPeriod) * elapsed + _refillRemainder;
+        uint256 refilled = (_capacity / _refillPeriod) * elapsed + numerator / _refillPeriod;
+        uint256 missing = _capacity - _available;
+        if (refilled >= missing) return (_capacity, 0);
+
+        return (_available + refilled, uint64(numerator % _refillPeriod));
+    }
+}

--- a/packages/contracts-bedrock/src/libraries/WithdrawalThrottle.sol
+++ b/packages/contracts-bedrock/src/libraries/WithdrawalThrottle.sol
@@ -2,50 +2,173 @@
 pragma solidity 0.8.15;
 
 /// @title WithdrawalThrottle
-/// @notice Arithmetic helpers for percentage-based withdrawal token buckets.
+/// @notice Arithmetic and packing helpers for percentage-based withdrawal token buckets.
 library WithdrawalThrottle {
+    /// @notice Thrown when a timestamp cannot be represented by the packed bucket.
+    error WithdrawalThrottle_TimestampOverflow();
+
     /// @notice Denominator used for basis point values.
     uint256 internal constant MAX_BPS = 10_000;
 
+    /// @notice Maximum capacity representable by the packed configuration.
+    uint256 internal constant MAX_CAPACITY = type(uint128).max;
+
+    /// @notice Bit offsets in the packed configuration word.
+    uint256 internal constant CONFIG_REFILL_PERIOD_OFFSET = 128;
+    uint256 internal constant CONFIG_MAX_BPS_OFFSET = 192;
+    uint256 internal constant CONFIG_ENABLED_OFFSET = 208;
+
+    /// @notice Bit offsets in the packed mutable bucket word.
+    uint256 internal constant BUCKET_LAST_UPDATED_OFFSET = 128;
+    uint256 internal constant BUCKET_REFILL_REMAINDER_OFFSET = 192;
+
     /// @notice Computes bucket capacity as a percentage of an asset stock.
+    ///         Values above uint128 are conservatively saturated so an oversized stock cannot
+    ///         weaken the throttle or make withdrawals unavailable due to an arithmetic revert.
     /// @param _stock  Current stock of the asset.
     /// @param _maxBps Maximum withdrawable stock in basis points.
-    /// @return Bucket capacity.
-    function capacity(uint256 _stock, uint16 _maxBps) internal pure returns (uint256) {
-        return (_stock / MAX_BPS) * _maxBps + ((_stock % MAX_BPS) * _maxBps) / MAX_BPS;
+    /// @return capacity_ Packed bucket capacity.
+    function capacity(uint256 _stock, uint16 _maxBps) internal pure returns (uint128 capacity_) {
+        if (_maxBps == 0) return 0;
+
+        uint256 wholeStock = _stock / MAX_BPS;
+        if (wholeStock > MAX_CAPACITY / _maxBps) return type(uint128).max;
+
+        uint256 value = wholeStock * _maxBps + ((_stock % MAX_BPS) * _maxBps) / MAX_BPS;
+        if (value > MAX_CAPACITY) return type(uint128).max;
+        return uint128(value);
     }
 
-    /// @notice Computes available capacity after a pending linear refill.
-    /// @param _capacity        Maximum bucket capacity.
-    /// @param _available       Stored available capacity.
-    /// @param _refillRemainder Stored fractional refill numerator.
-    /// @param _refillPeriod    Time for the bucket to refill from empty to full.
-    /// @param _lastUpdated     Timestamp of the last materialized refill.
-    /// @param _timestamp       Timestamp at which to compute availability.
+    /// @notice Packs the immutable-per-withdrawal configuration fields into one word.
+    function config(
+        uint128 _capacity,
+        uint64 _refillPeriod,
+        uint16 _maxBps,
+        bool _enabled
+    )
+        internal
+        pure
+        returns (uint256 config_)
+    {
+        config_ = uint256(_capacity) | uint256(_refillPeriod) << CONFIG_REFILL_PERIOD_OFFSET
+            | uint256(_maxBps) << CONFIG_MAX_BPS_OFFSET;
+        if (_enabled) config_ |= uint256(1) << CONFIG_ENABLED_OFFSET;
+    }
+
+    /// @notice Returns the capacity encoded in a packed configuration word.
+    function capacity(uint256 _config) internal pure returns (uint128 capacity_) {
+        return uint128(_config);
+    }
+
+    /// @notice Returns the refill period encoded in a packed configuration word.
+    function refillPeriod(uint256 _config) internal pure returns (uint64 refillPeriod_) {
+        return uint64(_config >> CONFIG_REFILL_PERIOD_OFFSET);
+    }
+
+    /// @notice Returns the maximum basis points encoded in a packed configuration word.
+    function maxBps(uint256 _config) internal pure returns (uint16 maxBps_) {
+        return uint16(_config >> CONFIG_MAX_BPS_OFFSET);
+    }
+
+    /// @notice Returns whether a packed configuration word enables throttling.
+    function enabled(uint256 _config) internal pure returns (bool enabled_) {
+        return (_config >> CONFIG_ENABLED_OFFSET) & 1 != 0;
+    }
+
+    /// @notice Packs mutable token-bucket accounting into one word.
+    function bucket(
+        uint128 _available,
+        uint64 _lastUpdated,
+        uint64 _refillRemainder
+    )
+        internal
+        pure
+        returns (uint256 bucket_)
+    {
+        bucket_ = uint256(_available) | uint256(_lastUpdated) << BUCKET_LAST_UPDATED_OFFSET
+            | uint256(_refillRemainder) << BUCKET_REFILL_REMAINDER_OFFSET;
+    }
+
+    /// @notice Returns stored availability from a packed mutable bucket word.
+    function storedAvailable(uint256 _bucket) internal pure returns (uint128 available_) {
+        return uint128(_bucket);
+    }
+
+    /// @notice Returns the last-updated timestamp from a packed mutable bucket word.
+    function lastUpdated(uint256 _bucket) internal pure returns (uint64 lastUpdated_) {
+        return uint64(_bucket >> BUCKET_LAST_UPDATED_OFFSET);
+    }
+
+    /// @notice Returns the fractional refill numerator from a packed mutable bucket word.
+    function refillRemainder(uint256 _bucket) internal pure returns (uint64 refillRemainder_) {
+        return uint64(_bucket >> BUCKET_REFILL_REMAINDER_OFFSET);
+    }
+
+    /// @notice Checks and narrows a timestamp for packed storage.
+    function timestamp(uint256 _timestamp) internal pure returns (uint64 timestamp_) {
+        if (_timestamp > type(uint64).max) revert WithdrawalThrottle_TimestampOverflow();
+        return uint64(_timestamp);
+    }
+
+    /// @notice Computes available capacity after a pending exact fractional refill.
+    ///         uint128 capacity multiplied by uint64 elapsed time fits safely in uint192, while
+    ///         all intermediate arithmetic is performed in uint256.
+    /// @param _capacity     Maximum bucket capacity.
+    /// @param _bucket       Packed mutable bucket state.
+    /// @param _refillPeriod Time for the bucket to refill from empty to full.
+    /// @param _timestamp    Timestamp at which to compute availability.
     /// @return available_ Available capacity at `_timestamp`.
     /// @return remainder_ Fractional refill numerator to preserve when materializing the refill.
     function available(
-        uint256 _capacity,
-        uint256 _available,
-        uint64 _refillRemainder,
+        uint128 _capacity,
+        uint256 _bucket,
         uint64 _refillPeriod,
-        uint64 _lastUpdated,
         uint256 _timestamp
     )
         internal
         pure
-        returns (uint256 available_, uint64 remainder_)
+        returns (uint128 available_, uint64 remainder_)
     {
-        if (_available >= _capacity) return (_capacity, 0);
+        uint128 stored = storedAvailable(_bucket);
+        if (stored >= _capacity) return (_capacity, 0);
 
-        uint256 elapsed = _timestamp - _lastUpdated;
+        uint64 updated = lastUpdated(_bucket);
+        if (_timestamp <= updated) return (stored, refillRemainder(_bucket));
+
+        uint256 elapsed = _timestamp - updated;
         if (elapsed >= _refillPeriod) return (_capacity, 0);
 
-        uint256 numerator = (_capacity % _refillPeriod) * elapsed + _refillRemainder;
-        uint256 refilled = (_capacity / _refillPeriod) * elapsed + numerator / _refillPeriod;
-        uint256 missing = _capacity - _available;
+        uint256 numerator = uint256(_capacity) * elapsed + refillRemainder(_bucket);
+        uint256 refilled = numerator / _refillPeriod;
+        uint256 missing = uint256(_capacity) - stored;
         if (refilled >= missing) return (_capacity, 0);
 
-        return (_available + refilled, uint64(numerator % _refillPeriod));
+        uint256 value = uint256(stored) + refilled;
+        assert(value <= type(uint128).max);
+        available_ = uint128(value);
+
+        uint256 remainder = numerator % _refillPeriod;
+        assert(remainder <= type(uint64).max);
+        remainder_ = uint64(remainder);
+    }
+
+    /// @notice Synchronizes a refilled bucket to a new live-stock capacity snapshot.
+    ///         Absolute accrued availability and its fractional remainder are preserved when the
+    ///         capacity grows. Capacity reductions accrue at the lower live rate, clamp
+    ///         availability, and clear the remainder when the reduced bucket is full.
+    function sync(
+        uint128 _oldCapacity,
+        uint256 _bucket,
+        uint64 _refillPeriod,
+        uint128 _newCapacity,
+        uint256 _timestamp
+    )
+        internal
+        pure
+        returns (uint128 available_, uint64 remainder_)
+    {
+        uint128 refillCapacity = _oldCapacity < _newCapacity ? _oldCapacity : _newCapacity;
+        (available_, remainder_) = available(refillCapacity, _bucket, _refillPeriod, _timestamp);
+        if (available_ >= _newCapacity) return (_newCapacity, 0);
     }
 }

--- a/packages/contracts-bedrock/src/libraries/WithdrawalThrottle.sol
+++ b/packages/contracts-bedrock/src/libraries/WithdrawalThrottle.sol
@@ -2,8 +2,27 @@
 pragma solidity 0.8.15;
 
 /// @title WithdrawalThrottle
-/// @notice Arithmetic and packing helpers for percentage-based withdrawal token buckets.
+/// @notice Storage, arithmetic, and packing helpers for percentage-based withdrawal token buckets.
 library WithdrawalThrottle {
+    /// @notice Two-slot packed token-bucket state.
+    /// @custom:field config Capacity, refill period, maximum basis points, and enabled flag.
+    /// @custom:field bucket Available capacity, last-updated timestamp, and fractional remainder.
+    struct State {
+        uint256 config;
+        uint256 bucket;
+    }
+
+    /// @notice Logical view of a packed token-bucket state.
+    struct Snapshot {
+        uint128 capacity;
+        uint128 available;
+        uint64 refillPeriod;
+        uint64 lastUpdated;
+        uint64 refillRemainder;
+        uint16 maxBps;
+        bool enabled;
+    }
+
     /// @notice Thrown when a timestamp cannot be represented by the packed bucket.
     error WithdrawalThrottle_TimestampOverflow();
 
@@ -170,5 +189,131 @@ library WithdrawalThrottle {
         uint128 refillCapacity = _oldCapacity < _newCapacity ? _oldCapacity : _newCapacity;
         (available_, remainder_) = available(refillCapacity, _bucket, _refillPeriod, _timestamp);
         if (available_ >= _newCapacity) return (_newCapacity, 0);
+    }
+
+    /// @notice Returns a logical snapshot of the stored state before pending refill is materialized.
+    function snapshot(State storage _state) internal view returns (Snapshot memory snapshot_) {
+        uint256 config_ = _state.config;
+        uint256 bucket_ = _state.bucket;
+        snapshot_ = Snapshot({
+            capacity: capacity(config_),
+            available: storedAvailable(bucket_),
+            refillPeriod: refillPeriod(config_),
+            lastUpdated: lastUpdated(bucket_),
+            refillRemainder: refillRemainder(bucket_),
+            maxBps: maxBps(config_),
+            enabled: enabled(config_)
+        });
+    }
+
+    /// @notice Configures a throttle against a live stock value.
+    ///         Reconfiguration preserves accrued whole units, resets the fractional remainder,
+    ///         and clamps availability to the new capacity.
+    function configure(
+        State storage _state,
+        uint256 _stock,
+        uint16 _maxBps,
+        uint64 _refillPeriod,
+        uint256 _timestamp
+    )
+        internal
+        returns (uint128 capacity_, uint128 available_)
+    {
+        uint256 oldConfig = _state.config;
+        if (enabled(oldConfig)) {
+            uint128 liveOldCapacity = capacity(_stock, maxBps(oldConfig));
+            (available_,) =
+                sync(capacity(oldConfig), _state.bucket, refillPeriod(oldConfig), liveOldCapacity, _timestamp);
+        } else {
+            available_ = type(uint128).max;
+        }
+
+        capacity_ = capacity(_stock, _maxBps);
+        if (available_ > capacity_) available_ = capacity_;
+
+        uint64 updated = timestamp(_timestamp);
+        _state.config = config(capacity_, _refillPeriod, _maxBps, true);
+        _state.bucket = bucket(available_, updated, 0);
+    }
+
+    /// @notice Synchronizes a configured throttle against a live stock value and materializes refill.
+    /// @dev The caller must pass the state's current config word and ensure the throttle is enabled.
+    function refresh(
+        State storage _state,
+        uint256 _config,
+        uint256 _stock,
+        uint256 _timestamp
+    )
+        internal
+        returns (uint128 capacity_, uint128 available_)
+    {
+        uint16 maxBps_ = maxBps(_config);
+        uint64 refillPeriod_ = refillPeriod(_config);
+        capacity_ = capacity(_stock, maxBps_);
+        uint64 remainder;
+        (available_, remainder) = sync(capacity(_config), _state.bucket, refillPeriod_, capacity_, _timestamp);
+
+        uint64 updated = timestamp(_timestamp);
+        if (capacity_ != capacity(_config)) {
+            _state.config = config(capacity_, refillPeriod_, maxBps_, true);
+        }
+        _state.bucket = bucket(available_, updated, remainder);
+    }
+
+    /// @notice Returns currently available capacity against a live stock value.
+    /// @dev The caller must pass the state's current config word and ensure the throttle is enabled.
+    function availableCapacity(
+        State storage _state,
+        uint256 _config,
+        uint256 _stock,
+        uint256 _timestamp
+    )
+        internal
+        view
+        returns (uint128 available_)
+    {
+        uint128 liveCapacity = capacity(_stock, maxBps(_config));
+        (available_,) = sync(capacity(_config), _state.bucket, refillPeriod(_config), liveCapacity, _timestamp);
+    }
+
+    /// @notice Attempts to consume capacity against a live stock value.
+    /// @dev The caller must pass the state's current config word and ensure the throttle is enabled
+    ///      and the amount is non-zero. State is unchanged when the requested amount exceeds
+    ///      available capacity.
+    /// @return capacity_        Capacity synchronized to the supplied live stock.
+    /// @return available_       Available capacity before consumption.
+    /// @return remaining_       Available capacity after consumption when allowed.
+    /// @return capacityChanged_ Whether live-stock synchronization changed stored capacity.
+    function consume(
+        State storage _state,
+        uint256 _config,
+        uint256 _stock,
+        uint256 _amount,
+        uint256 _timestamp
+    )
+        internal
+        returns (uint128 capacity_, uint128 available_, uint128 remaining_, bool capacityChanged_)
+    {
+        capacity_ = capacity(_stock, maxBps(_config));
+        uint64 remainder;
+        (available_, remainder) = sync(capacity(_config), _state.bucket, refillPeriod(_config), capacity_, _timestamp);
+        if (_amount > available_) return (capacity_, available_, 0, false);
+
+        uint256 remainingValue = uint256(available_) - _amount;
+        assert(remainingValue <= type(uint128).max);
+        remaining_ = uint128(remainingValue);
+        capacityChanged_ = capacity_ != capacity(_config);
+
+        uint64 updated = timestamp(_timestamp);
+        if (capacityChanged_) {
+            _state.config = config(capacity_, refillPeriod(_config), maxBps(_config), true);
+        }
+        _state.bucket = bucket(remaining_, updated, remainder);
+    }
+
+    /// @notice Disables a throttle and clears both packed slots.
+    function disable(State storage _state) internal {
+        _state.config = 0;
+        _state.bucket = 0;
     }
 }

--- a/packages/contracts-bedrock/src/universal/StandardBridge.sol
+++ b/packages/contracts-bedrock/src/universal/StandardBridge.sol
@@ -289,6 +289,7 @@ abstract contract StandardBridge is Initializable {
 
             IOptimismMintableERC20(_localToken).mint(_to, _amount);
         } else {
+            _beforeFinalizeBridgeERC20(_localToken, _amount);
             deposits[_localToken][_remoteToken] = deposits[_localToken][_remoteToken] - _amount;
             IERC20(_localToken).safeTransfer(_to, _amount);
         }
@@ -297,6 +298,11 @@ abstract contract StandardBridge is Initializable {
         // contracts may override this function in order to emit legacy events as well.
         _emitERC20BridgeFinalized(_localToken, _remoteToken, _from, _to, _amount, _extraData);
     }
+
+    /// @notice Hook called before escrowed ERC20 tokens are released by a bridge finalization.
+    /// @param _localToken Address of the escrowed ERC20 on this chain.
+    /// @param _amount     Amount of the ERC20 to release.
+    function _beforeFinalizeBridgeERC20(address _localToken, uint256 _amount) internal virtual { }
 
     /// @notice Initiates a bridge of ETH through the CrossDomainMessenger.
     /// @param _from        Address of the sender.

--- a/packages/contracts-bedrock/test/L1/ETHLockbox.t.sol
+++ b/packages/contracts-bedrock/test/L1/ETHLockbox.t.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.15;
 
 // Testing
+import { VmSafe } from "forge-std/Vm.sol";
 import { CommonTest } from "test/setup/CommonTest.sol";
 
 // Contracts
@@ -448,6 +449,8 @@ contract ETHLockbox_RefreshWithdrawalThrottle_Test is ETHLockbox_WithdrawalThrot
         IETHLockbox.WithdrawalThrottleConfig memory throttle = ethLockbox.withdrawalThrottle();
         assertEq(throttle.capacity, 200);
         assertEq(throttle.available, 40);
+        assertEq(throttle.lastUpdated, block.timestamp);
+        assertEq(throttle.refillRemainder, 0);
     }
 }
 
@@ -472,6 +475,62 @@ contract ETHLockbox_DisableWithdrawalThrottle_Test is ETHLockbox_WithdrawalThrot
 /// @title ETHLockbox_UnlockETH_Test
 /// @notice Test contract for the unlockETH function.
 contract ETHLockbox_UnlockETH_Test is ETHLockbox_WithdrawalThrottle_TestInit {
+    /// @notice Tests that consumption with unchanged stock writes only the mutable bucket slot.
+    function test_unlockETH_unchangedStockWritesOnlyBucketSlot_succeeds() external {
+        _configureWithdrawalThrottle();
+        vm.warp(block.timestamp + 1);
+        StorageSlot memory stateSlot = ForgeArtifacts.getSlot("ETHLockbox", "_withdrawalThrottle");
+        bytes32 configSlot = bytes32(stateSlot.slot);
+        bytes32 bucketSlot = bytes32(stateSlot.slot + 1);
+
+        vm.startStateDiffRecording();
+        vm.prank(address(optimismPortal2));
+        ethLockbox.unlockETH(40);
+        VmSafe.AccountAccess[] memory accountAccesses = vm.stopAndReturnStateDiff();
+
+        uint256 configWrites;
+        uint256 bucketWrites;
+        for (uint256 i; i < accountAccesses.length; i++) {
+            for (uint256 j; j < accountAccesses[i].storageAccesses.length; j++) {
+                VmSafe.StorageAccess memory access = accountAccesses[i].storageAccesses[j];
+                if (access.account == address(ethLockbox) && access.isWrite) {
+                    if (access.slot == configSlot) configWrites++;
+                    if (access.slot == bucketSlot) bucketWrites++;
+                }
+            }
+        }
+        assertEq(configWrites, 0);
+        assertEq(bucketWrites, 1);
+    }
+
+    /// @notice Tests that consumption after a stock change writes the config and mutable bucket slots.
+    function test_unlockETH_changedStockWritesBothThrottleSlots_succeeds() external {
+        _configureWithdrawalThrottle();
+        vm.deal(address(ethLockbox), STOCK * 2);
+        StorageSlot memory stateSlot = ForgeArtifacts.getSlot("ETHLockbox", "_withdrawalThrottle");
+        bytes32 configSlot = bytes32(stateSlot.slot);
+        bytes32 bucketSlot = bytes32(stateSlot.slot + 1);
+
+        vm.startStateDiffRecording();
+        vm.prank(address(optimismPortal2));
+        ethLockbox.unlockETH(40);
+        VmSafe.AccountAccess[] memory accountAccesses = vm.stopAndReturnStateDiff();
+
+        uint256 configWrites;
+        uint256 bucketWrites;
+        for (uint256 i; i < accountAccesses.length; i++) {
+            for (uint256 j; j < accountAccesses[i].storageAccesses.length; j++) {
+                VmSafe.StorageAccess memory access = accountAccesses[i].storageAccesses[j];
+                if (access.account == address(ethLockbox) && access.isWrite) {
+                    if (access.slot == configSlot) configWrites++;
+                    if (access.slot == bucketSlot) bucketWrites++;
+                }
+            }
+        }
+        assertEq(configWrites, 1);
+        assertEq(bucketWrites, 1);
+    }
+
     /// @notice Tests `unlockETH` reverts when the contract is paused.
     function testFuzz_unlockETH_paused_reverts(address _caller, uint256 _value) public {
         // Mock the superchain config to return true for the paused status
@@ -656,6 +715,21 @@ contract ETHLockbox_UnlockETH_Test is ETHLockbox_WithdrawalThrottle_TestInit {
         ethLockbox.unlockETH(1);
     }
 
+    /// @notice Tests that a withdrawal above uint128 max is throttled without narrowing the request.
+    function test_unlockETH_amountAboveUint128Max_reverts() external {
+        uint256 amount = uint256(type(uint128).max) + 1;
+        vm.deal(address(ethLockbox), amount * 10);
+        _configureWithdrawalThrottle();
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IETHLockbox.ETHLockbox_WithdrawalThrottled.selector, amount, type(uint128).max, type(uint128).max
+            )
+        );
+        vm.prank(address(optimismPortal2));
+        ethLockbox.unlockETH(amount);
+    }
+
     /// @notice Tests that increased stock raises the ceiling without immediately topping up availability.
     function test_unlockETH_increasedStockLazilyRaisesCapacity_succeeds() external {
         _configureWithdrawalThrottle();
@@ -674,7 +748,7 @@ contract ETHLockbox_UnlockETH_Test is ETHLockbox_WithdrawalThrottle_TestInit {
 
         assertEq(ethLockbox.withdrawalThrottle().capacity, 190);
         vm.warp(block.timestamp + REFILL_PERIOD / 2);
-        assertEq(ethLockbox.availableWithdrawalCapacity(), 95);
+        assertEq(ethLockbox.availableWithdrawalCapacity(), 92);
     }
 
     /// @notice Tests that decreased stock immediately clamps effective availability.
@@ -844,5 +918,54 @@ contract ETHLockbox_Uncategorized_Test is ETHLockbox_TestInit {
     /// @notice Tests the proxy admin owner is correctly returned.
     function test_proxyProxyAdminOwner_succeeds() public view {
         assertEq(ethLockbox.proxyAdminOwner(), proxyAdminOwner);
+    }
+}
+
+/// @title ETHLockbox_Gas_TestInit
+/// @notice Common cold-slot gas measurement helpers for ETHLockbox withdrawals.
+abstract contract ETHLockbox_Gas_TestInit is ETHLockbox_WithdrawalThrottle_TestInit {
+    function _measureLockboxWithdrawal(string memory _snapshotName) internal {
+        address lockboxImplementation = EIP1967Helper.getImplementation(address(ethLockbox));
+        address portalImplementation = EIP1967Helper.getImplementation(address(optimismPortal2));
+        StorageSlot memory stateSlot = ForgeArtifacts.getSlot("ETHLockbox", "_withdrawalThrottle");
+        vm.cool(address(ethLockbox));
+        vm.coolSlot(address(ethLockbox), bytes32(stateSlot.slot));
+        vm.coolSlot(address(ethLockbox), bytes32(stateSlot.slot + 1));
+        vm.cool(lockboxImplementation);
+        vm.cool(address(optimismPortal2));
+        vm.cool(portalImplementation);
+        vm.cool(address(systemConfig));
+
+        vm.prank(address(optimismPortal2));
+        ethLockbox.unlockETH(40);
+        vm.snapshotGasLastCall("WithdrawalFinalizationGas", _snapshotName);
+    }
+}
+
+/// @title ETHLockbox_UnlockETH_GasDisabled_Test
+/// @notice Measures ETHLockbox withdrawal with committed unconfigured throttle storage.
+contract ETHLockbox_UnlockETH_GasDisabled_Test is ETHLockbox_Gas_TestInit {
+    function setUp() public override {
+        super.setUp();
+        vm.deal(address(ethLockbox), STOCK * 2);
+    }
+
+    function test_unlockETH_throttleDisabledGas_benchmark() external {
+        _measureLockboxWithdrawal("eth-lockbox-unthrottled");
+    }
+}
+
+/// @title ETHLockbox_UnlockETH_GasEnabled_Test
+/// @notice Measures the capacity-changing packed ETHLockbox throttle path from committed storage.
+contract ETHLockbox_UnlockETH_GasEnabled_Test is ETHLockbox_Gas_TestInit {
+    function setUp() public override {
+        super.setUp();
+        _configureWithdrawalThrottle();
+        vm.deal(address(ethLockbox), STOCK * 2);
+        vm.warp(block.timestamp + 1);
+    }
+
+    function test_unlockETH_throttleEnabledGas_benchmark() external {
+        _measureLockboxWithdrawal("eth-lockbox-throttled");
     }
 }

--- a/packages/contracts-bedrock/test/L1/ETHLockbox.t.sol
+++ b/packages/contracts-bedrock/test/L1/ETHLockbox.t.sol
@@ -356,9 +356,122 @@ contract ETHLockbox_LockETH_Test is ETHLockbox_TestInit {
     }
 }
 
+/// @title ETHLockbox_WithdrawalThrottle_TestInit
+/// @notice Reusable initialization for ETHLockbox withdrawal throttle tests.
+abstract contract ETHLockbox_WithdrawalThrottle_TestInit is ETHLockbox_TestInit {
+    uint16 internal constant MAX_BPS = 1000;
+    uint64 internal constant REFILL_PERIOD = 100;
+    uint256 internal constant STOCK = 1000;
+    uint256 internal constant CAPACITY = 100;
+
+    /// @notice Sets a deterministic ETH stock for withdrawal throttle tests.
+    function setUp() public virtual override {
+        CommonTest.setUp();
+        if (address(ethLockbox) == address(0)) {
+            vm.skip(true, "Skipping test because ETHLockbox is not deployed");
+        }
+        vm.deal(address(ethLockbox), STOCK);
+    }
+
+    /// @notice Configures the lockbox withdrawal throttle.
+    function _configureWithdrawalThrottle() internal {
+        vm.prank(proxyAdminOwner);
+        ethLockbox.setWithdrawalThrottle(MAX_BPS, REFILL_PERIOD);
+    }
+}
+
+/// @title ETHLockbox_SetWithdrawalThrottle_Test
+/// @notice Tests the `setWithdrawalThrottle` function.
+contract ETHLockbox_SetWithdrawalThrottle_Test is ETHLockbox_WithdrawalThrottle_TestInit {
+    /// @notice Tests that configuration snapshots the shared ETH stock and starts full.
+    function test_setWithdrawalThrottle_succeeds() external {
+        vm.expectEmit(address(ethLockbox));
+        emit WithdrawalThrottleConfigured(MAX_BPS, REFILL_PERIOD, STOCK, CAPACITY, CAPACITY);
+        _configureWithdrawalThrottle();
+
+        IETHLockbox.WithdrawalThrottleConfig memory throttle = ethLockbox.withdrawalThrottle();
+        assertEq(throttle.capacity, CAPACITY);
+        assertEq(throttle.available, CAPACITY);
+        assertEq(throttle.refillPeriod, REFILL_PERIOD);
+        assertEq(throttle.lastUpdated, block.timestamp);
+        assertEq(throttle.refillRemainder, 0);
+        assertEq(throttle.maxBps, MAX_BPS);
+        assertTrue(throttle.enabled);
+    }
+
+    /// @notice Tests that only the ProxyAdmin owner can configure the throttle.
+    function testFuzz_setWithdrawalThrottle_notProxyAdminOwner_reverts(address _caller) external {
+        vm.assume(_caller != proxyAdminOwner);
+
+        vm.expectRevert(IProxyAdminOwnedBase.ProxyAdminOwnedBase_NotProxyAdminOwner.selector);
+        vm.prank(_caller);
+        ethLockbox.setWithdrawalThrottle(MAX_BPS, REFILL_PERIOD);
+    }
+
+    /// @notice Tests that zero basis points revert.
+    function test_setWithdrawalThrottle_zeroBps_reverts() external {
+        vm.expectRevert(IETHLockbox.ETHLockbox_InvalidWithdrawalThrottleBps.selector);
+        vm.prank(proxyAdminOwner);
+        ethLockbox.setWithdrawalThrottle(0, REFILL_PERIOD);
+    }
+
+    /// @notice Tests that basis points above 100% revert.
+    function test_setWithdrawalThrottle_bpsAboveMaximum_reverts() external {
+        vm.expectRevert(IETHLockbox.ETHLockbox_InvalidWithdrawalThrottleBps.selector);
+        vm.prank(proxyAdminOwner);
+        ethLockbox.setWithdrawalThrottle(10_001, REFILL_PERIOD);
+    }
+
+    /// @notice Tests that a zero refill period reverts.
+    function test_setWithdrawalThrottle_zeroRefillPeriod_reverts() external {
+        vm.expectRevert(IETHLockbox.ETHLockbox_InvalidWithdrawalThrottlePeriod.selector);
+        vm.prank(proxyAdminOwner);
+        ethLockbox.setWithdrawalThrottle(MAX_BPS, 0);
+    }
+}
+
+/// @title ETHLockbox_RefreshWithdrawalThrottle_Test
+/// @notice Tests the `refreshWithdrawalThrottle` function.
+contract ETHLockbox_RefreshWithdrawalThrottle_Test is ETHLockbox_WithdrawalThrottle_TestInit {
+    /// @notice Tests that refreshing increased stock preserves rather than refills availability.
+    function test_refreshWithdrawalThrottle_preservesAvailable_succeeds() external {
+        _configureWithdrawalThrottle();
+        vm.prank(address(optimismPortal2));
+        ethLockbox.unlockETH(60);
+        vm.deal(address(ethLockbox), 2000);
+
+        vm.expectEmit(address(ethLockbox));
+        emit WithdrawalThrottleRefreshed(2000, 200, 40);
+        vm.prank(proxyAdminOwner);
+        ethLockbox.refreshWithdrawalThrottle();
+
+        IETHLockbox.WithdrawalThrottleConfig memory throttle = ethLockbox.withdrawalThrottle();
+        assertEq(throttle.capacity, 200);
+        assertEq(throttle.available, 40);
+    }
+}
+
+/// @title ETHLockbox_DisableWithdrawalThrottle_Test
+/// @notice Tests the `disableWithdrawalThrottle` function.
+contract ETHLockbox_DisableWithdrawalThrottle_Test is ETHLockbox_WithdrawalThrottle_TestInit {
+    /// @notice Tests that disabling restores unrestricted ETH unlocks.
+    function test_disableWithdrawalThrottle_succeeds() external {
+        _configureWithdrawalThrottle();
+
+        vm.expectEmit(address(ethLockbox));
+        emit WithdrawalThrottleDisabled();
+        vm.prank(proxyAdminOwner);
+        ethLockbox.disableWithdrawalThrottle();
+
+        assertEq(ethLockbox.availableWithdrawalCapacity(), type(uint256).max);
+        vm.prank(address(optimismPortal2));
+        ethLockbox.unlockETH(CAPACITY + 1);
+    }
+}
+
 /// @title ETHLockbox_UnlockETH_Test
 /// @notice Test contract for the unlockETH function.
-contract ETHLockbox_UnlockETH_Test is ETHLockbox_TestInit {
+contract ETHLockbox_UnlockETH_Test is ETHLockbox_WithdrawalThrottle_TestInit {
     /// @notice Tests `unlockETH` reverts when the contract is paused.
     function testFuzz_unlockETH_paused_reverts(address _caller, uint256 _value) public {
         // Mock the superchain config to return true for the paused status
@@ -459,6 +572,9 @@ contract ETHLockbox_UnlockETH_Test is ETHLockbox_TestInit {
         vm.mockCall(
             address(_portal), abi.encodeCall(IOptimismPortal2.superchainConfig, ()), abi.encode(superchainConfig)
         );
+        vm.mockCall(
+            address(_portal), abi.encodeCall(IOptimismPortal2.l2Sender, ()), abi.encode(Constants.DEFAULT_L2_SENDER)
+        );
 
         // Set the portal as an authorized portal if needed
         if (!ethLockbox.authorizedPortals(_portal)) {
@@ -471,24 +587,73 @@ contract ETHLockbox_UnlockETH_Test is ETHLockbox_TestInit {
 
         // Get the balance of the portal and lockbox before the unlock to compare later on the
         // assertions
-        uint256 portalBalanceBefore = address(optimismPortal2).balance;
+        uint256 portalBalanceBefore = address(_portal).balance;
         uint256 lockboxBalanceBefore = address(ethLockbox).balance;
 
         // Expect `donateETH` function to be called on Portal
-        vm.expectCall(address(optimismPortal2), abi.encodeCall(IOptimismPortal2.donateETH, ()));
+        vm.expectCall(address(_portal), abi.encodeCall(IOptimismPortal2.donateETH, ()));
 
         // Look for the emit of the `ETHUnlocked` event
         vm.expectEmit(address(ethLockbox));
-        emit ETHUnlocked(optimismPortal2, _value);
+        emit ETHUnlocked(_portal, _value);
 
         // Call the `unlockETH` function with the portal
-        vm.prank(address(optimismPortal2));
+        vm.prank(address(_portal));
         ethLockbox.unlockETH(_value);
 
         // Assert the portal's balance increased and the lockbox's balance decreased by the amount
         // unlocked
-        assertEq(address(optimismPortal2).balance, portalBalanceBefore + _value);
+        assertEq(address(_portal).balance, portalBalanceBefore + _value);
         assertEq(address(ethLockbox).balance, lockboxBalanceBefore - _value);
+    }
+
+    /// @notice Tests that authorized portals consume one shared withdrawal bucket.
+    function test_unlockETH_multiplePortalsConsumeSharedCapacity_succeeds() external {
+        IOptimismPortal2 portal = IOptimismPortal2(payable(address(0xBEEF)));
+        vm.mockCall(
+            address(portal), abi.encodeCall(IProxyAdminOwnedBase.proxyAdminOwner, ()), abi.encode(proxyAdminOwner)
+        );
+        vm.mockCall(
+            address(portal), abi.encodeCall(IOptimismPortal2.superchainConfig, ()), abi.encode(superchainConfig)
+        );
+        vm.mockCall(
+            address(portal), abi.encodeCall(IOptimismPortal2.l2Sender, ()), abi.encode(Constants.DEFAULT_L2_SENDER)
+        );
+        vm.prank(proxyAdminOwner);
+        ethLockbox.authorizePortal(portal);
+        _configureWithdrawalThrottle();
+
+        vm.prank(address(optimismPortal2));
+        ethLockbox.unlockETH(40);
+        vm.prank(address(portal));
+        ethLockbox.unlockETH(60);
+
+        assertEq(ethLockbox.availableWithdrawalCapacity(), 0);
+    }
+
+    /// @notice Tests that consuming exact capacity succeeds and exhausts the shared bucket.
+    function test_unlockETH_exactWithdrawalCapacity_succeeds() external {
+        _configureWithdrawalThrottle();
+
+        vm.expectEmit(address(ethLockbox));
+        emit WithdrawalThrottleCapacityConsumed(CAPACITY, 0);
+        vm.expectEmit(address(ethLockbox));
+        emit WithdrawalThrottleCapacityExhausted();
+        vm.prank(address(optimismPortal2));
+        ethLockbox.unlockETH(CAPACITY);
+
+        assertEq(ethLockbox.availableWithdrawalCapacity(), 0);
+    }
+
+    /// @notice Tests that an unlock reverts when the shared bucket lacks capacity.
+    function test_unlockETH_insufficientWithdrawalCapacity_reverts() external {
+        _configureWithdrawalThrottle();
+        vm.prank(address(optimismPortal2));
+        ethLockbox.unlockETH(CAPACITY);
+
+        vm.expectRevert(abi.encodeWithSelector(IETHLockbox.ETHLockbox_WithdrawalThrottled.selector, 1, 0, CAPACITY));
+        vm.prank(address(optimismPortal2));
+        ethLockbox.unlockETH(1);
     }
 }
 

--- a/packages/contracts-bedrock/test/L1/ETHLockbox.t.sol
+++ b/packages/contracts-bedrock/test/L1/ETHLockbox.t.sol
@@ -651,9 +651,44 @@ contract ETHLockbox_UnlockETH_Test is ETHLockbox_WithdrawalThrottle_TestInit {
         vm.prank(address(optimismPortal2));
         ethLockbox.unlockETH(CAPACITY);
 
-        vm.expectRevert(abi.encodeWithSelector(IETHLockbox.ETHLockbox_WithdrawalThrottled.selector, 1, 0, CAPACITY));
+        vm.expectRevert(abi.encodeWithSelector(IETHLockbox.ETHLockbox_WithdrawalThrottled.selector, 1, 0, 90));
         vm.prank(address(optimismPortal2));
         ethLockbox.unlockETH(1);
+    }
+
+    /// @notice Tests that increased stock raises the ceiling without immediately topping up availability.
+    function test_unlockETH_increasedStockLazilyRaisesCapacity_succeeds() external {
+        _configureWithdrawalThrottle();
+        vm.prank(address(optimismPortal2));
+        ethLockbox.unlockETH(CAPACITY);
+
+        vm.deal(address(ethLockbox), 1900);
+        assertEq(ethLockbox.availableWithdrawalCapacity(), 0);
+
+        vm.warp(block.timestamp + REFILL_PERIOD / 2);
+        assertEq(ethLockbox.availableWithdrawalCapacity(), 50);
+        vm.expectEmit(address(ethLockbox));
+        emit WithdrawalThrottleRefreshed(1900, 190, 50);
+        vm.prank(address(optimismPortal2));
+        ethLockbox.unlockETH(50);
+
+        assertEq(ethLockbox.withdrawalThrottle().capacity, 190);
+        vm.warp(block.timestamp + REFILL_PERIOD / 2);
+        assertEq(ethLockbox.availableWithdrawalCapacity(), 95);
+    }
+
+    /// @notice Tests that decreased stock immediately clamps effective availability.
+    function test_unlockETH_decreasedStockLazilyClampsCapacity_succeeds() external {
+        _configureWithdrawalThrottle();
+        vm.deal(address(ethLockbox), 500);
+
+        assertEq(ethLockbox.availableWithdrawalCapacity(), 50);
+        vm.expectEmit(address(ethLockbox));
+        emit WithdrawalThrottleRefreshed(500, 50, 50);
+        vm.prank(address(optimismPortal2));
+        ethLockbox.unlockETH(50);
+
+        assertEq(ethLockbox.withdrawalThrottle().capacity, 50);
     }
 }
 

--- a/packages/contracts-bedrock/test/L1/L1StandardBridge.t.sol
+++ b/packages/contracts-bedrock/test/L1/L1StandardBridge.t.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.15;
 
 // Testing
 import { stdStorage, StdStorage } from "forge-std/StdStorage.sol";
+import { stdError } from "forge-std/StdError.sol";
 import { CommonTest } from "test/setup/CommonTest.sol";
 import { ForgeArtifacts, StorageSlot } from "scripts/libraries/ForgeArtifacts.sol";
 
@@ -964,5 +965,359 @@ contract L1StandardBridge_Uncategorized_Test is L1StandardBridge_TestInit {
         vm.prank(alice);
         vm.expectRevert(IOptimismPortal2.OptimismPortal_NotAllowedOnCGTMode.selector);
         l1StandardBridge.bridgeETHTo{ value: _value }(_to, _minGasLimit, hex"dead");
+    }
+}
+
+/// @title L1StandardBridge_WithdrawalThrottle_TestInit
+/// @notice Reusable test initialization for L1StandardBridge withdrawal throttle tests.
+abstract contract L1StandardBridge_WithdrawalThrottle_TestInit is CommonTest {
+    using stdStorage for StdStorage;
+
+    uint16 internal constant MAX_BPS = 1000;
+    uint64 internal constant REFILL_PERIOD = 100;
+    uint256 internal constant STOCK = 1000;
+    uint256 internal constant CAPACITY = 100;
+
+    address internal bridgeMessenger;
+    address internal bridgeOwner;
+
+    /// @notice Sets up an escrowed token and an authenticated L2 bridge caller.
+    function setUp() public virtual override {
+        super.setUp();
+
+        bridgeMessenger = address(l1StandardBridge.messenger());
+        bridgeOwner = l1StandardBridge.proxyAdminOwner();
+        deal(address(L1Token), address(l1StandardBridge), STOCK, true);
+        _setDeposits(address(L1Token), address(L2Token), STOCK);
+        vm.mockCall(
+            bridgeMessenger,
+            abi.encodeCall(ICrossDomainMessenger.xDomainMessageSender, ()),
+            abi.encode(address(l1StandardBridge.OTHER_BRIDGE()))
+        );
+    }
+
+    /// @notice Configures the default L1 token's withdrawal throttle.
+    function _configureThrottle() internal {
+        vm.prank(bridgeOwner);
+        l1StandardBridge.setWithdrawalThrottle(address(L1Token), MAX_BPS, REFILL_PERIOD);
+    }
+
+    /// @notice Sets the escrow accounting for a local and remote token pair.
+    function _setDeposits(address _localToken, address _remoteToken, uint256 _amount) internal {
+        uint256 slot = stdstore.target(address(l1StandardBridge)).sig("deposits(address,address)").with_key(_localToken)
+            .with_key(_remoteToken).find();
+        vm.store(address(l1StandardBridge), bytes32(slot), bytes32(_amount));
+    }
+
+    /// @notice Finalizes an ERC20 withdrawal through the authenticated messenger.
+    function _withdraw(address _localToken, address _remoteToken, uint256 _amount) internal {
+        vm.prank(bridgeMessenger);
+        l1StandardBridge.finalizeBridgeERC20(_localToken, _remoteToken, alice, alice, _amount, hex"");
+    }
+}
+
+/// @title L1StandardBridge_SetWithdrawalThrottle_Test
+/// @notice Tests the `setWithdrawalThrottle` function of the `L1StandardBridge` contract.
+contract L1StandardBridge_SetWithdrawalThrottle_Test is L1StandardBridge_WithdrawalThrottle_TestInit {
+    /// @notice Tests that configuring a withdrawal throttle snapshots stock and starts full.
+    function test_setWithdrawalThrottle_succeeds() external {
+        vm.expectEmit(address(l1StandardBridge));
+        emit WithdrawalThrottleConfigured(address(L1Token), MAX_BPS, REFILL_PERIOD, STOCK, CAPACITY, CAPACITY);
+
+        _configureThrottle();
+
+        IL1StandardBridge.WithdrawalThrottleConfig memory throttle =
+            l1StandardBridge.withdrawalThrottle(address(L1Token));
+        assertEq(throttle.capacity, CAPACITY);
+        assertEq(throttle.available, CAPACITY);
+        assertEq(throttle.refillPeriod, REFILL_PERIOD);
+        assertEq(throttle.lastUpdated, block.timestamp);
+        assertEq(throttle.maxBps, MAX_BPS);
+        assertTrue(throttle.enabled);
+        assertEq(l1StandardBridge.availableWithdrawalCapacity(address(L1Token)), CAPACITY);
+    }
+
+    /// @notice Tests that only the ProxyAdmin owner can configure a withdrawal throttle.
+    function testFuzz_setWithdrawalThrottle_notProxyAdminOwner_reverts(address _caller) external {
+        vm.assume(_caller != bridgeOwner);
+
+        vm.expectRevert(IProxyAdminOwnedBase.ProxyAdminOwnedBase_NotProxyAdminOwner.selector);
+        vm.prank(_caller);
+        l1StandardBridge.setWithdrawalThrottle(address(L1Token), MAX_BPS, REFILL_PERIOD);
+    }
+
+    /// @notice Tests that configuring the zero token address reverts.
+    function test_setWithdrawalThrottle_zeroToken_reverts() external {
+        vm.expectRevert(IL1StandardBridge.L1StandardBridge_InvalidWithdrawalThrottleToken.selector);
+        vm.prank(bridgeOwner);
+        l1StandardBridge.setWithdrawalThrottle(address(0), MAX_BPS, REFILL_PERIOD);
+    }
+
+    /// @notice Tests that configuring a mintable local token reverts because it is not escrowed.
+    function test_setWithdrawalThrottle_mintableToken_reverts() external {
+        vm.expectRevert(IL1StandardBridge.L1StandardBridge_UnsupportedWithdrawalThrottleToken.selector);
+        vm.prank(bridgeOwner);
+        l1StandardBridge.setWithdrawalThrottle(address(BadL1Token), MAX_BPS, REFILL_PERIOD);
+    }
+
+    /// @notice Tests that a zero basis point value reverts.
+    function test_setWithdrawalThrottle_zeroBps_reverts() external {
+        vm.expectRevert(IL1StandardBridge.L1StandardBridge_InvalidWithdrawalThrottleBps.selector);
+        vm.prank(bridgeOwner);
+        l1StandardBridge.setWithdrawalThrottle(address(L1Token), 0, REFILL_PERIOD);
+    }
+
+    /// @notice Tests that a basis point value above 100% reverts.
+    function test_setWithdrawalThrottle_bpsAboveMaximum_reverts() external {
+        vm.expectRevert(IL1StandardBridge.L1StandardBridge_InvalidWithdrawalThrottleBps.selector);
+        vm.prank(bridgeOwner);
+        l1StandardBridge.setWithdrawalThrottle(address(L1Token), 10_001, REFILL_PERIOD);
+    }
+
+    /// @notice Tests that a zero refill period reverts.
+    function test_setWithdrawalThrottle_zeroRefillPeriod_reverts() external {
+        vm.expectRevert(IL1StandardBridge.L1StandardBridge_InvalidWithdrawalThrottlePeriod.selector);
+        vm.prank(bridgeOwner);
+        l1StandardBridge.setWithdrawalThrottle(address(L1Token), MAX_BPS, 0);
+    }
+
+    /// @notice Tests that reconfiguration preserves and clamps accrued capacity under new parameters.
+    function test_setWithdrawalThrottle_reconfigurePreservesAvailable_succeeds() external {
+        _configureThrottle();
+        _withdraw(address(L1Token), address(L2Token), 60);
+        vm.warp(block.timestamp + REFILL_PERIOD / 2);
+
+        vm.prank(bridgeOwner);
+        l1StandardBridge.setWithdrawalThrottle(address(L1Token), 500, REFILL_PERIOD * 2);
+
+        IL1StandardBridge.WithdrawalThrottleConfig memory throttle =
+            l1StandardBridge.withdrawalThrottle(address(L1Token));
+        assertEq(throttle.capacity, 47);
+        assertEq(throttle.available, 47);
+        assertEq(throttle.refillPeriod, REFILL_PERIOD * 2);
+        assertEq(throttle.lastUpdated, block.timestamp);
+        assertEq(throttle.refillRemainder, 0);
+        assertEq(throttle.maxBps, 500);
+    }
+}
+
+/// @title L1StandardBridge_RefreshWithdrawalThrottle_Test
+/// @notice Tests the `refreshWithdrawalThrottle` function of the `L1StandardBridge` contract.
+contract L1StandardBridge_RefreshWithdrawalThrottle_Test is L1StandardBridge_WithdrawalThrottle_TestInit {
+    /// @notice Tests that refreshing increased stock does not refill the bucket.
+    function test_refreshWithdrawalThrottle_increasedStockPreservesAvailable_succeeds() external {
+        _configureThrottle();
+        _withdraw(address(L1Token), address(L2Token), 60);
+        deal(address(L1Token), address(l1StandardBridge), 2000, true);
+
+        vm.expectEmit(address(l1StandardBridge));
+        emit WithdrawalThrottleRefreshed(address(L1Token), 2000, 200, 40);
+        vm.prank(bridgeOwner);
+        l1StandardBridge.refreshWithdrawalThrottle(address(L1Token));
+
+        IL1StandardBridge.WithdrawalThrottleConfig memory throttle =
+            l1StandardBridge.withdrawalThrottle(address(L1Token));
+        assertEq(throttle.capacity, 200);
+        assertEq(throttle.available, 40);
+    }
+
+    /// @notice Tests that refreshing decreased stock clamps available capacity.
+    function test_refreshWithdrawalThrottle_decreasedStockClampsAvailable_succeeds() external {
+        _configureThrottle();
+        deal(address(L1Token), address(l1StandardBridge), 50, true);
+
+        vm.prank(bridgeOwner);
+        l1StandardBridge.refreshWithdrawalThrottle(address(L1Token));
+
+        IL1StandardBridge.WithdrawalThrottleConfig memory throttle =
+            l1StandardBridge.withdrawalThrottle(address(L1Token));
+        assertEq(throttle.capacity, 5);
+        assertEq(throttle.available, 5);
+    }
+
+    /// @notice Tests that refreshing a disabled throttle reverts.
+    function test_refreshWithdrawalThrottle_notEnabled_reverts() external {
+        vm.expectRevert(IL1StandardBridge.L1StandardBridge_WithdrawalThrottleNotEnabled.selector);
+        vm.prank(bridgeOwner);
+        l1StandardBridge.refreshWithdrawalThrottle(address(L1Token));
+    }
+
+    /// @notice Tests that only the ProxyAdmin owner can refresh a withdrawal throttle.
+    function testFuzz_refreshWithdrawalThrottle_notProxyAdminOwner_reverts(address _caller) external {
+        _configureThrottle();
+        vm.assume(_caller != bridgeOwner);
+
+        vm.expectRevert(IProxyAdminOwnedBase.ProxyAdminOwnedBase_NotProxyAdminOwner.selector);
+        vm.prank(_caller);
+        l1StandardBridge.refreshWithdrawalThrottle(address(L1Token));
+    }
+}
+
+/// @title L1StandardBridge_DisableWithdrawalThrottle_Test
+/// @notice Tests the `disableWithdrawalThrottle` function of the `L1StandardBridge` contract.
+contract L1StandardBridge_DisableWithdrawalThrottle_Test is L1StandardBridge_WithdrawalThrottle_TestInit {
+    /// @notice Tests that disabling removes the throttle and restores unrestricted withdrawals.
+    function test_disableWithdrawalThrottle_succeeds() external {
+        _configureThrottle();
+
+        vm.expectEmit(address(l1StandardBridge));
+        emit WithdrawalThrottleDisabled(address(L1Token));
+        vm.prank(bridgeOwner);
+        l1StandardBridge.disableWithdrawalThrottle(address(L1Token));
+
+        IL1StandardBridge.WithdrawalThrottleConfig memory throttle =
+            l1StandardBridge.withdrawalThrottle(address(L1Token));
+        assertFalse(throttle.enabled);
+        assertEq(l1StandardBridge.availableWithdrawalCapacity(address(L1Token)), type(uint256).max);
+
+        _withdraw(address(L1Token), address(L2Token), CAPACITY + 1);
+        assertEq(L1Token.balanceOf(alice), CAPACITY + 1);
+    }
+
+    /// @notice Tests that disabling an absent throttle reverts.
+    function test_disableWithdrawalThrottle_notEnabled_reverts() external {
+        vm.expectRevert(IL1StandardBridge.L1StandardBridge_WithdrawalThrottleNotEnabled.selector);
+        vm.prank(bridgeOwner);
+        l1StandardBridge.disableWithdrawalThrottle(address(L1Token));
+    }
+
+    /// @notice Tests that only the ProxyAdmin owner can disable a withdrawal throttle.
+    function testFuzz_disableWithdrawalThrottle_notProxyAdminOwner_reverts(address _caller) external {
+        _configureThrottle();
+        vm.assume(_caller != bridgeOwner);
+
+        vm.expectRevert(IProxyAdminOwnedBase.ProxyAdminOwnedBase_NotProxyAdminOwner.selector);
+        vm.prank(_caller);
+        l1StandardBridge.disableWithdrawalThrottle(address(L1Token));
+    }
+}
+
+/// @title L1StandardBridge_FinalizeBridgeERC20_Test
+/// @notice Tests withdrawal throttle behavior during ERC20 finalization.
+contract L1StandardBridge_FinalizeBridgeERC20_Test is L1StandardBridge_WithdrawalThrottle_TestInit {
+    /// @notice Tests that an unconfigured token remains unrestricted.
+    function test_finalizeBridgeERC20_throttleDisabled_succeeds() external {
+        _withdraw(address(L1Token), address(L2Token), CAPACITY + 1);
+
+        assertEq(L1Token.balanceOf(alice), CAPACITY + 1);
+        assertEq(l1StandardBridge.availableWithdrawalCapacity(address(L1Token)), type(uint256).max);
+    }
+
+    /// @notice Tests that consuming exactly the bucket capacity succeeds and emits monitoring events.
+    function test_finalizeBridgeERC20_exactCapacity_succeeds() external {
+        _configureThrottle();
+
+        vm.expectEmit(address(l1StandardBridge));
+        emit WithdrawalThrottleCapacityConsumed(address(L1Token), CAPACITY, 0);
+        vm.expectEmit(address(l1StandardBridge));
+        emit WithdrawalThrottleCapacityExhausted(address(L1Token));
+        _withdraw(address(L1Token), address(L2Token), CAPACITY);
+
+        assertEq(l1StandardBridge.availableWithdrawalCapacity(address(L1Token)), 0);
+        assertEq(L1Token.balanceOf(alice), CAPACITY);
+    }
+
+    /// @notice Tests that a withdrawal reverts when its bucket does not have enough capacity.
+    function test_finalizeBridgeERC20_insufficientCapacity_reverts() external {
+        _configureThrottle();
+        _withdraw(address(L1Token), address(L2Token), CAPACITY);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IL1StandardBridge.L1StandardBridge_WithdrawalThrottled.selector, address(L1Token), 1, 0, CAPACITY
+            )
+        );
+        _withdraw(address(L1Token), address(L2Token), 1);
+
+        assertEq(l1StandardBridge.deposits(address(L1Token), address(L2Token)), STOCK - CAPACITY);
+        assertEq(L1Token.balanceOf(alice), CAPACITY);
+    }
+
+    /// @notice Tests that withdrawal capacity refills linearly over the configured period.
+    function test_finalizeBridgeERC20_refillsOverTime_succeeds() external {
+        _configureThrottle();
+        _withdraw(address(L1Token), address(L2Token), CAPACITY);
+
+        uint256 emptiedAt = block.timestamp;
+        vm.warp(emptiedAt + REFILL_PERIOD / 2);
+        assertEq(l1StandardBridge.availableWithdrawalCapacity(address(L1Token)), CAPACITY / 2);
+        _withdraw(address(L1Token), address(L2Token), CAPACITY / 2);
+
+        vm.warp(block.timestamp + REFILL_PERIOD);
+        assertEq(l1StandardBridge.availableWithdrawalCapacity(address(L1Token)), CAPACITY);
+    }
+
+    /// @notice Tests that staggered withdrawals preserve fractional refill capacity.
+    function test_finalizeBridgeERC20_fractionalRefillRemainder_succeeds() external {
+        vm.prank(bridgeOwner);
+        l1StandardBridge.setWithdrawalThrottle(address(L1Token), MAX_BPS, 3);
+        _withdraw(address(L1Token), address(L2Token), CAPACITY);
+
+        vm.warp(block.timestamp + 1);
+        _withdraw(address(L1Token), address(L2Token), 33);
+        vm.warp(block.timestamp + 1);
+
+        assertEq(l1StandardBridge.availableWithdrawalCapacity(address(L1Token)), 33);
+        _withdraw(address(L1Token), address(L2Token), 33);
+        vm.warp(block.timestamp + 1);
+
+        assertEq(l1StandardBridge.availableWithdrawalCapacity(address(L1Token)), 34);
+        _withdraw(address(L1Token), address(L2Token), 34);
+    }
+
+    /// @notice Tests the monitoring event emitted by a partial capacity consumption.
+    function test_finalizeBridgeERC20_partialCapacityEmitsRemaining_succeeds() external {
+        _configureThrottle();
+
+        vm.expectEmit(address(l1StandardBridge));
+        emit WithdrawalThrottleCapacityConsumed(address(L1Token), 40, 60);
+        _withdraw(address(L1Token), address(L2Token), 40);
+
+        assertEq(l1StandardBridge.availableWithdrawalCapacity(address(L1Token)), 60);
+    }
+
+    /// @notice Tests that all remote representations of an L1 token share one bucket.
+    function test_finalizeBridgeERC20_remoteRepresentationsShareBucket_reverts() external {
+        address alternateRemoteToken = makeAddr("alternateRemoteToken");
+        _setDeposits(address(L1Token), alternateRemoteToken, STOCK);
+        _configureThrottle();
+        _withdraw(address(L1Token), address(L2Token), 60);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IL1StandardBridge.L1StandardBridge_WithdrawalThrottled.selector, address(L1Token), 41, 40, CAPACITY
+            )
+        );
+        _withdraw(address(L1Token), alternateRemoteToken, 41);
+    }
+
+    /// @notice Tests that a configured token's bucket does not affect another L1 token.
+    function test_finalizeBridgeERC20_tokensHaveIndependentBuckets_succeeds() external {
+        ERC20 otherToken = new ERC20("Other Token", "OTHR");
+        address remoteOtherToken = makeAddr("remoteOtherToken");
+        deal(address(otherToken), address(l1StandardBridge), STOCK, true);
+        _setDeposits(address(otherToken), remoteOtherToken, STOCK);
+        _configureThrottle();
+        _withdraw(address(L1Token), address(L2Token), CAPACITY);
+
+        _withdraw(address(otherToken), remoteOtherToken, CAPACITY + 1);
+
+        assertEq(otherToken.balanceOf(alice), CAPACITY + 1);
+    }
+
+    /// @notice Tests that capacity consumption rolls back if escrow accounting later fails.
+    function test_finalizeBridgeERC20_laterFailureRollsBackConsumption_reverts() external {
+        _configureThrottle();
+        IL1StandardBridge.WithdrawalThrottleConfig memory beforeThrottle =
+            l1StandardBridge.withdrawalThrottle(address(L1Token));
+        _setDeposits(address(L1Token), address(L2Token), 10);
+
+        vm.expectRevert(stdError.arithmeticError);
+        _withdraw(address(L1Token), address(L2Token), CAPACITY / 2);
+
+        IL1StandardBridge.WithdrawalThrottleConfig memory afterThrottle =
+            l1StandardBridge.withdrawalThrottle(address(L1Token));
+        assertEq(afterThrottle.available, beforeThrottle.available);
+        assertEq(afterThrottle.lastUpdated, beforeThrottle.lastUpdated);
     }
 }

--- a/packages/contracts-bedrock/test/L1/L1StandardBridge.t.sol
+++ b/packages/contracts-bedrock/test/L1/L1StandardBridge.t.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.15;
 
 // Testing
+import { VmSafe } from "forge-std/Vm.sol";
 import { stdStorage, StdStorage } from "forge-std/StdStorage.sol";
 import { stdError } from "forge-std/StdError.sol";
 import { CommonTest } from "test/setup/CommonTest.sol";
@@ -1014,6 +1015,18 @@ abstract contract L1StandardBridge_WithdrawalThrottle_TestInit is CommonTest {
         vm.prank(bridgeMessenger);
         l1StandardBridge.finalizeBridgeERC20(_localToken, _remoteToken, alice, alice, _amount, hex"");
     }
+
+    /// @notice Returns the config and mutable bucket slots for a token's withdrawal throttle.
+    function _withdrawalThrottleSlots(address _token) internal returns (bytes32 configSlot_, bytes32 bucketSlot_) {
+        StorageSlot memory mappingSlot = ForgeArtifacts.getSlot("L1StandardBridge", "_withdrawalThrottles");
+        configSlot_ = keccak256(abi.encode(_token, mappingSlot.slot));
+        bucketSlot_ = bytes32(uint256(configSlot_) + 1);
+    }
+
+    /// @notice Returns the L1 token balance slot for an account.
+    function _tokenBalanceSlot(address _account) internal returns (bytes32 slot_) {
+        slot_ = bytes32(stdstore.target(address(L1Token)).sig("balanceOf(address)").with_key(_account).find());
+    }
 }
 
 /// @title L1StandardBridge_SetWithdrawalThrottle_Test
@@ -1032,6 +1045,7 @@ contract L1StandardBridge_SetWithdrawalThrottle_Test is L1StandardBridge_Withdra
         assertEq(throttle.available, CAPACITY);
         assertEq(throttle.refillPeriod, REFILL_PERIOD);
         assertEq(throttle.lastUpdated, block.timestamp);
+        assertEq(throttle.refillRemainder, 0);
         assertEq(throttle.maxBps, MAX_BPS);
         assertTrue(throttle.enabled);
         assertEq(l1StandardBridge.availableWithdrawalCapacity(address(L1Token)), CAPACITY);
@@ -1099,6 +1113,45 @@ contract L1StandardBridge_SetWithdrawalThrottle_Test is L1StandardBridge_Withdra
         assertEq(throttle.refillRemainder, 0);
         assertEq(throttle.maxBps, 500);
     }
+
+    /// @notice Tests that reconfiguration preserves non-full availability under a new refill period.
+    function test_setWithdrawalThrottle_reconfigurePeriodPreservesAvailable_succeeds() external {
+        _configureThrottle();
+        _withdraw(address(L1Token), address(L2Token), 80);
+        vm.warp(block.timestamp + 10);
+
+        vm.expectEmit(address(l1StandardBridge));
+        emit WithdrawalThrottleConfigured(address(L1Token), 2000, 200, 920, 184, 29);
+        vm.prank(bridgeOwner);
+        l1StandardBridge.setWithdrawalThrottle(address(L1Token), 2000, 200);
+
+        IL1StandardBridge.WithdrawalThrottleConfig memory throttle =
+            l1StandardBridge.withdrawalThrottle(address(L1Token));
+        assertEq(throttle.capacity, 184);
+        assertEq(throttle.available, 29);
+        assertEq(throttle.refillPeriod, 200);
+        assertEq(throttle.lastUpdated, block.timestamp);
+        assertEq(throttle.refillRemainder, 0);
+        assertEq(throttle.maxBps, 2000);
+    }
+
+    /// @notice Tests that reconfiguration preserves whole units and resets fractional refill credit.
+    function test_setWithdrawalThrottle_reconfigureResetsFractionalRemainder_succeeds() external {
+        vm.prank(bridgeOwner);
+        l1StandardBridge.setWithdrawalThrottle(address(L1Token), MAX_BPS, 3);
+        _withdraw(address(L1Token), address(L2Token), CAPACITY);
+        deal(address(L1Token), address(l1StandardBridge), STOCK, true);
+        _setDeposits(address(L1Token), address(L2Token), STOCK);
+        vm.warp(block.timestamp + 1);
+
+        vm.prank(bridgeOwner);
+        l1StandardBridge.setWithdrawalThrottle(address(L1Token), MAX_BPS, 3);
+
+        IL1StandardBridge.WithdrawalThrottleConfig memory throttle =
+            l1StandardBridge.withdrawalThrottle(address(L1Token));
+        assertEq(throttle.available, 33);
+        assertEq(throttle.refillRemainder, 0);
+    }
 }
 
 /// @title L1StandardBridge_RefreshWithdrawalThrottle_Test
@@ -1119,6 +1172,8 @@ contract L1StandardBridge_RefreshWithdrawalThrottle_Test is L1StandardBridge_Wit
             l1StandardBridge.withdrawalThrottle(address(L1Token));
         assertEq(throttle.capacity, 200);
         assertEq(throttle.available, 40);
+        assertEq(throttle.lastUpdated, block.timestamp);
+        assertEq(throttle.refillRemainder, 0);
     }
 
     /// @notice Tests that refreshing decreased stock clamps available capacity.
@@ -1133,6 +1188,8 @@ contract L1StandardBridge_RefreshWithdrawalThrottle_Test is L1StandardBridge_Wit
             l1StandardBridge.withdrawalThrottle(address(L1Token));
         assertEq(throttle.capacity, 5);
         assertEq(throttle.available, 5);
+        assertEq(throttle.lastUpdated, block.timestamp);
+        assertEq(throttle.refillRemainder, 0);
     }
 
     /// @notice Tests that refreshing a disabled throttle reverts.
@@ -1195,6 +1252,59 @@ contract L1StandardBridge_DisableWithdrawalThrottle_Test is L1StandardBridge_Wit
 /// @title L1StandardBridge_FinalizeBridgeERC20_Test
 /// @notice Tests withdrawal throttle behavior during ERC20 finalization.
 contract L1StandardBridge_FinalizeBridgeERC20_Test is L1StandardBridge_WithdrawalThrottle_TestInit {
+    /// @notice Asserts the exact config and mutable bucket writes in recorded account accesses.
+    function _assertThrottleWrites(
+        VmSafe.AccountAccess[] memory _accountAccesses,
+        bytes32 _configSlot,
+        bytes32 _bucketSlot,
+        uint256 _expectedConfigWrites,
+        uint256 _expectedBucketWrites
+    )
+        internal
+        view
+    {
+        uint256 configWrites;
+        uint256 bucketWrites;
+        for (uint256 i; i < _accountAccesses.length; i++) {
+            for (uint256 j; j < _accountAccesses[i].storageAccesses.length; j++) {
+                VmSafe.StorageAccess memory access = _accountAccesses[i].storageAccesses[j];
+                if (access.account == address(l1StandardBridge) && access.isWrite) {
+                    if (access.slot == _configSlot) configWrites++;
+                    if (access.slot == _bucketSlot) bucketWrites++;
+                }
+            }
+        }
+        assertEq(configWrites, _expectedConfigWrites);
+        assertEq(bucketWrites, _expectedBucketWrites);
+    }
+
+    /// @notice Tests that unchanged live stock writes only the mutable throttle bucket.
+    function test_finalizeBridgeERC20_unchangedStockWritesBucketOnly_succeeds() external {
+        _configureThrottle();
+        vm.warp(block.timestamp + 1);
+        (bytes32 configSlot, bytes32 bucketSlot) = _withdrawalThrottleSlots(address(L1Token));
+
+        vm.startStateDiffRecording();
+        _withdraw(address(L1Token), address(L2Token), 40);
+        VmSafe.AccountAccess[] memory accountAccesses = vm.stopAndReturnStateDiff();
+
+        _assertThrottleWrites(accountAccesses, configSlot, bucketSlot, 0, 1);
+    }
+
+    /// @notice Tests that changed live stock writes both the config and mutable throttle bucket.
+    function test_finalizeBridgeERC20_changedStockWritesConfigAndBucket_succeeds() external {
+        _configureThrottle();
+        deal(address(L1Token), address(l1StandardBridge), 2000, true);
+        _setDeposits(address(L1Token), address(L2Token), 2000);
+        (bytes32 configSlot, bytes32 bucketSlot) = _withdrawalThrottleSlots(address(L1Token));
+
+        vm.startStateDiffRecording();
+        _withdraw(address(L1Token), address(L2Token), 40);
+        VmSafe.AccountAccess[] memory accountAccesses = vm.stopAndReturnStateDiff();
+
+        _assertThrottleWrites(accountAccesses, configSlot, bucketSlot, 1, 1);
+    }
+
     /// @notice Tests that an unconfigured token remains unrestricted.
     function test_finalizeBridgeERC20_throttleDisabled_succeeds() external {
         _withdraw(address(L1Token), address(L2Token), CAPACITY + 1);
@@ -1233,6 +1343,26 @@ contract L1StandardBridge_FinalizeBridgeERC20_Test is L1StandardBridge_Withdrawa
         assertEq(L1Token.balanceOf(alice), CAPACITY);
     }
 
+    /// @notice Tests that a withdrawal above uint128 is throttled without truncating its amount.
+    function test_finalizeBridgeERC20_amountAboveUint128_reverts() external {
+        uint256 amount = uint256(type(uint128).max) + 1;
+        uint256 stock = amount * 10;
+        deal(address(L1Token), address(l1StandardBridge), stock, true);
+        _setDeposits(address(L1Token), address(L2Token), stock);
+        _configureThrottle();
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IL1StandardBridge.L1StandardBridge_WithdrawalThrottled.selector,
+                address(L1Token),
+                amount,
+                type(uint128).max,
+                type(uint128).max
+            )
+        );
+        _withdraw(address(L1Token), address(L2Token), amount);
+    }
+
     /// @notice Tests that withdrawal capacity refills linearly over the configured period.
     function test_finalizeBridgeERC20_refillsOverTime_succeeds() external {
         _configureThrottle();
@@ -1240,8 +1370,8 @@ contract L1StandardBridge_FinalizeBridgeERC20_Test is L1StandardBridge_Withdrawa
 
         uint256 emptiedAt = block.timestamp;
         vm.warp(emptiedAt + REFILL_PERIOD / 2);
-        assertEq(l1StandardBridge.availableWithdrawalCapacity(address(L1Token)), CAPACITY / 2);
-        _withdraw(address(L1Token), address(L2Token), CAPACITY / 2);
+        assertEq(l1StandardBridge.availableWithdrawalCapacity(address(L1Token)), 45);
+        _withdraw(address(L1Token), address(L2Token), 45);
 
         vm.warp(block.timestamp + REFILL_PERIOD);
         assertEq(l1StandardBridge.availableWithdrawalCapacity(address(L1Token)), 85);
@@ -1264,7 +1394,7 @@ contract L1StandardBridge_FinalizeBridgeERC20_Test is L1StandardBridge_Withdrawa
 
         assertEq(l1StandardBridge.withdrawalThrottle(address(L1Token)).capacity, 190);
         vm.warp(block.timestamp + REFILL_PERIOD / 2);
-        assertEq(l1StandardBridge.availableWithdrawalCapacity(address(L1Token)), 95);
+        assertEq(l1StandardBridge.availableWithdrawalCapacity(address(L1Token)), 92);
     }
 
     /// @notice Tests that decreased stock immediately clamps effective availability.
@@ -1357,7 +1487,58 @@ contract L1StandardBridge_FinalizeBridgeERC20_Test is L1StandardBridge_Withdrawa
 
         IL1StandardBridge.WithdrawalThrottleConfig memory afterThrottle =
             l1StandardBridge.withdrawalThrottle(address(L1Token));
+        assertEq(afterThrottle.capacity, beforeThrottle.capacity);
         assertEq(afterThrottle.available, beforeThrottle.available);
         assertEq(afterThrottle.lastUpdated, beforeThrottle.lastUpdated);
+        assertEq(afterThrottle.refillRemainder, beforeThrottle.refillRemainder);
+    }
+}
+
+/// @title L1StandardBridge_Gas_TestInit
+/// @notice Common cold-slot gas measurement helpers for ERC20 withdrawal finalization.
+abstract contract L1StandardBridge_Gas_TestInit is L1StandardBridge_WithdrawalThrottle_TestInit {
+    function _measureBridgeWithdrawal(string memory _snapshotName) internal {
+        address implementation = EIP1967Helper.getImplementation(address(l1StandardBridge));
+        (bytes32 configSlot, bytes32 bucketSlot) = _withdrawalThrottleSlots(address(L1Token));
+        vm.cool(address(l1StandardBridge));
+        vm.coolSlot(address(l1StandardBridge), configSlot);
+        vm.coolSlot(address(l1StandardBridge), bucketSlot);
+        vm.cool(implementation);
+        vm.cool(address(L1Token));
+        vm.coolSlot(address(L1Token), _tokenBalanceSlot(address(l1StandardBridge)));
+        vm.cool(bridgeMessenger);
+
+        _withdraw(address(L1Token), address(L2Token), 40);
+        vm.snapshotGasLastCall("WithdrawalFinalizationGas", _snapshotName);
+    }
+}
+
+/// @title L1StandardBridge_FinalizeBridgeERC20_GasDisabled_Test
+/// @notice Measures ERC20 finalization with committed unconfigured throttle storage.
+contract L1StandardBridge_FinalizeBridgeERC20_GasDisabled_Test is L1StandardBridge_Gas_TestInit {
+    function setUp() public override {
+        super.setUp();
+        deal(address(L1Token), address(l1StandardBridge), STOCK * 2, true);
+        _setDeposits(address(L1Token), address(L2Token), STOCK * 2);
+    }
+
+    function test_finalizeBridgeERC20_throttleDisabledGas_benchmark() external {
+        _measureBridgeWithdrawal("l1-standard-bridge-unthrottled");
+    }
+}
+
+/// @title L1StandardBridge_FinalizeBridgeERC20_GasEnabled_Test
+/// @notice Measures the capacity-changing packed ERC20 throttle path from committed storage.
+contract L1StandardBridge_FinalizeBridgeERC20_GasEnabled_Test is L1StandardBridge_Gas_TestInit {
+    function setUp() public override {
+        super.setUp();
+        _configureThrottle();
+        deal(address(L1Token), address(l1StandardBridge), STOCK * 2, true);
+        _setDeposits(address(L1Token), address(L2Token), STOCK * 2);
+        vm.warp(block.timestamp + 1);
+    }
+
+    function test_finalizeBridgeERC20_throttleEnabledGas_benchmark() external {
+        _measureBridgeWithdrawal("l1-standard-bridge-throttled");
     }
 }

--- a/packages/contracts-bedrock/test/L1/L1StandardBridge.t.sol
+++ b/packages/contracts-bedrock/test/L1/L1StandardBridge.t.sol
@@ -1224,7 +1224,7 @@ contract L1StandardBridge_FinalizeBridgeERC20_Test is L1StandardBridge_Withdrawa
 
         vm.expectRevert(
             abi.encodeWithSelector(
-                IL1StandardBridge.L1StandardBridge_WithdrawalThrottled.selector, address(L1Token), 1, 0, CAPACITY
+                IL1StandardBridge.L1StandardBridge_WithdrawalThrottled.selector, address(L1Token), 1, 0, 90
             )
         );
         _withdraw(address(L1Token), address(L2Token), 1);
@@ -1244,7 +1244,41 @@ contract L1StandardBridge_FinalizeBridgeERC20_Test is L1StandardBridge_Withdrawa
         _withdraw(address(L1Token), address(L2Token), CAPACITY / 2);
 
         vm.warp(block.timestamp + REFILL_PERIOD);
-        assertEq(l1StandardBridge.availableWithdrawalCapacity(address(L1Token)), CAPACITY);
+        assertEq(l1StandardBridge.availableWithdrawalCapacity(address(L1Token)), 85);
+    }
+
+    /// @notice Tests that increased stock raises the ceiling without immediately topping up availability.
+    function test_finalizeBridgeERC20_increasedStockLazilyRaisesCapacity_succeeds() external {
+        _configureThrottle();
+        _withdraw(address(L1Token), address(L2Token), CAPACITY);
+
+        deal(address(L1Token), address(l1StandardBridge), 1900, true);
+        _setDeposits(address(L1Token), address(L2Token), 1900);
+        assertEq(l1StandardBridge.availableWithdrawalCapacity(address(L1Token)), 0);
+
+        vm.warp(block.timestamp + REFILL_PERIOD / 2);
+        assertEq(l1StandardBridge.availableWithdrawalCapacity(address(L1Token)), 50);
+        vm.expectEmit(address(l1StandardBridge));
+        emit WithdrawalThrottleRefreshed(address(L1Token), 1900, 190, 50);
+        _withdraw(address(L1Token), address(L2Token), 50);
+
+        assertEq(l1StandardBridge.withdrawalThrottle(address(L1Token)).capacity, 190);
+        vm.warp(block.timestamp + REFILL_PERIOD / 2);
+        assertEq(l1StandardBridge.availableWithdrawalCapacity(address(L1Token)), 95);
+    }
+
+    /// @notice Tests that decreased stock immediately clamps effective availability.
+    function test_finalizeBridgeERC20_decreasedStockLazilyClampsCapacity_succeeds() external {
+        _configureThrottle();
+        deal(address(L1Token), address(l1StandardBridge), 500, true);
+        _setDeposits(address(L1Token), address(L2Token), 500);
+
+        assertEq(l1StandardBridge.availableWithdrawalCapacity(address(L1Token)), 50);
+        vm.expectEmit(address(l1StandardBridge));
+        emit WithdrawalThrottleRefreshed(address(L1Token), 500, 50, 50);
+        _withdraw(address(L1Token), address(L2Token), 50);
+
+        assertEq(l1StandardBridge.withdrawalThrottle(address(L1Token)).capacity, 50);
     }
 
     /// @notice Tests that staggered withdrawals preserve fractional refill capacity.
@@ -1252,13 +1286,19 @@ contract L1StandardBridge_FinalizeBridgeERC20_Test is L1StandardBridge_Withdrawa
         vm.prank(bridgeOwner);
         l1StandardBridge.setWithdrawalThrottle(address(L1Token), MAX_BPS, 3);
         _withdraw(address(L1Token), address(L2Token), CAPACITY);
+        deal(address(L1Token), address(l1StandardBridge), STOCK, true);
+        _setDeposits(address(L1Token), address(L2Token), STOCK);
 
         vm.warp(block.timestamp + 1);
         _withdraw(address(L1Token), address(L2Token), 33);
+        deal(address(L1Token), address(l1StandardBridge), STOCK, true);
+        _setDeposits(address(L1Token), address(L2Token), STOCK);
         vm.warp(block.timestamp + 1);
 
         assertEq(l1StandardBridge.availableWithdrawalCapacity(address(L1Token)), 33);
         _withdraw(address(L1Token), address(L2Token), 33);
+        deal(address(L1Token), address(l1StandardBridge), STOCK, true);
+        _setDeposits(address(L1Token), address(L2Token), STOCK);
         vm.warp(block.timestamp + 1);
 
         assertEq(l1StandardBridge.availableWithdrawalCapacity(address(L1Token)), 34);
@@ -1285,7 +1325,7 @@ contract L1StandardBridge_FinalizeBridgeERC20_Test is L1StandardBridge_Withdrawa
 
         vm.expectRevert(
             abi.encodeWithSelector(
-                IL1StandardBridge.L1StandardBridge_WithdrawalThrottled.selector, address(L1Token), 41, 40, CAPACITY
+                IL1StandardBridge.L1StandardBridge_WithdrawalThrottled.selector, address(L1Token), 41, 40, 94
             )
         );
         _withdraw(address(L1Token), alternateRemoteToken, 41);

--- a/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
+++ b/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
@@ -2307,6 +2307,40 @@ contract OptimismPortal2_FinalizeWithdrawalTransaction_Test is OptimismPortal2_W
         assertFalse(optimismPortal2.finalizedWithdrawals(_withdrawalHash));
     }
 
+    /// @notice Tests that increased direct ETH stock raises the ceiling without immediately topping up availability.
+    function test_finalizeWithdrawalTransaction_increasedStockLazilyRaisesCapacity_succeeds() external {
+        skipIfSysFeatureEnabled(Features.CUSTOM_GAS_TOKEN);
+        _useDirectPortalCustody();
+        _configurePortalWithdrawalThrottle(WITHDRAWAL_MAX_BPS);
+        vm.deal(address(optimismPortal2), 2000);
+
+        assertEq(optimismPortal2.availableWithdrawalCapacity(), WITHDRAWAL_CAPACITY);
+        _prepareDefaultWithdrawal();
+        vm.expectEmit(address(optimismPortal2));
+        emit WithdrawalThrottleRefreshed(2000, 200, WITHDRAWAL_CAPACITY);
+        optimismPortal2.finalizeWithdrawalTransaction(_defaultTx);
+
+        assertEq(optimismPortal2.withdrawalThrottle().capacity, 200);
+        vm.warp(block.timestamp + WITHDRAWAL_REFILL_PERIOD / 2);
+        assertEq(optimismPortal2.availableWithdrawalCapacity(), WITHDRAWAL_CAPACITY);
+    }
+
+    /// @notice Tests that decreased direct ETH stock immediately clamps effective availability.
+    function test_finalizeWithdrawalTransaction_decreasedStockLazilyClampsCapacity_succeeds() external {
+        skipIfSysFeatureEnabled(Features.CUSTOM_GAS_TOKEN);
+        _useDirectPortalCustody();
+        _configurePortalWithdrawalThrottle(2000);
+        vm.deal(address(optimismPortal2), 500);
+
+        assertEq(optimismPortal2.availableWithdrawalCapacity(), WITHDRAWAL_CAPACITY);
+        _prepareDefaultWithdrawal();
+        vm.expectEmit(address(optimismPortal2));
+        emit WithdrawalThrottleRefreshed(500, WITHDRAWAL_CAPACITY, WITHDRAWAL_CAPACITY);
+        optimismPortal2.finalizeWithdrawalTransaction(_defaultTx);
+
+        assertEq(optimismPortal2.withdrawalThrottle().capacity, WITHDRAWAL_CAPACITY);
+    }
+
     /// @notice Tests that lockbox custody bypasses a stale portal withdrawal throttle.
     function test_finalizeWithdrawalTransaction_lockboxUsesLockboxThrottle_succeeds() external {
         skipIfSysFeatureEnabled(Features.CUSTOM_GAS_TOKEN);

--- a/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
+++ b/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
@@ -36,6 +36,7 @@ import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.so
 import { IFaultDisputeGame } from "interfaces/dispute/IFaultDisputeGame.sol";
 import { IETHLockbox } from "interfaces/L1/IETHLockbox.sol";
 import { IProxyAdminOwnedBase } from "interfaces/universal/IProxyAdminOwnedBase.sol";
+import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
 
 abstract contract OptimismPortal2_TestInit is DisputeGameFactory_TestInit {
     address depositor;
@@ -207,6 +208,100 @@ abstract contract OptimismPortal2_TestInit is DisputeGameFactory_TestInit {
     function setUseCustomGasToken(bool _useCustomGasToken) public {
         vm.prank(address(proxyAdmin));
         systemConfig.setFeature(Features.CUSTOM_GAS_TOKEN, _useCustomGasToken);
+    }
+}
+
+/// @title OptimismPortal2_WithdrawalThrottle_TestInit
+/// @notice Reusable initialization for portal-held ETH withdrawal throttle tests.
+abstract contract OptimismPortal2_WithdrawalThrottle_TestInit is OptimismPortal2_TestInit {
+    uint16 internal constant WITHDRAWAL_MAX_BPS = 1000;
+    uint64 internal constant WITHDRAWAL_REFILL_PERIOD = 100;
+    uint256 internal constant WITHDRAWAL_STOCK = 1000;
+    uint256 internal constant WITHDRAWAL_CAPACITY = 100;
+
+    /// @notice Mocks direct portal ETH custody and funds its stock.
+    function _useDirectPortalCustody() internal {
+        vm.mockCall(
+            address(systemConfig),
+            abi.encodeCall(ISystemConfig.isFeatureEnabled, (Features.ETH_LOCKBOX)),
+            abi.encode(false)
+        );
+        vm.mockCall(
+            address(systemConfig),
+            abi.encodeCall(ISystemConfig.isFeatureEnabled, (Features.CUSTOM_GAS_TOKEN)),
+            abi.encode(false)
+        );
+        vm.deal(address(optimismPortal2), WITHDRAWAL_STOCK);
+    }
+
+    /// @notice Configures the direct-custody portal withdrawal throttle.
+    function _configurePortalWithdrawalThrottle(uint16 _maxBps) internal {
+        vm.prank(proxyAdminOwner);
+        optimismPortal2.setWithdrawalThrottle(_maxBps, WITHDRAWAL_REFILL_PERIOD);
+    }
+
+    /// @notice Proves the default withdrawal and advances it to finalizability.
+    function _prepareDefaultWithdrawal() internal {
+        optimismPortal2.proveWithdrawalTransaction({
+            _tx: _defaultTx,
+            _disputeGameIndex: _proposedGameIndex,
+            _outputRootProof: _outputRootProof,
+            _withdrawalProof: _withdrawalProof
+        });
+        game.resolveClaim(0, 0);
+        game.resolve();
+        vm.warp(block.timestamp + optimismPortal2.proofMaturityDelaySeconds() + 1 seconds);
+    }
+}
+
+/// @title OptimismPortal2_SetWithdrawalThrottle_Test
+/// @notice Tests the `setWithdrawalThrottle` function.
+contract OptimismPortal2_SetWithdrawalThrottle_Test is OptimismPortal2_WithdrawalThrottle_TestInit {
+    /// @notice Tests that configuration snapshots portal-held ETH and starts full.
+    function test_setWithdrawalThrottle_succeeds() external {
+        _useDirectPortalCustody();
+
+        vm.expectEmit(address(optimismPortal2));
+        emit WithdrawalThrottleConfigured(
+            WITHDRAWAL_MAX_BPS, WITHDRAWAL_REFILL_PERIOD, WITHDRAWAL_STOCK, WITHDRAWAL_CAPACITY, WITHDRAWAL_CAPACITY
+        );
+        _configurePortalWithdrawalThrottle(WITHDRAWAL_MAX_BPS);
+
+        assertEq(optimismPortal2.availableWithdrawalCapacity(), WITHDRAWAL_CAPACITY);
+    }
+
+    /// @notice Tests that lockbox deployments must configure throttling on the shared lockbox.
+    function test_setWithdrawalThrottle_usingLockbox_reverts() external {
+        forceEnableLockbox(address(ethLockbox));
+
+        vm.expectRevert(IOptimismPortal.OptimismPortal_WithdrawalThrottleManagedByLockbox.selector);
+        vm.prank(proxyAdminOwner);
+        optimismPortal2.setWithdrawalThrottle(WITHDRAWAL_MAX_BPS, WITHDRAWAL_REFILL_PERIOD);
+    }
+
+    /// @notice Tests that only the ProxyAdmin owner can configure the throttle.
+    function testFuzz_setWithdrawalThrottle_notProxyAdminOwner_reverts(address _caller) external {
+        _useDirectPortalCustody();
+        vm.assume(_caller != proxyAdminOwner);
+
+        vm.expectRevert(IProxyAdminOwnedBase.ProxyAdminOwnedBase_NotProxyAdminOwner.selector);
+        vm.prank(_caller);
+        optimismPortal2.setWithdrawalThrottle(WITHDRAWAL_MAX_BPS, WITHDRAWAL_REFILL_PERIOD);
+    }
+}
+
+/// @title OptimismPortal2_DisableWithdrawalThrottle_Test
+/// @notice Tests the `disableWithdrawalThrottle` function.
+contract OptimismPortal2_DisableWithdrawalThrottle_Test is OptimismPortal2_WithdrawalThrottle_TestInit {
+    /// @notice Tests that disabling restores unrestricted portal-held ETH withdrawals.
+    function test_disableWithdrawalThrottle_succeeds() external {
+        _useDirectPortalCustody();
+        _configurePortalWithdrawalThrottle(WITHDRAWAL_MAX_BPS);
+
+        vm.prank(proxyAdminOwner);
+        optimismPortal2.disableWithdrawalThrottle();
+
+        assertEq(optimismPortal2.availableWithdrawalCapacity(), type(uint256).max);
     }
 }
 
@@ -1298,7 +1393,7 @@ contract OptimismPortal2_ProveWithdrawalTransaction_Test is OptimismPortal2_Test
 
 /// @title OptimismPortal2_FinalizeWithdrawalTransaction_Test
 /// @notice Test contract for OptimismPortal2 `finalizeWithdrawalTransaction` function.
-contract OptimismPortal2_FinalizeWithdrawalTransaction_Test is OptimismPortal2_TestInit {
+contract OptimismPortal2_FinalizeWithdrawalTransaction_Test is OptimismPortal2_WithdrawalThrottle_TestInit {
     /// @notice Tests that `finalizeWithdrawalTransaction` reverts when the target is the portal
     ///         contract or the lockbox.
     function test_finalizeWithdrawalTransaction_badTarget_reverts() external {
@@ -2173,6 +2268,90 @@ contract OptimismPortal2_FinalizeWithdrawalTransaction_Test is OptimismPortal2_T
         vm.warp(block.timestamp + 1 seconds);
         optimismPortal2.finalizeWithdrawalTransaction(_defaultTx);
         assertTrue(optimismPortal2.finalizedWithdrawals(_withdrawalHash));
+    }
+
+    /// @notice Tests that direct portal-held ETH finalization consumes exact withdrawal capacity.
+    function test_finalizeWithdrawalTransaction_exactWithdrawalCapacity_succeeds() external {
+        skipIfSysFeatureEnabled(Features.CUSTOM_GAS_TOKEN);
+        _useDirectPortalCustody();
+        _configurePortalWithdrawalThrottle(WITHDRAWAL_MAX_BPS);
+        _prepareDefaultWithdrawal();
+
+        vm.expectEmit(address(optimismPortal2));
+        emit WithdrawalThrottleCapacityConsumed(WITHDRAWAL_CAPACITY, 0);
+        vm.expectEmit(address(optimismPortal2));
+        emit WithdrawalThrottleCapacityExhausted();
+        optimismPortal2.finalizeWithdrawalTransaction(_defaultTx);
+
+        assertTrue(optimismPortal2.finalizedWithdrawals(_withdrawalHash));
+        assertEq(optimismPortal2.availableWithdrawalCapacity(), 0);
+    }
+
+    /// @notice Tests that direct portal-held ETH finalization reverts above available capacity.
+    function test_finalizeWithdrawalTransaction_insufficientWithdrawalCapacity_reverts() external {
+        skipIfSysFeatureEnabled(Features.CUSTOM_GAS_TOKEN);
+        _useDirectPortalCustody();
+        _configurePortalWithdrawalThrottle(500);
+        _prepareDefaultWithdrawal();
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IOptimismPortal.OptimismPortal_WithdrawalThrottled.selector,
+                WITHDRAWAL_CAPACITY,
+                WITHDRAWAL_CAPACITY / 2,
+                WITHDRAWAL_CAPACITY / 2
+            )
+        );
+        optimismPortal2.finalizeWithdrawalTransaction(_defaultTx);
+
+        assertFalse(optimismPortal2.finalizedWithdrawals(_withdrawalHash));
+    }
+
+    /// @notice Tests that lockbox custody bypasses a stale portal withdrawal throttle.
+    function test_finalizeWithdrawalTransaction_lockboxUsesLockboxThrottle_succeeds() external {
+        skipIfSysFeatureEnabled(Features.CUSTOM_GAS_TOKEN);
+        _useDirectPortalCustody();
+        _configurePortalWithdrawalThrottle(500);
+        forceEnableLockbox(address(ethLockbox));
+        vm.deal(address(ethLockbox), WITHDRAWAL_STOCK);
+        vm.prank(proxyAdminOwner);
+        ethLockbox.setWithdrawalThrottle(2000, WITHDRAWAL_REFILL_PERIOD);
+        vm.mockCall(
+            address(systemConfig),
+            abi.encodeCall(ISystemConfig.isFeatureEnabled, (Features.ETH_LOCKBOX)),
+            abi.encode(true)
+        );
+        _prepareDefaultWithdrawal();
+
+        vm.expectEmit(address(ethLockbox));
+        emit WithdrawalThrottleCapacityConsumed(WITHDRAWAL_CAPACITY, WITHDRAWAL_CAPACITY);
+        optimismPortal2.finalizeWithdrawalTransaction(_defaultTx);
+
+        assertTrue(optimismPortal2.finalizedWithdrawals(_withdrawalHash));
+        assertEq(optimismPortal2.availableWithdrawalCapacity(), WITHDRAWAL_CAPACITY / 2);
+        assertEq(ethLockbox.availableWithdrawalCapacity(), WITHDRAWAL_CAPACITY);
+    }
+
+    /// @notice Tests that shared lockbox capacity throttles portal finalization.
+    function test_finalizeWithdrawalTransaction_lockboxInsufficientWithdrawalCapacity_reverts() external {
+        skipIfSysFeatureEnabled(Features.CUSTOM_GAS_TOKEN);
+        forceEnableLockbox(address(ethLockbox));
+        vm.deal(address(ethLockbox), WITHDRAWAL_STOCK);
+        vm.prank(proxyAdminOwner);
+        ethLockbox.setWithdrawalThrottle(500, WITHDRAWAL_REFILL_PERIOD);
+        _prepareDefaultWithdrawal();
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IETHLockbox.ETHLockbox_WithdrawalThrottled.selector,
+                WITHDRAWAL_CAPACITY,
+                WITHDRAWAL_CAPACITY / 2,
+                WITHDRAWAL_CAPACITY / 2
+            )
+        );
+        optimismPortal2.finalizeWithdrawalTransaction(_defaultTx);
+
+        assertFalse(optimismPortal2.finalizedWithdrawals(_withdrawalHash));
     }
 }
 

--- a/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
+++ b/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
@@ -267,6 +267,14 @@ contract OptimismPortal2_SetWithdrawalThrottle_Test is OptimismPortal2_Withdrawa
         );
         _configurePortalWithdrawalThrottle(WITHDRAWAL_MAX_BPS);
 
+        IOptimismPortal.WithdrawalThrottleConfig memory throttle = optimismPortal2.withdrawalThrottle();
+        assertEq(throttle.capacity, WITHDRAWAL_CAPACITY);
+        assertEq(throttle.available, WITHDRAWAL_CAPACITY);
+        assertEq(throttle.refillPeriod, WITHDRAWAL_REFILL_PERIOD);
+        assertEq(throttle.lastUpdated, block.timestamp);
+        assertEq(throttle.refillRemainder, 0);
+        assertEq(throttle.maxBps, WITHDRAWAL_MAX_BPS);
+        assertTrue(throttle.enabled);
         assertEq(optimismPortal2.availableWithdrawalCapacity(), WITHDRAWAL_CAPACITY);
     }
 
@@ -1394,6 +1402,56 @@ contract OptimismPortal2_ProveWithdrawalTransaction_Test is OptimismPortal2_Test
 /// @title OptimismPortal2_FinalizeWithdrawalTransaction_Test
 /// @notice Test contract for OptimismPortal2 `finalizeWithdrawalTransaction` function.
 contract OptimismPortal2_FinalizeWithdrawalTransaction_Test is OptimismPortal2_WithdrawalThrottle_TestInit {
+    /// @notice Returns the packed configuration and mutable bucket storage slots for a throttle.
+    function _withdrawalThrottleSlots(string memory _contractName)
+        internal
+        returns (bytes32 configSlot_, bytes32 bucketSlot_)
+    {
+        StorageSlot memory stateSlot = ForgeArtifacts.getSlot(_contractName, "_withdrawalThrottle");
+        configSlot_ = bytes32(stateSlot.slot);
+        bucketSlot_ = bytes32(stateSlot.slot + 1);
+    }
+
+    /// @notice Counts writes to the packed configuration and mutable bucket storage slots.
+    function _countWithdrawalThrottleWrites(
+        VmSafe.AccountAccess[] memory _accountAccesses,
+        address _account,
+        bytes32 _configSlot,
+        bytes32 _bucketSlot
+    )
+        internal
+        pure
+        returns (uint256 configWrites_, uint256 bucketWrites_)
+    {
+        for (uint256 i; i < _accountAccesses.length; i++) {
+            for (uint256 j; j < _accountAccesses[i].storageAccesses.length; j++) {
+                VmSafe.StorageAccess memory access = _accountAccesses[i].storageAccesses[j];
+                if (access.account == _account && access.isWrite) {
+                    if (access.slot == _configSlot) configWrites_++;
+                    if (access.slot == _bucketSlot) bucketWrites_++;
+                }
+            }
+        }
+    }
+
+    /// @notice Tests that consumption against unchanged stock writes only mutable bucket state.
+    function test_finalizeWithdrawalTransaction_unchangedStockOnlyWritesMutableThrottleState_succeeds() external {
+        skipIfSysFeatureEnabled(Features.CUSTOM_GAS_TOKEN);
+        _useDirectPortalCustody();
+        _configurePortalWithdrawalThrottle(2000);
+        _prepareDefaultWithdrawal();
+        (bytes32 configSlot, bytes32 bucketSlot) = _withdrawalThrottleSlots("OptimismPortal2");
+
+        vm.startStateDiffRecording();
+        optimismPortal2.finalizeWithdrawalTransaction(_defaultTx);
+        VmSafe.AccountAccess[] memory accountAccesses = vm.stopAndReturnStateDiff();
+
+        (uint256 configWrites, uint256 bucketWrites) =
+            _countWithdrawalThrottleWrites(accountAccesses, address(optimismPortal2), configSlot, bucketSlot);
+        assertEq(configWrites, 0);
+        assertEq(bucketWrites, 1);
+    }
+
     /// @notice Tests that `finalizeWithdrawalTransaction` reverts when the target is the portal
     ///         contract or the lockbox.
     function test_finalizeWithdrawalTransaction_badTarget_reverts() external {
@@ -2284,6 +2342,10 @@ contract OptimismPortal2_FinalizeWithdrawalTransaction_Test is OptimismPortal2_W
         optimismPortal2.finalizeWithdrawalTransaction(_defaultTx);
 
         assertTrue(optimismPortal2.finalizedWithdrawals(_withdrawalHash));
+        IOptimismPortal.WithdrawalThrottleConfig memory throttle = optimismPortal2.withdrawalThrottle();
+        assertEq(throttle.available, 0);
+        assertEq(throttle.lastUpdated, block.timestamp);
+        assertEq(throttle.refillRemainder, 0);
         assertEq(optimismPortal2.availableWithdrawalCapacity(), 0);
     }
 
@@ -2318,11 +2380,23 @@ contract OptimismPortal2_FinalizeWithdrawalTransaction_Test is OptimismPortal2_W
         _prepareDefaultWithdrawal();
         vm.expectEmit(address(optimismPortal2));
         emit WithdrawalThrottleRefreshed(2000, 200, WITHDRAWAL_CAPACITY);
-        optimismPortal2.finalizeWithdrawalTransaction(_defaultTx);
+        (bytes32 configSlot, bytes32 bucketSlot) = _withdrawalThrottleSlots("OptimismPortal2");
 
-        assertEq(optimismPortal2.withdrawalThrottle().capacity, 200);
+        vm.startStateDiffRecording();
+        optimismPortal2.finalizeWithdrawalTransaction(_defaultTx);
+        VmSafe.AccountAccess[] memory accountAccesses = vm.stopAndReturnStateDiff();
+
+        (uint256 configWrites, uint256 bucketWrites) =
+            _countWithdrawalThrottleWrites(accountAccesses, address(optimismPortal2), configSlot, bucketSlot);
+        assertEq(configWrites, 1);
+        assertEq(bucketWrites, 1);
+        IOptimismPortal.WithdrawalThrottleConfig memory throttle = optimismPortal2.withdrawalThrottle();
+        assertEq(throttle.capacity, 200);
+        assertEq(throttle.available, 0);
+        assertEq(throttle.lastUpdated, block.timestamp);
+        assertEq(throttle.refillRemainder, 0);
         vm.warp(block.timestamp + WITHDRAWAL_REFILL_PERIOD / 2);
-        assertEq(optimismPortal2.availableWithdrawalCapacity(), WITHDRAWAL_CAPACITY);
+        assertEq(optimismPortal2.availableWithdrawalCapacity(), 95);
     }
 
     /// @notice Tests that decreased direct ETH stock immediately clamps effective availability.
@@ -2336,9 +2410,21 @@ contract OptimismPortal2_FinalizeWithdrawalTransaction_Test is OptimismPortal2_W
         _prepareDefaultWithdrawal();
         vm.expectEmit(address(optimismPortal2));
         emit WithdrawalThrottleRefreshed(500, WITHDRAWAL_CAPACITY, WITHDRAWAL_CAPACITY);
-        optimismPortal2.finalizeWithdrawalTransaction(_defaultTx);
+        (bytes32 configSlot, bytes32 bucketSlot) = _withdrawalThrottleSlots("OptimismPortal2");
 
-        assertEq(optimismPortal2.withdrawalThrottle().capacity, WITHDRAWAL_CAPACITY);
+        vm.startStateDiffRecording();
+        optimismPortal2.finalizeWithdrawalTransaction(_defaultTx);
+        VmSafe.AccountAccess[] memory accountAccesses = vm.stopAndReturnStateDiff();
+
+        (uint256 configWrites, uint256 bucketWrites) =
+            _countWithdrawalThrottleWrites(accountAccesses, address(optimismPortal2), configSlot, bucketSlot);
+        assertEq(configWrites, 1);
+        assertEq(bucketWrites, 1);
+        IOptimismPortal.WithdrawalThrottleConfig memory throttle = optimismPortal2.withdrawalThrottle();
+        assertEq(throttle.capacity, WITHDRAWAL_CAPACITY);
+        assertEq(throttle.available, 0);
+        assertEq(throttle.lastUpdated, block.timestamp);
+        assertEq(throttle.refillRemainder, 0);
     }
 
     /// @notice Tests that lockbox custody bypasses a stale portal withdrawal throttle.
@@ -2994,5 +3080,121 @@ contract OptimismPortal2_Params_Test is CommonTest {
         bytes32 slot21After = vm.load(address(optimismPortal2), bytes32(uint256(21)));
         bytes32 slot21Expected = NextImpl(address(optimismPortal2)).slot21Init();
         assertEq(slot21Expected, slot21After);
+    }
+}
+
+/// @title OptimismPortal2_Gas_TestInit
+/// @notice Common cold-slot gas measurement helpers for direct and shared ETH finalization.
+abstract contract OptimismPortal2_Gas_TestInit is OptimismPortal2_WithdrawalThrottle_TestInit {
+    function _withdrawalThrottleSlots(string memory _contractName)
+        internal
+        returns (bytes32 configSlot_, bytes32 bucketSlot_)
+    {
+        StorageSlot memory stateSlot = ForgeArtifacts.getSlot(_contractName, "_withdrawalThrottle");
+        configSlot_ = bytes32(stateSlot.slot);
+        bucketSlot_ = bytes32(stateSlot.slot + 1);
+    }
+
+    function _coolPortalDependencies() internal {
+        address portalImplementation = EIP1967Helper.getImplementation(address(optimismPortal2));
+        address systemConfigImplementation = EIP1967Helper.getImplementation(address(systemConfig));
+        vm.cool(address(optimismPortal2));
+        vm.cool(portalImplementation);
+        vm.cool(address(systemConfig));
+        vm.cool(systemConfigImplementation);
+        vm.cool(address(anchorStateRegistry));
+        vm.cool(address(game));
+        vm.cool(bob);
+    }
+
+    function _measureDirectWithdrawal(string memory _snapshotName) internal {
+        (bytes32 configSlot, bytes32 bucketSlot) = _withdrawalThrottleSlots("OptimismPortal2");
+        _coolPortalDependencies();
+        vm.coolSlot(address(optimismPortal2), configSlot);
+        vm.coolSlot(address(optimismPortal2), bucketSlot);
+
+        optimismPortal2.finalizeWithdrawalTransaction(_defaultTx);
+        vm.snapshotGasLastCall("WithdrawalFinalizationGas", _snapshotName);
+    }
+
+    function _measureSharedWithdrawal(string memory _snapshotName) internal {
+        address lockboxImplementation = EIP1967Helper.getImplementation(address(ethLockbox));
+        (bytes32 configSlot, bytes32 bucketSlot) = _withdrawalThrottleSlots("ETHLockbox");
+        _coolPortalDependencies();
+        vm.cool(address(ethLockbox));
+        vm.cool(lockboxImplementation);
+        vm.coolSlot(address(ethLockbox), configSlot);
+        vm.coolSlot(address(ethLockbox), bucketSlot);
+
+        optimismPortal2.finalizeWithdrawalTransaction(_defaultTx);
+        vm.snapshotGasLastCall("WithdrawalFinalizationGas", _snapshotName);
+    }
+}
+
+/// @title OptimismPortal2_FinalizeWithdrawalTransaction_GasDisabled_Test
+/// @notice Measures direct ETH finalization with committed unconfigured throttle storage.
+contract OptimismPortal2_FinalizeWithdrawalTransaction_GasDisabled_Test is OptimismPortal2_Gas_TestInit {
+    function setUp() public override {
+        super.setUp();
+        skipIfSysFeatureEnabled(Features.CUSTOM_GAS_TOKEN);
+        _useDirectPortalCustody();
+        vm.deal(address(optimismPortal2), WITHDRAWAL_STOCK * 2);
+        _prepareDefaultWithdrawal();
+    }
+
+    function test_finalizeWithdrawalTransaction_throttleDisabledGas_benchmark() external {
+        _measureDirectWithdrawal("optimism-portal-unthrottled");
+    }
+}
+
+/// @title OptimismPortal2_FinalizeWithdrawalTransaction_GasEnabled_Test
+/// @notice Measures capacity-changing direct ETH throttling from committed storage.
+contract OptimismPortal2_FinalizeWithdrawalTransaction_GasEnabled_Test is OptimismPortal2_Gas_TestInit {
+    function setUp() public override {
+        super.setUp();
+        skipIfSysFeatureEnabled(Features.CUSTOM_GAS_TOKEN);
+        _useDirectPortalCustody();
+        _configurePortalWithdrawalThrottle(2000);
+        vm.deal(address(optimismPortal2), WITHDRAWAL_STOCK * 2);
+        _prepareDefaultWithdrawal();
+    }
+
+    function test_finalizeWithdrawalTransaction_throttleEnabledGas_benchmark() external {
+        _measureDirectWithdrawal("optimism-portal-throttled");
+    }
+}
+
+/// @title OptimismPortal2_FinalizeWithdrawalTransaction_SharedGasDisabled_Test
+/// @notice Measures shared-lockbox ETH finalization with committed unconfigured throttle storage.
+contract OptimismPortal2_FinalizeWithdrawalTransaction_SharedGasDisabled_Test is OptimismPortal2_Gas_TestInit {
+    function setUp() public override {
+        super.setUp();
+        skipIfSysFeatureEnabled(Features.CUSTOM_GAS_TOKEN);
+        forceEnableLockbox(address(ethLockbox));
+        vm.deal(address(ethLockbox), WITHDRAWAL_STOCK * 2);
+        _prepareDefaultWithdrawal();
+    }
+
+    function test_finalizeWithdrawalTransaction_lockboxThrottleDisabledGas_benchmark() external {
+        _measureSharedWithdrawal("eth-lockbox-shared-unthrottled");
+    }
+}
+
+/// @title OptimismPortal2_FinalizeWithdrawalTransaction_SharedGasEnabled_Test
+/// @notice Measures capacity-changing shared-lockbox ETH throttling from committed storage.
+contract OptimismPortal2_FinalizeWithdrawalTransaction_SharedGasEnabled_Test is OptimismPortal2_Gas_TestInit {
+    function setUp() public override {
+        super.setUp();
+        skipIfSysFeatureEnabled(Features.CUSTOM_GAS_TOKEN);
+        forceEnableLockbox(address(ethLockbox));
+        vm.deal(address(ethLockbox), WITHDRAWAL_STOCK);
+        vm.prank(proxyAdminOwner);
+        ethLockbox.setWithdrawalThrottle(2000, WITHDRAWAL_REFILL_PERIOD);
+        vm.deal(address(ethLockbox), WITHDRAWAL_STOCK * 2);
+        _prepareDefaultWithdrawal();
+    }
+
+    function test_finalizeWithdrawalTransaction_lockboxThrottleEnabledGas_benchmark() external {
+        _measureSharedWithdrawal("eth-lockbox-shared-throttled");
     }
 }

--- a/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
@@ -36,6 +36,7 @@ import { IDisputeGameFactory } from "interfaces/dispute/IDisputeGameFactory.sol"
 import { IDelayedWETH } from "interfaces/dispute/IDelayedWETH.sol";
 import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.sol";
 import { IETHLockbox } from "interfaces/L1/IETHLockbox.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 /// @title OPContractsManagerV2_TestInit
 /// @notice Base test initialization contract for OPContractsManagerV2.
@@ -2385,6 +2386,213 @@ contract OPContractsManagerV2_DevFeatureBitmap_Test is OPContractsManagerV2_Test
     }
 }
 
+/// @title OPContractsManagerV2_Upgrade_WithdrawalThrottle_Test
+/// @notice Tests withdrawal throttle upgrade instructions.
+contract OPContractsManagerV2_Upgrade_WithdrawalThrottle_Test is OPContractsManagerV2_TestInit {
+    /// @notice Skips fork tests because these cases exercise a locally deployed OPCM chain.
+    function setUp() public override {
+        super.setUp();
+        skipIfForkTest("Withdrawal throttle instruction tests use local deployments");
+    }
+
+    /// @notice Builds the current chain's dispute game configuration for an OPCM upgrade.
+    function _upgradeGameConfigs()
+        internal
+        view
+        returns (IOPContractsManagerUtils.DisputeGameConfig[] memory configs_)
+    {
+        bool superRoot = GameTypes.isSuperGame(anchorStateRegistry.respectedGameType());
+        configs_ = new IOPContractsManagerUtils.DisputeGameConfig[](6);
+        configs_[0] = IOPContractsManagerUtils.DisputeGameConfig({
+            enabled: false,
+            initBond: 0,
+            gameType: GameTypes.CANNON,
+            gameArgs: bytes("")
+        });
+        configs_[1] = IOPContractsManagerUtils.DisputeGameConfig({
+            enabled: !superRoot,
+            initBond: superRoot ? 0 : disputeGameFactory.initBonds(GameTypes.PERMISSIONED_CANNON),
+            gameType: GameTypes.PERMISSIONED_CANNON,
+            gameArgs: superRoot
+                ? bytes("")
+                : abi.encode(
+                    IOPContractsManagerUtils.PermissionedDisputeGameConfig({
+                        absolutePrestate: cannonPrestate,
+                        proposer: DisputeGames.permissionedGameProposer(disputeGameFactory),
+                        challenger: DisputeGames.permissionedGameChallenger(disputeGameFactory)
+                    })
+                )
+        });
+        configs_[2] = IOPContractsManagerUtils.DisputeGameConfig({
+            enabled: false,
+            initBond: 0,
+            gameType: GameTypes.CANNON_KONA,
+            gameArgs: bytes("")
+        });
+        configs_[3] = IOPContractsManagerUtils.DisputeGameConfig({
+            enabled: superRoot,
+            initBond: 0,
+            gameType: GameTypes.SUPER_PERMISSIONED,
+            gameArgs: superRoot
+                ? abi.encode(
+                    IOPContractsManagerUtils.SuperPermissionedDisputeGameConfig({
+                        proposer: DisputeGames.permissionedGameProposer(disputeGameFactory)
+                    })
+                )
+                : bytes("")
+        });
+        configs_[4] = IOPContractsManagerUtils.DisputeGameConfig({
+            enabled: false,
+            initBond: 0,
+            gameType: GameTypes.SUPER_CANNON_KONA,
+            gameArgs: bytes("")
+        });
+        configs_[5] = IOPContractsManagerUtils.DisputeGameConfig({
+            enabled: false,
+            initBond: 0,
+            gameType: GameTypes.ZK_DISPUTE_GAME,
+            gameArgs: bytes("")
+        });
+    }
+
+    /// @notice Builds a withdrawal throttle instruction.
+    function _instruction(IOPContractsManagerUtils.WithdrawalThrottleConfig[] memory _configs)
+        internal
+        pure
+        returns (IOPContractsManagerUtils.ExtraInstruction[] memory instructions_)
+    {
+        instructions_ = new IOPContractsManagerUtils.ExtraInstruction[](1);
+        instructions_[0] = IOPContractsManagerUtils.ExtraInstruction({
+            key: Constants.WITHDRAWAL_THROTTLE_CONFIG_KEY,
+            data: abi.encode(_configs)
+        });
+    }
+
+    /// @notice Executes a chain upgrade with the supplied withdrawal throttle configs.
+    function _upgrade(IOPContractsManagerUtils.WithdrawalThrottleConfig[] memory _configs)
+        internal
+        returns (bool success_, bytes memory reason_)
+    {
+        IOPContractsManagerV2.UpgradeInput memory input = IOPContractsManagerV2.UpgradeInput({
+            systemConfig: systemConfig,
+            disputeGameConfigs: _upgradeGameConfigs(),
+            extraInstructions: _instruction(_configs)
+        });
+        prankDelegateCall(proxyAdminOwner);
+        (success_, reason_) = address(opcmV2).delegatecall(abi.encodeCall(IOPContractsManagerV2.upgrade, (input)));
+    }
+
+    /// @notice Tests that a feature-enabled instruction configures ERC20 and direct ETH buckets once.
+    function test_upgrade_withdrawalThrottleInstruction_succeeds() external {
+        skipIfDevFeatureDisabled(DevFeatures.WITHDRAWAL_THROTTLE);
+        skipIfSysFeatureEnabled(Features.CUSTOM_GAS_TOKEN);
+        skipIfSysFeatureEnabled(Features.ETH_LOCKBOX);
+
+        vm.mockCall(
+            address(L1Token), abi.encodeCall(IERC20.balanceOf, (address(l1StandardBridge))), abi.encode(uint256(1000))
+        );
+        vm.deal(address(optimismPortal2), 2000);
+
+        IOPContractsManagerUtils.WithdrawalThrottleConfig[] memory configs =
+            new IOPContractsManagerUtils.WithdrawalThrottleConfig[](2);
+        configs[0] = IOPContractsManagerUtils.WithdrawalThrottleConfig({
+            token: address(L1Token),
+            maxBps: 1000,
+            refillPeriod: 100
+        });
+        configs[1] =
+            IOPContractsManagerUtils.WithdrawalThrottleConfig({ token: address(0), maxBps: 1000, refillPeriod: 100 });
+
+        (bool success,) = _upgrade(configs);
+        assertTrue(success, "upgrade failed");
+        assertEq(l1StandardBridge.withdrawalThrottle(address(L1Token)).capacity, 100);
+        assertEq(optimismPortal2.availableWithdrawalCapacity(), 200);
+
+        vm.mockCall(
+            address(L1Token), abi.encodeCall(IERC20.balanceOf, (address(l1StandardBridge))), abi.encode(uint256(2000))
+        );
+        vm.deal(address(optimismPortal2), 4000);
+        (success,) = _upgrade(configs);
+        assertTrue(success, "repeat upgrade failed");
+        assertEq(l1StandardBridge.withdrawalThrottle(address(L1Token)).capacity, 100);
+        assertEq(optimismPortal2.availableWithdrawalCapacity(), 200);
+    }
+
+    /// @notice Tests that the instruction is rejected when its development feature is disabled.
+    function test_upgrade_withdrawalThrottleFeatureDisabled_reverts() external {
+        skipIfDevFeatureEnabled(DevFeatures.WITHDRAWAL_THROTTLE);
+
+        IOPContractsManagerUtils.WithdrawalThrottleConfig[] memory configs =
+            new IOPContractsManagerUtils.WithdrawalThrottleConfig[](1);
+        configs[0] = IOPContractsManagerUtils.WithdrawalThrottleConfig({
+            token: address(L1Token),
+            maxBps: 1000,
+            refillPeriod: 100
+        });
+
+        (bool success, bytes memory reason) = _upgrade(configs);
+        assertFalse(success);
+        assertEq(bytes4(reason), IOPContractsManagerV2.OPContractsManagerV2_InvalidUpgradeInstruction.selector);
+    }
+
+    /// @notice Tests that custom gas token chains reject an ETH throttle entry.
+    function test_upgrade_customGasTokenETHThrottle_reverts() external {
+        skipIfDevFeatureDisabled(DevFeatures.WITHDRAWAL_THROTTLE);
+        skipIfSysFeatureDisabled(Features.CUSTOM_GAS_TOKEN);
+
+        IOPContractsManagerUtils.WithdrawalThrottleConfig[] memory configs =
+            new IOPContractsManagerUtils.WithdrawalThrottleConfig[](1);
+        configs[0] =
+            IOPContractsManagerUtils.WithdrawalThrottleConfig({ token: address(0), maxBps: 1000, refillPeriod: 100 });
+
+        (bool success, bytes memory reason) = _upgrade(configs);
+        assertFalse(success);
+        assertEq(bytes4(reason), IOPContractsManagerV2.OPContractsManagerV2_InvalidWithdrawalThrottleConfig.selector);
+    }
+
+    /// @notice Tests that an active lockbox is configured once and exact replays preserve its capacity.
+    function test_upgrade_activeLockboxETHThrottle_succeeds() external {
+        skipIfDevFeatureDisabled(DevFeatures.WITHDRAWAL_THROTTLE);
+        skipIfSysFeatureDisabled(Features.ETH_LOCKBOX);
+
+        vm.deal(address(ethLockbox), 2000);
+
+        IOPContractsManagerUtils.WithdrawalThrottleConfig[] memory configs =
+            new IOPContractsManagerUtils.WithdrawalThrottleConfig[](1);
+        configs[0] =
+            IOPContractsManagerUtils.WithdrawalThrottleConfig({ token: address(0), maxBps: 1000, refillPeriod: 100 });
+
+        (bool success,) = _upgrade(configs);
+        assertTrue(success, "upgrade failed");
+        assertEq(ethLockbox.withdrawalThrottle().capacity, 200);
+
+        vm.deal(address(ethLockbox), 4000);
+        (success,) = _upgrade(configs);
+        assertTrue(success, "repeat upgrade failed");
+        assertEq(ethLockbox.withdrawalThrottle().capacity, 200);
+    }
+
+    /// @notice Tests that an instruction cannot silently replace a different existing configuration.
+    function test_upgrade_conflictingWithdrawalThrottle_reverts() external {
+        skipIfDevFeatureDisabled(DevFeatures.WITHDRAWAL_THROTTLE);
+        skipIfSysFeatureEnabled(Features.CUSTOM_GAS_TOKEN);
+        skipIfSysFeatureEnabled(Features.ETH_LOCKBOX);
+
+        vm.deal(address(optimismPortal2), 2000);
+        vm.prank(proxyAdminOwner);
+        optimismPortal2.setWithdrawalThrottle(500, 100);
+
+        IOPContractsManagerUtils.WithdrawalThrottleConfig[] memory configs =
+            new IOPContractsManagerUtils.WithdrawalThrottleConfig[](1);
+        configs[0] =
+            IOPContractsManagerUtils.WithdrawalThrottleConfig({ token: address(0), maxBps: 1000, refillPeriod: 100 });
+
+        (bool success, bytes memory reason) = _upgrade(configs);
+        assertFalse(success);
+        assertEq(bytes4(reason), IOPContractsManagerV2.OPContractsManagerV2_WithdrawalThrottleConfigConflict.selector);
+    }
+}
+
 /// @title OPContractsManagerV2_Migrate_Test
 /// @notice Tests the `migrate` function of the `OPContractsManagerV2` contract.
 contract OPContractsManagerV2_Migrate_Test is OPContractsManagerV2_TestInit {
@@ -2638,6 +2846,44 @@ contract OPContractsManagerV2_Migrate_Test is OPContractsManagerV2_TestInit {
         assertLt(gasBefore - gasAfter, 20_000_000, "Gas usage too high");
     }
 
+    /// @notice Executes a migration with one-off instructions.
+    function _doMigrationWithInstructions(
+        IOPContractsManagerMigrator.MigrateInput memory _input,
+        IOPContractsManagerUtils.ExtraInstruction[] memory _extraInstructions,
+        bytes4 _revertSelector
+    )
+        internal
+    {
+        address proxyAdminOwner = chainContracts1.proxyAdmin.owner();
+        prankDelegateCall(proxyAdminOwner);
+        (bool success, bytes memory reason) = address(opcmV2).delegatecall(
+            abi.encodeCall(IOPContractsManagerV2.migrateWithInstructions, (_input, _extraInstructions))
+        );
+        if (_revertSelector == bytes4(0)) {
+            assertTrue(success, "migration with instructions failed");
+        } else {
+            assertFalse(success, "migration with instructions succeeded");
+            assertEq(bytes4(reason), _revertSelector);
+        }
+    }
+
+    /// @notice Builds one shared ETH withdrawal throttle instruction.
+    function _sharedETHWithdrawalThrottleInstruction()
+        internal
+        pure
+        returns (IOPContractsManagerUtils.ExtraInstruction[] memory instructions_)
+    {
+        IOPContractsManagerUtils.WithdrawalThrottleConfig[] memory configs =
+            new IOPContractsManagerUtils.WithdrawalThrottleConfig[](1);
+        configs[0] =
+            IOPContractsManagerUtils.WithdrawalThrottleConfig({ token: address(0), maxBps: 1000, refillPeriod: 100 });
+        instructions_ = new IOPContractsManagerUtils.ExtraInstruction[](1);
+        instructions_[0] = IOPContractsManagerUtils.ExtraInstruction({
+            key: Constants.WITHDRAWAL_THROTTLE_CONFIG_KEY,
+            data: abi.encode(configs)
+        });
+    }
+
     /// @notice Helper function to enable a chain's existing per-chain ETHLockbox before migration.
     /// @param _cts The chain contracts to update.
     function _enableEthLockbox(IOPContractsManagerV2.ChainContracts memory _cts) internal {
@@ -2687,6 +2933,39 @@ contract OPContractsManagerV2_Migrate_Test is OPContractsManagerV2_TestInit {
         IOPContractsManagerMigrator.MigrateInput memory input = _getDefaultMigrateInput();
         vm.expectRevert(IOPContractsManagerV2.OPContractsManagerV2_OnlyDelegateCall.selector);
         opcmV2.migrate(input);
+    }
+
+    /// @notice Tests that migration instructions require the withdrawal throttle feature.
+    function test_migrateWithInstructions_withdrawalThrottleFeatureDisabled_reverts() public {
+        skipIfDevFeatureEnabled(DevFeatures.WITHDRAWAL_THROTTLE);
+        _doMigrationWithInstructions(
+            _getDefaultMigrateInput(),
+            _sharedETHWithdrawalThrottleInstruction(),
+            IOPContractsManagerMigrator.OPContractsManagerMigrator_InvalidMigrationInstruction.selector
+        );
+    }
+
+    /// @notice Tests that shared ETH capacity snapshots aggregate liquidity exactly once.
+    function test_migrateWithInstructions_sharedETHWithdrawalThrottle_succeeds() public {
+        skipIfDevFeatureDisabled(DevFeatures.WITHDRAWAL_THROTTLE);
+        _enableEthLockboxes();
+
+        IOptimismPortal2 portal1 = IOptimismPortal2(payable(chainContracts1.systemConfig.optimismPortal()));
+        IOptimismPortal2 portal2 = IOptimismPortal2(payable(chainContracts2.systemConfig.optimismPortal()));
+        vm.deal(address(portal1), 10 ether);
+        vm.deal(address(portal2), 5 ether);
+        vm.deal(address(chainContracts1.ethLockbox), 3 ether);
+        vm.deal(address(chainContracts2.ethLockbox), 2 ether);
+
+        _doMigrationWithInstructions(_getDefaultMigrateInput(), _sharedETHWithdrawalThrottleInstruction(), bytes4(0));
+
+        IETHLockbox sharedLockbox = portal1.ethLockbox();
+        IETHLockbox.WithdrawalThrottleConfig memory throttle = sharedLockbox.withdrawalThrottle();
+        assertEq(address(sharedLockbox).balance, 20 ether);
+        assertEq(throttle.capacity, 2 ether);
+        assertEq(throttle.available, 2 ether);
+        assertTrue(throttle.enabled);
+        assertEq(address(portal2.ethLockbox()), address(sharedLockbox));
     }
 
     /// @notice Tests that upgrade re-points the shared dispute games of a migrated interop set.

--- a/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
@@ -2401,27 +2401,32 @@ contract OPContractsManagerV2_Upgrade_WithdrawalThrottle_Test is OPContractsMana
         view
         returns (IOPContractsManagerUtils.DisputeGameConfig[] memory configs_)
     {
-        bool superRoot = GameTypes.isSuperGame(anchorStateRegistry.respectedGameType());
+        GameType respectedGameType = anchorStateRegistry.respectedGameType();
+        bool cannon = respectedGameType.raw() == GameTypes.CANNON.raw();
+        bool permissionedCannon = respectedGameType.raw() == GameTypes.PERMISSIONED_CANNON.raw();
+        bool superPermissioned = respectedGameType.raw() == GameTypes.SUPER_PERMISSIONED.raw();
         configs_ = new IOPContractsManagerUtils.DisputeGameConfig[](6);
         configs_[0] = IOPContractsManagerUtils.DisputeGameConfig({
-            enabled: false,
-            initBond: 0,
+            enabled: cannon,
+            initBond: cannon ? DEFAULT_DISPUTE_GAME_INIT_BOND : 0,
             gameType: GameTypes.CANNON,
-            gameArgs: bytes("")
+            gameArgs: cannon
+                ? abi.encode(IOPContractsManagerUtils.FaultDisputeGameConfig({ absolutePrestate: cannonPrestate }))
+                : bytes("")
         });
         configs_[1] = IOPContractsManagerUtils.DisputeGameConfig({
-            enabled: !superRoot,
-            initBond: superRoot ? 0 : disputeGameFactory.initBonds(GameTypes.PERMISSIONED_CANNON),
+            enabled: permissionedCannon,
+            initBond: permissionedCannon ? DEFAULT_DISPUTE_GAME_INIT_BOND : 0,
             gameType: GameTypes.PERMISSIONED_CANNON,
-            gameArgs: superRoot
-                ? bytes("")
-                : abi.encode(
+            gameArgs: permissionedCannon
+                ? abi.encode(
                     IOPContractsManagerUtils.PermissionedDisputeGameConfig({
                         absolutePrestate: cannonPrestate,
                         proposer: DisputeGames.permissionedGameProposer(disputeGameFactory),
                         challenger: DisputeGames.permissionedGameChallenger(disputeGameFactory)
                     })
                 )
+                : bytes("")
         });
         configs_[2] = IOPContractsManagerUtils.DisputeGameConfig({
             enabled: false,
@@ -2430,10 +2435,10 @@ contract OPContractsManagerV2_Upgrade_WithdrawalThrottle_Test is OPContractsMana
             gameArgs: bytes("")
         });
         configs_[3] = IOPContractsManagerUtils.DisputeGameConfig({
-            enabled: superRoot,
+            enabled: superPermissioned,
             initBond: 0,
             gameType: GameTypes.SUPER_PERMISSIONED,
-            gameArgs: superRoot
+            gameArgs: superPermissioned
                 ? abi.encode(
                     IOPContractsManagerUtils.SuperPermissionedDisputeGameConfig({
                         proposer: DisputeGames.permissionedGameProposer(disputeGameFactory)

--- a/packages/contracts-bedrock/test/libraries/WithdrawalThrottle.t.sol
+++ b/packages/contracts-bedrock/test/libraries/WithdrawalThrottle.t.sol
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+// Testing
+import { Test } from "test/setup/Test.sol";
+
+// Libraries
+import { WithdrawalThrottle } from "src/libraries/WithdrawalThrottle.sol";
+
+/// @title WithdrawalThrottle_Harness
+/// @notice Exposes internal `WithdrawalThrottle` functions for testing.
+contract WithdrawalThrottle_Harness {
+    function capacity(uint256 _stock, uint16 _maxBps) external pure returns (uint128) {
+        return WithdrawalThrottle.capacity(_stock, _maxBps);
+    }
+
+    function config(
+        uint128 _capacity,
+        uint64 _refillPeriod,
+        uint16 _maxBps,
+        bool _enabled
+    )
+        external
+        pure
+        returns (uint256)
+    {
+        return WithdrawalThrottle.config(_capacity, _refillPeriod, _maxBps, _enabled);
+    }
+
+    function capacity(uint256 _config) external pure returns (uint128) {
+        return WithdrawalThrottle.capacity(_config);
+    }
+
+    function refillPeriod(uint256 _config) external pure returns (uint64) {
+        return WithdrawalThrottle.refillPeriod(_config);
+    }
+
+    function maxBps(uint256 _config) external pure returns (uint16) {
+        return WithdrawalThrottle.maxBps(_config);
+    }
+
+    function enabled(uint256 _config) external pure returns (bool) {
+        return WithdrawalThrottle.enabled(_config);
+    }
+
+    function bucket(uint128 _available, uint64 _lastUpdated, uint64 _refillRemainder) external pure returns (uint256) {
+        return WithdrawalThrottle.bucket(_available, _lastUpdated, _refillRemainder);
+    }
+
+    function storedAvailable(uint256 _bucket) external pure returns (uint128) {
+        return WithdrawalThrottle.storedAvailable(_bucket);
+    }
+
+    function lastUpdated(uint256 _bucket) external pure returns (uint64) {
+        return WithdrawalThrottle.lastUpdated(_bucket);
+    }
+
+    function refillRemainder(uint256 _bucket) external pure returns (uint64) {
+        return WithdrawalThrottle.refillRemainder(_bucket);
+    }
+
+    function timestamp(uint256 _timestamp) external pure returns (uint64) {
+        return WithdrawalThrottle.timestamp(_timestamp);
+    }
+
+    function available(
+        uint128 _capacity,
+        uint256 _bucket,
+        uint64 _refillPeriod,
+        uint256 _timestamp
+    )
+        external
+        pure
+        returns (uint128, uint64)
+    {
+        return WithdrawalThrottle.available(_capacity, _bucket, _refillPeriod, _timestamp);
+    }
+
+    function sync(
+        uint128 _oldCapacity,
+        uint256 _bucket,
+        uint64 _refillPeriod,
+        uint128 _newCapacity,
+        uint256 _timestamp
+    )
+        external
+        pure
+        returns (uint128, uint64)
+    {
+        return WithdrawalThrottle.sync(_oldCapacity, _bucket, _refillPeriod, _newCapacity, _timestamp);
+    }
+}
+
+/// @title WithdrawalThrottle_TestInit
+/// @notice Reusable initialization for `WithdrawalThrottle` tests.
+abstract contract WithdrawalThrottle_TestInit is Test {
+    WithdrawalThrottle_Harness internal harness;
+
+    function setUp() public {
+        harness = new WithdrawalThrottle_Harness();
+    }
+}
+
+/// @title WithdrawalThrottle_Config_Test
+/// @notice Tests packed withdrawal throttle configuration.
+contract WithdrawalThrottle_Config_Test is WithdrawalThrottle_TestInit {
+    function test_config_packsAndDecodesFields_succeeds() external view {
+        uint128 capacity = type(uint128).max;
+        uint64 refillPeriod = type(uint64).max;
+        uint16 maxBps = 10_000;
+        uint256 config = harness.config(capacity, refillPeriod, maxBps, true);
+        uint256 expected = uint256(capacity) | uint256(refillPeriod) << 128 | uint256(maxBps) << 192 | uint256(1) << 208;
+
+        assertEq(config, expected);
+        assertEq(harness.capacity(config), capacity);
+        assertEq(harness.refillPeriod(config), refillPeriod);
+        assertEq(harness.maxBps(config), maxBps);
+        assertTrue(harness.enabled(config));
+        assertFalse(harness.enabled(harness.config(capacity, refillPeriod, maxBps, false)));
+    }
+}
+
+/// @title WithdrawalThrottle_Bucket_Test
+/// @notice Tests packed mutable bucket accounting.
+contract WithdrawalThrottle_Bucket_Test is WithdrawalThrottle_TestInit {
+    function test_bucket_packsAndDecodesFields_succeeds() external view {
+        uint128 available = type(uint128).max;
+        uint64 lastUpdated = type(uint64).max;
+        uint64 refillRemainder = type(uint64).max;
+        uint256 bucket = harness.bucket(available, lastUpdated, refillRemainder);
+
+        assertEq(bucket, type(uint256).max);
+        assertEq(harness.storedAvailable(bucket), available);
+        assertEq(harness.lastUpdated(bucket), lastUpdated);
+        assertEq(harness.refillRemainder(bucket), refillRemainder);
+    }
+}
+
+/// @title WithdrawalThrottle_Capacity_Test
+/// @notice Tests percentage capacity calculations.
+contract WithdrawalThrottle_Capacity_Test is WithdrawalThrottle_TestInit {
+    function test_capacity_preservesIntegerPrecision_succeeds() external view {
+        assertEq(harness.capacity(12_345, 1234), 1523);
+    }
+
+    function test_capacity_uint128BoundaryIsExact_succeeds() external view {
+        assertEq(harness.capacity(type(uint128).max, 10_000), type(uint128).max);
+    }
+
+    function test_capacity_aboveUint128Saturates_succeeds() external view {
+        assertEq(harness.capacity(uint256(type(uint128).max) + 1, 10_000), type(uint128).max);
+    }
+
+    function test_capacity_hugeStockSaturatesWithoutOverflow_succeeds() external view {
+        assertEq(harness.capacity(type(uint256).max, 9999), type(uint128).max);
+    }
+}
+
+/// @title WithdrawalThrottle_Available_Test
+/// @notice Tests exact fractional refills.
+contract WithdrawalThrottle_Available_Test is WithdrawalThrottle_TestInit {
+    function test_available_preservesExactFractionalRefill_succeeds() external view {
+        uint64 refillPeriod = 3;
+        uint256 timestamp = 1000;
+        uint256 bucket = harness.bucket(0, uint64(timestamp), 0);
+
+        (uint128 available, uint64 remainder) = harness.available(100, bucket, refillPeriod, timestamp + 1);
+        assertEq(available, 33);
+        assertEq(remainder, 1);
+
+        bucket = harness.bucket(available, uint64(timestamp + 1), remainder);
+        (available, remainder) = harness.available(100, bucket, refillPeriod, timestamp + 2);
+        assertEq(available, 66);
+        assertEq(remainder, 2);
+
+        bucket = harness.bucket(available, uint64(timestamp + 2), remainder);
+        (available, remainder) = harness.available(100, bucket, refillPeriod, timestamp + 3);
+        assertEq(available, 100);
+        assertEq(remainder, 0);
+    }
+}
+
+/// @title WithdrawalThrottle_Sync_Test
+/// @notice Tests capacity snapshot synchronization.
+contract WithdrawalThrottle_Sync_Test is WithdrawalThrottle_TestInit {
+    function test_sync_capacityGrowthPreservesAccruedAvailability_succeeds() external view {
+        uint256 bucket = harness.bucket(0, 1000, 0);
+
+        (uint128 available, uint64 remainder) = harness.sync(100, bucket, 3, 200, 1001);
+        assertEq(available, 33);
+        assertEq(remainder, 1);
+    }
+
+    function test_sync_capacityReductionUsesLowerRefillRate_succeeds() external view {
+        uint256 bucket = harness.bucket(0, 1000, 0);
+
+        (uint128 available, uint64 remainder) = harness.sync(100, bucket, 3, 50, 1002);
+        assertEq(available, 33);
+        assertEq(remainder, 1);
+    }
+
+    function test_sync_saturatedCapacityReductionClamps_succeeds() external view {
+        uint128 saturatedCapacity = harness.capacity(type(uint256).max, 10_000);
+        uint256 bucket = harness.bucket(saturatedCapacity, 1000, type(uint64).max);
+
+        (uint128 available, uint64 remainder) = harness.sync(saturatedCapacity, bucket, 1, 123, 1000);
+        assertEq(available, 123);
+        assertEq(remainder, 0);
+    }
+}
+
+/// @title WithdrawalThrottle_Timestamp_Test
+/// @notice Tests checked timestamp narrowing.
+contract WithdrawalThrottle_Timestamp_Test is WithdrawalThrottle_TestInit {
+    function test_timestamp_uint64BoundaryIsExact_succeeds() external view {
+        assertEq(harness.timestamp(type(uint64).max), type(uint64).max);
+    }
+
+    function test_timestamp_aboveUint64_reverts() external {
+        vm.expectRevert(WithdrawalThrottle.WithdrawalThrottle_TimestampOverflow.selector);
+        harness.timestamp(uint256(type(uint64).max) + 1);
+    }
+}

--- a/packages/contracts-bedrock/test/opcm/InteropMigration.t.sol
+++ b/packages/contracts-bedrock/test/opcm/InteropMigration.t.sol
@@ -74,6 +74,16 @@ contract InteropMigrationInput_Test is Test {
         assertEq(storedInput, abi.encode(migrateInput));
     }
 
+    function test_setExtraInstructions_succeeds() public {
+        IOPContractsManagerUtils.ExtraInstruction[] memory extraInstructions =
+            new IOPContractsManagerUtils.ExtraInstruction[](1);
+        extraInstructions[0] = IOPContractsManagerUtils.ExtraInstruction({ key: "test", data: hex"deadbeef" });
+
+        input.set(input.extraInstructions.selector, extraInstructions);
+
+        assertEq(input.extraInstructions(), abi.encode(extraInstructions));
+    }
+
     function test_setAddress_withZeroAddress_reverts() public {
         vm.expectRevert("InteropMigrationInput: cannot set zero address");
         input.set(input.prank.selector, address(0));
@@ -90,13 +100,30 @@ contract InteropMigrationInput_Test is Test {
 
 contract MockOPCM {
     event MigrateV2Called(address indexed sysCfg, uint32 indexed gameType);
+    event MigrateWithInstructionsCalled(
+        address indexed sysCfg, uint32 indexed gameType, string instructionKey, bytes instructionData
+    );
 
     function version() public pure returns (string memory) {
-        return "7.0.0";
+        return "8.0.4";
     }
 
     function migrate(IOPContractsManagerMigrator.MigrateInput memory _input) public {
         emit MigrateV2Called(address(_input.chainSystemConfigs[0]), GameType.unwrap(_input.startingRespectedGameType));
+    }
+
+    function migrateWithInstructions(
+        IOPContractsManagerMigrator.MigrateInput memory _input,
+        IOPContractsManagerUtils.ExtraInstruction[] memory _extraInstructions
+    )
+        public
+    {
+        emit MigrateWithInstructionsCalled(
+            address(_input.chainSystemConfigs[0]),
+            GameType.unwrap(_input.startingRespectedGameType),
+            _extraInstructions[0].key,
+            _extraInstructions[0].data
+        );
     }
 }
 
@@ -119,6 +146,9 @@ contract InteropMigrationV2_Test is Test {
     address prank;
 
     event MigrateV2Called(address indexed sysCfg, uint32 indexed gameType);
+    event MigrateWithInstructionsCalled(
+        address indexed sysCfg, uint32 indexed gameType, string instructionKey, bytes instructionData
+    );
 
     function setUp() public {
         mockOPCM = new MockOPCM();
@@ -173,6 +203,38 @@ contract InteropMigrationV2_Test is Test {
         migration.run(input, output);
 
         assertEq(address(output.disputeGameFactory()), dgf);
+    }
+
+    function test_migrateV2_withInstructions_succeeds() public {
+        IOPContractsManagerUtils.ExtraInstruction[] memory extraInstructions =
+            new IOPContractsManagerUtils.ExtraInstruction[](1);
+        extraInstructions[0] = IOPContractsManagerUtils.ExtraInstruction({ key: "test", data: hex"deadbeef" });
+        input.set(input.extraInstructions.selector, extraInstructions);
+
+        vm.expectEmit(address(prank));
+        emit MigrateWithInstructionsCalled(address(systemConfig), 0, "test", hex"deadbeef");
+
+        address portal = makeAddr("optimismPortal");
+        address dgf = makeAddr("disputeGameFactory");
+        vm.mockCall(address(systemConfig), abi.encodeCall(ISystemConfig.optimismPortal, ()), abi.encode(portal));
+        vm.etch(dgf, hex"01");
+        vm.mockCall(portal, abi.encodeCall(IOptimismPortal.disputeGameFactory, ()), abi.encode(dgf));
+
+        InteropMigrationOutput output = new InteropMigrationOutput();
+        migration.run(input, output);
+
+        assertEq(address(output.disputeGameFactory()), dgf);
+    }
+
+    function test_migrateV2_withInstructionsBeforeV804_reverts() public {
+        IOPContractsManagerUtils.ExtraInstruction[] memory extraInstructions =
+            new IOPContractsManagerUtils.ExtraInstruction[](1);
+        extraInstructions[0] = IOPContractsManagerUtils.ExtraInstruction({ key: "test", data: hex"deadbeef" });
+        input.set(input.extraInstructions.selector, extraInstructions);
+        input.set(input.opcm.selector, address(new MockOPCMRevert()));
+
+        vm.expectRevert("InteropMigration: OPCM must be v8.0.4 or later when using extra instructions.");
+        migration.run(input, new InteropMigrationOutput());
     }
 
     function test_migrateV2_migrate_reverts() public {

--- a/packages/contracts-bedrock/test/setup/Events.sol
+++ b/packages/contracts-bedrock/test/setup/Events.sol
@@ -91,6 +91,37 @@ abstract contract Events {
         bytes data
     );
 
+    event WithdrawalThrottleConfigured(
+        address indexed token,
+        uint16 maxBps,
+        uint64 refillPeriod,
+        uint256 stockSnapshot,
+        uint256 capacity,
+        uint256 available
+    );
+
+    event WithdrawalThrottleRefreshed(
+        address indexed token, uint256 stockSnapshot, uint256 capacity, uint256 available
+    );
+
+    event WithdrawalThrottleDisabled(address indexed token);
+
+    event WithdrawalThrottleCapacityConsumed(address indexed token, uint256 amount, uint256 remaining);
+
+    event WithdrawalThrottleCapacityExhausted(address indexed token);
+
+    event WithdrawalThrottleConfigured(
+        uint16 maxBps, uint64 refillPeriod, uint256 stockSnapshot, uint256 capacity, uint256 available
+    );
+
+    event WithdrawalThrottleRefreshed(uint256 stockSnapshot, uint256 capacity, uint256 available);
+
+    event WithdrawalThrottleDisabled();
+
+    event WithdrawalThrottleCapacityConsumed(uint256 amount, uint256 remaining);
+
+    event WithdrawalThrottleCapacityExhausted();
+
     event Paused(address identifier);
 
     event Unpaused(address identifier);

--- a/packages/contracts-bedrock/test/setup/FeatureFlags.sol
+++ b/packages/contracts-bedrock/test/setup/FeatureFlags.sol
@@ -49,6 +49,10 @@ abstract contract FeatureFlags {
             console.log("Setup: DEV_FEATURE__SUPER_ROOT_GAMES_MIGRATION is enabled");
             devFeatureBitmap |= DevFeatures.SUPER_ROOT_GAMES_MIGRATION;
         }
+        if (Config.devFeatureWithdrawalThrottle()) {
+            console.log("Setup: DEV_FEATURE__WITHDRAWAL_THROTTLE is enabled");
+            devFeatureBitmap |= DevFeatures.WITHDRAWAL_THROTTLE;
+        }
     }
 
     /// @notice Returns the string name of a feature.
@@ -61,6 +65,8 @@ abstract contract FeatureFlags {
             return "DEV_FEATURE__ZK_DISPUTE_GAME";
         } else if (_feature == DevFeatures.SUPER_ROOT_GAMES_MIGRATION) {
             return "DEV_FEATURE__SUPER_ROOT_GAMES_MIGRATION";
+        } else if (_feature == DevFeatures.WITHDRAWAL_THROTTLE) {
+            return "DEV_FEATURE__WITHDRAWAL_THROTTLE";
         } else if (_feature == Features.CUSTOM_GAS_TOKEN) {
             return "SYS_FEATURE__CUSTOM_GAS_TOKEN";
         } else if (_feature == Features.ETH_LOCKBOX) {


### PR DESCRIPTION
## Summary

Adds development-gated withdrawal throttling for whitelisted ERC20s and ETH using percentage-based token buckets.

- Supports `L1StandardBridge`, `OptimismPortal2`, and shared `ETHLockbox` custody.
- Uses live escrow balances, lazy exact fractional refill, and revert-on-exhaustion.
- Adds owner configuration/refresh APIs and monitoring events.
- Configures throttles through OPCM instructions behind `WITHDRAWAL_THROTTLE`.
- Centralizes accounting in a reusable two-slot packed `WithdrawalThrottle.State`.
- Conservatively saturates capacities above `uint128.max`.

Cold-path benchmarks measure throttle overhead at approximately 17.3k gas for ERC20 finalization and 14.9k gas for ETH finalization.

## Testing

Added coverage for refill precision, overflow boundaries, reconfiguration, live-stock changes, shared-lockbox behavior, OPCM configuration, storage writes, and cold-path gas benchmarks.