### PR TITLE
kona-genesis!: reject unknown rollup.json keys

### DIFF
--- a/docs/ai/derivation.md
+++ b/docs/ai/derivation.md
@@ -65,7 +65,15 @@ Two guards fail loudly on a field left unwired:
 - **Strict decoding** rejects registry keys that no struct field models —
   `jsonutil.DecodeTOMLStrict` (Go, used by `op-core/superchain`) and
   `#[serde(deny_unknown_fields)]` (kona's `ChainConfig` / `HardForkConfig`). A registry bump that
-  adds an unmodeled field fails to load until the struct consumes it.
+  adds an unmodeled field fails to load until the struct consumes it. kona's `RollupConfig` and the
+  nested types it holds are strict the same way, so an operator-supplied `rollup.json` carrying a
+  key kona does not model fails to load instead of being silently dropped. op-node's
+  `ParseRollupConfig` is lenient, which makes the asymmetry cut both ways: a **new** `rollup.Config`
+  field has to be modeled in kona before a config carrying it loads in kona-node
+  (`TestKonaRollupConfigFixture`, `op-node/rollup/kona_rollup_config_test.go`, fails when the two
+  drift apart), and a **retired** one that op-node simply stops modeling has to stay modeled-and-
+  ignored in kona, or configs still carrying it stop loading there while op-node keeps accepting
+  them.
 - **A reflection completeness test** (`TestRollupConfigFromRegistry_AllFieldsSet`) asserts every
   `rollup.Config` field is populated from a fully-populated `ChainConfig`, catching a field that
   is modeled but never copied in the conversion.

--- a/op-node/rollup/kona_rollup_config_test.go
+++ b/op-node/rollup/kona_rollup_config_test.go
@@ -1,0 +1,133 @@
+package rollup
+
+import (
+	"encoding/json"
+	"math/big"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+
+	opparams "github.com/ethereum-optimism/optimism/op-core/params"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/ptr"
+)
+
+// konaRollupConfigFixture is parsed by kona-genesis in `test_op_node_rollup_config_parses`
+// (rust/kona/crates/protocol/genesis/src/rollup.rs). kona's `RollupConfig` rejects unknown keys, so
+// a `Config` field that kona does not model turns a rollup.json op-node accepts into one kona-node
+// refuses to start on.
+const konaRollupConfigFixture = "../../rust/kona/crates/protocol/genesis/tests/fixtures/op_node_rollup_config.json"
+
+// updateFixtureEnvVar set to "1" rewrites the fixture instead of asserting against it.
+const updateFixtureEnvVar = "UPDATE_KONA_ROLLUP_CONFIG_FIXTURE"
+
+// fullyPopulatedConfig returns a Config with every field non-zero, so marshalling it emits every
+// key op-node can write to a rollup.json — `omitempty` drops nothing. Adding a Config field means
+// updating this, `fullyPopulatedChainConfig` (op-node/superchain), and the fixture.
+//
+// Values are distinct wherever two fields share a type or a packed encoding, so a decoder that
+// reads the wrong half of a packed field, or crosses two fields, fails on the kona side.
+func fullyPopulatedConfig() *Config {
+	return &Config{
+		Genesis: Genesis{
+			L1:     eth.BlockID{Hash: common.HexToHash("0xaa"), Number: 100},
+			L2:     eth.BlockID{Hash: common.HexToHash("0xbb"), Number: 1},
+			L2Time: 1725557164,
+			SystemConfig: eth.SystemConfig{
+				BatcherAddr:          common.HexToAddress("0x1111111111111111111111111111111111111111"),
+				Overhead:             eth.Bytes32(common.HexToHash("0xbc")),
+				Scalar:               eth.Bytes32(common.HexToHash("0xa6fe0")),
+				GasLimit:             30_000_000,
+				EIP1559Params:        eth.Bytes8{0, 0, 0, 101, 0, 0, 0, 7},
+				OperatorFeeParams:    eth.EncodeOperatorFeeParams(eth.OperatorFeeParams{Scalar: 23, Constant: 42}),
+				MinBaseFee:           1_000_000,
+				DAFootprintGasScalar: 400,
+			},
+		},
+		BlockTime:              2,
+		MaxSequencerDrift:      600,
+		SeqWindowSize:          3600,
+		ChannelTimeoutBedrock:  300,
+		L1ChainID:              big.NewInt(1),
+		L2ChainID:              big.NewInt(10),
+		RegolithTime:           ptr.New(uint64(1)),
+		CanyonTime:             ptr.New(uint64(2)),
+		DeltaTime:              ptr.New(uint64(3)),
+		EcotoneTime:            ptr.New(uint64(4)),
+		FjordTime:              ptr.New(uint64(5)),
+		GraniteTime:            ptr.New(uint64(6)),
+		HoloceneTime:           ptr.New(uint64(7)),
+		IsthmusTime:            ptr.New(uint64(8)),
+		JovianTime:             ptr.New(uint64(9)),
+		KarstTime:              ptr.New(uint64(10)),
+		KeepKarstUpgradeGas:    true,
+		LagoonTime:             ptr.New(uint64(11)),
+		BatchInboxAddress:      common.HexToAddress("0xff00000000000000000000000000000000000010"),
+		DepositContractAddress: common.HexToAddress("0x2222222222222222222222222222222222222222"),
+		L1SystemConfigAddress:  common.HexToAddress("0x3333333333333333333333333333333333333333"),
+		ChainOpConfig: &opparams.OptimismConfig{
+			EIP1559Elasticity:        6,
+			EIP1559Denominator:       50,
+			EIP1559DenominatorCanyon: ptr.New(uint64(250)),
+		},
+		AltDAConfig: &AltDAConfig{
+			DAChallengeAddress: common.HexToAddress("0x4444444444444444444444444444444444444444"),
+			CommitmentType:     "KeccakCommitment",
+			MaxInputSize:       ptr.New(uint64(130_672)),
+			DAChallengeWindow:  160,
+			DAResolveWindow:    180,
+		},
+		PectraBlobScheduleTime: ptr.New(uint64(12)),
+	}
+}
+
+// requireAllJSONFieldsSet asserts every marshalled field of v is non-zero, so `omitempty` drops
+// nothing. Fields tagged `json:"-"` are never emitted and are exempt.
+func requireAllJSONFieldsSet(t *testing.T, v any) {
+	rv := reflect.ValueOf(v)
+	typ := rv.Type()
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		if field.Tag.Get("json") == "-" {
+			continue
+		}
+		require.Falsef(t, rv.Field(i).IsZero(),
+			"%s field %q is zero, so marshalling omits it: give it a value in fullyPopulatedConfig",
+			typ.Name(), field.Name)
+	}
+}
+
+// TestKonaRollupConfigFixture keeps the rollup.json kona-genesis parses in sync with what op-node
+// emits. It fails when Config gains a field, which is the point: the new key has to be modelled in
+// kona's RollupConfig before a rollup.json carrying it will load in kona-node.
+func TestKonaRollupConfigFixture(t *testing.T) {
+	cfg := fullyPopulatedConfig()
+
+	// Every struct that reaches the JSON, so a new `omitempty` field nested inside one of them
+	// cannot stay unemitted — an unemitted key leaves the fixture unchanged and the drift unseen.
+	requireAllJSONFieldsSet(t, *cfg)
+	requireAllJSONFieldsSet(t, cfg.Genesis)
+	requireAllJSONFieldsSet(t, cfg.Genesis.SystemConfig)
+	requireAllJSONFieldsSet(t, *cfg.ChainOpConfig)
+	requireAllJSONFieldsSet(t, *cfg.AltDAConfig)
+
+	require.NoError(t, cfg.Check(), "the fixture must be a config op-node itself accepts")
+
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	require.NoError(t, err)
+	data = append(data, '\n')
+
+	if os.Getenv(updateFixtureEnvVar) == "1" {
+		require.NoError(t, os.WriteFile(konaRollupConfigFixture, data, 0o644))
+		t.Skip("rewrote " + konaRollupConfigFixture)
+	}
+
+	fixture, err := os.ReadFile(konaRollupConfigFixture)
+	require.NoError(t, err)
+	require.Equal(t, string(fixture), string(data),
+		"%s is stale: model any new key in kona's RollupConfig, then regenerate with %s=1 go test ./op-node/rollup -run TestKonaRollupConfigFixture",
+		konaRollupConfigFixture, updateFixtureEnvVar)
+}

