### PR TITLE
docs: fix stale references in AI docs

### DIFF
--- a/docs/ai/acceptance-tests.md
+++ b/docs/ai/acceptance-tests.md
@@ -8,7 +8,7 @@ Acceptance tests live in `op-acceptance-tests/tests/` and run full in-process de
 
 ## Running Tests
 
-All `just` targets below automatically build dependencies (contracts, cannon prestates, Rust binaries) before running tests. The builds are incremental — re-running is fast when nothing changed.
+The `just test` target automatically builds dependencies (contracts, cannon prestates, Rust binaries) before running tests. The builds are incremental — re-running is fast when nothing changed.
 
 **Prerequisites:** mise tools must be installed (see [dev-workflow.md](dev-workflow.md#setup)), and a working C toolchain (`clang` or `gcc`) must be available for Rust builds.
 
@@ -20,10 +20,10 @@ Run from `op-acceptance-tests/`:
 
 ```bash
 # Run a single test
-RUST_JIT_BUILD=1 cd op-acceptance-tests && mise exec -- just test -run TestMyTest ./op-acceptance-tests/tests/base/
+cd op-acceptance-tests && RUST_JIT_BUILD=1 mise exec -- just test -run TestMyTest ./op-acceptance-tests/tests/base/
 
 # Run a package
-RUST_JIT_BUILD=1 cd op-acceptance-tests && mise exec -- just test ./op-acceptance-tests/tests/base/...
+cd op-acceptance-tests && RUST_JIT_BUILD=1 mise exec -- just test ./op-acceptance-tests/tests/base/...
 ```
 
 The `just test` target builds deps, then runs `go test -count=1 -timeout 30m` with your arguments.
@@ -31,20 +31,29 @@ The `just test` target builds deps, then runs `go test -count=1 -timeout 30m` wi
 ### All Tests
 
 ```bash
-RUST_JIT_BUILD=1 cd op-acceptance-tests && mise exec -- just acceptance-test
+cd op-acceptance-tests && RUST_JIT_BUILD=1 mise exec -- just acceptance-test
 ```
 
-Runs all test packages with gotestsum, structured logging, and auto-tuned parallelism.
+Runs all test packages with gotestsum, structured logging, and bounded parallelism.
 
-### Gated Subsets
+### Selecting the L2 Clients
 
-Gate files in `op-acceptance-tests/gates/` list package subsets:
+Every run covers the whole `./op-acceptance-tests/tests/...` tree; there is no per-package
+subset target. Which clients the devstack starts is chosen by two environment variables, read
+in `op-devstack/sysgo/mixed_runtime.go`:
+
+- `DEVSTACK_L2CL_KIND` — `op-node` (the default) or `kona-node`
+- `DEVSTACK_L2EL_KIND` — `op-reth` (the default) or `op-geth`
 
 ```bash
-RUST_JIT_BUILD=1 cd op-acceptance-tests && mise exec -- just acceptance-test base
+cd op-acceptance-tests && DEVSTACK_L2CL_KIND=kona-node RUST_JIT_BUILD=1 mise exec -- just acceptance-test
 ```
 
-This runs only packages listed in `gates/base.txt`.
+CI runs two variants of the `op-acceptance-tests` job: `memory-all-opn-op-reth-<l1_fork>`
+(op-node + op-reth) and `memory-all-kona-op-reth-<l1_fork>` (kona-node + op-reth).
+
+A test that cannot run under a given client skips itself in code rather than being left out of
+a list — `sysgo.SkipOnKonaNode`, `sysgo.SkipOnOpReth` and `sysgo.SkipOnOpGeth`.
 
 ### Kona Prestate
 
@@ -68,7 +77,7 @@ Only works on **Linux** with the **MIPS cross-compile toolchain** installed. The
 
 ## What `build-deps` Does
 
-The `just build-deps` target (called automatically by `just test` and `just acceptance-test`) runs these steps when not in CI:
+The `just build-deps` target (called automatically by `just test`) runs these steps when not in CI:
 
 1. **mise** — `mise install` (ensures gotestsum, forge, etc. are available)
 2. **Contracts** — `cd packages/contracts-bedrock && just install && just build-no-tests`
@@ -81,15 +90,15 @@ You can also run `just build-deps` directly to pre-build without running tests.
 
 ## Tuning Parallelism (`acceptance-test` only)
 
-When using `just acceptance-test`, the runner auto-detects CPU count and sets:
-- `ACCEPTANCE_TEST_JOBS` — number of packages to test in parallel (default: CPU count)
-- `ACCEPTANCE_TEST_PARALLEL` — `go test -parallel` value per package (default: CPU count / 2)
-- `ACCEPTANCE_TEST_TIMEOUT` — per-package timeout (default: 2h)
+When using `just acceptance-test`, the runner sets:
+- `ACCEPTANCE_TEST_JOBS` — number of packages to test in parallel (default: 12)
+- `ACCEPTANCE_TEST_PARALLEL` — `go test -parallel` value per package (default: 1)
+- `ACCEPTANCE_TEST_TIMEOUT` — per-package timeout (default: 30m)
 
 Override with environment variables:
 
 ```bash
-ACCEPTANCE_TEST_PARALLEL=2 ACCEPTANCE_TEST_TIMEOUT=1h cd op-acceptance-tests && mise exec -- just acceptance-test
+cd op-acceptance-tests && ACCEPTANCE_TEST_PARALLEL=2 ACCEPTANCE_TEST_TIMEOUT=1h mise exec -- just acceptance-test
 ```
 
 ## Log Output (`acceptance-test` only)

--- a/docs/ai/acceptance-tests.md
+++ b/docs/ai/acceptance-tests.md
@@ -43,7 +43,7 @@ subset target. Which clients the devstack starts is chosen by two environment va
 in `op-devstack/sysgo/mixed_runtime.go`:
 
 - `DEVSTACK_L2CL_KIND` — `op-node` (the default) or `kona-node`
-- `DEVSTACK_L2EL_KIND` — `op-reth` (the default) or `op-geth`
+- `DEVSTACK_L2EL_KIND` — `op-reth` (the default), `op-geth` or `op-reth-proof-v2`
 
 ```bash
 cd op-acceptance-tests && DEVSTACK_L2CL_KIND=kona-node RUST_JIT_BUILD=1 mise exec -- just acceptance-test

--- a/docs/ai/ci-config-review.md
+++ b/docs/ai/ci-config-review.md
@@ -45,14 +45,14 @@ single fragment:
 # 1. Merge the fragments into /tmp/merged-config.yml (uses mise's yq; resolves anchors).
 mise exec -- bash .circleci/scripts/merge-configs.sh
 
-# 2. Validate it. --org is REQUIRED: the private org orb
+# 2. Validate it. --org-slug is REQUIRED: the private org orb
 #    ethereum-optimism/circleci-utils won't resolve without it (and the CLI
-#    needs CIRCLE_TOKEN set to resolve --org).
-export CIRCLE_TOKEN="<your token>"
-circleci config validate --org gh/ethereum-optimism /tmp/merged-config.yml
+#    needs CIRCLECI_CLI_TOKEN set to resolve --org-slug).
+export CIRCLECI_CLI_TOKEN="<your token>"
+circleci config validate --org-slug gh/ethereum-optimism /tmp/merged-config.yml
 
 # 3. The setup config imports the private orb too, so it needs the same flag.
-circleci config validate --org gh/ethereum-optimism .circleci/config.yml
+circleci config validate --org-slug gh/ethereum-optimism .circleci/config.yml
 ```
 
 Install the CLI without sudo:
@@ -77,8 +77,8 @@ here, fastest-signal/highest-cost first:
 - **develop-only** — `filters:` restricting to the `develop`/`main` branch; runs
   post-merge. For checks too slow, flaky, or expensive to block every PR but where
   you still want fast signal on the integration branch.
-- **Scheduled** — a `scheduled_*` workflow gated on a `c-run_scheduled_*` param and
-  dispatched by the schedule-name mapping in `config.yml` (`build_four_hours` /
+- **Scheduled** — a `scheduled-*` workflow gated on a `c-run_scheduled_*` param and
+  dispatched by the schedule-name mapping in `routing.yml` (`build_four_hours` /
   `build_daily` / `build_weekly`). For exhaustive/expensive suites (full Cannon,
   heavy fuzz, reproducibility, link checks). A new scheduled job not added to that
   mapping never fires — verify the wiring, not just the workflow definition.
@@ -145,9 +145,9 @@ here. Treat items 1–4 as **blocking**.
    output on lockfile+source+profile+features). Fallback `restore` keys are
    deliberate: a chain restores a near-match and recompiles the delta; no fallback
    forces a full refresh (right for download caches, so they can't accrete stale
-   versions). Keys carry a version buster (`-v16-`, `go-cache-version`) for manual
-   invalidation when the key formula itself is wrong. Check `save` and `restore`
-   keys stay consistent.
+   versions). Keys carry a version buster (`rust-cache-version`, `go-cache-version`)
+   for manual invalidation when the key formula itself is wrong. Check `save` and
+   `restore` keys stay consistent.
 
    Also check **cache coverage**: every job that builds or compiles should restore
    the relevant dependency cache, at minimum — a Go job should restore the Go

--- a/docs/ai/ci-ops.md
+++ b/docs/ai/ci-ops.md
@@ -38,9 +38,9 @@ Notes that matter in practice:
   run on fast paths; for every other suite, look for an open flake issue instead. A rerun
   that hides a real regression costs more than the minutes it saved, and a confirmed
   flake needs an issue, not a silent retry. Reruns through the CircleCI v2 API need a
-  personal API token in `CIRCLE_TOKEN` — the same variable
-  [ci-config-review.md](ci-config-review.md) uses for `circleci config validate --org`;
-  the `CIRCLE_API_TOKEN` in `.circleci/` is the in-job context token, not this one. For
+  personal API token in `CIRCLE_TOKEN` — not the `CIRCLECI_CLI_TOKEN` the CLI reads for
+  [ci-config-review.md](ci-config-review.md)'s `circleci config validate --org-slug`, and
+  not the `CIRCLE_API_TOKEN` in `.circleci/`, which is the in-job context token. For
   flakes in `op-acceptance-tests/`/`op-devstack/`,
   [flake-prevention.md](flake-prevention.md) catalogues the recurring causes.
 
@@ -78,14 +78,14 @@ it `//go:embed`s. The zip is **gitignored** and built only by the `prep-supercha
 several other binaries, but also `op-e2e`, `op-acceptance-tests`, `op-deployer`, and the
 `kona`/`op-reth` Go tests (`TestBundleReachability` in `op-core/superchain/deps_test.go`
 pins the full set) — so a **Go-only** change can red-wash unrelated-looking jobs
-(fuzz-golang, rust-e2e) all at compile time. It passes locally and in review because the
+(`rust-e2e`) all at compile time. It passes locally and in review because the
 developer already has the zip on disk (see [go-dev.md](go-dev.md)).
 
 Provision the bundle in the failing job:
 
 - **`main.yml` jobs** (the `prep-superchain` job lives in that workflow): add
   `prep-superchain` to the job's `requires` and attach its workspace
-  (`uses_artifacts: true`) — the same pattern `go-tests` uses.
+  (`attach_workspace`) — the same pattern `go-tests` uses.
 - **Other workflows** (`rust-ci.yml`, `rust-e2e.yml` — no `prep-superchain` job there):
   add an in-job `just build-superchain-go` step (verify mode: regenerates from the
   superchain-registry submodule and asserts the committed `.sha256`).

--- a/docs/ai/contract-dev.md
+++ b/docs/ai/contract-dev.md
@@ -141,10 +141,10 @@ src/
 Every new implementation contract must follow this pattern:
 
 1. Extend OpenZeppelin's `Initializable`.
-2. Include `initialize()` with the `initializer` modifier.
+2. Include `initialize()` with the `reinitializer(initVersion())` modifier.
 3. In the constructor: call `_disableInitializers()` and set immutables only.
 4. Extend `ReinitializableBase(N)` with the current init version.
-5. Never use `reinitializer(uint64 version)` — this codebase does not use it.
+5. Never pass a hardcoded literal version to `reinitializer(...)` — always `initVersion()`.
 
 ### Upgrade Process (Atomic 3-Step)
 
@@ -195,7 +195,7 @@ Reference implementations: `SystemConfig.sol` and `OptimismPortal2.sol`.
 pragma solidity 0.8.15;
 
 // Contracts
-import { ProxyAdminOwnedBase } from "src/L1/ProxyAdminOwnedBase.sol";
+import { ProxyAdminOwnedBase } from "src/universal/ProxyAdminOwnedBase.sol";
 import { Initializable } from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 
 // Libraries
@@ -394,7 +394,7 @@ function testTransferSucceeds() external { }          // No underscores
 
 - `CommonTest` base class deploys the full OP Stack (L1 + L2).
 - Pre-configured actors: alice and bob with 10,000 ETH each.
-- Feature flags for testing variants: altDA, interop, revenue sharing, custom gas token.
+- Feature flags for testing variants: altDA, interop, custom gas token.
 - Fork test support: automatic detection via the `FORK_TEST` env var.
 - Invariant tests in `test/invariants/` with guided and unguided fuzz modes.
 - Kontrol formal verification in `test/kontrol/`.
@@ -415,11 +415,11 @@ function testTransferSucceeds() external { }          // No underscores
 | default | 999,999 runs | 64 | Production builds |
 | lite | disabled | 8 | Fast dev iteration |
 | ci | 999,999 runs | 128 | CI testing |
-| ciheavy | 999,999 runs | 20,000 | Stress testing |
+| ciheavy | disabled | 20,000 | Stress testing |
 | cicoverage | disabled | 1 | Coverage only |
 | kprove | default | — | Kontrol formal verification |
 
-Dispute games, OPCM, OptimismPortal2, and ProtocolVersions compile with 5,000 optimizer runs
+Dispute games, OPCM, and OptimismPortal2 compile with 5,000 optimizer runs
 for bytecode size management.
 
 ## Build and Test Commands
@@ -445,7 +445,7 @@ mise x -- just semver-lock-no-build  # Regenerate from existing artifacts (faste
 (e.g. `mise x -- just test-dev --match-contract OptimismPortal2_Test`) — much faster than the
 whole suite. Run the full `just test` before opening a PR, since that's what CI runs.
 
-`just test-upgrade` forks mainnet (or Sepolia) at a weekly-pinned block, applies the upgrade
+`just test-upgrade` forks mainnet (or Sepolia) at a daily-pinned block, applies the upgrade
 path, and runs tests in `test/{L1,dispute,cannon}/`. It verifies that upgrades work against
 real deployed state — the actual upgrade path, not just a clean deployment. Requires
 `ETH_RPC_URL`. Run it when modifying upgradeable contracts or the upgrade flow itself.

--- a/docs/ai/contract-dev.md
+++ b/docs/ai/contract-dev.md
@@ -229,7 +229,7 @@ contract ContractName is Initializable, ProxyAdminOwnedBase, ReinitializableBase
   go-ffi, profiles, and the script cache for you.
 - `just build` builds the contracts; `just build-dev` is the faster variant
   (`FOUNDRY_PROFILE=lite`) for local iteration. Builds must produce zero warnings
-  (`deny_warnings = true` in `foundry.toml`).
+  (`deny = "warnings"` in `foundry.toml`).
 - `just test` runs the suite; `just test-dev` is the faster `lite`-profile variant for local
   iteration. Default 64 fuzz runs; CI uses 128.
 - `just lint` formats and checks (`forge fmt` under the hood: 120-char line length, bracket

--- a/docs/ai/contract-dev.md
+++ b/docs/ai/contract-dev.md
@@ -419,8 +419,9 @@ function testTransferSucceeds() external { }          // No underscores
 | cicoverage | disabled | 1 | Coverage only |
 | kprove | default | — | Kontrol formal verification |
 
-Dispute games, OPCM, and OptimismPortal2 compile with 5,000 optimizer runs
-for bytecode size management.
+Dispute games, OPCM, OptimismPortal2, StorageSetter and L2ContractsManager compile with
+5,000 optimizer runs for bytecode size management (`compilation_restrictions` in
+`foundry.toml`; `OPContractsManagerStandardValidator` is the outlier at 200).
 
 ## Build and Test Commands
 

--- a/docs/ai/derivation.md
+++ b/docs/ai/derivation.md
@@ -55,7 +55,7 @@ field that comes from the registry means wiring it through **every** ingestion e
 (`DeployConfig.RollupConfig`) path:
 
 - **op-node (Go)**: the TOML-decoded `superchain.HardforkConfig` (`op-core/superchain`) **and**
-  the `superchain.ChainConfig` → `rollup.Config` conversion in `op-node/rollup/superchain.go`
+  the `superchain.ChainConfig` → `rollup.Config` conversion in `op-node/superchain/superchain.go`
   (`applyHardforks` / `rollupConfigFromRegistry`).
 - **kona (Rust)**: `HardForkConfig` / `ChainConfig::as_rollup_config`
   (`rust/kona/crates/protocol/genesis`).

--- a/docs/ai/devfeatures.md
+++ b/docs/ai/devfeatures.md
@@ -30,7 +30,7 @@ The predicate is a bitwise AND (`(bitmap & flag) == flag && flag != 0`) — exce
 The bitmap has **two operator-facing input surfaces**, both in op-deployer:
 
 1. **CLI flag on `op-deployer bootstrap implementations`**
-   - `--dev-feature-bitmap` (env: `OP_DEPLOYER_DEV_FEATURE_BITMAP`), defined in `op-deployer/pkg/deployer/bootstrap/flags.go`
+   - `--dev-feature-bitmap` (env: `DEPLOYER_DEV_FEATURE_BITMAP`), defined in `op-deployer/pkg/deployer/bootstrap/flags.go`
    - Raw 32-byte hex; default empty
    - Flows into `ImplementationsConfig.DevFeatureBitmap` and on into `DeployImplementationsInput` for L1 implementation deployment.
    - When the ZK bit is enabled, Ethereum mainnet and Sepolia default to Succinct's v6.1.0 PLONK verifier, resolved by `standard.SP1VerifierFor`. `--sp1-verifier-address` (env: `DEPLOYER_SP1_VERIFIER_ADDRESS`) overrides that release input and is required on other L1 networks.
@@ -71,7 +71,7 @@ A separate, **test-only** assembler exists for Foundry tests and fork scripts. I
 Interop and ZK are read via `vm.envOr(..., false)` in `packages/contracts-bedrock/scripts/libraries/Config.sol`; `devFeatureSuperRootGamesMigration()` returns `true` unconditionally. The only callers are under `test/`:
 
 - `test/setup/FeatureFlags.sol` — `resolveFeaturesFromEnv()` OR-s each enabled flag into `devFeatureBitmap`
-- `test/setup/CommonTest.sol`, `test/setup/ForkL1Live.s.sol`, `test/setup/ForkL2Live.s.sol` — branch on individual `Config.devFeature*` returns
+- `test/setup/ForkL1Live.s.sol` — branches on individual `Config.devFeature*` returns
 - `test/L1/OPContractsManagerStandardValidator.t.sol` — `vm.skip()` based on flag state
 
 The env vars and default-on helper exist purely to set up local test fixtures and to skip or branch tests. They never reach a deployed chain. To exercise an opt-in feature in production you must set the bitmap via op-deployer.
@@ -91,11 +91,10 @@ The Foundry test-only assembler in `FeatureFlags.sol` is a separate composition 
 
 ## D. Propagation — where the bitmap travels
 
-From op-deployer the bitmap fans out three ways:
+From op-deployer the bitmap fans out two ways:
 
 1. **Into L2 genesis state** — `scripts/L2Genesis.s.sol` (Foundry script) writes the bitmap into the **`L2DevFeatureFlags` predeploy at `0x42...2D`** via `setDevFeatureBitmap()`. Only `DEPOSITOR_ACCOUNT` can write; effectively write-once at genesis.
 2. **Into L1 implementation deployment** — `scripts/deploy/DeployImplementations.s.sol` consults the bitmap to decide which implementation contracts to deploy / configure.
-3. **Into NUT bundle generation** — `scripts/upgrade/GenerateNUTBundle.s.sol` uses it to decide which predeploy upgrades to include.
 
 It does **not** flow to op-node, op-program, or kona at runtime. They learn about feature activation through other channels (hardfork timestamps in rollup config, primarily).
 

--- a/docs/ai/docker.md
+++ b/docs/ai/docker.md
@@ -3,7 +3,7 @@
 Guidance for writing and editing Dockerfiles in the monorepo.
 
 The overriding rule: **every external network fetch must retry.** The package registries
-and CDNs these builds depend on — `dl-cdn.alpinelinux.org`, `apk.cgr.dev`, the Debian/Ubuntu
+and CDNs these builds depend on — `dl-cdn.alpinelinux.org`, `packages.wolfi.dev`, the Debian/Ubuntu
 mirrors, GitHub releases — intermittently drop connections or return transient server errors.
 Unwrapped, each one is a CI flake.
 

--- a/docs/ai/fault-proofs.md
+++ b/docs/ai/fault-proofs.md
@@ -80,7 +80,7 @@ from the normal `go test ./...` suite — they only run under kona-host.
 
 > [!NOTE]
 > These tests cover **op-node as well as kona-client**. The chain is built and derived by op-node
-> — the action-test `L2Sequencer`/`L2Verifier` drives `op-node/rollup/driver` through
+> — the action-test `L2Sequencer`/`L2Verifier` drives `op-node/rollup/derive` through
 > `PreparePayloadAttributes` → `PayloadToSystemConfig` — and the `RunFaultProofProgram` step then
 > has kona-client re-derive and prove that same chain. So a single test exercises both
 > consensus-layer implementations of the state transition.

--- a/docs/ai/flake-prevention.md
+++ b/docs/ai/flake-prevention.md
@@ -126,7 +126,7 @@ retryProve(ctx, 30*time.Second)   // now scoped to transient submit/confirm erro
 // BAD — CL/supervisor state reached the target, but the EL label/content is
 // updated through an async forkchoice/reorg path. A synchronous EL read can
 // still observe the previous safe label or old block contents.
-cl.Reached(types.CrossSafe, target, 30)
+cl.Reached(safety.CrossSafe, target, 30)
 safe := el.BlockRefByLabel(eth.Safe)
 require.GreaterOrEqual(t, safe.Number, target)
 
@@ -134,7 +134,7 @@ require.GreaterOrEqual(t, safe.Number, target)
 // reads. If the assertion is about EL labels or block contents, include an
 // EL-side wait before the synchronous assertion.
 dsl.CheckAll(t,
-    cl.ReachedFn(types.CrossSafe, target, 30),
+    cl.ReachedFn(safety.CrossSafe, target, 30),
     el.ReachedFn(eth.Safe, target, 30),
 )
 safe = el.BlockRefByLabel(eth.Safe)
@@ -181,7 +181,7 @@ on it directly.
 // BAD — preset's NewSingleChainMultiNode auto-detects ELSync and applies a 4x
 // budget. WithoutCheck plus a manual 120-attempt loop undoes that fix.
 sys := presets.NewSingleChainMultiNodeWithoutCheck(t, opts)
-require.NoError(t, dsl.MatchedFn(sys, types.CrossSafe, 60, 2*time.Second)(ctx))
+require.NoError(t, dsl.MatchedFn(sys, safety.CrossSafe, 60, 2*time.Second)(ctx))
 
 // GOOD — use the auto-budgeted entry point.
 sys := presets.NewSingleChainMultiNode(t, opts)

--- a/docs/ai/go-dev.md
+++ b/docs/ai/go-dev.md
@@ -59,7 +59,7 @@ just go-tests
 
 ### Generating Mocks
 
-Each service justfile has a `generate-mocks` target:
+Some service justfiles have a `generate-mocks` target:
 
 ```bash
 cd <service> && just generate-mocks

--- a/docs/ai/reth-update-review.md
+++ b/docs/ai/reth-update-review.md
@@ -78,8 +78,8 @@ Organised by **detection difficulty** — the point is catching what the compile
   often assumes L1 semantics that are wrong for OP.
 - **New struct field absorbed silently.** A struct we build with `..Default::default()`
   or `..rest` gains a field. It defaults silently where OP may need to set it.
-- **New trait-method parameter dropped via `_`-prefix.** UPDATING-RETH advises prefixing
-  added params with `_` to silence warnings (e.g. `_block_access_list_hash: Option<B256>`).
+- **New trait-method parameter dropped via `_`-prefix.** An added param is commonly
+  `_`-prefixed to silence warnings (e.g. `_block_access_list_hash: Option<B256>`).
   That is correct _only if_ OP genuinely doesn't need the value — verify, don't assume.
 - **Changed constant / default value** that op- reads or duplicated.
 

--- a/docs/ai/rust-dev.md
+++ b/docs/ai/rust-dev.md
@@ -53,7 +53,7 @@ just build-lokahi   # lokahi
 
 ### superchain-registry submodule (op-reth)
 
-The `reth-optimism-chainspec` crate's `build.rs` materializes its chain-config archive (`res/superchain-configs.tar`, gitignored) from the `superchain-registry` submodule at the repo root. Any op-reth build that enables the `superchain-configs` feature (the `op-reth` binary, `clippy --all-features`, the chainspec tests) needs that submodule checked out, or the build fails. Initialize it with `just update-superchain-registry-submodule` (or `just sync-superchain`, which also does it). Once `res/` holds the archive, later builds reuse it without touching the submodule (default mode mirrors kona's `KONA_SYNC_SUPERCHAIN`); set `OP_RETH_SYNC_SUPERCHAIN=1` to force a regeneration.
+The `reth-optimism-chainspec` crate's `build.rs` materializes its chain-config archive (`res/superchain-configs.tar`, gitignored) from the `superchain-registry` submodule at the repo root. Any op-reth build that enables the `superchain-configs` feature (the `op-reth` binary, `clippy --all-features`, the chainspec tests) needs that submodule checked out, or the build fails. Initialize it from the repo root with `just update-superchain-registry-submodule` (or `just sync-superchain`, which also does it). Once `res/` holds the archive, later builds reuse it without touching the submodule (default mode mirrors kona's `KONA_SYNC_SUPERCHAIN`); set `OP_RETH_SYNC_SUPERCHAIN=1` to force a regeneration.
 
 ### Running Tests
 
