### PR TITLE
kona-node: recover from a stale sequencer build instead of hot-looping FCUs

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -7022,6 +7022,7 @@ dependencies = [
  "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
  "alloy-hardforks",
+ "alloy-json-rpc 2.1.1",
  "alloy-network 2.1.1",
  "alloy-primitives",
  "alloy-provider",

--- a/rust/kona/crates/node/engine/Cargo.toml
+++ b/rust/kona/crates/node/engine/Cargo.toml
@@ -20,6 +20,7 @@ kona-protocol = {workspace = true, features = ["serde", "std"]}
 # alloy
 alloy-hardforks.workspace = true
 alloy-eips.workspace = true
+alloy-json-rpc.workspace = true
 alloy-consensus.workspace = true
 alloy-network.workspace = true
 alloy-transport.workspace = true

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/build/error.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/build/error.rs
@@ -40,24 +40,38 @@ pub enum EngineBuildError {
     /// The engine is syncing.
     #[error("The engine is syncing")]
     EngineSyncing,
+    /// The forkchoice state sent alongside the payload attributes was rejected by the engine as
+    /// inconsistent, i.e. the safe or finalized block is not an ancestor of the parent block the
+    /// attributes build on.
+    #[error("Invalid forkchoice state")]
+    InvalidForkchoiceState,
 }
 
 /// An error that occurs when running the [`crate::BuildTask`].
 #[derive(Debug, Error)]
 pub enum BuildTaskError {
     /// An error occurred when building the payload attributes in the engine.
-    #[error("An error occurred when building the payload attributes to the engine.")]
-    EngineBuildError(EngineBuildError),
-    /// Error sending the built payload envelope.
     #[error(transparent)]
-    MpscSend(#[from] Box<mpsc::error::SendError<PayloadId>>),
+    EngineBuildError(#[from] EngineBuildError),
+    /// Error sending the payload id.
+    #[error(transparent)]
+    MpscSend(#[from] Box<mpsc::error::SendError<Result<PayloadId, Self>>>),
+    /// The unsafe head moved between the caller reading it and this build reaching the engine, so
+    /// the attributes no longer extend the unsafe chain. Building them anyway would send the
+    /// execution layer a forkchoice state whose safe block is not an ancestor of the head.
+    ///
+    /// The caller is expected to re-build on the new unsafe head. The task queue drops the job
+    /// rather than retrying it, since the forkchoice update it would send is one the execution
+    /// layer is guaranteed to reject.
+    #[error("Unsafe head changed before the build started")]
+    UnsafeHeadChangedSinceBuild,
 }
 
 impl EngineTaskError for BuildTaskError {
     fn severity(&self) -> EngineTaskErrorSeverity {
         match self {
-            Self::EngineBuildError(EngineBuildError::FinalizedAheadOfUnsafe(_, _)) => {
-                EngineTaskErrorSeverity::Critical
+            Self::EngineBuildError(EngineBuildError::InvalidForkchoiceState) => {
+                EngineTaskErrorSeverity::Reset
             }
             Self::EngineBuildError(
                 EngineBuildError::AttributesInsertionFailed(_) |
@@ -66,7 +80,9 @@ impl EngineTaskError for BuildTaskError {
                 EngineBuildError::MissingPayloadId |
                 EngineBuildError::EngineSyncing,
             ) => EngineTaskErrorSeverity::Temporary,
-            Self::MpscSend(_) => EngineTaskErrorSeverity::Critical,
+            Self::EngineBuildError(EngineBuildError::FinalizedAheadOfUnsafe(_, _)) |
+            Self::MpscSend(_) |
+            Self::UnsafeHeadChangedSinceBuild => EngineTaskErrorSeverity::Critical,
         }
     }
 }

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/build/task.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/build/task.rs
@@ -1,8 +1,9 @@
 //! A task for building a new block and importing it.
 use super::BuildTaskError;
 use crate::{
-    EngineClient, EngineForkchoiceVersion, EngineState, EngineTaskExt,
-    state::EngineSyncStateUpdate, task_queue::tasks::build::error::EngineBuildError,
+    BuildSealCoupling, EngineClient, EngineForkchoiceVersion, EngineState, EngineTaskExt,
+    state::EngineSyncStateUpdate,
+    task_queue::tasks::{build::error::EngineBuildError, is_invalid_forkchoice_state},
 };
 use alloy_rpc_types_engine::{PayloadId, PayloadStatusEnum};
 use async_trait::async_trait;
@@ -32,9 +33,11 @@ pub struct BuildTask<EngineClient_: EngineClient> {
     pub cfg: Arc<RollupConfig>,
     /// The [`OpAttributesWithParent`] to instruct the execution layer to build.
     pub attributes: OpAttributesWithParent,
-    /// The optional sender through which [`PayloadId`] will be sent after the
-    /// block build has been started.
-    pub payload_id_tx: Option<mpsc::Sender<PayloadId>>,
+    /// How this build is coupled to the seal that will follow it.
+    pub coupling: BuildSealCoupling,
+    /// The optional sender through which the build result will be sent after the block build has
+    /// been started.
+    pub result_tx: Option<mpsc::Sender<Result<PayloadId, BuildTaskError>>>,
 }
 
 impl<EngineClient_: EngineClient> BuildTask<EngineClient_> {
@@ -72,7 +75,7 @@ impl<EngineClient_: EngineClient> BuildTask<EngineClient_> {
     ///
     /// ### Success (`VALID`)
     /// If the build is successful, the [`PayloadId`] is returned for sealing and the successful
-    /// forkchoice update identifier is relayed via the stored `payload_id_tx` sender.
+    /// forkchoice update identifier is relayed via the stored `result_tx` sender.
     ///
     /// ### Failure (`INVALID`)
     /// If the forkchoice update fails, the [`BuildTaskError`].
@@ -129,7 +132,15 @@ impl<EngineClient_: EngineClient> BuildTask<EngineClient_> {
         }
         .map_err(|e| {
             error!(target: "engine_builder", "Forkchoice update failed: {}", e);
-            BuildTaskError::EngineBuildError(EngineBuildError::AttributesInsertionFailed(e))
+
+            // A forkchoice state the engine rejects as inconsistent can never be made valid by
+            // re-sending it. Ask for a reset instead, mirroring the attribute-less forkchoice
+            // update in `SynchronizeTask`.
+            BuildTaskError::EngineBuildError(if is_invalid_forkchoice_state(&e) {
+                EngineBuildError::InvalidForkchoiceState
+            } else {
+                EngineBuildError::AttributesInsertionFailed(e)
+            })
         })?;
 
         Self::validate_forkchoice_status(update.payload_status.status)?;
@@ -164,6 +175,22 @@ impl<EngineClient_: EngineClient> EngineTaskExt for BuildTask<EngineClient_> {
             "Starting new build job"
         );
 
+        if self.coupling.job_is_stale(state, &self.attributes.parent) {
+            info!(
+                target: "engine_builder",
+                unsafe_block_info = ?state.sync_state.unsafe_head().block_info,
+                parent_block_info = ?self.attributes.parent.block_info,
+                "Build attributes parent does not match unsafe head, returning rebuild error"
+            );
+
+            if let Some(tx) = &self.result_tx {
+                tx.send(Err(BuildTaskError::UnsafeHeadChangedSinceBuild))
+                    .await
+                    .map_err(Box::new)?;
+            }
+            return Err(BuildTaskError::UnsafeHeadChangedSinceBuild);
+        }
+
         // Start the build by sending an FCU call with the current forkchoice and the input
         // payload attributes.
         let fcu_start_time = Instant::now();
@@ -177,8 +204,8 @@ impl<EngineClient_: EngineClient> EngineTaskExt for BuildTask<EngineClient_> {
         );
 
         // If a channel was provided, send the payload ID to it.
-        if let Some(tx) = &self.payload_id_tx {
-            tx.send(payload_id).await.map_err(Box::new)?;
+        if let Some(tx) = &self.result_tx {
+            tx.send(Ok(payload_id)).await.map_err(Box::new)?;
         }
 
         Ok(payload_id)

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/build/task_test.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/build/task_test.rs
@@ -1,13 +1,16 @@
 use crate::{
-    BuildTask, BuildTaskError, EngineBuildError, EngineClient, EngineForkchoiceVersion,
-    EngineState, EngineTaskExt,
+    BuildSealCoupling, BuildTask, BuildTaskError, EngineBuildError, EngineClient,
+    EngineForkchoiceVersion, EngineState, EngineTaskError, EngineTaskErrorSeverity, EngineTaskExt,
     test_utils::{
         MockEngineClientBuilder, TestAttributesBuilder, TestEngineStateBuilder, test_block_info,
         test_engine_client_builder,
     },
 };
+use alloy_json_rpc::ErrorPayload;
 use alloy_primitives::FixedBytes;
-use alloy_rpc_types_engine::{ForkchoiceUpdated, PayloadId, PayloadStatus, PayloadStatusEnum};
+use alloy_rpc_types_engine::{
+    ForkchoiceUpdated, INVALID_FORK_CHOICE_STATE_ERROR, PayloadId, PayloadStatus, PayloadStatusEnum,
+};
 use kona_genesis::RollupConfig;
 use rstest::rstest;
 use std::sync::Arc;
@@ -58,6 +61,10 @@ enum TestErr {
     Unexpected,
     #[error("MpscSend.")]
     MpscSend,
+    #[error("InvalidForkchoiceState.")]
+    InvalidForkchoiceState,
+    #[error("UnsafeHeadChangedSinceBuild.")]
+    UnsafeHeadChangedSinceBuild,
 }
 
 // Wraps real errors, ignoring details so we can easily match on results.
@@ -76,8 +83,12 @@ async fn wrapped_execute<EngineClient_: EngineClient>(
             EngineBuildError::InvalidPayload(_) => Err(TestErr::InvalidPayload),
             EngineBuildError::MissingPayloadId => Err(TestErr::MissingPayloadId),
             EngineBuildError::UnexpectedPayloadStatus(_) => Err(TestErr::Unexpected),
+            EngineBuildError::InvalidForkchoiceState => Err(TestErr::InvalidForkchoiceState),
         },
         Err(BuildTaskError::MpscSend(_)) => Err(TestErr::MpscSend),
+        Err(BuildTaskError::UnsafeHeadChangedSinceBuild) => {
+            Err(TestErr::UnsafeHeadChangedSinceBuild)
+        }
     }
 }
 
@@ -99,12 +110,14 @@ async fn test_execute_variants(
     #[values(true, false)] with_channel: bool,
     #[values(EngineForkchoiceVersion::V2, EngineForkchoiceVersion::V3)]
     fcu_version: EngineForkchoiceVersion,
+    // A detached build whose parent is the unsafe head must behave exactly like an atomic one; the
+    // staleness check is covered separately below. Without this, an inverted check would pass.
+    #[values(BuildSealCoupling::Atomic, BuildSealCoupling::Detached)] coupling: BuildSealCoupling,
 ) {
     let payload_id = payload_id_present.then(|| PayloadId::new([1u8; 8]));
 
     let parent_block = test_block_info(0);
-    let unsafe_block = test_block_info(1);
-    let attributes_timestamp = unsafe_block.block_info.timestamp;
+    let attributes_timestamp = parent_block.block_info.timestamp;
 
     let mut cfg = RollupConfig::default();
 
@@ -132,11 +145,12 @@ async fn test_execute_variants(
         Arc::new(engine_client.clone()),
         Arc::new(cfg),
         attributes.clone(),
+        coupling,
         with_channel.then_some(tx),
     );
 
     let mut state = TestEngineStateBuilder::new()
-        .with_unsafe_head(unsafe_block)
+        .with_unsafe_head(parent_block)
         .with_safe_head(parent_block)
         .with_finalized_head(parent_block)
         .build();
@@ -152,14 +166,84 @@ async fn test_execute_variants(
         assert_eq!(result.unwrap(), payload_id.unwrap(), "Should return the correct payload ID");
 
         // test channel payload send
-        if task.payload_id_tx.is_some() {
+        if task.result_tx.is_some() {
             let res = rx.recv().await;
             assert!(res.is_some(), "channel result is None");
             assert_eq!(
-                res.unwrap(),
+                res.unwrap().expect("build succeeded"),
                 payload_id.unwrap(),
                 "channel should have received correct payload id"
             );
         }
     }
+}
+
+#[tokio::test]
+async fn invalid_forkchoice_state_requests_a_reset() {
+    // The pre-block-creation forkchoice update is rejected by the EL when the safe head is no
+    // longer an ancestor of the parent the attributes build on. Retrying it can never succeed, so
+    // it must surface as a reset rather than a temporary error the task queue spins on.
+    let parent_block = test_block_info(0);
+    let engine_client = test_engine_client_builder()
+        .with_fork_choice_updated_error(ErrorPayload {
+            code: INVALID_FORK_CHOICE_STATE_ERROR as i64,
+            message: "invalid forkchoice state".into(),
+            data: None,
+        })
+        .build();
+
+    let attributes = TestAttributesBuilder::new()
+        .with_parent(parent_block)
+        .with_timestamp(parent_block.block_info.timestamp)
+        .build();
+
+    let task = BuildTask::new(
+        Arc::new(engine_client),
+        Arc::new(RollupConfig::default()),
+        attributes,
+        BuildSealCoupling::Atomic,
+        None,
+    );
+    let mut state = TestEngineStateBuilder::new().with_unsafe_head(parent_block).build();
+
+    let err = task.execute(&mut state).await.expect_err("forkchoice update is rejected");
+    assert_eq!(err.severity(), EngineTaskErrorSeverity::Reset);
+}
+
+#[tokio::test]
+async fn stale_sequencer_build_is_rejected_without_a_forkchoice_update() {
+    // A sequencer picks the parent from its own snapshot of the unsafe head and only then asks the
+    // engine to build. If derivation reorged the chain in the meantime, the forkchoice update this
+    // build would send has a safe block that is no longer an ancestor of the head, which the
+    // execution layer rejects. Reject the job here instead, so the caller re-builds on the new
+    // head.
+    // Same height, different hash: exactly the shape a force-included derived block takes.
+    let stale_parent = test_block_info(42);
+    let unsafe_head = test_block_info(42);
+
+    // No forkchoice response is configured: the mock errors if the task calls the engine at all.
+    let engine_client = test_engine_client_builder().build();
+    let attributes = TestAttributesBuilder::new()
+        .with_parent(stale_parent)
+        .with_timestamp(unsafe_head.block_info.timestamp)
+        .build();
+
+    let (tx, mut rx) = mpsc::channel(1);
+    let task = BuildTask::new(
+        Arc::new(engine_client),
+        Arc::new(RollupConfig::default()),
+        attributes,
+        BuildSealCoupling::Detached,
+        Some(tx),
+    );
+    let mut state = TestEngineStateBuilder::new().with_unsafe_head(unsafe_head).build();
+
+    assert_eq!(
+        wrapped_execute(&task, &mut state).await.err(),
+        Some(TestErr::UnsafeHeadChangedSinceBuild)
+    );
+    assert!(
+        matches!(rx.recv().await, Some(Err(BuildTaskError::UnsafeHeadChangedSinceBuild))),
+        "the caller must be told to re-build rather than left waiting"
+    );
 }

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/mod.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/mod.rs
@@ -24,4 +24,5 @@ mod finalize;
 pub use finalize::{FinalizeBlockId, FinalizeTask, FinalizeTaskError};
 
 mod util;
+pub(in crate::task_queue) use util::is_invalid_forkchoice_state;
 pub(super) use util::{BuildAndSealError, build_and_seal};

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/seal/task.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/seal/task.rs
@@ -15,16 +15,31 @@ use op_alloy_rpc_types_engine::OpExecutionPayloadEnvelope;
 use std::{sync::Arc, time::Instant};
 use tokio::sync::mpsc;
 
-/// How a [`SealTask`] is coupled to the build that produced its payload.
+/// How a [`crate::BuildTask`] and the [`SealTask`] that finishes its payload are coupled.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum BuildSealCoupling {
     /// Build and seal run inside the same engine task, so no other task can advance the unsafe
-    /// head between them. The unsafe-head staleness check is skipped: a derivation-driven reorg
-    /// legitimately seals a payload whose parent differs from the current unsafe head.
+    /// head between them, and the parent was chosen from the engine state itself. The unsafe-head
+    /// staleness check is skipped on both: a derivation-driven reorg legitimately builds and seals
+    /// a payload whose parent differs from the current unsafe head.
     Atomic,
-    /// The seal is enqueued as a task separate from its build, so another task may advance the
-    /// unsafe head in between, invalidating the built payload as stale.
+    /// Build and seal are enqueued as separate tasks on behalf of an external caller that picked
+    /// the parent from its own snapshot of the unsafe head. Another task may advance the unsafe
+    /// head before either runs, making the job stale.
     Detached,
+}
+
+impl BuildSealCoupling {
+    /// Whether a job whose attributes build on `parent` no longer extends the engine's unsafe
+    /// head, and so must be re-created by its caller rather than sent to the execution layer.
+    pub(in crate::task_queue) fn job_is_stale(
+        self,
+        state: &EngineState,
+        parent: &L2BlockInfo,
+    ) -> bool {
+        self == Self::Detached &&
+            state.sync_state.unsafe_head().block_info.hash != parent.block_info.hash
+    }
 }
 
 /// Task for block sealing and canonicalization.
@@ -283,18 +298,11 @@ impl<EngineClient_: EngineClient> EngineTaskExt for SealTask<EngineClient_> {
             "Starting new seal job"
         );
 
-        let unsafe_block_info = state.sync_state.unsafe_head().block_info;
-        let parent_block_info = self.attributes.parent.block_info;
-
-        let build_is_stale = self.coupling == BuildSealCoupling::Detached &&
-            (unsafe_block_info.hash != parent_block_info.hash ||
-                unsafe_block_info.number != parent_block_info.number);
-
-        let res = if build_is_stale {
+        let res = if self.coupling.job_is_stale(state, &self.attributes.parent) {
             info!(
                 target: "engine",
-                unsafe_block_info = ?unsafe_block_info,
-                parent_block_info = ?parent_block_info,
+                unsafe_block_info = ?state.sync_state.unsafe_head().block_info,
+                parent_block_info = ?self.attributes.parent.block_info,
                 "Seal attributes parent does not match unsafe head, returning rebuild error"
             );
             Err(SealTaskError::UnsafeHeadChangedSinceBuild)

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/synchronize/task.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/synchronize/task.rs
@@ -2,8 +2,9 @@
 
 use crate::{
     EngineClient, EngineState, EngineTaskExt, SynchronizeTaskError, state::EngineSyncStateUpdate,
+    task_queue::tasks::is_invalid_forkchoice_state,
 };
-use alloy_rpc_types_engine::{INVALID_FORK_CHOICE_STATE_ERROR, PayloadStatusEnum};
+use alloy_rpc_types_engine::PayloadStatusEnum;
 use async_trait::async_trait;
 use derive_more::Constructor;
 use kona_genesis::RollupConfig;
@@ -124,13 +125,11 @@ impl<EngineClient_: EngineClient> EngineTaskExt for SynchronizeTask<EngineClient
 
         let valid_response = response.map_err(|e| {
             // Fatal forkchoice update error.
-            let error = e
-                .as_error_resp()
-                .and_then(|e| {
-                    (e.code == INVALID_FORK_CHOICE_STATE_ERROR as i64)
-                        .then_some(SynchronizeTaskError::InvalidForkchoiceState)
-                })
-                .unwrap_or_else(|| SynchronizeTaskError::ForkchoiceUpdateFailed(e));
+            let error = if is_invalid_forkchoice_state(&e) {
+                SynchronizeTaskError::InvalidForkchoiceState
+            } else {
+                SynchronizeTaskError::ForkchoiceUpdateFailed(e)
+            };
 
             debug!(target: "engine", error = ?error, "Unexpected forkchoice update error");
 

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/task.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/task.rs
@@ -11,9 +11,17 @@ use crate::{
 use alloy_rpc_types_engine::PayloadStatusEnum;
 use async_trait::async_trait;
 use derive_more::Display;
-use std::cmp::Ordering;
+use std::{cmp::Ordering, time::Duration};
 use thiserror::Error;
-use tokio::task::yield_now;
+use tokio::{task::yield_now, time::sleep};
+
+/// The delay before the second attempt at a task that keeps failing temporarily. Each further
+/// attempt doubles it, up to [`MAX_RETRY_BACKOFF_SHIFT`] doublings.
+const RETRY_BACKOFF_BASE: Duration = Duration::from_millis(10);
+
+/// Caps the exponential backoff between retries of a temporarily failing task at
+/// `RETRY_BACKOFF_BASE * 2^MAX_RETRY_BACKOFF_SHIFT`.
+const MAX_RETRY_BACKOFF_SHIFT: u32 = 7;
 
 /// The severity of an engine task error.
 ///
@@ -125,9 +133,17 @@ impl<EngineClient_: EngineClient> EngineTask<EngineClient_> {
             Self::Seal(task) => task.execute(state).await?,
             Self::Consolidate(task) => task.execute(state).await?,
             Self::Finalize(task) => task.execute(state).await?,
-            Self::Build(task) => {
-                task.execute(state).await?;
-            }
+            Self::Build(task) => match task.execute(state).await {
+                // The caller picked this parent from a snapshot of the unsafe head that has since
+                // been reorged out. It has been told to rebuild, so drop the job instead of
+                // retrying a forkchoice update the execution layer is guaranteed to reject.
+                // Without a channel there is nobody to rebuild, which is a bug: let the error out.
+                Err(BuildTaskError::UnsafeHeadChangedSinceBuild) if task.result_tx.is_some() => {
+                    warn!(target: "engine", "Dropping stale block build job");
+                }
+                Err(err) => return Err(err.into()),
+                Ok(_) => {}
+            },
         };
 
         Ok(())
@@ -212,6 +228,8 @@ impl<EngineClient_: EngineClient> EngineTaskExt for EngineTask<EngineClient_> {
     type Error = EngineTaskErrors;
 
     async fn execute(&self, state: &mut EngineState) -> Result<(), Self::Error> {
+        let mut temporary_failures = 0u32;
+
         // Retry the task until it succeeds or a critical error occurs.
         while let Err(e) = self.execute_inner(state).await {
             let severity = e.severity();
@@ -224,10 +242,20 @@ impl<EngineClient_: EngineClient> EngineTaskExt for EngineTask<EngineClient_> {
 
             match severity {
                 EngineTaskErrorSeverity::Temporary => {
-                    trace!(target: "engine", "{e}");
+                    trace!(target: "engine", temporary_failures, "{e}");
 
-                    // Yield the task to allow other tasks to execute to avoid starvation.
-                    yield_now().await;
+                    // Yield the task to allow other tasks to execute to avoid starvation. An
+                    // engine API call that keeps failing - an execution layer that is restarting,
+                    // say - would otherwise spin this loop as fast as the transport can answer,
+                    // so back off once the first retry has not cleared it.
+                    match temporary_failures {
+                        0 => yield_now().await,
+                        n => {
+                            sleep(RETRY_BACKOFF_BASE * 2u32.pow(n.min(MAX_RETRY_BACKOFF_SHIFT)))
+                                .await
+                        }
+                    }
+                    temporary_failures += 1;
                 }
                 EngineTaskErrorSeverity::Critical => {
                     error!(target: "engine", "{e}");
@@ -253,10 +281,19 @@ impl<EngineClient_: EngineClient> EngineTaskExt for EngineTask<EngineClient_> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::MockEngineClient;
+    use crate::{
+        BuildSealCoupling, EngineState,
+        test_utils::{
+            MockEngineClient, TestAttributesBuilder, TestEngineStateBuilder, test_block_info,
+            test_engine_client_builder,
+        },
+    };
     use alloy_consensus::Block;
+    use alloy_json_rpc::ErrorPayload;
     use alloy_primitives::Bytes;
-    use alloy_rpc_types_engine::{ExecutionPayloadV1, PayloadStatus};
+    use alloy_rpc_types_engine::{
+        ExecutionPayloadV1, INVALID_FORK_CHOICE_STATE_ERROR, PayloadStatus,
+    };
     use kona_genesis::RollupConfig;
     use op_alloy_consensus::OpTxEnvelope;
     use op_alloy_rpc_types_engine::OpExecutionPayloadEnvelope;
@@ -349,5 +386,71 @@ mod tests {
             .await
             .expect("invalid unsafe payload task should not retry")
             .unwrap();
+    }
+
+    #[tokio::test]
+    async fn build_with_invalid_forkchoice_state_does_not_retry() {
+        // `-38002` means the engine considers the forkchoice state itself inconsistent: the safe
+        // or finalized block is not an ancestor of the head. Re-sending it can never succeed, so
+        // the queue must stop and ask for a reset rather than spin on the engine API.
+        let parent = test_block_info(7);
+        let client = Arc::new(
+            test_engine_client_builder()
+                .with_fork_choice_updated_error(ErrorPayload {
+                    code: INVALID_FORK_CHOICE_STATE_ERROR as i64,
+                    message: "invalid forkchoice state".into(),
+                    data: None,
+                })
+                .build(),
+        );
+        let attributes = TestAttributesBuilder::new()
+            .with_parent(parent)
+            .with_timestamp(parent.block_info.timestamp)
+            .build();
+        let task = EngineTask::Build(Box::new(BuildTask::new(
+            client,
+            Arc::new(RollupConfig::default()),
+            attributes,
+            BuildSealCoupling::Atomic,
+            None,
+        )));
+        let mut state = TestEngineStateBuilder::new().with_unsafe_head(parent).build();
+
+        let err = tokio::time::timeout(Duration::from_secs(1), task.execute(&mut state))
+            .await
+            .expect("an invalid forkchoice state must not be retried")
+            .expect_err("the task fails");
+        assert_eq!(err.severity(), EngineTaskErrorSeverity::Reset);
+    }
+
+    #[tokio::test]
+    async fn stale_build_completes_without_retry() {
+        // The build was requested against an unsafe head that has since been reorged out. The
+        // caller has been told to re-build, so the queue drops the job and moves on.
+        // Same height, different hash: exactly the shape a force-included derived block takes.
+        let stale_parent = test_block_info(42);
+        let unsafe_head = test_block_info(42);
+
+        // No forkchoice response is configured: the mock errors if the engine is called at all.
+        let client = Arc::new(test_engine_client_builder().build());
+        let attributes = TestAttributesBuilder::new()
+            .with_parent(stale_parent)
+            .with_timestamp(unsafe_head.block_info.timestamp)
+            .build();
+        let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+        let task = EngineTask::Build(Box::new(BuildTask::new(
+            client,
+            Arc::new(RollupConfig::default()),
+            attributes,
+            BuildSealCoupling::Detached,
+            Some(tx),
+        )));
+        let mut state = TestEngineStateBuilder::new().with_unsafe_head(unsafe_head).build();
+
+        tokio::time::timeout(Duration::from_secs(1), task.execute(&mut state))
+            .await
+            .expect("a stale build must not be retried")
+            .expect("the queue drops the stale job instead of failing");
+        assert!(matches!(rx.recv().await, Some(Err(BuildTaskError::UnsafeHeadChangedSinceBuild))));
     }
 }

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/util.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/util.rs
@@ -2,9 +2,20 @@
 
 use super::{BuildSealCoupling, BuildTask, BuildTaskError, EngineTaskExt, SealTask, SealTaskError};
 use crate::{EngineClient, EngineState, ImportedBlockSink};
+use alloy_rpc_types_engine::INVALID_FORK_CHOICE_STATE_ERROR;
+use alloy_transport::{RpcError, TransportErrorKind};
 use kona_genesis::RollupConfig;
 use kona_protocol::OpAttributesWithParent;
 use std::sync::Arc;
+
+/// Whether the engine rejected a forkchoice update because the state itself is inconsistent, i.e.
+/// the safe or finalized block is not an ancestor of the head. Re-sending such an update can never
+/// succeed; the node has to reset.
+pub(in crate::task_queue) fn is_invalid_forkchoice_state(
+    err: &RpcError<TransportErrorKind>,
+) -> bool {
+    err.as_error_resp().is_some_and(|e| e.code == INVALID_FORK_CHOICE_STATE_ERROR as i64)
+}
 
 /// Error type for build and seal operations.
 #[derive(Debug, thiserror::Error)]
@@ -47,6 +58,7 @@ pub(in crate::task_queue) async fn build_and_seal<EngineClient_: EngineClient>(
         engine.clone(),
         cfg.clone(),
         attributes.clone(),
+        BuildSealCoupling::Atomic,
         None, // Build task doesn't send the payload yet
     )
     .execute(state)

--- a/rust/kona/crates/node/engine/src/test_utils/engine_client.rs
+++ b/rust/kona/crates/node/engine/src/test_utils/engine_client.rs
@@ -2,6 +2,7 @@
 
 use crate::{EngineClient, HyperAuthClient};
 use alloy_eips::{BlockId, eip1898::BlockNumberOrTag};
+use alloy_json_rpc::ErrorPayload;
 use alloy_network::{Ethereum, Network};
 use alloy_primitives::{Address, B256, BlockHash, StorageKey};
 use alloy_provider::{EthGetBlock, ProviderCall, RpcWithBlock};
@@ -11,7 +12,7 @@ use alloy_rpc_types_engine::{
     PayloadStatus,
 };
 use alloy_rpc_types_eth::{Block, EIP1186AccountProofResponse, Transaction as EthTransaction};
-use alloy_transport::{TransportError, TransportErrorKind, TransportResult};
+use alloy_transport::{RpcError, TransportError, TransportErrorKind, TransportResult};
 use alloy_transport_http::Http;
 use async_trait::async_trait;
 use kona_genesis::RollupConfig;
@@ -56,6 +57,9 @@ pub struct MockEngineStorage {
     pub fork_choice_updated_v2_response: Option<ForkchoiceUpdated>,
     /// Storage for `fork_choice_updated_v3` responses.
     pub fork_choice_updated_v3_response: Option<ForkchoiceUpdated>,
+    /// A JSON-RPC error payload that every `fork_choice_updated` call returns, taking precedence
+    /// over the version-specific responses above.
+    pub fork_choice_updated_error: Option<ErrorPayload>,
 
     // Version-specific get_payload responses
     /// Storage for execution payload envelope v2 responses.
@@ -169,6 +173,12 @@ impl MockEngineClientBuilder {
     /// Sets the `fork_choice_updated_v3` response.
     pub fn with_fork_choice_updated_v3_response(mut self, response: ForkchoiceUpdated) -> Self {
         self.storage.fork_choice_updated_v3_response = Some(response);
+        self
+    }
+
+    /// Makes every `fork_choice_updated` call fail with the provided JSON-RPC error payload.
+    pub fn with_fork_choice_updated_error(mut self, error: ErrorPayload) -> Self {
+        self.storage.fork_choice_updated_error = Some(error);
         self
     }
 
@@ -523,6 +533,9 @@ impl OpEngineApi<Optimism, Http<HyperAuthClient>> for MockEngineClient {
         _payload_attributes: Option<OpPayloadAttributes>,
     ) -> TransportResult<ForkchoiceUpdated> {
         let storage = self.storage.read().await;
+        if let Some(error) = storage.fork_choice_updated_error.clone() {
+            return Err(RpcError::ErrorResp(error));
+        }
         storage.fork_choice_updated_v2_response.clone().ok_or_else(|| {
             TransportError::from(TransportErrorKind::custom_str(
                 "fork_choice_updated_v2 was called but no v2 response configured. \
@@ -537,6 +550,9 @@ impl OpEngineApi<Optimism, Http<HyperAuthClient>> for MockEngineClient {
         _payload_attributes: Option<OpPayloadAttributes>,
     ) -> TransportResult<ForkchoiceUpdated> {
         let storage = self.storage.read().await;
+        if let Some(error) = storage.fork_choice_updated_error.clone() {
+            return Err(RpcError::ErrorResp(error));
+        }
         storage.fork_choice_updated_v3_response.clone().ok_or_else(|| {
             TransportError::from(TransportErrorKind::custom_str(
                 "fork_choice_updated_v3 was called but no v3 response configured. \

--- a/rust/kona/crates/node/service/src/actors/engine/actor.rs
+++ b/rust/kona/crates/node/service/src/actors/engine/actor.rs
@@ -99,6 +99,12 @@ where
         // Reset the engine.
         let l2_safe_head = self.engine.reset(self.client.clone(), self.rollup.clone()).await?;
 
+        // The reset moved the unsafe head. Publish it before the awaits below, which can block on
+        // a full derivation-actor channel, so that a caller woken by its dropped request cannot
+        // read a pre-reset head. This is also what lets the sequencer's first build after startup
+        // see a real unsafe head rather than the channel's default.
+        self.publish_unsafe_head();
+
         // Signal the derivation actor to reset.
         let signal = Signal::Reset(ResetSignal { l2_safe_head });
         match self.derivation_client.send_signal(signal).await {
@@ -112,6 +118,17 @@ where
         self.send_derivation_actor_safe_head_if_updated().await?;
 
         Ok(())
+    }
+
+    /// Publishes the engine's current unsafe head to the outbound channel, if the node is in
+    /// sequencer mode.
+    fn publish_unsafe_head(&self) {
+        if let Some(unsafe_head_tx) = self.unsafe_head_tx.as_ref() {
+            unsafe_head_tx.send_if_modified(|val| {
+                let new_head = self.engine.state().sync_state.unsafe_head();
+                (*val != new_head).then(|| *val = new_head).is_some()
+            });
+        }
     }
 
     /// Drains the inner [`Engine`] task queue and attempts to update the safe head.
@@ -222,12 +239,7 @@ where
             .inspect_err(|err| error!(target: "engine", ?err, "Failed to drain engine tasks"))?;
 
         // If the unsafe head has updated, propagate it to the outbound channels.
-        if let Some(unsafe_head_tx) = self.unsafe_head_tx.as_ref() {
-            unsafe_head_tx.send_if_modified(|val| {
-                let new_head = self.engine.state().sync_state.unsafe_head();
-                (*val != new_head).then(|| *val = new_head).is_some()
-            });
-        }
+        self.publish_unsafe_head();
 
         // Wait for the next processing request.
         let request = self.inbound_request_rx.recv().await.ok_or_else(|| {
@@ -242,6 +254,9 @@ where
                     self.client.clone(),
                     self.rollup.clone(),
                     attributes,
+                    // The requester chose the parent from its own snapshot of the unsafe head,
+                    // which the engine may have moved since.
+                    BuildSealCoupling::Detached,
                     Some(result_tx),
                 )));
                 self.engine.enqueue(task);

--- a/rust/kona/crates/node/service/src/actors/engine/request.rs
+++ b/rust/kona/crates/node/service/src/actors/engine/request.rs
@@ -44,7 +44,7 @@ pub struct BuildRequest {
     /// The [`OpAttributesWithParent`] from which the block build should be started.
     pub attributes: OpAttributesWithParent,
     /// The channel on which the result, successful or not, will be sent.
-    pub result_tx: mpsc::Sender<PayloadId>,
+    pub result_tx: mpsc::Sender<Result<PayloadId, BuildTaskError>>,
 }
 
 /// A request to reset the engine forkchoice.

--- a/rust/kona/crates/node/service/src/actors/sequencer/actor.rs
+++ b/rust/kona/crates/node/service/src/actors/sequencer/actor.rs
@@ -20,7 +20,7 @@ use crate::{
 use alloy_rpc_types_engine::PayloadId;
 use async_trait::async_trait;
 use kona_derive::{AttributesBuilder, PipelineErrorKind};
-use kona_engine::{InsertTaskError, SealTaskError, SynchronizeTaskError};
+use kona_engine::{BuildTaskError, InsertTaskError, SealTaskError, SynchronizeTaskError};
 use kona_genesis::RollupConfig;
 use kona_protocol::{BlockInfo, L2BlockInfo, OpAttributesWithParent};
 use op_alloy_rpc_types_engine::OpPayloadAttributes;
@@ -243,7 +243,31 @@ where
         let build_request_start = Instant::now();
 
         let payload_id =
-            self.engine_client.start_build_block(attributes_with_parent.clone()).await?;
+            match self.engine_client.start_build_block(attributes_with_parent.clone()).await {
+                Ok(payload_id) => payload_id,
+                // The engine moved on from the unsafe head these attributes were built against:
+                // it reorged onto a derived chain, or reset out from under the request and dropped
+                // it. Either way the attributes are stale; re-build on the new head next tick.
+                Err(EngineClientError::StartBuildError(err)) if !is_build_task_err_fatal(&err) => {
+                    warn!(
+                        target: "sequencer",
+                        ?err,
+                        parent = ?attributes_with_parent.parent(),
+                        "Engine rejected the block build. Re-attempting on next tick."
+                    );
+                    return Ok(None);
+                }
+                Err(err @ EngineClientError::ResponseError(_)) => {
+                    warn!(
+                        target: "sequencer",
+                        ?err,
+                        parent = ?attributes_with_parent.parent(),
+                        "Engine dropped the block build request. Re-attempting on next tick."
+                    );
+                    return Ok(None);
+                }
+                Err(err) => return Err(err.into()),
+            };
 
         update_block_build_duration_metrics(build_request_start.elapsed());
 
@@ -505,6 +529,16 @@ where
                 Ok(())
             }
         }
+    }
+}
+
+// Determines whether the provided [`BuildTaskError`] is fatal for the sequencer.
+//
+// NB: See `is_seal_task_err_fatal` for why this is an explicit match rather than `err.severity()`.
+const fn is_build_task_err_fatal(err: &BuildTaskError) -> bool {
+    match err {
+        BuildTaskError::UnsafeHeadChangedSinceBuild => false,
+        BuildTaskError::EngineBuildError(_) | BuildTaskError::MpscSend(_) => true,
     }
 }
 

--- a/rust/kona/crates/node/service/src/actors/sequencer/engine_client.rs
+++ b/rust/kona/crates/node/service/src/actors/sequencer/engine_client.rs
@@ -80,28 +80,32 @@ impl SequencerEngineClient for QueuedSequencerEngineClient {
         &self,
         attributes: OpAttributesWithParent,
     ) -> EngineClientResult<PayloadId> {
-        let (payload_id_tx, mut payload_id_rx) = mpsc::channel(1);
+        let (result_tx, mut result_rx) = mpsc::channel(1);
 
         trace!(target: "sequencer", "Sending start build request to engine.");
         if self
             .engine_actor_request_tx
-            .send(EngineActorRequest::Build(Box::new(BuildRequest {
-                attributes,
-                result_tx: payload_id_tx,
-            })))
+            .send(EngineActorRequest::Build(Box::new(BuildRequest { attributes, result_tx })))
             .await
             .is_err()
         {
             return Err(EngineClientError::RequestError("request channel closed.".to_string()));
         }
 
-        payload_id_rx.recv()
-            .await
-            .inspect(|payload_id| trace!(target: "sequencer", ?payload_id, "Start build request successfully."))
-            .ok_or_else(|| {
-            error!(target: "block_engine", "Failed to receive payload for initiated block build");
-            EngineClientError::ResponseError("response channel closed.".to_string())
-        })
+        match result_rx.recv().await {
+            Some(Ok(payload_id)) => {
+                trace!(target: "sequencer", ?payload_id, "Start build request successful.");
+                Ok(payload_id)
+            }
+            Some(Err(err)) => {
+                info!(target: "sequencer", ?err, "Start build failed.");
+                Err(EngineClientError::StartBuildError(err))
+            }
+            None => {
+                error!(target: "block_engine", "Failed to receive payload for initiated block build");
+                Err(EngineClientError::ResponseError("response channel closed.".to_string()))
+            }
+        }
     }
 
     async fn seal_and_canonicalize_block(

--- a/rust/kona/crates/node/service/src/actors/sequencer/tests/actor_test.rs
+++ b/rust/kona/crates/node/service/src/actors/sequencer/tests/actor_test.rs
@@ -1,12 +1,15 @@
 #[cfg(test)]
 use crate::{
-    SequencerActorError,
+    EngineClientError, SequencerActorError,
     actors::{
         MockOriginSelector, MockSequencerEngineClient, sequencer::tests::test_util::test_actor,
     },
 };
+use alloy_rpc_types_engine::PayloadId;
 use kona_derive::{BuilderError, PipelineErrorKind, test_utils::TestAttributesBuilder};
+use kona_engine::BuildTaskError;
 use kona_protocol::{BlockInfo, L2BlockInfo};
+use op_alloy_rpc_types_engine::OpPayloadAttributes;
 use rstest::rstest;
 
 #[rstest]
@@ -49,4 +52,50 @@ async fn test_build_unsealed_payload_prepare_payload_attributes_error(
     } else {
         assert!(result.is_ok());
     }
+}
+
+#[rstest]
+#[case::stale_parent(EngineClientError::StartBuildError(
+    BuildTaskError::UnsafeHeadChangedSinceBuild,
+))]
+#[case::request_dropped(EngineClientError::ResponseError("response channel closed.".to_string()))]
+#[tokio::test]
+async fn test_build_unsealed_payload_retries_when_the_engine_rejects_the_build(
+    #[case] forced_error: EngineClientError,
+) {
+    // The engine reorged onto a derived chain (or reset) after the unsafe head was read, so these
+    // attributes no longer extend it. The sequencer must re-build on the new head next tick rather
+    // than treat this as fatal.
+    let payload_id = PayloadId::new([7u8; 8]);
+    let reorged_head = L2BlockInfo {
+        block_info: BlockInfo { number: 42, ..Default::default() },
+        ..Default::default()
+    };
+
+    let mut client = MockSequencerEngineClient::new();
+    let mut heads = vec![reorged_head, L2BlockInfo::default()];
+    client.expect_get_unsafe_head().times(2).returning(move || Ok(heads.pop().unwrap()));
+    let mut results = vec![Ok(payload_id), Err(forced_error)];
+    client.expect_start_build_block().times(2).returning(move |_| results.pop().unwrap());
+
+    let mut origin_selector = MockOriginSelector::new();
+    origin_selector.expect_next_l1_origin().times(2).returning(|_, _| Ok(BlockInfo::default()));
+
+    let mut actor = test_actor();
+    actor.origin_selector = origin_selector;
+    actor.engine_client = client;
+    actor.attributes_builder = TestAttributesBuilder {
+        attributes: vec![Ok(OpPayloadAttributes::default()), Ok(OpPayloadAttributes::default())],
+    };
+
+    assert!(actor.build_unsealed_payload().await.expect("a rejected build is not fatal").is_none());
+
+    // The engine has since published the head it reorged to, so the next attempt succeeds there.
+    let handle = actor
+        .build_unsealed_payload()
+        .await
+        .expect("the retry builds")
+        .expect("a payload was started");
+    assert_eq!(handle.payload_id, payload_id);
+    assert_eq!(handle.attributes_with_parent.parent(), &reorged_head);
 }


### PR DESCRIPTION
A kona-node sequencer could be permanently wedged — hot-looping `engine_forkchoiceUpdatedV3` at thousands of calls per second — whenever the engine reorged its unsafe head while a build was in flight. Derivation force-inclusion after a batcher outage makes that reorg happen deterministically, so a sequencing-window expiry reliably killed the node. Full mechanism in #22681.

The sequencer reads the unsafe head from a watch channel, then does network-bound async work (L1 origin selection, attributes building) before submitting the build. If derivation reorgs in that window, `BuildTask::start_build` sends the EL `head = <stale sequencer block>`, `safe = <derived block>` and gets `-38002`. That was classified `Temporary`, and `EngineTask::execute` retries temporary errors in a `while let Err(..)` loop whose only pause is `yield_now().await`. The forkchoice state cannot change while the queue is draining, so the retry could never succeed: the engine actor was stuck inside `Engine::drain` and the sequencer parked awaiting a payload id, with no path left to a reset.

## Changes

Both guards are lifted from op-node's `EngineController`:

- `-38002` on the build forkchoice update maps to a new `EngineBuildError::InvalidForkchoiceState` with severity `Reset`, mirroring `SynchronizeTask` (which already special-cased the same code on the attribute-less FCU) and op-node's `startPayload`.
- A `Detached` build whose parent is no longer the unsafe head is rejected before the engine is called, mirroring op-node's `startBuild`. The gate reuses the existing `BuildSealCoupling` flag that `SealTask` already uses for this exact distinction: `Atomic` for the derivation-driven `build_and_seal` path, where the parent legitimately differs from the unsafe head, `Detached` for a caller working from its own snapshot. `BuildTask`'s result channel now carries a `Result` so the caller learns why, instead of waiting on a sender that gets dropped.
- The sequencer treats a rejected or dropped build as "re-build on the current head", not a fatal actor error — every `NodeActor::step` error shuts the whole node down. Build errors are classified by an explicit `is_build_task_err_fatal` match rather than a wildcard, for the same reason `is_seal_task_err_fatal` next to it is written that way. `ResponseError` (the engine cleared the queue during a reset) gets the same treatment; a genuinely dead engine actor surfaces as `RequestError`, which stays fatal.
- Retries of a temporarily failing task now back off (10ms, doubling to ~1.3s). Without this the hot loop is still reachable by a different trigger: any transport-level FCU failure — an EL restarting — maps to `AttributesInsertionFailed`, which is `Temporary`, and spun the actor at the rate the transport answered.
- The engine actor publishes the unsafe head after a reset, before the awaits that can block on a full derivation-actor channel. This is load-bearing rather than defensive: without it the new staleness guard would reject the sequencer's first build on every startup, since the watch channel still holds `L2BlockInfo::default()`.

## Testing

Unit tests only; no full-system repro. `-38002` on a build now surfaces as `Reset` and is not retried (that test blows its timeout before the fix), a stale detached build is rejected without touching the engine and tells its caller, and the sequencer retries onto the reorged head instead of dying. The build-task success cases are parameterized over both couplings so an inverted staleness guard fails CI — verified by inverting it.

A devstack repro is blocked on a harness gap documented in #22681: nothing anywhere exercises batcher outage → window expiry → force-include → sequencer reorg against a kona-node sequencer, and the one test that models the whole loop (`TestSequencingWindowExpiry`) is bound to a supernode preset that cannot start a `KonaNode`. The gap is fillable via `presets.NewMinimal` + `sysgo.WithSequencingWindow`, which the kona-node acceptance job already covers.

## Review

`rust-code-reviewer` run; no blocking findings. Taken: the retry backoff, the exhaustive build-error classification, deduplicating the staleness check and the `-38002` detection, moving the post-reset publish earlier, surfacing the inner build error in `Display`, and the two test gaps (no `Detached` success coverage, no recovery assertion).

Deferred to follow-ups on #22681, all pre-existing and out of scope here:

- `SealTask` routes every error to its caller and returns `Ok`, so a `-38002` raised during a sequencer seal still never triggers a reset.
- `QueuedSequencerEngineClient`'s `recv().await` calls have no timeout, so the sequencer can still be parked indefinitely on an engine round-trip and stops servicing its admin API.
- The sequencer's next parent comes from a watch channel that lags the seal result, which is what makes the new guard fire at all; taking the parent from the seal's return value (what op-node does) removes the race rather than handling it.

`go-code-reviewer` not run — no Go changes.

Fixes #22681

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fi2GEEBE6LmUwLS25WPKfq
