### PR TITLE
mise: Update bun to 1.4.0

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,7 +1,7 @@
 [tools]
 
 # Core dependencies
-bun = "1.2.5"
+bun = "1.4.0"
 go = "1.26.5"
 golangci-lint = "2.8.0"
 gotestsum = "1.12.3"


### PR DESCRIPTION
Bun 1.2.5 cannot parse bundles that use recent JavaScript syntax. Any tool that runs under the repo-pinned bun fails with a parse error inside this repository.

The only in-repo bun consumer is `.circleci/scripts/test-schedule-triggers.js`. I ran it locally under bun 1.4.0. It works.