### PR TITLE
kona-engine!: label the engine task failure counter by type and severity

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -7049,6 +7049,7 @@ dependencies = [
  "rstest",
  "serde",
  "serde_json",
+ "strum",
  "thiserror 2.0.18",
  "tokio",
  "tower 0.5.3",

--- a/rust/kona/crates/node/engine/Cargo.toml
+++ b/rust/kona/crates/node/engine/Cargo.toml
@@ -48,6 +48,7 @@ tower.workspace = true
 http-body-util.workspace = true
 derive_more = { workspace = true, features = ["display", "deref", "from_str", "constructor"] }
 serde_json.workspace = true
+strum = { workspace = true, features = ["derive"] }
 
 # metrics
 metrics = { workspace = true, optional = true }

--- a/rust/kona/crates/node/engine/src/lib.rs
+++ b/rust/kona/crates/node/engine/src/lib.rs
@@ -42,9 +42,9 @@ mod task_queue;
 pub use task_queue::{
     BuildSealCoupling, BuildTask, BuildTaskError, ConsolidateInput, ConsolidateTask,
     ConsolidateTaskError, Engine, EngineBuildError, EngineResetError, EngineTask, EngineTaskError,
-    EngineTaskErrorSeverity, EngineTaskErrors, EngineTaskExt, FinalizeBlockId, FinalizeTask,
-    FinalizeTaskError, InsertTask, InsertTaskError, SealTask, SealTaskError, SynchronizeTask,
-    SynchronizeTaskError,
+    EngineTaskErrorSeverity, EngineTaskErrors, EngineTaskExt, EngineTaskKind, FinalizeBlockId,
+    FinalizeTask, FinalizeTaskError, InsertTask, InsertTaskError, SealTask, SealTaskError,
+    SynchronizeTask, SynchronizeTaskError,
 };
 
 mod attributes;

--- a/rust/kona/crates/node/engine/src/metrics/mod.rs
+++ b/rust/kona/crates/node/engine/src/metrics/mod.rs
@@ -51,8 +51,6 @@ impl Metrics {
     pub const INSERT_TASK_LABEL: &str = "insert";
     /// Consolidate task label.
     pub const CONSOLIDATE_TASK_LABEL: &str = "consolidate";
-    /// Forkchoice task label.
-    pub const FORKCHOICE_TASK_LABEL: &str = "forkchoice-update";
     /// Build task label.
     pub const BUILD_TASK_LABEL: &str = "build";
     /// Seal task label.
@@ -110,18 +108,26 @@ impl Metrics {
 
     /// Initializes metrics to `0` so they can be queried immediately by consumers of prometheus
     /// metrics.
+    ///
+    /// The full task x severity product is pre-created: narrowing it to the reachable pairs
+    /// would drift as the error enums change.
     #[cfg(feature = "metrics")]
     pub fn zero() {
-        // Engine task counts
-        kona_macros::set!(counter, Self::ENGINE_TASK_SUCCESS, Self::INSERT_TASK_LABEL, 0);
-        kona_macros::set!(counter, Self::ENGINE_TASK_SUCCESS, Self::CONSOLIDATE_TASK_LABEL, 0);
-        kona_macros::set!(counter, Self::ENGINE_TASK_SUCCESS, Self::BUILD_TASK_LABEL, 0);
-        kona_macros::set!(counter, Self::ENGINE_TASK_SUCCESS, Self::FINALIZE_TASK_LABEL, 0);
+        use strum::IntoEnumIterator;
 
-        kona_macros::set!(counter, Self::ENGINE_TASK_FAILURE, Self::INSERT_TASK_LABEL, 0);
-        kona_macros::set!(counter, Self::ENGINE_TASK_FAILURE, Self::CONSOLIDATE_TASK_LABEL, 0);
-        kona_macros::set!(counter, Self::ENGINE_TASK_FAILURE, Self::BUILD_TASK_LABEL, 0);
-        kona_macros::set!(counter, Self::ENGINE_TASK_FAILURE, Self::FINALIZE_TASK_LABEL, 0);
+        for task in crate::EngineTaskKind::iter() {
+            kona_macros::set!(counter, Self::ENGINE_TASK_SUCCESS, task.label(), 0);
+
+            for severity in crate::EngineTaskErrorSeverity::iter() {
+                // `kona_macros::set!` has no two-label arm.
+                metrics::counter!(
+                    Self::ENGINE_TASK_FAILURE,
+                    "type" => task.label(),
+                    "severity" => severity.to_string()
+                )
+                .absolute(0);
+            }
+        }
 
         // Engine reset count
         kona_macros::set!(counter, Self::ENGINE_RESET_COUNT, 0);

--- a/rust/kona/crates/node/engine/src/state/core.rs
+++ b/rust/kona/crates/node/engine/src/state/core.rs
@@ -207,17 +207,22 @@ mod test {
         #[case] label_name: &str,
         #[case] number: u64,
     ) {
-        let handle = PrometheusBuilder::new().install_recorder().unwrap();
-        crate::Metrics::init();
+        // A local recorder: `install_recorder` sets the process global, which succeeds once.
+        let recorder = PrometheusBuilder::new().build_recorder();
+        let handle = recorder.handle();
 
-        let mut state = EngineState::default();
-        set_fn(
-            &mut state,
-            L2BlockInfo {
-                block_info: BlockInfo { number, ..Default::default() },
-                ..Default::default()
-            },
-        );
+        metrics::with_local_recorder(&recorder, || {
+            crate::Metrics::init();
+
+            let mut state = EngineState::default();
+            set_fn(
+                &mut state,
+                L2BlockInfo {
+                    block_info: BlockInfo { number, ..Default::default() },
+                    ..Default::default()
+                },
+            );
+        });
 
         assert!(handle.render().contains(
             format!("kona_node_block_labels{{label=\"{label_name}\"}} {number}").as_str()

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/mod.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/mod.rs
@@ -3,6 +3,7 @@
 mod task;
 pub use task::{
     EngineTask, EngineTaskError, EngineTaskErrorSeverity, EngineTaskErrors, EngineTaskExt,
+    EngineTaskKind,
 };
 
 mod synchronize;

--- a/rust/kona/crates/node/engine/src/task_queue/tasks/task.rs
+++ b/rust/kona/crates/node/engine/src/task_queue/tasks/task.rs
@@ -18,7 +18,7 @@ use tokio::task::yield_now;
 /// The severity of an engine task error.
 ///
 /// This is used to determine how to handle the error when draining the engine task queue.
-#[derive(Debug, PartialEq, Eq, Display, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Display, Clone, Copy, strum::EnumIter)]
 pub enum EngineTaskErrorSeverity {
     /// The error is temporary and the task is retried.
     #[display("temporary")]
@@ -32,6 +32,36 @@ pub enum EngineTaskErrorSeverity {
     /// The error indicates that the engine should be flushed.
     #[display("flush")]
     Flush,
+}
+
+/// The kind of an [`EngineTask`], and the `type` label its metrics carry.
+///
+/// Separate from [`EngineTask`] so the label set can be enumerated.
+#[derive(Debug, PartialEq, Eq, Clone, Copy, strum::EnumIter)]
+pub enum EngineTaskKind {
+    /// An [`EngineTask::Insert`].
+    Insert,
+    /// An [`EngineTask::Consolidate`].
+    Consolidate,
+    /// An [`EngineTask::Build`].
+    Build,
+    /// An [`EngineTask::Seal`].
+    Seal,
+    /// An [`EngineTask::Finalize`].
+    Finalize,
+}
+
+impl EngineTaskKind {
+    /// The `type` label value for this kind.
+    pub const fn label(&self) -> &'static str {
+        match self {
+            Self::Insert => crate::Metrics::INSERT_TASK_LABEL,
+            Self::Consolidate => crate::Metrics::CONSOLIDATE_TASK_LABEL,
+            Self::Build => crate::Metrics::BUILD_TASK_LABEL,
+            Self::Seal => crate::Metrics::SEAL_TASK_LABEL,
+            Self::Finalize => crate::Metrics::FINALIZE_TASK_LABEL,
+        }
+    }
 }
 
 /// The interface for an engine task error.
@@ -133,13 +163,13 @@ impl<EngineClient_: EngineClient> EngineTask<EngineClient_> {
         Ok(())
     }
 
-    const fn task_metrics_label(&self) -> &'static str {
+    const fn kind(&self) -> EngineTaskKind {
         match self {
-            Self::Insert(_) => crate::Metrics::INSERT_TASK_LABEL,
-            Self::Consolidate(_) => crate::Metrics::CONSOLIDATE_TASK_LABEL,
-            Self::Build(_) => crate::Metrics::BUILD_TASK_LABEL,
-            Self::Seal(_) => crate::Metrics::SEAL_TASK_LABEL,
-            Self::Finalize(_) => crate::Metrics::FINALIZE_TASK_LABEL,
+            Self::Insert(_) => EngineTaskKind::Insert,
+            Self::Consolidate(_) => EngineTaskKind::Consolidate,
+            Self::Build(_) => EngineTaskKind::Build,
+            Self::Seal(_) => EngineTaskKind::Seal,
+            Self::Finalize(_) => EngineTaskKind::Finalize,
         }
     }
 }
@@ -219,7 +249,8 @@ impl<EngineClient_: EngineClient> EngineTaskExt for EngineTask<EngineClient_> {
             kona_macros::inc!(
                 counter,
                 crate::Metrics::ENGINE_TASK_FAILURE,
-                self.task_metrics_label() => severity.to_string()
+                "type" => self.kind().label(),
+                "severity" => severity.to_string()
             );
 
             match severity {
@@ -244,7 +275,7 @@ impl<EngineClient_: EngineClient> EngineTaskExt for EngineTask<EngineClient_> {
             }
         }
 
-        kona_macros::inc!(counter, crate::Metrics::ENGINE_TASK_SUCCESS, self.task_metrics_label());
+        kona_macros::inc!(counter, crate::Metrics::ENGINE_TASK_SUCCESS, self.kind().label());
 
         Ok(())
     }
@@ -261,6 +292,8 @@ mod tests {
     use op_alloy_consensus::OpTxEnvelope;
     use op_alloy_rpc_types_engine::OpExecutionPayloadEnvelope;
     use std::{sync::Arc, time::Duration};
+    #[cfg(feature = "metrics")]
+    use strum::IntoEnumIterator;
 
     /// Records the blocks the engine hands over after a successful import.
     #[derive(Debug, Default)]
@@ -349,5 +382,69 @@ mod tests {
             .await
             .expect("invalid unsafe payload task should not retry")
             .unwrap();
+    }
+
+    /// A task whose first failure is `Critical`: the default `RollupConfig` does not pin
+    /// genesis, so the `L2BlockInfo` cannot be built.
+    #[cfg(feature = "metrics")]
+    fn critically_failing_insert_task() -> EngineTask<MockEngineClient> {
+        let config = Arc::new(RollupConfig::default());
+        let client = Arc::new(
+            MockEngineClient::builder()
+                .with_config(config.clone())
+                .with_new_payload_v1_response(PayloadStatus::from_status(PayloadStatusEnum::Valid))
+                .build(),
+        );
+        let payload = ExecutionPayloadV1::from_block_slow(&Block::<OpTxEnvelope>::default());
+
+        EngineTask::Insert(Box::new(InsertTask::new(
+            client,
+            config,
+            OpExecutionPayloadEnvelope::V1(payload),
+            false,
+            Arc::new(crate::NoopBlockSink),
+        )))
+    }
+
+    /// The task must be the `type` label's value, not the label key.
+    #[cfg(feature = "metrics")]
+    #[test]
+    fn task_failure_metric_carries_type_and_severity_labels() {
+        let recorder = metrics_exporter_prometheus::PrometheusBuilder::new().build_recorder();
+        let handle = recorder.handle();
+        let task = critically_failing_insert_task();
+
+        // Driven inside the closure so the task is polled on the thread holding the recorder.
+        let runtime = tokio::runtime::Builder::new_current_thread().enable_time().build().unwrap();
+        metrics::with_local_recorder(&recorder, || {
+            crate::Metrics::zero();
+            runtime
+                .block_on(async {
+                    tokio::time::timeout(
+                        Duration::from_secs(1),
+                        task.execute(&mut EngineState::default()),
+                    )
+                    .await
+                })
+                .expect("a critical insert failure must not retry")
+                .expect_err("a critical insert failure must propagate");
+        });
+
+        let rendered = handle.render();
+        assert!(
+            rendered
+                .contains("kona_node_engine_task_failure{type=\"insert\",severity=\"critical\"} 1"),
+            "expected a labelled failure series, got:\n{rendered}"
+        );
+
+        let series = rendered
+            .lines()
+            .filter(|line| line.starts_with("kona_node_engine_task_failure{"))
+            .count();
+        assert_eq!(
+            series,
+            EngineTaskKind::iter().count() * EngineTaskErrorSeverity::iter().count(),
+            "the emitted series must be one of the pre-created ones:\n{rendered}"
+        );
     }
 }


### PR DESCRIPTION
`kona_node_engine_task_failure` used the task name as the label **key** and the severity as its value, so the emit at `task_queue/tasks/task.rs:219` produced `{insert="critical"}`. Two consequences: every task type minted a new label key, and `Metrics::zero` pre-created `{type="insert"}`, a series nothing ever incremented. The counter therefore rendered one set of series at startup and a different, incompatible set once anything failed.

It now emits `{type=<task>,severity=<severity>}`, matching `kona_node_engine_task_count`.

`zero` pre-creates the task × severity cross product, and picks up the `seal` task it omitted — `EngineTask::task_metrics_label` returns it and the engine actor enqueues seal tasks, so `{type="seal"}` was absent from both counters until the sequencer's first seal. `EngineTaskErrorSeverity::ALL` supplies the severity list so the pre-created set cannot drift from the emitted one.

One adjacent fix, because it is what makes the new test runnable: `test_chain_label_metrics` called `PrometheusBuilder::install_recorder`, which may only succeed once per process, so three of its four `rstest` cases panicked with `FailedToSetGlobalRecorder` under `--features metrics`. It was green in CI only because `metrics` is not a default feature of `kona-engine`. It uses a local recorder now.

Split out of #22569, which found this while adding a chain dimension. It is an independent bug, so it should not wait on that work.

### Verification

`cargo test -p kona-engine --features metrics,test-utils`: 76 passed, 0 failed (was 3 failed). `clippy --features metrics,test-utils --all-targets -D warnings` clean; without the feature the crate reports the same 13 pre-existing errors as `develop`. Reverting the emit to the old shape makes `task_failure_metric_carries_type_and_severity_labels` fail, so it is a regression test rather than a claim.

BREAKING CHANGE: `kona_node_engine_task_failure` changes shape. It emitted `{insert="critical"}`; it now emits `{type="insert",severity="critical"}`. Operators selecting `kona_node_engine_task_failure{insert=...}` (or `consolidate`/`build`/`finalize`) must migrate those panels and alert rules. No in-repo Grafana dashboard selects this metric — `docker/recipes/kona-node*/grafana/dashboards/overview.json` uses `kona_node_engine_task_count`, whose shape is unchanged — so the blast radius is external dashboards only.