### PR TITLE
contracts: prototype L1-certified event relay

### DIFF
--- a/packages/contracts-bedrock/interfaces/L1/IL1EventRegistry.sol
+++ b/packages/contracts-bedrock/interfaces/L1/IL1EventRegistry.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import { Identifier } from "interfaces/L2/ICrossL2Inbox.sol";
+import { IETHLockbox } from "interfaces/L1/IETHLockbox.sol";
+import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
+import { ISemver } from "interfaces/universal/ISemver.sol";
+
+/// @title IL1EventRegistry
+/// @notice L1 registry for event certificates exported through an OptimismPortal withdrawal.
+interface IL1EventRegistry is ISemver {
+    error L1EventRegistry_InvalidLockbox();
+    error L1EventRegistry_UnauthorizedPortal();
+    error L1EventRegistry_UnauthorizedL2Sender();
+    error L1EventRegistry_WrongSourceChain();
+    error L1EventRegistry_EventNotRegistered();
+
+    event EventRegistered(bytes32 indexed certificate, bytes32 indexed payloadHash, Identifier id);
+    event EventRelayed(bytes32 indexed certificate, address indexed portal, bool executeMessage);
+
+    function ethLockbox() external view returns (IETHLockbox);
+
+    function registeredEvents(bytes32) external view returns (bool);
+
+    function calculateCertificate(Identifier memory _id, bytes32 _payloadHash) external pure returns (bytes32);
+
+    function registerEvent(Identifier calldata _id, bytes32 _payloadHash) external;
+
+    function relayEvent(
+        IOptimismPortal2 _destinationPortal,
+        Identifier calldata _id,
+        bytes32 _payloadHash,
+        uint64 _gasLimit
+    )
+        external;
+
+    function relayMessage(
+        IOptimismPortal2 _destinationPortal,
+        Identifier calldata _id,
+        bytes calldata _sentMessage,
+        uint64 _gasLimit
+    )
+        external;
+
+    function __constructor__(IETHLockbox _ethLockbox) external;
+}

--- a/packages/contracts-bedrock/interfaces/L2/ICrossL2Inbox.sol
+++ b/packages/contracts-bedrock/interfaces/L2/ICrossL2Inbox.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+import { IProxyAdminOwnedBase } from "interfaces/universal/IProxyAdminOwnedBase.sol";
+
 /// @notice Identifier of a cross chain message.
 
 struct Identifier {
@@ -11,18 +13,44 @@ struct Identifier {
     uint256 chainId;
 }
 
-interface ICrossL2Inbox {
+interface ICrossL2Inbox is IProxyAdminOwnedBase {
     error CrossL2Inbox_NoExecutingDeposits();
+    error CrossL2Inbox_InvalidEventRegistry();
+    error CrossL2Inbox_NotEventRegistry();
+    error CrossL2Inbox_EventNotFound();
+    error CrossL2Inbox_EventTooOld();
+    error CrossL2Inbox_EventFromAnotherChain();
+    error CrossL2Inbox_EventNotInPreviousBlock();
     error NotInAccessList();
     error BlockNumberTooHigh();
     error TimestampTooHigh();
     error LogIndexTooHigh();
 
     event ExecutingMessage(bytes32 indexed msgHash, Identifier id);
+    event ExecutingCertifiedMessage(bytes32 indexed msgHash, Identifier id);
+    event EventExported(bytes32 indexed checksum, bytes32 indexed payloadHash, Identifier id);
+    event EventImported(bytes32 indexed checksum, bytes32 indexed payloadHash, Identifier id);
+    event L1EventRegistryUpdated(address indexed oldRegistry, address indexed newRegistry);
 
     function version() external view returns (string memory);
 
+    function EVENT_LOOKUP_WINDOW() external view returns (uint256);
+
+    function REGISTER_EVENT_GAS_LIMIT() external view returns (uint256);
+
     function validateMessage(Identifier calldata _id, bytes32 _msgHash) external;
+
+    function exportEvent(Identifier calldata _id, bytes32 _payloadHash) external;
+
+    function importEvent(Identifier calldata _id, bytes32 _payloadHash) external;
+
+    function importAndExecute(Identifier calldata _id, bytes calldata _sentMessage) external;
+
+    function setL1EventRegistry(address _l1EventRegistry) external;
+
+    function l1EventRegistry() external view returns (address);
+
+    function certifiedMessages(bytes32) external view returns (bool);
 
     function calculateChecksum(Identifier memory _id, bytes32 _msgHash) external pure returns (bytes32 checksum_);
 }

--- a/packages/contracts-bedrock/interfaces/L2/ILocalLogOracle.sol
+++ b/packages/contracts-bedrock/interfaces/L2/ILocalLogOracle.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import { Identifier } from "interfaces/L2/ICrossL2Inbox.sol";
+
+/// @title ILocalLogOracle
+/// @notice Execution-client interface for proving that a log exists on the current L2.
+/// @dev Implementations must reject logs from another chain, the current block, future blocks,
+///      and blocks older than the protocol event lookup window.
+interface ILocalLogOracle {
+    /// @notice Returns whether the identified log has the supplied payload hash.
+    /// @param _id Identifier of the log on the current chain.
+    /// @param _payloadHash Hash of the complete encoded log payload.
+    function containsLog(Identifier calldata _id, bytes32 _payloadHash) external view returns (bool);
+}

--- a/packages/contracts-bedrock/snapshots/abi/CrossL2Inbox.json
+++ b/packages/contracts-bedrock/snapshots/abi/CrossL2Inbox.json
@@ -1,5 +1,31 @@
 [
   {
+    "inputs": [],
+    "name": "EVENT_LOOKUP_WINDOW",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "REGISTER_EVENT_GAS_LIMIT",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [
       {
         "components": [
@@ -48,6 +74,212 @@
       }
     ],
     "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "certifiedMessages",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "origin",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "blockNumber",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "logIndex",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "timestamp",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "chainId",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct Identifier",
+        "name": "_id",
+        "type": "tuple"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "_payloadHash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "exportEvent",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "origin",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "blockNumber",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "logIndex",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "timestamp",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "chainId",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct Identifier",
+        "name": "_id",
+        "type": "tuple"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_sentMessage",
+        "type": "bytes"
+      }
+    ],
+    "name": "importAndExecute",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "origin",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "blockNumber",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "logIndex",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "timestamp",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "chainId",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct Identifier",
+        "name": "_id",
+        "type": "tuple"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "_payloadHash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "importEvent",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "l1EventRegistry",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "proxyAdmin",
+    "outputs": [
+      {
+        "internalType": "contract IProxyAdmin",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "proxyAdminOwner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_l1EventRegistry",
+        "type": "address"
+      }
+    ],
+    "name": "setL1EventRegistry",
+    "outputs": [],
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
@@ -114,6 +346,156 @@
       {
         "indexed": true,
         "internalType": "bytes32",
+        "name": "checksum",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "payloadHash",
+        "type": "bytes32"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "origin",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "blockNumber",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "logIndex",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "timestamp",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "chainId",
+            "type": "uint256"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct Identifier",
+        "name": "id",
+        "type": "tuple"
+      }
+    ],
+    "name": "EventExported",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "checksum",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "payloadHash",
+        "type": "bytes32"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "origin",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "blockNumber",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "logIndex",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "timestamp",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "chainId",
+            "type": "uint256"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct Identifier",
+        "name": "id",
+        "type": "tuple"
+      }
+    ],
+    "name": "EventImported",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "msgHash",
+        "type": "bytes32"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "origin",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "blockNumber",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "logIndex",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "timestamp",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "chainId",
+            "type": "uint256"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct Identifier",
+        "name": "id",
+        "type": "tuple"
+      }
+    ],
+    "name": "ExecutingCertifiedMessage",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
         "name": "msgHash",
         "type": "bytes32"
       },