--- a/op-node/rollup/types_test.go
+++ b/op-node/rollup/types_test.go
@@ -68,12 +68,15 @@ func randConfig() *Config {
 }
 
 func TestConfigJSON(t *testing.T) {
-	config := randConfig()
-	data, err := json.Marshal(config)
-	assert.NoError(t, err)
-	var roundTripped Config
-	assert.NoError(t, json.Unmarshal(data, &roundTripped))
-	assert.Equal(t, &roundTripped, config)
+	// fullyPopulatedConfig covers the optional fields randConfig leaves nil, where a
+	// marshal/unmarshal tag mismatch would otherwise be invisible.
+	for _, config := range []*Config{randConfig(), fullyPopulatedConfig()} {
+		data, err := json.Marshal(config)
+		assert.NoError(t, err)
+		var roundTripped Config
+		assert.NoError(t, json.Unmarshal(data, &roundTripped))
+		assert.Equal(t, &roundTripped, config)
+	}
 }
 
 func TestAltDAConfigMaxInputSize(t *testing.T) {

--- a/rust/kona/crates/protocol/genesis/src/params.rs
+++ b/rust/kona/crates/protocol/genesis/src/params.rs
@@ -148,6 +148,9 @@ pub const BASE_MAINNET_BASE_FEE_CONFIG: BaseFeeConfig = BaseFeeConfig {
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+// Strict like every other type in the `rollup.json` tree: these are the chain's EIP-1559 consensus
+// parameters, so a key that is dropped is a parameter that is not honored.
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 pub struct BaseFeeConfig {
     /// EIP 1559 Elasticity Parameter
     #[cfg_attr(

--- a/rust/kona/crates/protocol/genesis/src/rollup.rs
+++ b/rust/kona/crates/protocol/genesis/src/rollup.rs
@@ -34,6 +34,17 @@ const fn default_fjord_max_sequencer_drift() -> u64 {
 /// The Rollup configuration.
 #[derive(Debug, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+// Reject any `rollup.json` key this struct does not model. The rollup config is the chain's
+// consensus-parameter file, so a key that is dropped is a parameter that is not honored: the node
+// boots and derives a chain other than the one the config describes. Every nested type in the
+// `rollup.json` tree is strict the same way.
+//
+// `hardforks` is `#[serde(flatten)]`ed, a combination serde's documentation calls unsupported. It
+// works: the derive checks the keys left over after every flattened field has taken its own, so the
+// hardfork keys still parse and anything else is an error. The flattened `HardForkConfig`'s own
+// `deny_unknown_fields` is inert and does not contribute. Since that rests on derive behavior
+// rather than a documented guarantee, `test_rollup_config_rejects_unknown_field` pins both halves.
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 pub struct RollupConfig {
     /// The genesis state of the rollup.
     pub genesis: ChainGenesis,
@@ -931,10 +942,9 @@ mod tests {
         }
     }
 
-    #[test]
+    /// A reference `rollup.json`, of the shape op-deployer writes for a devnet chain.
     #[cfg(feature = "serde")]
-    fn test_deserialize_reference_rollup_config() {
-        let raw: &str = r#"
+    const REFERENCE_ROLLUP_CONFIG_JSON: &str = r#"
         {
           "genesis": {
             "l1": {
@@ -984,65 +994,143 @@ mod tests {
         }
         "#;
 
-        let expected = expected_rollup_config();
-        let deserialized: RollupConfig = serde_json::from_str(raw).unwrap();
-        assert_eq!(deserialized, expected);
+    #[test]
+    #[cfg(feature = "serde")]
+    fn test_deserialize_reference_rollup_config() {
+        let deserialized: RollupConfig =
+            serde_json::from_str(REFERENCE_ROLLUP_CONFIG_JSON).unwrap();
+        assert_eq!(deserialized, expected_rollup_config());
     }
 
-    #[test]
-    fn test_rollup_config_unknown_field() {
-        let raw: &str = r#"
-        {
-          "genesis": {
-            "l1": {
-              "hash": "0x481724ee99b1f4cb71d826e2ec5a37265f460e9b112315665c977f4050b0af54",
-              "number": 10
-            },
-            "l2": {
-              "hash": "0x88aedfbf7dea6bfa2c4ff315784ad1a7f145d8f650969359c003bbed68c87631",
-              "number": 0
-            },
-            "l2_time": 1725557164,
-            "system_config": {
-              "batcherAddr": "0xc81f87a644b41e49b3221f41251f15c6cb00ce03",
-              "overhead": "0x0000000000000000000000000000000000000000000000000000000000000000",
-              "scalar": "0x00000000000000000000000000000000000000000000000000000000000f4240",
-              "gasLimit": 30000000,
-              "baseFeeScalar": 1234,
-              "blobBaseFeeScalar": 5678,
-              "eip1559Denominator": 10,
-              "eip1559Elasticity": 20,
-              "operatorFeeScalar": 30,
-              "operatorFeeConstant": 40,
-              "minBaseFee": 50,
-              "daFootprintGasScalar": 10
-            }
-          },
-          "block_time": 2,
-          "max_sequencer_drift": 600,
-          "seq_window_size": 3600,
-          "channel_timeout": 300,
-          "l1_chain_id": 3151908,
-          "l2_chain_id": 1337,
-          "regolith_time": 0,
-          "canyon_time": 0,
-          "delta_time": 0,
-          "ecotone_time": 0,
-          "fjord_time": 0,
-          "batch_inbox_address": "0xff00000000000000000000000000000000042069",
-          "deposit_contract_address": "0x08073dc48dde578137b8af042bcbc1c2491f1eb2",
-          "l1_system_config_address": "0x94ee52a9d8edd72a85dea7fae3ba6d75e4bf1710",
-          "chain_op_config": {
-            "eip1559_elasticity": 6,
-            "eip1559_denominator": 50,
-            "eip1559_denominator_canyon": 250
-          },
-          "unknown_field": "unknown"
-        }
-        "#;
+    /// Adds `key` to `REFERENCE_ROLLUP_CONFIG_JSON`, at the top level when `object` is `None` and
+    /// inside that nested object otherwise, so a rejection test differs from the config that
+    /// parses by exactly that one key.
+    #[cfg(feature = "serde")]
+    fn reference_config_with_extra_key(object: Option<&str>, key: &str) -> alloc::string::String {
+        let mut value: serde_json::Value =
+            serde_json::from_str(REFERENCE_ROLLUP_CONFIG_JSON).unwrap();
+        let target = match object {
+            Some(name) => value.get_mut(name).expect("nested object is present"),
+            None => &mut value,
+        };
+        target
+            .as_object_mut()
+            .expect("object")
+            .insert(key.into(), serde_json::Value::from("unknown"));
+        value.to_string()
+    }
 
-        let expected = expected_rollup_config();
-        let deserialized: RollupConfig = serde_json::from_str(raw).unwrap();
+    /// A `rollup.json` key that [`RollupConfig`] does not model must be rejected, not ignored: an
+    /// ignored consensus parameter is one the node does not honor, so it would derive a chain other
+    /// than the one the config describes. The input is the reference config, which parses, plus one
+    /// unknown key — and it carries flattened hardfork keys, so this also pins that
+    /// `deny_unknown_fields` still lets the flattened `HardForkConfig` take its own.
+    #[test]
+    #[cfg(feature = "serde")]
+    fn test_rollup_config_rejects_unknown_field() {
+        for object in [None, Some("genesis"), Some("chain_op_config")] {
+            let raw = reference_config_with_extra_key(object, "unknown_field");
+            let err = serde_json::from_str::<RollupConfig>(&raw).unwrap_err();
+            assert!(
+                err.to_string().contains("unknown field `unknown_field`"),
+                "expected the unknown key in {object:?} to be rejected, got: {err}"
+            );
+        }
+    }
+
+    /// Every key op-node can write to a `rollup.json` has to parse here. op-node's `rollup.Config`
+    /// is what op-deployer emits, and [`RollupConfig`] rejects keys it does not model, so a field
+    /// added there and not here is a config kona-node refuses to start on. The fixture is generated
+    /// from a fully-populated `rollup.Config` by `TestKonaRollupConfigFixture`
+    /// (`op-node/rollup/kona_rollup_config_test.go`), which fails when the two drift apart.
+    ///
+    /// It pins the maximal shape. op-deployer also writes a pre-Holocene `system_config` — only
+    /// `batcherAddr`, `overhead`, `scalar` and `gasLimit` — which parses because everything else
+    /// is optional.
+    #[test]
+    #[cfg(feature = "serde")]
+    fn test_op_node_rollup_config_parses() {
+        use crate::SystemConfig;
+        use alloc::string::ToString;
+
+        let raw = include_str!("../tests/fixtures/op_node_rollup_config.json");
+        let deserialized: RollupConfig =
+            serde_json::from_str(raw).expect("op-node rollup.json must parse");
+
+        let expected = RollupConfig {
+            genesis: ChainGenesis {
+                l1: BlockNumHash {
+                    hash: b256!("00000000000000000000000000000000000000000000000000000000000000aa"),
+                    number: 100,
+                },
+                l2: BlockNumHash {
+                    hash: b256!("00000000000000000000000000000000000000000000000000000000000000bb"),
+                    number: 1,
+                },
+                l2_time: 1725557164,
+                system_config: Some(SystemConfig {
+                    batcher_address: address!("1111111111111111111111111111111111111111"),
+                    overhead: U256::from(0xbc),
+                    scalar: U256::from(0xa6fe0),
+                    gas_limit: 30_000_000,
+                    base_fee_scalar: None,
+                    blob_base_fee_scalar: None,
+                    // Decoded from the packed `eip1559Params` op-node writes.
+                    eip1559_denominator: Some(101),
+                    eip1559_elasticity: Some(7),
+                    // Decoded from the packed `operatorFeeParams` op-node writes.
+                    operator_fee_scalar: Some(23),
+                    operator_fee_constant: Some(42),
+                    min_base_fee: Some(1_000_000),
+                    da_footprint_gas_scalar: Some(400),
+                }),
+            },
+            block_time: 2,
+            max_sequencer_drift: 600,
+            seq_window_size: 3600,
+            channel_timeout: 300,
+            // op-node has no such config field; it hardcodes the same value
+            // (`opparams.ChannelTimeoutGranite`), so the default is parity.
+            granite_channel_timeout: GRANITE_CHANNEL_TIMEOUT,
+            #[cfg(feature = "rollup_config_override")]
+            fjord_max_sequencer_drift: FJORD_MAX_SEQUENCER_DRIFT,
+            l1_chain_id: 1,
+            l2_chain_id: Chain::from_id(10),
+            hardforks: HardForkConfig {
+                regolith_time: Some(1),
+                canyon_time: Some(2),
+                delta_time: Some(3),
+                ecotone_time: Some(4),
+                fjord_time: Some(5),
+                granite_time: Some(6),
+                holocene_time: Some(7),
+                pectra_blob_schedule_time: Some(12),
+                isthmus_time: Some(8),
+                jovian_time: Some(9),
+                karst_time: Some(10),
+                keep_karst_upgrade_gas: true,
+                lagoon_time: Some(11),
+            },
+            batch_inbox_address: address!("ff00000000000000000000000000000000000010"),
+            deposit_contract_address: address!("2222222222222222222222222222222222222222"),
+            l1_system_config_address: address!("3333333333333333333333333333333333333333"),
+            superchain_config_address: None,
+            blobs_enabled_l1_timestamp: None,
+            da_challenge_address: None,
+            alt_da_config: Some(AltDAConfig {
+                da_challenge_address: Some(address!("4444444444444444444444444444444444444444")),
+                da_challenge_window: Some(160),
+                da_resolve_window: Some(180),
+                da_commitment_type: Some("KeccakCommitment".to_string()),
+                da_max_input_size: Some(130_672),
+            }),
+            chain_op_config: BaseFeeConfig {
+                eip1559_elasticity: 6,
+                eip1559_denominator: 50,
+                eip1559_denominator_canyon: 250,
+            },
+        };
+
         assert_eq!(deserialized, expected);
     }
 

--- a/rust/kona/crates/protocol/genesis/tests/fixtures/op_node_rollup_config.json
+++ b/rust/kona/crates/protocol/genesis/tests/fixtures/op_node_rollup_config.json
@@ -1,0 +1,57 @@
+{
+  "genesis": {
+    "l1": {
+      "hash": "0x00000000000000000000000000000000000000000000000000000000000000aa",
+      "number": 100
+    },
+    "l2": {
+      "hash": "0x00000000000000000000000000000000000000000000000000000000000000bb",
+      "number": 1
+    },
+    "l2_time": 1725557164,
+    "system_config": {
+      "batcherAddr": "0x1111111111111111111111111111111111111111",
+      "overhead": "0x00000000000000000000000000000000000000000000000000000000000000bc",
+      "scalar": "0x00000000000000000000000000000000000000000000000000000000000a6fe0",
+      "gasLimit": 30000000,
+      "eip1559Params": "0x0000006500000007",
+      "operatorFeeParams": "0x000000000000000000000000000000000000000000000017000000000000002a",
+      "minBaseFee": 1000000,
+      "daFootprintGasScalar": 400
+    }
+  },
+  "block_time": 2,
+  "max_sequencer_drift": 600,
+  "seq_window_size": 3600,
+  "channel_timeout": 300,
+  "l1_chain_id": 1,
+  "l2_chain_id": 10,
+  "regolith_time": 1,
+  "canyon_time": 2,
+  "delta_time": 3,
+  "ecotone_time": 4,
+  "fjord_time": 5,
+  "granite_time": 6,
+  "holocene_time": 7,
+  "isthmus_time": 8,
+  "jovian_time": 9,
+  "karst_time": 10,
+  "keep_karst_upgrade_gas": true,
+  "lagoon_time": 11,
+  "batch_inbox_address": "0xff00000000000000000000000000000000000010",
+  "deposit_contract_address": "0x2222222222222222222222222222222222222222",
+  "l1_system_config_address": "0x3333333333333333333333333333333333333333",
+  "chain_op_config": {
+    "eip1559Elasticity": 6,
+    "eip1559Denominator": 50,
+    "eip1559DenominatorCanyon": 250
+  },
+  "alt_da": {
+    "da_challenge_contract_address": "0x4444444444444444444444444444444444444444",
+    "da_commitment_type": "KeccakCommitment",
+    "da_max_input_size": 130672,
+    "da_challenge_window": 160,
+    "da_resolve_window": 180
+  },
+  "pectra_blob_schedule_time": 12
+}


### PR DESCRIPTION
**This restores the guard #20379 removed, and needs your call before it can leave draft.** #20379 dropped `deny_unknown_fields` from kona's `RollupConfig` *and* `DisallowUnknownFields()` from op-node's `ParseRollupConfig` in one commit, so configs still carrying `protocol_versions_address` would load after #20317 dropped that field. The test flipped here is that commit's own regression test. op-node stays lenient, so kona becomes the stricter of the two — #22682 lists the retired keys (`protocol_versions_address`, `channel_timeout_granite`, `use_plasma`, legacy top-level `da_*_window`) and the three ways to handle them. The cleanest is probably to model them as accepted-and-ignored `Option` fields, the way `blobs_data` and top-level `da_challenge_address` already are.

Why do it at all: the rollup config is the chain's consensus-parameter file, so a key kona drops is a parameter kona does not honor — the node boots and derives a chain other than the one the config describes. Nothing is dropped today, but the next `rollup.Config` field would be, silently.

`deny_unknown_fields` works alongside the flattened `HardForkConfig`, which serde's docs call unsupported: the derive checks the keys left over after every flattened field has taken its own (`collected_deny_unknown_fields`, serde_derive 1.0.228 and back to at least 1.0.145). No custom `Deserialize`, no format change. The flattened `HardForkConfig`'s own `deny_unknown_fields` is inert — that is why the unknown key was accepted even before #20379 touched anything.

`BaseFeeConfig` gets the attribute too: `chain_op_config` was the one nested type in the tree still lenient, and it holds the EIP-1559 consensus params. Checked against all 56 superchain-registry chain TOMLs — `[optimism]` carries exactly the three keys kona models.

The fixture is generated from a fully-populated op-node `rollup.Config`; `TestKonaRollupConfigFixture` fails when `rollup.Config` gains a field, so the fixture and kona have to be updated together, and the fixture lives under `rust/` so regenerating it triggers the Rust CI that parses it.

**Local checks** (all exit 0): `cargo test -p kona-genesis -p kona-registry -p kona-host -p kona-node -p kona-proof -p kona-proof-interop -p kona-protocol -p kona-derive -p kona-interop`; `cargo test -p kona-genesis --all-features`; `cargo clippy -p kona-genesis --all-features --all-targets -D warnings`; `cargo check -p kona-genesis --target riscv32imac-unknown-none-elf`; `just fmt-check`; `just lint-go`; `go test ./op-node/rollup`.

**Reviews**: ran `rust-code-reviewer` and `go-code-reviewer`. Both surfaced findings, all addressed: the #20379 revert (above, and #22682), lenient `BaseFeeConfig` (fixed), the nested-`omitempty` hole in the Go completeness guard (fixed — it now walks every struct that reaches the JSON), a false claim in a test doc comment (fixed by building the rejection input from the reference config instead of duplicating it), and non-discriminating fixture values for the packed `eip1559Params` / `operatorFeeParams` (fixed). One suggestion not taken: naming the failing path in `SingleChainHostError::ParseError` / `InteropHostError::ParseError` — a real improvement, but it belongs with whichever resolution #22682 lands on.

Fixes #22682

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fi2GEEBE6LmUwLS25WPKfq
