### PR TITLE
op-deployer: update SCR dep and CurrentTag for op-contracts/v8.0.0-rc.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0
 	github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.4-0.20251001155152-4eb15ccedf7e
-	github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20260611202829-ac4e48516794
+	github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20260830012948-52037bfea66a
 	github.com/ethereum/go-ethereum v1.17.0
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/golang/snappy v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -173,8 +173,6 @@ github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.4-0.20251001155152-4eb15c
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.4-0.20251001155152-4eb15ccedf7e/go.mod h1:DYj7+vYJ4cIB7zera9mv4LcAynCL5u4YVfoeUu6Wa+w=
 github.com/ethereum-optimism/op-geth v1.101702.3-rc.6 h1:Ky9Tu5U2OjJyUF411zODyjF/oldxjAs04XDCaXxBHps=
 github.com/ethereum-optimism/op-geth v1.101702.3-rc.6/go.mod h1:HzvOtk7c9KwFaSxRvUBPFHGSjIjomWtw4iSXX6vruQE=
-github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20260611202829-ac4e48516794 h1:pZtEiAqYCO5MzgPmoNOv/b/Wy8oDRC4xlNcZB0CEY7U=
-github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20260611202829-ac4e48516794/go.mod h1:NZ816PzLU1TLv1RdAvYAb6KWOj4Zm5aInT0YpDVml2Y=
 github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20260830012948-52037bfea66a h1:X0cWN6guCasp0rHoEQcNBT7SQBBaS7LOPHUMfwPJsao=
 github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20260830012948-52037bfea66a/go.mod h1:NZ816PzLU1TLv1RdAvYAb6KWOj4Zm5aInT0YpDVml2Y=
 github.com/ethereum/c-kzg-4844/v2 v2.1.6 h1:xQymkKCT5E2Jiaoqf3v4wsNgjZLY0lRSkZn27fRjSls=

--- a/go.sum
+++ b/go.sum
@@ -175,6 +175,8 @@ github.com/ethereum-optimism/op-geth v1.101702.3-rc.6 h1:Ky9Tu5U2OjJyUF411zODyjF
 github.com/ethereum-optimism/op-geth v1.101702.3-rc.6/go.mod h1:HzvOtk7c9KwFaSxRvUBPFHGSjIjomWtw4iSXX6vruQE=
 github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20260611202829-ac4e48516794 h1:pZtEiAqYCO5MzgPmoNOv/b/Wy8oDRC4xlNcZB0CEY7U=
 github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20260611202829-ac4e48516794/go.mod h1:NZ816PzLU1TLv1RdAvYAb6KWOj4Zm5aInT0YpDVml2Y=
+github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20260830012948-52037bfea66a h1:X0cWN6guCasp0rHoEQcNBT7SQBBaS7LOPHUMfwPJsao=
+github.com/ethereum-optimism/superchain-registry/validation v0.0.0-20260830012948-52037bfea66a/go.mod h1:NZ816PzLU1TLv1RdAvYAb6KWOj4Zm5aInT0YpDVml2Y=
 github.com/ethereum/c-kzg-4844/v2 v2.1.6 h1:xQymkKCT5E2Jiaoqf3v4wsNgjZLY0lRSkZn27fRjSls=
 github.com/ethereum/c-kzg-4844/v2 v2.1.6/go.mod h1:8HMkUZ5JRv4hpw/XUrYWSQNAUzhHMg2UDb/U+5m+XNw=
 github.com/ethereum/go-bigmodexpfix v0.0.0-20250911101455-f9e208c548ab h1:rvv6MJhy07IMfEKuARQ9TKojGqLVNxQajaXEp/BoqSk=

--- a/op-deployer/pkg/deployer/standard/standard.go
+++ b/op-deployer/pkg/deployer/standard/standard.go
@@ -56,7 +56,8 @@ const (
 	ContractsV500Tag        = "op-contracts/v5.0.0"
 	ContractsV600Tag        = "op-contracts/v6.0.0-rc.2"
 	ContractsV700Tag        = "op-contracts/v7.0.0-rc.4"
-	CurrentTag              = ContractsV700Tag
+	ContractsV800Tag        = "op-contracts/v8.0.0-rc.3"
+	CurrentTag              = ContractsV800Tag
 )
 
 var DisputeAbsolutePrestate = common.HexToHash("0x038512e02c4c3f7bdaec27d00edf55b7155e0905301e1a88083e4e0a6764d54c")


### PR DESCRIPTION
Bumps `github.com/ethereum-optimism/superchain-registry/validation` to the commit that adds the `op-contracts/v8.0.0-rc.3` standard versions (ethereum-optimism/superchain-registry#1321), and sets `CurrentTag` to `op-contracts/v8.0.0-rc.3`.

Prep for the op-deployer v8 RC release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)