@@ -155,13 +537,62 @@
     "type": "event"
   },
   {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "oldRegistry",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newRegistry",
+        "type": "address"
+      }
+    ],
+    "name": "L1EventRegistryUpdated",
+    "type": "event"
+  },
+  {
     "inputs": [],
     "name": "BlockNumberTooHigh",
     "type": "error"
   },
   {
     "inputs": [],
+    "name": "CrossL2Inbox_EventFromAnotherChain",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "CrossL2Inbox_EventNotFound",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "CrossL2Inbox_EventNotInPreviousBlock",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "CrossL2Inbox_EventTooOld",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "CrossL2Inbox_InvalidEventRegistry",
+    "type": "error"
+  },
+  {
+    "inputs": [],
     "name": "CrossL2Inbox_NoExecutingDeposits",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "CrossL2Inbox_NotEventRegistry",
     "type": "error"
   },
   {
@@ -172,6 +603,36 @@
   {
     "inputs": [],
     "name": "NotInAccessList",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ProxyAdminOwnedBase_NotProxyAdmin",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ProxyAdminOwnedBase_NotProxyAdminOrProxyAdminOwner",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ProxyAdminOwnedBase_NotProxyAdminOwner",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ProxyAdminOwnedBase_NotResolvedDelegateProxy",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ProxyAdminOwnedBase_NotSharedProxyAdminOwner",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ProxyAdminOwnedBase_ProxyAdminNotFound",
     "type": "error"
   },
   {

--- a/packages/contracts-bedrock/snapshots/abi/L1EventRegistry.json
+++ b/packages/contracts-bedrock/snapshots/abi/L1EventRegistry.json
@@ -1,0 +1,366 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "contract IETHLockbox",
+        "name": "_ethLockbox",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "origin",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "blockNumber",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "logIndex",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "timestamp",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "chainId",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct Identifier",
+        "name": "_id",
+        "type": "tuple"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "_payloadHash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "calculateCertificate",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "ethLockbox",
+    "outputs": [
+      {
+        "internalType": "contract IETHLockbox",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "origin",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "blockNumber",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "logIndex",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "timestamp",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "chainId",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct Identifier",
+        "name": "_id",
+        "type": "tuple"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "_payloadHash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "registerEvent",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "registeredEvents",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IOptimismPortal2",
+        "name": "_destinationPortal",
+        "type": "address"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "origin",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "blockNumber",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "logIndex",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "timestamp",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "chainId",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct Identifier",
+        "name": "_id",
+        "type": "tuple"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "_payloadHash",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint64",
+        "name": "_gasLimit",
+        "type": "uint64"
+      }
+    ],
+    "name": "relayEvent",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IOptimismPortal2",
+        "name": "_destinationPortal",
+        "type": "address"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "origin",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "blockNumber",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "logIndex",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "timestamp",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "chainId",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct Identifier",
+        "name": "_id",
+        "type": "tuple"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_sentMessage",
+        "type": "bytes"
+      },
+      {
+        "internalType": "uint64",
+        "name": "_gasLimit",
+        "type": "uint64"
+      }
+    ],
+    "name": "relayMessage",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "version",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "certificate",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "payloadHash",
+        "type": "bytes32"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "origin",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "blockNumber",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "logIndex",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "timestamp",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "chainId",
+            "type": "uint256"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct Identifier",
+        "name": "id",
+        "type": "tuple"
+      }
+    ],
+    "name": "EventRegistered",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "certificate",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "portal",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "executeMessage",
+        "type": "bool"
+      }
+    ],
+    "name": "EventRelayed",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "L1EventRegistry_EventNotRegistered",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "L1EventRegistry_InvalidLockbox",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "L1EventRegistry_UnauthorizedL2Sender",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "L1EventRegistry_UnauthorizedPortal",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "L1EventRegistry_WrongSourceChain",
+    "type": "error"
+  }
+]

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -15,6 +15,10 @@
     "initCodeHash": "0x8754f400a5110749e26f9820e0532b86f0122a6b8ceb10028fd997d39b023ff7",
     "sourceCodeHash": "0xfd4d13c09f30072475e2286457a35abaa122223c26ae40398524ad77d5dbb9e1"
   },