@@ -74,7 +74,7 @@ just test-docs
 
 ### Running op-reth E2E Tests
 
-The op-reth E2E tests (`rust/op-reth/tests/proofs/`) run a full devnet with op-geth (sequencer) and op-reth (validator). They require two build prerequisites:
+The op-reth E2E tests (`rust/op-reth/tests/proofs/`) run a full devnet with op-reth as both the sequencer and the validator EL. They require two build prerequisites:
 
 1. **Forge artifacts** — the devnet deploys contracts from compiled artifacts:
    ```bash
@@ -82,7 +82,7 @@ The op-reth E2E tests (`rust/op-reth/tests/proofs/`) run a full devnet with op-g
    mise exec -- just build-no-tests
    ```
 
-2. **op-reth release binary** — the test harness (`op-devstack/sysgo/rust_binary.go`) only searches `target/release/`, not `target/debug/`. Options:
+2. **op-reth binary** — the test harness (`op-devstack/shared/rustbin/rust_binary.go`) uses the most recently built binary under `target/release/` or `target/debug/`. Options:
    ```bash
    # Option A: let the test build it (slow first run, cached after)
    RUST_JIT_BUILD=1 go test -v -run TestName ./rust/op-reth/tests/proofs/core/

--- a/docs/ai/rust-dev.md
+++ b/docs/ai/rust-dev.md
@@ -74,7 +74,7 @@ just test-docs
 
 ### Running op-reth E2E Tests
 
-The op-reth E2E tests (`rust/op-reth/tests/proofs/`) run a full devnet with op-reth as both the sequencer and the validator EL. They require two build prerequisites:
+The op-reth E2E tests (`rust/op-reth/tests/proofs/`) run a full devnet with op-reth as both the sequencer and the validator EL by default; `OP_DEVSTACK_PROOF_SEQUENCER_EL` and `OP_DEVSTACK_PROOF_VALIDATOR_EL` override either role (`rust/op-reth/tests/proofs/utils/preset.go`). They require two build prerequisites:
 
 1. **Forge artifacts** — the devnet deploys contracts from compiled artifacts:
    ```bash

