### PR TITLE
alloy-op-evm,op-reth: drop hardcoded block times from Canyon activation and the pending env

### DIFF
--- a/rust/alloy-op-evm/src/block/canyon.rs
+++ b/rust/alloy-op-evm/src/block/canyon.rs
@@ -1,5 +1,5 @@
 use alloy_evm::Database;
-use alloy_op_hardforks::OpHardforks;
+use alloy_op_hardforks::{OpHardfork, OpHardforks};
 use alloy_primitives::{Address, B256, Bytes, address, b256, hex};
 use revm::{DatabaseCommit, primitives::HashMap, state::Bytecode};
 
@@ -15,9 +15,20 @@ const CREATE_2_DEPLOYER_BYTECODE: [u8; 1584] = hex!(
     "6080604052600436106100435760003560e01c8063076c37b21461004f578063481286e61461007157806356299481146100ba57806366cfa057146100da57600080fd5b3661004a57005b600080fd5b34801561005b57600080fd5b5061006f61006a366004610327565b6100fa565b005b34801561007d57600080fd5b5061009161008c366004610327565b61014a565b60405173ffffffffffffffffffffffffffffffffffffffff909116815260200160405180910390f35b3480156100c657600080fd5b506100916100d5366004610349565b61015d565b3480156100e657600080fd5b5061006f6100f53660046103ca565b610172565b61014582826040518060200161010f9061031a565b7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe082820381018352601f90910116604052610183565b505050565b600061015683836102e7565b9392505050565b600061016a8484846102f0565b949350505050565b61017d838383610183565b50505050565b6000834710156101f4576040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601d60248201527f437265617465323a20696e73756666696369656e742062616c616e636500000060448201526064015b60405180910390fd5b815160000361025f576040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820181905260248201527f437265617465323a2062797465636f6465206c656e677468206973207a65726f60448201526064016101eb565b8282516020840186f5905073ffffffffffffffffffffffffffffffffffffffff8116610156576040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601960248201527f437265617465323a204661696c6564206f6e206465706c6f790000000000000060448201526064016101eb565b60006101568383305b6000604051836040820152846020820152828152600b8101905060ff815360559020949350505050565b61014e806104ad83390190565b6000806040838503121561033a57600080fd5b50508035926020909101359150565b60008060006060848603121561035e57600080fd5b8335925060208401359150604084013573ffffffffffffffffffffffffffffffffffffffff8116811461039057600080fd5b809150509250925092565b7f4e487b7100000000000000000000000000000000000000000000000000000000600052604160045260246000fd5b6000806000606084860312156103df57600080fd5b8335925060208401359150604084013567ffffffffffffffff8082111561040557600080fd5b818601915086601f83011261041957600080fd5b81358181111561042b5761042b61039b565b604051601f82017fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0908116603f011681019083821181831017156104715761047161039b565b8160405282815289602084870101111561048a57600080fd5b826020860160208301376000602084830101528095505050505050925092509256fe608060405234801561001057600080fd5b5061012e806100206000396000f3fe6080604052348015600f57600080fd5b506004361060285760003560e01c8063249cb3fa14602d575b600080fd5b603c603836600460b1565b604e565b60405190815260200160405180910390f35b60008281526020818152604080832073ffffffffffffffffffffffffffffffffffffffff8516845290915281205460ff16608857600060aa565b7fa2ef4600d742022d532d4747cb3547474667d6f13804902513b2ec01c848f4b45b9392505050565b6000806040838503121560c357600080fd5b82359150602083013573ffffffffffffffffffffffffffffffffffffffff8116811460ed57600080fd5b80915050925092905056fea26469706673582212205ffd4e6cede7d06a5daf93d48d0541fc68189eeb16608c1999a82063b666eb1164736f6c63430008130033a2646970667358221220fdc4a0fe96e3b21c108ca155438d37c9143fb01278a3c1d274948bad89c564ba64736f6c63430008130033"
 );
 
