### PR TITLE
op-node: serialise StatusTracker L1 handlers with the event loop

### DIFF
--- a/op-node/rollup/status/status.go
+++ b/op-node/rollup/status/status.go
@@ -88,6 +88,8 @@ func (st *StatusTracker) OnEvent(ctx context.Context, ev event.Event) bool {
 	return true
 }
 
+// UpdateSyncStatus publishes the current data as the new SyncStatus snapshot.
+// Callers must hold st.mu: it reads st.data, which the event and L1 handlers mutate.
 func (st *StatusTracker) UpdateSyncStatus() {
 	// If anything changes, then copy the state to the published SyncStatus
 	// @dev: If this becomes a performance bottleneck during sync (because mem copies onto heap, and 1KB comparisons),
@@ -100,6 +102,9 @@ func (st *StatusTracker) UpdateSyncStatus() {
 }
 
 func (st *StatusTracker) OnL1Unsafe(x eth.L1BlockRef) {
+	st.mu.Lock()
+	defer st.mu.Unlock()
+
 	st.metrics.RecordL1Ref("l1_head", x)
 	// We don't need to do anything if the head hasn't changed.
 	if st.data.HeadL1 == (eth.L1BlockRef{}) {
@@ -124,6 +129,9 @@ func (st *StatusTracker) OnL1Unsafe(x eth.L1BlockRef) {
 }
 
 func (st *StatusTracker) OnL1Safe(x eth.L1BlockRef) {
+	st.mu.Lock()
+	defer st.mu.Unlock()
+
 	st.log.Info("New L1 safe block", "l1_safe", x)
 	st.metrics.RecordL1Ref("l1_safe", x)
 	st.data.SafeL1 = x
@@ -131,6 +139,9 @@ func (st *StatusTracker) OnL1Safe(x eth.L1BlockRef) {
 }
 
 func (st *StatusTracker) OnL1Finalized(x eth.L1BlockRef) {
+	st.mu.Lock()
+	defer st.mu.Unlock()
+
 	st.log.Info("New L1 finalized block", "l1_finalized", x)
 	st.metrics.RecordL1Ref("l1_finalized", x)
 	st.data.FinalizedL1 = x

--- a/op-node/rollup/status/status_test.go
+++ b/op-node/rollup/status/status_test.go
@@ -3,6 +3,7 @@ package status
 import (
 	"context"
 	"math/rand"
+	"sync"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
@@ -10,6 +11,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum-optimism/optimism/op-service/testutils"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
 )
@@ -96,4 +98,37 @@ func TestForkchoiceUpdateSeedsLocalSafeWithGenesisSafe(t *testing.T) {
 	require.Equal(t, genesis, status.SafeL2)
 	require.Equal(t, genesis, status.LocalSafeL2)
 	require.Equal(t, genesis, status.FinalizedL2)
+}
+
+// The L1 handlers run on three separate goroutines — the head subscription and
+// the safe/finalized pollers — while OnEvent runs on the driver's event loop.
+// All four mutate st.data, so they must serialise on the same mutex. Run with
+// -race: without the locks this reports writes racing with UpdateSyncStatus.
+func TestStatusTrackerConcurrentUpdates(t *testing.T) {
+	tracker := NewStatusTracker(testlog.Logger(t, log.LevelError), NoopMetrics{})
+
+	const iterations = 200
+	writers := []func(i uint64){
+		func(i uint64) { tracker.OnL1Unsafe(eth.L1BlockRef{Number: i, Hash: common.Hash{byte(i)}}) },
+		func(i uint64) { tracker.OnL1Safe(eth.L1BlockRef{Number: i}) },
+		func(i uint64) { tracker.OnL1Finalized(eth.L1BlockRef{Number: i}) },
+		func(i uint64) {
+			tracker.OnEvent(context.Background(), engine.ForkchoiceUpdateEvent{
+				UnsafeL2Head: eth.L2BlockRef{Number: i},
+			})
+		},
+		func(i uint64) { require.NotNil(t, tracker.SyncStatus()) },
+	}
+
+	var wg sync.WaitGroup
+	for _, writer := range writers {
+		wg.Add(1)
+		go func(fn func(uint64)) {
+			defer wg.Done()
+			for i := uint64(0); i < iterations; i++ {
+				fn(i)
+			}
+		}(writer)
+	}
+	wg.Wait()
 }


### PR DESCRIPTION
`OnEvent` and `OnCrossSafeUpdate` take `st.mu` before touching `st.data`. `OnL1Unsafe`, `OnL1Safe` and `OnL1Finalized` do not, and they read and write the same struct.

The four run on different goroutines: the L1 head subscription (`WatchHeadChanges`) and the safe/finalized pollers (`PollBlockChanges`) each get their own via `event.NewSubscription`, wired at `op-node/node/node.go:337-352`, while `OnEvent` runs on the driver event loop.

So a poller can copy `st.data` in `UpdateSyncStatus`, the event loop can then advance `UnsafeL2` under the lock and publish, and the poller stores its stale copy over it — `optimism_syncStatus` moves backwards. op-batcher consumes that in `computeSyncActions` and op-conductor uses it for health.

`go test -race` on the added test, without the fix:

```
36 × WARNING: DATA RACE
  Write at ... status.go:122 (OnL1Safe) / :136 (OnL1Finalized)
  Previous read at ... status.go:96 (UpdateSyncStatus)
```

Fix takes the lock in the three handlers. `UpdateSyncStatus` stays lock-free and is now documented as requiring `st.mu` — it has no callers outside this file, so nothing else needs changing.

`go test -race ./op-node/rollup/... ./op-node/node/...` passes (14 packages), `go vet` clean.