--- a/rust/kona/CLAUDE.md
+++ b/rust/kona/CLAUDE.md
@@ -52,7 +52,7 @@ Kona provides OP Stack types, components, and services built in Rust, organized 
 - **`service`**: OP Stack rollup node service implementation
 - **`engine`**: Extensible rollup node engine client
 - **`rpc`**: OP Stack RPC types and extensions
-- **`peers`**: P2P networking including Gossip and Discovery
+- **`peers`**: P2P peer management
 - **`sources`**: Data source types and utilities
 
 ### Development Workflow
@@ -60,13 +60,13 @@ Kona provides OP Stack types, components, and services built in Rust, organized 
 1. **Testing**: The project uses `nextest` for test execution. Online tests are excluded by default and can be run separately with `just test-online`
 2. **Cross-compilation**: Docker-based builds for `cannon` (MIPS) and `asterisc` (RISC-V) targets
 3. **Documentation**: rustdoc for the public crate APIs
-4. **Monorepo Integration**: Pins and integrates with the Optimism monorepo for action tests
+4. **Monorepo Integration**: Integrates with the Optimism monorepo for action tests
 
 ### Key Configuration Files
-- `rust-toolchain.toml`: Pins the Rust toolchain version
-- `rustfmt.toml`: Custom formatting configuration with crate-level import grouping
-- `clippy.toml`: MSRV configuration for clippy
-- `deny.toml`: Dependency auditing and license compliance
+- `../rust-toolchain.toml`: Pins the Rust toolchain version
+- `../rustfmt.toml`: Custom formatting configuration with crate-level import grouping
+- `../clippy.toml`: MSRV configuration for clippy
+- `../deny.toml`: Dependency auditing and license compliance
 - `release.toml`: Configuration for `cargo-release` tool
 
 ### Target Architecture Support