+/// Returns `true` if a block at `timestamp` triggers the Canyon irregular state transition.
+///
+/// The condition is that the block timestamp is exactly the configured Canyon timestamp, which
+/// mirrors op-geth's `consensus/misc.EnsureCreate2Deployer` — the reference implementation of this
+/// state transition. Every OP chain schedules its fork timestamps on a block boundary, so this is
+/// the Canyon activation block; a chain that schedules Canyon between two blocks gets no
+/// force-deploy at all, in either client.
+fn is_canyon_activation_block(chain_spec: impl OpHardforks, timestamp: u64) -> bool {
+    chain_spec.op_fork_activation(OpHardfork::Canyon).as_timestamp() == Some(timestamp)
+}
+
 /// The Canyon hardfork issues an irregular state transition that force-deploys the create2
 /// deployer contract. This is done by directly setting the code of the create2 deployer account
-/// prior to executing any transactions on the timestamp activation of the fork.
+/// prior to executing any transactions on the activation block of the fork.
 pub(crate) fn ensure_create2_deployer<DB>(
     chain_spec: impl OpHardforks,
     timestamp: u64,
@@ -26,27 +37,79 @@ pub(crate) fn ensure_create2_deployer<DB>(
 where
     DB: Database + DatabaseCommit,
 {
-    // If the canyon hardfork is active at the current timestamp, and it was not active at the
-    // previous block timestamp (heuristically, block time is not perfectly constant at 2s), and the
-    // chain is an optimism chain, then we need to force-deploy the create2 deployer contract.
-    if chain_spec.is_canyon_active_at_timestamp(timestamp) &&
-        !chain_spec.is_canyon_active_at_timestamp(timestamp.saturating_sub(2))
-    {
-        // Load the create2 deployer account from the cache.
-        let mut acc_info = db.basic(CREATE_2_DEPLOYER_ADDR)?.unwrap_or_default();
-
-        // Update the account info with the create2 deployer codehash and bytecode.
-        acc_info.code_hash = CREATE_2_DEPLOYER_CODEHASH;
-        acc_info.code = Some(Bytecode::new_raw(Bytes::from_static(&CREATE_2_DEPLOYER_BYTECODE)));
-
-        // Convert the cache account back into a revm account and mark it as touched.
-        let mut revm_acc: revm::state::Account = acc_info.into();
-        revm_acc.mark_touch();
-
-        // Commit the create2 deployer account to the database.
-        db.commit(HashMap::from_iter([(CREATE_2_DEPLOYER_ADDR, revm_acc)]));
+    if !is_canyon_activation_block(chain_spec, timestamp) {
         return Ok(());
     }
 
+    // Load the create2 deployer account from the cache.
+    let mut acc_info = db.basic(CREATE_2_DEPLOYER_ADDR)?.unwrap_or_default();
+
+    // Update the account info with the create2 deployer codehash and bytecode.
+    acc_info.code_hash = CREATE_2_DEPLOYER_CODEHASH;
+    acc_info.code = Some(Bytecode::new_raw(Bytes::from_static(&CREATE_2_DEPLOYER_BYTECODE)));
+
+    // Convert the cache account back into a revm account and mark it as touched.
+    let mut revm_acc: revm::state::Account = acc_info.into();
+    revm_acc.mark_touch();
+
+    // Commit the create2 deployer account to the database.
+    db.commit(HashMap::from_iter([(CREATE_2_DEPLOYER_ADDR, revm_acc)]));
+
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_op_hardforks::{ForkCondition, OpChainHardforks};
+    use revm::{
+        Database as _,
+        database::{CacheDB, EmptyDB},
+    };
+
+    /// Canyon activation timestamp used by every case below.
+    const CANYON_TIME: u64 = 1_000;
+
+    fn chain_spec(canyon: ForkCondition) -> OpChainHardforks {
+        OpChainHardforks::new(OpHardfork::op_mainnet().map(|(fork, _)| match fork {
+            OpHardfork::Canyon => (fork, canyon),
+            _ => (fork, ForkCondition::Never),
+        }))
+    }
+
+    /// Runs the irregular state transition and reports whether it force-deployed the contract.
+    fn force_deployed_with(canyon: ForkCondition, timestamp: u64) -> bool {
+        let mut db = CacheDB::<EmptyDB>::default();
+        ensure_create2_deployer(chain_spec(canyon), timestamp, &mut db).unwrap();
+        db.basic(CREATE_2_DEPLOYER_ADDR)
+            .unwrap()
+            .is_some_and(|acc| acc.code_hash == CREATE_2_DEPLOYER_CODEHASH)
+    }
+
+    fn force_deployed(timestamp: u64) -> bool {
+        force_deployed_with(ForkCondition::Timestamp(CANYON_TIME), timestamp)
+    }
+
+    #[test]
+    fn deploys_on_the_fork_timestamp_for_any_block_time() {
+        for block_time in [1, 2, 5, 10] {
+            assert!(!force_deployed(CANYON_TIME - block_time), "block time {block_time}");
+            assert!(force_deployed(CANYON_TIME), "block time {block_time}");
+            assert!(!force_deployed(CANYON_TIME + block_time), "block time {block_time}");
+        }
+    }
+
+    #[test]
+    fn does_not_deploy_when_no_block_lands_on_the_fork_timestamp() {
+        // A 2-second chain with blocks at ..., CANYON_TIME - 1, CANYON_TIME + 1, ... never gets
+        // the force-deploy in op-geth, so it must not get one here either.
+        assert!(!force_deployed(CANYON_TIME - 1));
+        assert!(!force_deployed(CANYON_TIME + 1));
+    }
+
+    #[test]
+    fn does_not_deploy_without_a_canyon_timestamp() {
+        assert!(!force_deployed_with(ForkCondition::Never, CANYON_TIME));
+        assert!(!force_deployed_with(ForkCondition::Block(1), 1));
+    }
 }

--- a/rust/op-reth/crates/evm/src/config.rs
+++ b/rust/op-reth/crates/evm/src/config.rs
@@ -30,7 +30,11 @@ impl<H: alloy_consensus::BlockHeader> reth_rpc_eth_api::helpers::pending_block::
         block_overrides: Option<&alloy_rpc_types_eth::BlockOverrides>,
     ) -> Self {
         let mut attributes = Self {
-            timestamp: parent.timestamp().saturating_add(12),
+            // OP chains have no slot time and the EL chain spec carries no block time, so the
+            // next block's timestamp is unknown here. `parent + 1` is its lower bound for every
+            // OP block time, which keeps `pending` from executing under a hardfork that the
+            // block the sequencer actually produces next will not have activated.
+            timestamp: parent.timestamp().saturating_add(1),
             suggested_fee_recipient: parent.beneficiary(),
             prev_randao: B256::random(),
             gas_limit: parent.gas_limit(),
@@ -61,6 +65,49 @@ impl From<OpFlashblockPayloadBase> for OpNextBlockEnvAttributes {
             gas_limit: base.gas_limit,
             parent_beacon_block_root: Some(base.parent_beacon_block_root),
             extra_data: base.extra_data,
+        }
+    }
+}
+
+#[cfg(all(test, feature = "rpc"))]
+mod tests {
+    use super::*;
+    use alloy_consensus::Header;
+    use reth_optimism_chainspec::OP_MAINNET;
+    use reth_optimism_forks::{OpHardfork, OpHardforks};
+    use reth_primitives_traits::SealedHeader;
+    use reth_rpc_eth_api::helpers::pending_block::BuildPendingEnv;
+
+    fn pending_timestamp(parent_timestamp: u64) -> u64 {
+        let parent =
+            SealedHeader::seal_slow(Header { timestamp: parent_timestamp, ..Default::default() });
+        OpNextBlockEnvAttributes::build_pending_env(&parent, None).timestamp
+    }
+
+    #[test]
+    fn pending_timestamp_advances_past_the_parent() {
+        assert!(pending_timestamp(0) > 0);
+        assert!(pending_timestamp(u64::MAX - 1) > u64::MAX - 1);
+    }
+
+    #[test]
+    fn pending_timestamp_does_not_cross_a_fork_boundary_early() {
+        // Two blocks before each fork on a 2-second chain: the pending environment must still
+        // resolve to the fork that is active for the parent, not the one the fork activates.
+        for fork in OpHardfork::VARIANTS {
+            let Some(activation) = OP_MAINNET.op_fork_activation(*fork).as_timestamp() else {
+                continue;
+            };
+            let parent_timestamp = activation - 4;
+
+            assert_eq!(
+                revm_spec_by_timestamp_after_bedrock(
+                    &*OP_MAINNET,
+                    pending_timestamp(parent_timestamp)
+                ),
+                revm_spec_by_timestamp_after_bedrock(&*OP_MAINNET, parent_timestamp),
+                "{fork:?} leaks into the pending environment"
+            );
         }
     }
 }


### PR DESCRIPTION
Two independent activation/timestamp bugs in the Rust EL, each filed with its analysis.

### `alloy-op-evm`: Canyon create2-deploy keyed off `timestamp - 2`

`ensure_create2_deployer` decided whether a block triggered the Canyon irregular state transition by probing `timestamp - 2`, hardcoding a 2-second block time. OP chains run at 1, 2, 5 and 10 seconds: on a 1-second chain it force-deploys on two consecutive blocks, and on a chain whose Canyon timestamp falls between two blocks it deploys on a block op-geth leaves alone.

Now keyed off the fork timestamp itself, matching op-geth's `consensus/misc.EnsureCreate2Deployer` — the reference implementation, which force-deploys iff `block.timestamp == canyonTime`, on both its miner and its block-processing path. Every OP chain schedules Canyon on a block boundary, so this is the activation block, and the rule stops depending on block time.

**Behaviour is unchanged for every chain in the superchain registry.** Of the 53 chain configs, only ten ever ran this transition (op / zora / mode / lyra / orderly on mainnet, plus lisk, metal, op, zora, mode on sepolia); all have a 2-second block time and a Canyon timestamp that lands exactly on a block. Every chain with a block time other than 2 (1 s: celo, ink, unichain, settlus, celo-sep; 5 s: swan; 10 s: cyber-sep) has Canyon active at or before genesis, so the transition never fires there.

Worth recording for whoever touches this next: three definitions of "the Canyon activation block" exist across the stack — op-geth's `ts == canyonTime`, op-node's `IsCanyonActivationBlock` using the configured `BlockTime`, and (until this PR) alloy-op-evm's `ts - 2`. They agree on every real chain. The residual hole — a chain that schedules Canyon *between* two blocks activates Canyon's consensus rules but never gets the create2 deployer — is shared with op-geth and would have to be fixed on both sides together, if at all. This PR deliberately does not change that; matching the reference implementation is the point.

### `op-reth`: pending block env dated `parent + 12`

`build_pending_env` used Ethereum's L1 slot time, inherited verbatim from upstream reth. On a 2 s OP chain that is up to five blocks ahead of the real next block, so `eth_call` / `eth_estimateGas` / `eth_createAccessList` / the tracing call variants / `eth_simulateV1` against `pending` could execute under a hardfork the next block will not have activated — which also selects the wrong `L1Block` storage slots and L1-fee formula in op-revm.

The EL chain spec carries no block time, so this uses `parent + 1`: the lower bound of the next block's timestamp for every OP block time, and the same floor op-geth clamps to. Deriving the real block time needs chainspec plumbing — recorded as the follow-up option in the issue, along with the finding that `--rollup.compute-pending-block` is currently a no-op (`is_compute_pending_block()` has no callers).

### Review

Ran the repo's `rust-code-reviewer` per [CLAUDE.md](https://github.com/ethereum-optimism/optimism/blob/develop/CLAUDE.md) / [docs/ai/rust-dev.md](https://github.com/ethereum-optimism/optimism/blob/develop/docs/ai/rust-dev.md). Its critical finding — that an earlier parent-relative version of the Canyon rule would have diverged from op-geth and made the predicate differ between op-reth's building and validation paths — is what produced the rule above; that version also added a public field to `OpBlockExecutionCtx` and is now gone, so there is no API break. Its nits on test coverage and commit-message provenance are addressed. No other reviewer listed in CLAUDE.md has a matching trigger for this diff.

### Tests

`cargo test -p alloy-op-evm --all-features`, `cargo test -p reth-optimism-evm --all-features`, `just fmt-check`, `just check-no-std`, and `cargo clippy -p alloy-op-evm -p reth-optimism-evm --all-features --all-targets -- -D warnings`: all green. Each commit was built on its own via `git rebase --exec`. Three of the four new tests were confirmed to fail against the old code.

Fixes #22684
Fixes #22685

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fi2GEEBE6LmUwLS25WPKfq