+  "src/L1/L1EventRegistry.sol:L1EventRegistry": {
+    "initCodeHash": "0x6ba1835f5bb54c52dd485ec9829905dc97776fee49555da46e2a42e8f66cbbe4",
+    "sourceCodeHash": "0x416e00aa9139a5f3f9274a39d799947a66499500d8fc5b697513c248b23cb11f"
+  },
   "src/L1/L1StandardBridge.sol:L1StandardBridge": {
     "initCodeHash": "0x75b07cd638ef34349da3478aeab051472c1cba8c8074d3df48af3d7fbd97fd49",
     "sourceCodeHash": "0x0ef8461e8bc55314e61e60924465574db17bdf30bbbfe9739b52cac623bba2db"
@@ -48,8 +52,8 @@
     "sourceCodeHash": "0x7c83a95f65cfd963af0caf90579e8f8544e3f883a48bc803720ec251c72aeffe"
   },
   "src/L2/CrossL2Inbox.sol:CrossL2Inbox": {
-    "initCodeHash": "0x5f3a52829abafd34cae760e053927a44a1ec58f8f7e6380a9723632288d84d8c",
-    "sourceCodeHash": "0xb9ac578e4f6f2f9a528603d57242c49b32146b459113ccb3f50f4112d036cddb"
+    "initCodeHash": "0x257569d32b24f03015e611dbd10a5b66878895b9bee319962e49b2923c39181a",
+    "sourceCodeHash": "0x63d5ee495c3fbb22d3cd58ce37e538fe946d374cd3d33cb0f7799e5795a17697"
   },
   "src/L2/ETHLiquidity.sol:ETHLiquidity": {
     "initCodeHash": "0x3c32ddabff34450afd940aa8cf852783576c3ae2d453b66386c3ed3baa0d7a57",

--- a/packages/contracts-bedrock/snapshots/storageLayout/CrossL2Inbox.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/CrossL2Inbox.json
@@ -1,1 +1,16 @@
-[]
+[
+  {
+    "bytes": "20",
+    "label": "l1EventRegistry",
+    "offset": 0,
+    "slot": "0",
+    "type": "address"
+  },
+  {
+    "bytes": "32",
+    "label": "certifiedMessages",
+    "offset": 0,
+    "slot": "1",
+    "type": "mapping(bytes32 => bool)"
+  }
+]

--- a/packages/contracts-bedrock/snapshots/storageLayout/L1EventRegistry.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/L1EventRegistry.json
@@ -1,0 +1,9 @@
+[
+  {
+    "bytes": "32",
+    "label": "registeredEvents",
+    "offset": 0,
+    "slot": "0",
+    "type": "mapping(bytes32 => bool)"
+  }
+]

--- a/packages/contracts-bedrock/specs/event-certificates.md
+++ b/packages/contracts-bedrock/specs/event-certificates.md
@@ -1,0 +1,106 @@
+# L1-Certified L2 Events
+
+## Status
+
+Draft. The contracts in this change define and test the protocol boundary. The execution-client, fault-proof, genesis,
+upgrade, and deployment changes listed under [Required follow-up work](#required-follow-up-work) are not implemented.
+
+## Motivation
+
+Interop messages currently depend on destination-chain inclusion before their initiating event expires. A sequencer can
+therefore censor message execution until the event is no longer eligible. Users need an L1-mediated slow path that can
+be force-included, takes no dependency on a sequencer, and remains usable after the ordinary interop expiry window.
+
+The slow path turns a recent local L2 event into a durable L1 certificate. The event must be exported during the
+seven-day lookup window, but its certificate can be relayed and consumed later. A user can force-include both the
+source export and destination execution through the relevant portals.
+
+## Components
+
+- `LocalLogOracle` is a consensus-critical precompile at `0x4200000000000000000000000000000000000026`. It only proves
+  logs from previous blocks of the chain on which it is called and only while they are at most seven days old.
+- `CrossL2Inbox` exports a locally proven event through `L2ToL1MessagePasser`, imports an L1 certificate, and validates
+  cached certificates without an EIP-2930 access-list entry.
+- `L1EventRegistry` authenticates finalized exports and stores durable certificates. Its immutable `ETHLockbox`
+  identifies the portals in one interop cluster.
+- `OptimismPortal2` supplies the existing L2-to-L1 withdrawal proof path and L1-to-L2 force-inclusion path.
+
+## Certificate
+
+An event is identified by the existing `Identifier` fields:
+
+```text
+(origin, blockNumber, logIndex, timestamp, chainId)
+```
+
+The certificate is:
+
+```text
+keccak256(abi.encode(identifier, payloadHash))
+```
+
+`payloadHash` is the hash of the complete encoded log payload. For an interop message it is
+`keccak256(sentMessagePayload)`, matching the existing `L2ToL2CrossDomainMessenger.relayMessage` validation.
+
+## Protocol flow
+
+1. Before the seven-day lookup window closes, a normal transaction or forced deposit calls
+   `CrossL2Inbox.exportEvent(identifier, payloadHash)` on the source L2.
+2. `CrossL2Inbox` requires the source chain ID, a previous block, and an in-window timestamp, then asks
+   `LocalLogOracle.containsLog` to verify the exact local log.
+3. `CrossL2Inbox` creates a zero-value withdrawal targeting `L1EventRegistry.registerEvent`.
+4. Anyone proves and finalizes that withdrawal using the ordinary portal mechanism.
+5. `L1EventRegistry` accepts the certificate only when the calling portal is currently authorized by its immutable
+   `ETHLockbox`, the portal uses that lockbox, `portal.l2Sender()` is the canonical `CrossL2Inbox`, and the chain ID
+   derived from `portal.systemConfig()` matches the identifier.
+6. Anyone calls `relayEvent` or `relayMessage` with an authorized destination portal. The registry deposits a fixed
+   call to the destination `CrossL2Inbox`; the registry becomes the aliased L2 caller.
+7. The destination inbox authenticates the alias, stores the checksum, and either leaves generic consumption to the
+   application or calls `L2ToL2CrossDomainMessenger.relayMessage` in the same deposit.
+
+Certificates and imports are idempotent. Messenger replay protection remains the authority for whether a particular
+interop message has executed successfully.
+
+## Consensus separation
+
+Ordinary validation emits `ExecutingMessage`, which interop clients interpret as an executing-message dependency.
+Certified validation instead emits `ExecutingCertifiedMessage`. Clients must not apply ordinary expiry, dependency-set,
+or access-list hazard rules to that event: its safety derives from the L1 deposit and finalized certificate.
+
+This distinction is consensus-critical. Reusing `ExecutingMessage` for the certified path would cause old messages to
+be rejected by current supervisors even though the EVM call succeeded locally.
+
+## Security properties
+
+- Calldata cannot forge source identity. L1 derives it from the calling portal and `portal.l2Sender()`.
+- Certificates cannot cross ETHLockbox clusters unless a destination cluster explicitly trusts the registry.
+- Destination imports accept only the configured registry's standard L1-to-L2 address alias.
+- A failed one-shot message execution reverts the import deposit, but the L1 certificate remains registered and can be
+  retried.
+- The mechanism is censorship-resistant under the same L1 inclusion and portal force-inclusion assumptions as an
+  ordinary deposit.
+
+## Limitations
+
+The mechanism does not recover an event that was never exported before its seven-day local lookup window closed.
+Protocols requiring unconditional eventual recovery should export eagerly, allow a keeper to export, or batch recent
+event certificates. Withdrawal finality can then complete after ordinary interop expiry without losing the event.
+
+The registry establishes that a log existed. It does not establish application-specific absence, non-execution, or
+refund eligibility. An ETH bridge using certificates for recovery must still bind a unique transfer identifier and
+enforce a single terminal outcome across relay and refund paths.
+
+## Required follow-up work
+
+1. Specify `LocalLogOracle` gas, receipt encoding, pruning behavior, and exact boundary behavior.
+2. Make historical receipt access deterministic in op-geth, op-reth, Kona, and fault-proof re-execution. Reading an
+   execution client's optional archival database is insufficient. The final design needs either a state-committed
+   rolling receipt-root/history structure or explicit receipt and ancestry witnesses anchored to consensus state.
+3. Teach interop clients to recognize `ExecutingCertifiedMessage` as L1-certified rather than as an ordinary
+   executing-message dependency.
+4. Deploy `L1EventRegistry`, configure it in each participating `CrossL2Inbox`, and add genesis/NUT wiring and standard
+   validation checks.
+5. Add end-to-end tests for forced source export, withdrawal proving/finalization, destination deposit derivation,
+   one-shot execution, retries, reorgs, and the exact seven-day boundary.
+6. Define batching before production use; one withdrawal and one deposit per event is deliberately the simplest base
+   case, not the most economical form.

--- a/packages/contracts-bedrock/src/L1/L1EventRegistry.sol
+++ b/packages/contracts-bedrock/src/L1/L1EventRegistry.sol
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+// Libraries
+import { Predeploys } from "src/libraries/Predeploys.sol";
+
+// Interfaces
+import { IETHLockbox } from "interfaces/L1/IETHLockbox.sol";
+import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
+import { ICrossL2Inbox, Identifier } from "interfaces/L2/ICrossL2Inbox.sol";
+import { ISemver } from "interfaces/universal/ISemver.sol";
+
+/// @title L1EventRegistry
+/// @notice Records recent L2 events finalized through standard withdrawal proofs and relays their
+///         certificates to other chains in the same ETHLockbox cluster.
+/// @dev This contract is intentionally immutable. A new registry requires updating CrossL2Inbox
+///      through the L2 ProxyAdmin on each participating chain.
+contract L1EventRegistry is ISemver {
+    /// @notice Thrown when constructed with a zero ETHLockbox address.
+    error L1EventRegistry_InvalidLockbox();
+
+    /// @notice Thrown when a source or destination portal is not in the registry's cluster.
+    error L1EventRegistry_UnauthorizedPortal();
+
+    /// @notice Thrown when a source withdrawal was not initiated by CrossL2Inbox.
+    error L1EventRegistry_UnauthorizedL2Sender();
+
+    /// @notice Thrown when an identifier's chain ID does not match the source portal's chain.
+    error L1EventRegistry_WrongSourceChain();
+
+    /// @notice Thrown when attempting to relay an event that has not been registered.
+    error L1EventRegistry_EventNotRegistered();
+
+    /// @notice Emitted when an event is registered on L1.
+    event EventRegistered(bytes32 indexed certificate, bytes32 indexed payloadHash, Identifier id);
+
+    /// @notice Emitted when an event certificate is relayed to a destination portal.
+    event EventRelayed(bytes32 indexed certificate, address indexed portal, bool executeMessage);
+
+    /// @notice Shared ETHLockbox defining the set of source and destination portals.
+    IETHLockbox public immutable ethLockbox;
+
+    /// @notice Registered event certificates.
+    mapping(bytes32 => bool) public registeredEvents;
+
+    /// @notice Semantic version.
+    /// @custom:semver 1.0.0
+    string public constant version = "1.0.0";
+
+    /// @param _ethLockbox Shared ETHLockbox for the interop cluster.
+    constructor(IETHLockbox _ethLockbox) {
+        if (address(_ethLockbox) == address(0)) revert L1EventRegistry_InvalidLockbox();
+        ethLockbox = _ethLockbox;
+    }
+
+    /// @notice Records an event exported from an authorized L2 CrossL2Inbox.
+    /// @dev This function is the target of a zero-value L2 withdrawal. The portal authenticates
+    ///      the source CrossL2Inbox through l2Sender while the lockbox authenticates cluster membership.
+    function registerEvent(Identifier calldata _id, bytes32 _payloadHash) external {
+        IOptimismPortal2 portal = IOptimismPortal2(payable(msg.sender));
+        _assertAuthorizedPortal(portal);
+        if (portal.l2Sender() != Predeploys.CROSS_L2_INBOX) {
+            revert L1EventRegistry_UnauthorizedL2Sender();
+        }
+        if (portal.systemConfig().l2ChainId() != _id.chainId) revert L1EventRegistry_WrongSourceChain();
+
+        bytes32 certificate = calculateCertificate(_id, _payloadHash);
+        registeredEvents[certificate] = true;
+        emit EventRegistered(certificate, _payloadHash, _id);
+    }
+
+    /// @notice Relays a generic event certificate to another chain in the cluster.
+    function relayEvent(
+        IOptimismPortal2 _destinationPortal,
+        Identifier calldata _id,
+        bytes32 _payloadHash,
+        uint64 _gasLimit
+    )
+        external
+    {
+        bytes32 certificate = _assertRegistered(_id, _payloadHash);
+        _assertAuthorizedPortal(_destinationPortal);
+
+        bytes memory data = abi.encodeCall(ICrossL2Inbox.importEvent, (_id, _payloadHash));
+        _destinationPortal.depositTransaction(Predeploys.CROSS_L2_INBOX, 0, _gasLimit, false, data);
+        emit EventRelayed(certificate, address(_destinationPortal), false);
+    }
+
+    /// @notice Relays a certified SentMessage event and executes it in one destination deposit.
+    function relayMessage(
+        IOptimismPortal2 _destinationPortal,
+        Identifier calldata _id,
+        bytes calldata _sentMessage,
+        uint64 _gasLimit
+    )
+        external
+    {
+        bytes32 certificate = _assertRegistered(_id, keccak256(_sentMessage));
+        _assertAuthorizedPortal(_destinationPortal);
+
+        bytes memory data = abi.encodeCall(ICrossL2Inbox.importAndExecute, (_id, _sentMessage));
+        _destinationPortal.depositTransaction(Predeploys.CROSS_L2_INBOX, 0, _gasLimit, false, data);
+        emit EventRelayed(certificate, address(_destinationPortal), true);
+    }
+
+    /// @notice Calculates the canonical certificate for an event and payload hash.
+    function calculateCertificate(Identifier memory _id, bytes32 _payloadHash) public pure returns (bytes32) {
+        return keccak256(abi.encode(_id, _payloadHash));
+    }
+
+    /// @notice Verifies that a portal is a current member of this registry's ETHLockbox cluster.
+    function _assertAuthorizedPortal(IOptimismPortal2 _portal) internal view {
+        if (!_portalIsAuthorized(_portal)) revert L1EventRegistry_UnauthorizedPortal();
+    }
+
+    /// @notice Returns whether a portal is a current member of this registry's ETHLockbox cluster.
+    function _portalIsAuthorized(IOptimismPortal2 _portal) internal view returns (bool) {
+        return ethLockbox.authorizedPortals(_portal) && _portal.ethLockbox() == ethLockbox;
+    }
+
+    /// @notice Verifies and returns the certificate for an event and payload hash.
+    function _assertRegistered(
+        Identifier calldata _id,
+        bytes32 _payloadHash
+    )
+        internal
+        view
+        returns (bytes32 certificate_)
+    {
+        certificate_ = calculateCertificate(_id, _payloadHash);
+        if (!registeredEvents[certificate_]) revert L1EventRegistry_EventNotRegistered();
+    }
+}

--- a/packages/contracts-bedrock/src/L2/CrossL2Inbox.sol
+++ b/packages/contracts-bedrock/src/L2/CrossL2Inbox.sol
@@ -1,22 +1,20 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.25;
 
+// Contracts
+import { ProxyAdminOwnedBase } from "src/universal/ProxyAdminOwnedBase.sol";
+
+// Libraries
+import { Predeploys } from "src/libraries/Predeploys.sol";
+import { AddressAliasHelper } from "src/vendor/AddressAliasHelper.sol";
+
 // Interfaces
 import { ISemver } from "interfaces/universal/ISemver.sol";
-
-/// @notice The struct for a pointer to a message payload in a remote (or local) chain.
-/// @custom:field origin The origin address of the message.
-/// @custom:field blockNumber The block number of the message.
-/// @custom:field logIndex The log index of the message.
-/// @custom:field timestamp The timestamp of the message.
-/// @custom:field chainId The origin chain ID of the message.
-struct Identifier {
-    address origin;
-    uint256 blockNumber;
-    uint256 logIndex;
-    uint256 timestamp;
-    uint256 chainId;
-}
+import { Identifier } from "interfaces/L2/ICrossL2Inbox.sol";
+import { IL1EventRegistry } from "interfaces/L1/IL1EventRegistry.sol";
+import { IL2ToL1MessagePasser } from "interfaces/L2/IL2ToL1MessagePasser.sol";
+import { IL2ToL2CrossDomainMessenger } from "interfaces/L2/IL2ToL2CrossDomainMessenger.sol";
+import { ILocalLogOracle } from "interfaces/L2/ILocalLogOracle.sol";
 
 /// @custom:proxied true
 /// @custom:predeploy 0x4200000000000000000000000000000000000022
@@ -28,9 +26,27 @@ struct Identifier {
 ///      slot containing the message checksum is "warm" (pre-accessed), which fails if not included
 ///      in the tx's access list. Nodes pre-check message validity before execution. The checksum
 ///      combines the message's `Identifier` and `msgHash` with type-3 bit masking.
-contract CrossL2Inbox is ISemver {
+contract CrossL2Inbox is ProxyAdminOwnedBase, ISemver {
     /// @notice Thrown when trying to validate a cross chain message in a deposit transaction.
     error CrossL2Inbox_NoExecutingDeposits();
+
+    /// @notice Thrown when the configured L1 event registry is the zero address.
+    error CrossL2Inbox_InvalidEventRegistry();
+
+    /// @notice Thrown when an event certificate is not imported by the configured L1 event registry.
+    error CrossL2Inbox_NotEventRegistry();
+
+    /// @notice Thrown when the local log oracle cannot find the claimed event.
+    error CrossL2Inbox_EventNotFound();
+
+    /// @notice Thrown when an event is older than the local lookup window.
+    error CrossL2Inbox_EventTooOld();
+
+    /// @notice Thrown when attempting to export an event from another chain.
+    error CrossL2Inbox_EventFromAnotherChain();
+
+    /// @notice Thrown when attempting to export an event that is not from a previous block.
+    error CrossL2Inbox_EventNotInPreviousBlock();
 
     /// @notice Thrown when trying to validate a cross chain message with a checksum
     ///         that is invalid or was not provided in the transaction's access list to set the slot
@@ -50,8 +66,14 @@ contract CrossL2Inbox is ISemver {
     error LogIndexTooHigh();
 
     /// @notice Semantic version.
-    /// @custom:semver 1.1.0
-    string public constant version = "1.1.0";
+    /// @custom:semver 1.2.0
+    string public constant version = "1.2.0";
+
+    /// @notice Maximum age of an event accepted by the local log oracle.
+    uint256 public constant EVENT_LOOKUP_WINDOW = 7 days;
+
+    /// @notice Gas limit used to register an exported event on L1.
+    uint256 public constant REGISTER_EVENT_GAS_LIMIT = 200_000;
 
     /// @notice The mask for the most significant bits of the checksum.
     /// @dev    Used to set the most significant byte to zero.
@@ -63,10 +85,81 @@ contract CrossL2Inbox is ISemver {
     /// @notice The threshold to use to know whether the slot is warm or not.
     uint256 internal constant _WARM_READ_THRESHOLD = 1000;
 
+    /// @notice L1 registry trusted to import finalized event certificates.
+    address public l1EventRegistry;
+
+    /// @notice Event checksums certified through L1.
+    mapping(bytes32 => bool) public certifiedMessages;
+
     /// @notice Emitted when a cross chain message is being executed.
     /// @param msgHash Hash of message payload being executed.
     /// @param id Encoded Identifier of the message.
     event ExecutingMessage(bytes32 indexed msgHash, Identifier id);
+
+    /// @notice Emitted when an L1-certified event is being executed.
+    /// @dev This is intentionally distinct from ExecutingMessage. Interop clients must not apply
+    ///      the ordinary access-list dependency rules to this event.
+    event ExecutingCertifiedMessage(bytes32 indexed msgHash, Identifier id);
+
+    /// @notice Emitted when a locally proven event is exported through the L2ToL1MessagePasser.
+    event EventExported(bytes32 indexed checksum, bytes32 indexed payloadHash, Identifier id);
+
+    /// @notice Emitted when an L1-certified event is imported on this chain.
+    event EventImported(bytes32 indexed checksum, bytes32 indexed payloadHash, Identifier id);
+
+    /// @notice Emitted when the trusted L1 event registry changes.
+    event L1EventRegistryUpdated(address indexed oldRegistry, address indexed newRegistry);
+
+    /// @notice Configures the L1 event registry used by the censorship-resistant relay path.
+    /// @dev The ProxyAdmin or its owner may update this value as part of an upgrade or migration.
+    function setL1EventRegistry(address _l1EventRegistry) external {
+        _assertOnlyProxyAdminOrProxyAdminOwner();
+        if (_l1EventRegistry == address(0)) revert CrossL2Inbox_InvalidEventRegistry();
+
+        address oldRegistry = l1EventRegistry;
+        l1EventRegistry = _l1EventRegistry;
+        emit L1EventRegistryUpdated(oldRegistry, _l1EventRegistry);
+    }
+
+    /// @notice Proves a recent event on this L2 and exports a certificate to L1.
+    /// @dev The local log oracle is a consensus-critical execution-client precompile. The event
+    ///      must be exported while its receipt remains inside the lookup window.
+    function exportEvent(Identifier calldata _id, bytes32 _payloadHash) external {
+        address registry = l1EventRegistry;
+        if (registry == address(0)) revert CrossL2Inbox_InvalidEventRegistry();
+        if (_id.chainId != block.chainid) revert CrossL2Inbox_EventFromAnotherChain();
+        if (_id.blockNumber >= block.number || _id.timestamp > block.timestamp) {
+            revert CrossL2Inbox_EventNotInPreviousBlock();
+        }
+        if (block.timestamp - _id.timestamp > EVENT_LOOKUP_WINDOW) revert CrossL2Inbox_EventTooOld();
+
+        bool containsLog;
+        try ILocalLogOracle(Predeploys.LOCAL_LOG_ORACLE).containsLog(_id, _payloadHash) returns (bool exists_) {
+            containsLog = exists_;
+        } catch {
+            revert CrossL2Inbox_EventNotFound();
+        }
+        if (!containsLog) revert CrossL2Inbox_EventNotFound();
+
+        bytes32 checksum = calculateChecksum(_id, _payloadHash);
+        bytes memory data = abi.encodeCall(IL1EventRegistry.registerEvent, (_id, _payloadHash));
+        IL2ToL1MessagePasser(payable(Predeploys.L2_TO_L1_MESSAGE_PASSER)).initiateWithdrawal(
+            registry, REGISTER_EVENT_GAS_LIMIT, data
+        );
+
+        emit EventExported(checksum, _payloadHash, _id);
+    }
+
+    /// @notice Imports an event certificate delivered by the configured L1 event registry.
+    function importEvent(Identifier calldata _id, bytes32 _payloadHash) external {
+        _importEvent(_id, _payloadHash);
+    }
+
+    /// @notice Imports a certificate and relays a SentMessage event in the same deposit transaction.
+    function importAndExecute(Identifier calldata _id, bytes calldata _sentMessage) external {
+        _importEvent(_id, keccak256(_sentMessage));
+        IL2ToL2CrossDomainMessenger(Predeploys.L2_TO_L2_CROSS_DOMAIN_MESSENGER).relayMessage(_id, _sentMessage);
+    }
 
     /// @notice Validates a cross chain message on the destination chain and emits an ExecutingMessage
     ///         event. This function is useful for applications that understand the schema of the
@@ -77,14 +170,31 @@ contract CrossL2Inbox is ISemver {
     /// @param _id      Identifier of the message.
     /// @param _msgHash Hash of the message payload to call target with.
     function validateMessage(Identifier calldata _id, bytes32 _msgHash) external {
+        bytes32 checksum = calculateChecksum(_id, _msgHash);
+        if (certifiedMessages[checksum]) {
+            emit ExecutingCertifiedMessage(_msgHash, _id);
+            return;
+        }
+
         // Deposits have a zero gas price. When the base fee is positive, user transactions cannot.
         if (block.basefee > 0 && tx.gasprice == 0) revert CrossL2Inbox_NoExecutingDeposits();
 
-        bytes32 checksum = calculateChecksum(_id, _msgHash);
         (bool isWarm,) = _isWarm(checksum);
         if (!isWarm) revert NotInAccessList();
 
         emit ExecutingMessage(_msgHash, _id);
+    }
+
+    /// @notice Imports an event certificate after authenticating its L1 sender.
+    function _importEvent(Identifier calldata _id, bytes32 _payloadHash) internal {
+        address registry = l1EventRegistry;
+        if (registry == address(0) || AddressAliasHelper.undoL1ToL2Alias(msg.sender) != registry) {
+            revert CrossL2Inbox_NotEventRegistry();
+        }
+
+        bytes32 checksum = calculateChecksum(_id, _payloadHash);
+        certifiedMessages[checksum] = true;
+        emit EventImported(checksum, _payloadHash, _id);
     }
 
     /// @notice Calculates a custom checksum for a cross chain message `Identifier` and `msgHash`.

--- a/packages/contracts-bedrock/src/libraries/Predeploys.sol
+++ b/packages/contracts-bedrock/src/libraries/Predeploys.sol
@@ -102,6 +102,10 @@ library Predeploys {
     /// @notice Address of the ETHLiquidity predeploy.
     address internal constant ETH_LIQUIDITY = 0x4200000000000000000000000000000000000025;
 
+    /// @notice Address of the local log oracle precompile.
+    /// @dev The execution client implements this address directly. It is not a proxied predeploy.
+    address internal constant LOCAL_LOG_ORACLE = 0x4200000000000000000000000000000000000026;
+
     /// @notice Address of the NativeAssetLiquidity predeploy.
     address internal constant NATIVE_ASSET_LIQUIDITY = 0x4200000000000000000000000000000000000029;
 

--- a/packages/contracts-bedrock/test/L1/L1EventRegistry.t.sol
+++ b/packages/contracts-bedrock/test/L1/L1EventRegistry.t.sol
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+// Testing
+import { Test } from "test/setup/Test.sol";
+
+// Contracts
+import { L1EventRegistry } from "src/L1/L1EventRegistry.sol";
+
+// Libraries
+import { Predeploys } from "src/libraries/Predeploys.sol";
+
+// Interfaces
+import { IL1EventRegistry } from "interfaces/L1/IL1EventRegistry.sol";
+import { IETHLockbox } from "interfaces/L1/IETHLockbox.sol";
+import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
+import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
+import { ICrossL2Inbox, Identifier } from "interfaces/L2/ICrossL2Inbox.sol";
+
+/// @title L1EventRegistry_TestInit
+/// @notice Reusable test initialization for L1EventRegistry tests.
+abstract contract L1EventRegistry_TestInit is Test {
+    event EventRegistered(bytes32 indexed certificate, bytes32 indexed payloadHash, Identifier id);
+
+    IETHLockbox internal lockbox;
+    IOptimismPortal2 internal sourcePortal;
+    IOptimismPortal2 internal destinationPortal;
+    ISystemConfig internal sourceSystemConfig;
+    L1EventRegistry internal registry;
+
+    Identifier internal id;
+    bytes32 internal payloadHash = keccak256("payload");
+
+    function setUp() public virtual {
+        lockbox = IETHLockbox(makeAddr("lockbox"));
+        sourcePortal = IOptimismPortal2(payable(makeAddr("sourcePortal")));
+        destinationPortal = IOptimismPortal2(payable(makeAddr("destinationPortal")));
+        sourceSystemConfig = ISystemConfig(makeAddr("sourceSystemConfig"));
+        registry = new L1EventRegistry(lockbox);
+
+        id = Identifier({ origin: makeAddr("origin"), blockNumber: 100, logIndex: 2, timestamp: 1_000, chainId: 901 });
+
+        _mockAuthorizedPortal(sourcePortal);
+        _mockAuthorizedPortal(destinationPortal);
+        vm.mockCall(
+            address(sourcePortal), abi.encodeCall(IOptimismPortal2.l2Sender, ()), abi.encode(Predeploys.CROSS_L2_INBOX)
+        );
+        vm.mockCall(
+            address(sourcePortal), abi.encodeCall(IOptimismPortal2.systemConfig, ()), abi.encode(sourceSystemConfig)
+        );
+        vm.mockCall(address(sourceSystemConfig), abi.encodeCall(ISystemConfig.l2ChainId, ()), abi.encode(id.chainId));
+    }
+
+    function _mockAuthorizedPortal(IOptimismPortal2 _portal) internal {
+        vm.mockCall(address(lockbox), abi.encodeCall(IETHLockbox.authorizedPortals, (_portal)), abi.encode(true));
+        vm.mockCall(address(_portal), abi.encodeCall(IOptimismPortal2.ethLockbox, ()), abi.encode(lockbox));
+    }
+
+    function _registerEvent() internal {
+        vm.prank(address(sourcePortal));
+        registry.registerEvent(id, payloadHash);
+    }
+}
+
+/// @title L1EventRegistry_RegisterEvent_Test
+/// @notice Tests event registration through a source portal.
+contract L1EventRegistry_RegisterEvent_Test is L1EventRegistry_TestInit {
+    function test_registerEvent_succeeds() external {
+        bytes32 certificate = registry.calculateCertificate(id, payloadHash);
+
+        vm.expectEmit(address(registry));
+        emit EventRegistered(certificate, payloadHash, id);
+        vm.prank(address(sourcePortal));
+        registry.registerEvent(id, payloadHash);
+
+        assertTrue(registry.registeredEvents(certificate));
+    }
+
+    function test_registerEvent_wrongL2Sender_reverts() external {
+        vm.mockCall(address(sourcePortal), abi.encodeCall(IOptimismPortal2.l2Sender, ()), abi.encode(address(0xbad)));
+
+        vm.expectRevert(IL1EventRegistry.L1EventRegistry_UnauthorizedL2Sender.selector);
+        vm.prank(address(sourcePortal));
+        registry.registerEvent(id, payloadHash);
+    }
+
+    function test_registerEvent_wrongSourceChain_reverts() external {
+        vm.mockCall(
+            address(sourceSystemConfig), abi.encodeCall(ISystemConfig.l2ChainId, ()), abi.encode(id.chainId + 1)
+        );
+
+        vm.expectRevert(IL1EventRegistry.L1EventRegistry_WrongSourceChain.selector);
+        vm.prank(address(sourcePortal));
+        registry.registerEvent(id, payloadHash);
+    }
+
+    function test_registerEvent_unauthorizedPortal_reverts() external {
+        vm.mockCall(address(lockbox), abi.encodeCall(IETHLockbox.authorizedPortals, (sourcePortal)), abi.encode(false));
+
+        vm.expectRevert(IL1EventRegistry.L1EventRegistry_UnauthorizedPortal.selector);
+        vm.prank(address(sourcePortal));
+        registry.registerEvent(id, payloadHash);
+    }
+}
+
+/// @title L1EventRegistry_RelayEvent_Test
+/// @notice Tests relaying finalized event certificates into a destination portal.
+contract L1EventRegistry_RelayEvent_Test is L1EventRegistry_TestInit {
+    function test_relayEvent_succeeds() external {
+        _registerEvent();
+        uint64 gasLimit = 250_000;
+        bytes memory data = abi.encodeCall(ICrossL2Inbox.importEvent, (id, payloadHash));
+
+        vm.expectCall(
+            address(destinationPortal),
+            abi.encodeCall(IOptimismPortal2.depositTransaction, (Predeploys.CROSS_L2_INBOX, 0, gasLimit, false, data))
+        );
+        registry.relayEvent(destinationPortal, id, payloadHash, gasLimit);
+    }
+
+    function test_relayEvent_unregistered_reverts() external {
+        vm.expectRevert(IL1EventRegistry.L1EventRegistry_EventNotRegistered.selector);
+        registry.relayEvent(destinationPortal, id, payloadHash, 250_000);
+    }
+
+    function test_relayMessage_succeeds() external {
+        bytes memory sentMessage = hex"deadbeef";
+        payloadHash = keccak256(sentMessage);
+        _registerEvent();
+        uint64 gasLimit = 500_000;
+        bytes memory data = abi.encodeCall(ICrossL2Inbox.importAndExecute, (id, sentMessage));
+
+        vm.expectCall(
+            address(destinationPortal),
+            abi.encodeCall(IOptimismPortal2.depositTransaction, (Predeploys.CROSS_L2_INBOX, 0, gasLimit, false, data))
+        );
+        registry.relayMessage(destinationPortal, id, sentMessage, gasLimit);
+    }
+}

--- a/packages/contracts-bedrock/test/L2/CrossL2Inbox.t.sol
+++ b/packages/contracts-bedrock/test/L2/CrossL2Inbox.t.sol
@@ -6,8 +6,16 @@ import { Test } from "test/setup/Test.sol";
 import { CommonTest } from "test/setup/CommonTest.sol";
 import { VmSafe } from "forge-std/Vm.sol";
 
+// Libraries
+import { Predeploys } from "src/libraries/Predeploys.sol";
+import { AddressAliasHelper } from "src/vendor/AddressAliasHelper.sol";
+
 // Interfaces
 import { ICrossL2Inbox, Identifier } from "interfaces/L2/ICrossL2Inbox.sol";
+import { IL1EventRegistry } from "interfaces/L1/IL1EventRegistry.sol";
+import { IL2ProxyAdmin } from "interfaces/L2/IL2ProxyAdmin.sol";
+import { IL2ToL1MessagePasser } from "interfaces/L2/IL2ToL1MessagePasser.sol";
+import { ILocalLogOracle } from "interfaces/L2/ILocalLogOracle.sol";
 
 /// @title CrossL2Inbox_ValidateMessageRelayer_Harness
 /// @notice For test contract used to validate multiple messages in a single tx.
@@ -43,22 +51,113 @@ contract CrossL2Inbox_ValidateMessageRelayer_Harness is Test {
 /// @notice Reusable test initialization for `CrossL2Inbox` tests.
 abstract contract CrossL2Inbox_TestInit is CommonTest {
     event ExecutingMessage(bytes32 indexed msgHash, Identifier id);
+    event ExecutingCertifiedMessage(bytes32 indexed msgHash, Identifier id);
+    event EventExported(bytes32 indexed checksum, bytes32 indexed payloadHash, Identifier id);
+    event EventImported(bytes32 indexed checksum, bytes32 indexed payloadHash, Identifier id);
 
     CrossL2Inbox_ValidateMessageRelayer_Harness public validateMessageRelayer;
 
     mapping(bytes32 => bool) public relayedMessages;
     mapping(bytes32 => bool) public warmedSlots;
 
-    function setUp() public override {
+    function setUp() public virtual override {
         useInteropOverride = true;
         super.setUp();
         validateMessageRelayer = new CrossL2Inbox_ValidateMessageRelayer_Harness(address(crossL2Inbox));
     }
 }
 
+/// @title CrossL2Inbox_CertifiedEvent_TestInit
+/// @notice Tests exporting and importing event certificates through L1.
+abstract contract CrossL2Inbox_CertifiedEvent_TestInit is CrossL2Inbox_TestInit {
+    address internal l1EventRegistry = makeAddr("l1EventRegistry");
+    Identifier internal id;
+    bytes32 internal payloadHash = keccak256("payload");
+
+    function setUp() public override {
+        super.setUp();
+
+        vm.prank(IL2ProxyAdmin(Predeploys.PROXY_ADMIN).owner());
+        crossL2Inbox.setL1EventRegistry(l1EventRegistry);
+
+        vm.roll(100);
+        vm.warp(1_000_000);
+        id = Identifier({
+            origin: makeAddr("origin"),
+            blockNumber: block.number - 1,
+            logIndex: 2,
+            timestamp: block.timestamp,
+            chainId: block.chainid
+        });
+    }
+}
+
+/// @title CrossL2Inbox_ExportEvent_Test
+/// @notice Tests the `exportEvent` function of the `CrossL2Inbox` contract.
+contract CrossL2Inbox_ExportEvent_Test is CrossL2Inbox_CertifiedEvent_TestInit {
+    function test_exportEvent_succeeds() external {
+        // The exact seven-day boundary remains eligible.
+        id.timestamp = block.timestamp - crossL2Inbox.EVENT_LOOKUP_WINDOW();
+        bytes memory oracleCall = abi.encodeCall(ILocalLogOracle.containsLog, (id, payloadHash));
+        vm.mockCall(Predeploys.LOCAL_LOG_ORACLE, oracleCall, abi.encode(true));
+
+        bytes memory registryCall = abi.encodeCall(IL1EventRegistry.registerEvent, (id, payloadHash));
+        bytes memory withdrawalCall = abi.encodeCall(
+            IL2ToL1MessagePasser.initiateWithdrawal,
+            (l1EventRegistry, crossL2Inbox.REGISTER_EVENT_GAS_LIMIT(), registryCall)
+        );
+        vm.mockCall(Predeploys.L2_TO_L1_MESSAGE_PASSER, withdrawalCall, bytes(""));
+        vm.expectCall(Predeploys.LOCAL_LOG_ORACLE, oracleCall);
+        vm.expectCall(Predeploys.L2_TO_L1_MESSAGE_PASSER, withdrawalCall);
+
+        bytes32 checksum = crossL2Inbox.calculateChecksum(id, payloadHash);
+        vm.expectEmit(address(crossL2Inbox));
+        emit EventExported(checksum, payloadHash, id);
+        crossL2Inbox.exportEvent(id, payloadHash);
+    }
+
+    function test_exportEvent_tooOld_reverts() external {
+        id.timestamp = block.timestamp - crossL2Inbox.EVENT_LOOKUP_WINDOW() - 1;
+
+        vm.expectRevert(ICrossL2Inbox.CrossL2Inbox_EventTooOld.selector);
+        crossL2Inbox.exportEvent(id, payloadHash);
+    }
+}
+
+/// @title CrossL2Inbox_ImportEvent_Test
+/// @notice Tests the `importEvent` function of the `CrossL2Inbox` contract.
+contract CrossL2Inbox_ImportEvent_Test is CrossL2Inbox_CertifiedEvent_TestInit {
+    function test_importEvent_succeeds() external {
+        bytes32 checksum = crossL2Inbox.calculateChecksum(id, payloadHash);
+
+        vm.expectEmit(address(crossL2Inbox));
+        emit EventImported(checksum, payloadHash, id);
+        vm.prank(AddressAliasHelper.applyL1ToL2Alias(l1EventRegistry));
+        crossL2Inbox.importEvent(id, payloadHash);
+
+        assertTrue(crossL2Inbox.certifiedMessages(checksum));
+    }
+
+    function test_importEvent_untrustedSender_reverts() external {
+        vm.expectRevert(ICrossL2Inbox.CrossL2Inbox_NotEventRegistry.selector);
+        crossL2Inbox.importEvent(id, payloadHash);
+    }
+}
+
 /// @title CrossL2Inbox_ValidateMessage_Test
 /// @notice Tests the `validateMessage` function of the `CrossL2Inbox` contract.
-contract CrossL2Inbox_ValidateMessage_Test is CrossL2Inbox_TestInit {
+contract CrossL2Inbox_ValidateMessage_Test is CrossL2Inbox_CertifiedEvent_TestInit {
+    function test_validateMessage_certifiedDeposit_succeeds() external {
+        vm.prank(AddressAliasHelper.applyL1ToL2Alias(l1EventRegistry));
+        crossL2Inbox.importEvent(id, payloadHash);
+
+        vm.fee(1);
+        vm.txGasPrice(0);
+        vm.expectEmit(address(crossL2Inbox));
+        emit ExecutingCertifiedMessage(payloadHash, id);
+        crossL2Inbox.validateMessage(id, payloadHash);
+    }
+
     /// @notice Test that `validateMessage` reverts when executed in a deposit transaction.
     function testFuzz_validateMessage_depositTransaction_reverts(
         Identifier memory _id,


### PR DESCRIPTION
## Overview

This draft prototypes an L1-mediated, censorship-resistant slow path for L2 events and interop messages.

A source `CrossL2Inbox` asks a consensus `LocalLogOracle` precompile to verify a recent local log, then exports the certificate through the existing `L2ToL1MessagePasser`. After ordinary withdrawal proving/finalization, `L1EventRegistry` records the certificate and can force-deposit it into any destination portal authorized by the same `ETHLockbox`. The destination inbox caches it and can either expose generic event validation or execute a certified `SentMessage` in the same deposit.

The event must be exported within seven days. Once registered on L1, the certificate is durable and can be relayed after ordinary interop expiry.

## Security decisions

- L1 derives the source chain from the calling portal and authenticates `portal.l2Sender()` as the canonical `CrossL2Inbox`; source identity is never trusted from calldata.
- Source and destination portals must both be current members of the registry immutable `ETHLockbox` cluster.
- Destination imports authenticate the L1 registry through standard L1-to-L2 address aliasing.
- Certified execution emits `ExecutingCertifiedMessage`, not `ExecutingMessage`, so ordinary interop expiry/dependency hazard rules are not accidentally applied.
- Certificates bind the full existing `Identifier` and exact payload hash. Messenger replay protection remains authoritative.

## Included

- `ILocalLogOracle` execution-client boundary and reserved system address
- source export and destination certificate cache in `CrossL2Inbox`
- immutable `L1EventRegistry` with portal/lockbox/source-chain authentication
- generic `relayEvent` and one-deposit `relayMessage` paths
- ABI, storage-layout, and semver snapshots
- focused L1/L2 unit tests
- design note: `packages/contracts-bedrock/specs/event-certificates.md`

## Draft blockers / follow-ups

- Specify and implement deterministic historical receipt access in op-geth, op-reth, Kona, and fault-proof re-execution. An optional archival database lookup is not consensus-safe; the final design needs a state-committed history structure or explicit witnesses anchored to consensus state.
- Define precompile gas, receipt encoding, pruning, reorg, and exact boundary semantics.
- Update interop clients to classify `ExecutingCertifiedMessage` as L1-certified rather than an ordinary executing-message dependency.
- Add genesis/NUT/deployment/standard-validator wiring for the registry and inbox configuration.
- Add forced-deposit and withdrawal-finalization end-to-end coverage.
- For ETH bridge recovery, separately enforce a unique transfer ID and one terminal outcome across relay and refund paths. Event presence alone does not prove non-execution.
- Consider batched exports before production use.

## Verification

- `mise x -- just build` (passes; one pre-existing payable-fallback warning in `L2ContractsManager.t.sol`)
- `mise x -- just test-dev --match-path test/L2/CrossL2Inbox.t.sol` — 18 passed
- `mise x -- just test-dev --match-path test/L1/L1EventRegistry.t.sol` — 7 passed
- clean default-profile source build, interface check, snapshot generation, formatting, pragma, unused-import, spacer, reinitializer, semver, and test-structure checks pass