### PR DESCRIPTION
Sweep of `docs/ai/*.md`, `AGENTS.md` and the subdirectory instruction files for references that no longer match the tree. Every backticked path, `just`/`go`/`cargo` command, symbol, flag and env var was checked against the repo.

## Fixes

**`docs/ai/acceptance-tests.md`**
- "Gated Subsets" described `op-acceptance-tests/gates/*.txt` and `just acceptance-test base`. Neither exists — the justfile always runs `./op-acceptance-tests/tests/...` and the recipe takes no arguments. Replaced with the real mechanism: `DEVSTACK_L2CL_KIND` / `DEVSTACK_L2EL_KIND` (`op-devstack/sysgo/mixed_runtime.go`), the two CI variants, and the code-level `sysgo.SkipOn*` helpers.
- `ACCEPTANCE_TEST_JOBS` default was "CPU count" → `12`; `ACCEPTANCE_TEST_PARALLEL` "CPU count / 2" → `1`; `ACCEPTANCE_TEST_TIMEOUT` "2h" → `30m`. "auto-tuned parallelism" → "bounded" (the runner prints CPU count but uses fixed defaults).
- "All `just` targets below automatically build dependencies" / "called automatically by `just test` and `just acceptance-test`" — only `just test` depends on `build-deps`.
- `RUST_JIT_BUILD=1 cd op-acceptance-tests && …`: the env prefix applies to `cd`, so it never reaches the `&&`-chained command. Moved after the `cd`.

**`docs/ai/derivation.md`**
- `op-node/rollup/superchain.go` → `op-node/superchain/superchain.go` (`applyHardforks`, `rollupConfigFromRegistry`).

**`docs/ai/rust-dev.md`**
- `op-devstack/sysgo/rust_binary.go` → `op-devstack/shared/rustbin/rust_binary.go`.
- "only searches `target/release/`, not `target/debug/`" — `selectNewestBinary` checks both and picks by mtime.
- op-reth E2E devnet: "op-geth (sequencer) and op-reth (validator)" — both default to op-reth.
- `just update-superchain-registry-submodule` / `just sync-superchain` are root recipes, not `rust/` ones.

**`docs/ai/go-dev.md`**
- "Each service justfile has a `generate-mocks` target" — only op-node, op-service and op-conductor do.

**`docs/ai/contract-dev.md`**
- "Never use `reinitializer(uint64 version)` — this codebase does not use it": every upgradeable L1/dispute contract uses `reinitializer(initVersion())`. Corrected that step and step 2's `initializer` modifier.
- `src/L1/ProxyAdminOwnedBase.sol` → `src/universal/ProxyAdminOwnedBase.sol`.
- `deny_warnings = true` → `deny = "warnings"`.
- Test feature-flag list still named "revenue sharing"; it no longer exists.
- `ciheavy` profile listed as 999,999 runs; the optimizer is disabled there.
- `ProtocolVersions` listed among the 5,000-run contracts; the Solidity contract was removed.
- `just test-upgrade` pins the fork block daily, not weekly.

**`docs/ai/devfeatures.md`**
- Env var `OP_DEPLOYER_DEV_FEATURE_BITMAP` → `DEPLOYER_DEV_FEATURE_BITMAP` (prefix is `DEPLOYER`; the neighbouring `DEPLOYER_SP1_VERIFIER_ADDRESS` line was already right).
- `CommonTest.sol` and `ForkL2Live.s.sol` do not branch on `Config.devFeature*`; only `ForkL1Live.s.sol` does.
- "fans out three ways" — `scripts/upgrade/GenerateNUTBundle.s.sol` has no devfeature references; it is two ways.

**`docs/ai/fault-proofs.md`**
- `PreparePayloadAttributes` / `PayloadToSystemConfig` live in `op-node/rollup/derive`, not `op-node/rollup/driver`.

**`rust/kona/CLAUDE.md`**
- `rust-toolchain.toml`, `rustfmt.toml`, `clippy.toml`, `deny.toml` are listed as kona files but live one level up in `rust/` (only `release.toml` is local).
- `peers` no longer contains gossip/discovery — those are the separate `gossip` and `disc` crates.
- "Pins and integrates with the Optimism monorepo" — kona lives in the monorepo; there is no submodule pin.

**`docs/ai/ci-config-review.md`**
- `circleci config validate --org` → `--org-slug` (the CLI rejects `--org`), and the token it reads is `CIRCLECI_CLI_TOKEN`, not `CIRCLE_TOKEN`. Both verified against the installed CLI.
- Scheduled workflows are named `scheduled-*` (hyphens), and the schedule-name mapping lives in `.circleci/routing.yml`, not `config.yml` — the doc already says this correctly earlier on.
- Cache version buster `-v16-` → the anchor is `rust-cache-version` (currently 18).

**`docs/ai/ci-ops.md`**
- `CIRCLE_TOKEN` was described as "the same variable" ci-config-review.md uses for the CLI; they are different variables.
- `fuzz-golang` no longer exists (retired with the Go fuzz jobs).
- `uses_artifacts: true` no longer exists; jobs attach unconditionally with `attach_workspace`.

**`docs/ai/docker.md`**
- `apk.cgr.dev` appears nowhere in the repo; the Wolfi source is `packages.wolfi.dev`.

**`docs/ai/flake-prevention.md`**
- `types.CrossSafe` → `safety.CrossSafe` (`op-service/eth/safety`), 3 occurrences.

**`docs/ai/reth-update-review.md`**
- Attributed the `_`-prefix advice to `rust/UPDATING-RETH.md`, which does not contain it.

## Deliberately not fixed

- **`docs/ai/opgeth-decoupling.md`** is substantially stale as a *plan*: roughly a dozen "open work" items point at issues that are closed and swaps that already landed (#20263, #20264, #20269, #20270, #21746, #21901), several named symbols are gone (`Transaction.SetBlobTxSidecar`, `types.LogForStorage`, `e2esys.SystemConfig.L2Client`, `L2EndpointProvider.EthClient`), and the `InfoAndUserTxs`/`InfoAndDeposits`/`InfoAndFirstDeposit` accessors landed as paired `ByHash`/`ByNumber` variants. Refreshing that needs the decoupling owner's judgement about what is still open, so it is out of scope here.
- **`docs/ai/flake-prevention.md`** also has `presets.NewSuperFaultProofs` / `sys.DGF.CreateGame` in a BAD/GOOD block; neither ever existed (the real pairing is `presets.NewSingleChainInterop(t, presets.WithoutHonestProposer())`). Left with the same reasoning as below.
- **`docs/ai/writing-acceptance-tests.md`** names DSL methods that don't exist (`VerifyBalance`, `VerifyCountered`, `VerifyClaimant`, `TransferOpts`, `VerifyOperatorFeeCharged`, `contracts.SStoreContract.Deploy`), but they sit inside `// Good` / `// Bad` illustrative blocks that are aspirational by design. Left alone rather than rewriting the pedagogy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fi2GEEBE6LmUwLS25WPKfq
