### PR TITLE
kona: make the pre-created metric series match what the code emits

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6988,6 +6988,7 @@ dependencies = [
  "kona-peers",
  "libp2p",
  "metrics",
+ "metrics-util",
  "rand 0.9.4",
  "serde_json",
  "tempfile",
@@ -7575,6 +7576,7 @@ dependencies = [
  "kona-providers-local",
  "lru 0.18.2",
  "metrics",
+ "metrics-util",
  "op-alloy-consensus",
  "op-alloy-network",
  "reqwest 0.13.2",
@@ -7601,6 +7603,7 @@ dependencies = [
  "kona-protocol",
  "lru 0.18.2",
  "metrics",
+ "metrics-util",
  "op-alloy-consensus",
  "rstest",
  "thiserror 2.0.18",
@@ -7629,6 +7632,7 @@ dependencies = [
 name = "kona-rpc"
 version = "0.3.2"
 dependencies = [
+ "alloy-consensus 2.1.1",
  "alloy-eips 2.1.1",
  "alloy-primitives",
  "alloy-rpc-client",
@@ -7646,6 +7650,7 @@ dependencies = [
  "kona-protocol",
  "libp2p",
  "metrics",
+ "metrics-util",
  "op-alloy-consensus",
  "op-alloy-rpc-jsonrpsee",
  "op-alloy-rpc-types",

--- a/rust/kona/crates/node/disc/Cargo.toml
+++ b/rust/kona/crates/node/disc/Cargo.toml
@@ -40,6 +40,7 @@ rand = { workspace = true, features = ["thread_rng"] }
 metrics = { workspace = true, optional = true }
 
 [dev-dependencies]
+metrics-util = { workspace = true, features = ["debugging"] }
 tempfile.workspace = true
 serde_json.workspace = true
 kona-cli.workspace = true

--- a/rust/kona/crates/node/disc/src/metrics.rs
+++ b/rust/kona/crates/node/disc/src/metrics.rs
@@ -57,6 +57,32 @@ impl Metrics {
 
         // Peer Counts
         kona_macros::set!(gauge, Self::DISCOVERY_PEER_COUNT, 0);
-        kona_macros::set!(gauge, Self::FIND_NODE_REQUEST, 0);
+
+        // The emit carries a constant `find_node` label, which the shipped dashboard selects on.
+        kona_macros::set!(gauge, Self::FIND_NODE_REQUEST, "find_node", "find_node", 0);
+    }
+}
+
+#[cfg(all(test, feature = "metrics"))]
+mod tests {
+    use super::Metrics;
+    use metrics_util::debugging::DebuggingRecorder;
+
+    #[test]
+    fn find_node_requests_carry_the_label_the_emit_uses() {
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+        metrics::with_local_recorder(&recorder, Metrics::zero);
+
+        let labelled = snapshotter
+            .snapshot()
+            .into_vec()
+            .into_iter()
+            .filter(|(ckey, ..)| ckey.key().name() == Metrics::FIND_NODE_REQUEST)
+            .any(|(ckey, ..)| {
+                ckey.key().labels().any(|l| l.key() == "find_node" && l.value() == "find_node")
+            });
+
+        assert!(labelled, "the pre-created find-node series must carry the emitted label");
     }
 }

--- a/rust/kona/crates/node/gossip/src/metrics/mod.rs
+++ b/rust/kona/crates/node/gossip/src/metrics/mod.rs
@@ -8,9 +8,6 @@ impl Metrics {
     /// Identifier for the gauge that tracks gossip events.
     pub const GOSSIP_EVENT: &str = "kona_node_gossip_events";
 
-    /// Identifier for the gauge that tracks libp2p gossipsub events.
-    pub const GOSSIPSUB_EVENT: &str = "kona_node_gossipsub_events";
-
     /// Identifier for the gauge that tracks libp2p gossipsub connections.
     pub const GOSSIPSUB_CONNECTION: &str = "kona_node_gossipsub_connection";
 
@@ -90,9 +87,10 @@ impl Metrics {
     #[cfg(feature = "metrics")]
     pub fn describe() {
         metrics::describe_gauge!(Self::RPC_CALLS, "Calls made to the Gossip RPC module");
+        metrics::describe_gauge!(Self::GOSSIP_EVENT, "Events received from the libp2p Swarm");
         metrics::describe_gauge!(
-            Self::GOSSIPSUB_EVENT,
-            "Events received by the libp2p gossipsub Swarm"
+            Self::DIAL_PEER_ERROR,
+            "Number of failed peer dials by the libp2p Swarm, by reason"
         );
         metrics::describe_gauge!(Self::DIAL_PEER, "Number of peers dialed by the libp2p Swarm");
         metrics::describe_gauge!(
@@ -150,35 +148,54 @@ impl Metrics {
     /// metrics.
     #[cfg(feature = "metrics")]
     pub fn zero() {
-        // RPC Calls
-        kona_macros::set!(gauge, Self::RPC_CALLS, "method", "opp2p_self", 0);
-        kona_macros::set!(gauge, Self::RPC_CALLS, "method", "opp2p_peerCount", 0);
-        kona_macros::set!(gauge, Self::RPC_CALLS, "method", "opp2p_peers", 0);
-        kona_macros::set!(gauge, Self::RPC_CALLS, "method", "opp2p_peerStats", 0);
-        kona_macros::set!(gauge, Self::RPC_CALLS, "method", "opp2p_discoveryTable", 0);
-        kona_macros::set!(gauge, Self::RPC_CALLS, "method", "opp2p_blockPeer", 0);
-        kona_macros::set!(gauge, Self::RPC_CALLS, "method", "opp2p_listBlockedPeers", 0);
-        kona_macros::set!(gauge, Self::RPC_CALLS, "method", "opp2p_blockAddr", 0);
-        kona_macros::set!(gauge, Self::RPC_CALLS, "method", "opp2p_unblockAddr", 0);
-        kona_macros::set!(gauge, Self::RPC_CALLS, "method", "opp2p_listBlockedAddrs", 0);
-        kona_macros::set!(gauge, Self::RPC_CALLS, "method", "opp2p_blockSubnet", 0);
-        kona_macros::set!(gauge, Self::RPC_CALLS, "method", "opp2p_unblockSubnet", 0);
-        kona_macros::set!(gauge, Self::RPC_CALLS, "method", "opp2p_listBlockedSubnets", 0);
-        kona_macros::set!(gauge, Self::RPC_CALLS, "method", "opp2p_protectPeer", 0);
-        kona_macros::set!(gauge, Self::RPC_CALLS, "method", "opp2p_unprotectPeer", 0);
-        kona_macros::set!(gauge, Self::RPC_CALLS, "method", "opp2p_connectPeer", 0);
-        kona_macros::set!(gauge, Self::RPC_CALLS, "method", "opp2p_disconnectPeer", 0);
+        // The emits live in `kona-rpc`: `opp2p_*` in `p2p.rs`, `admin_postUnsafePayload` in
+        // `admin.rs`.
+        for method in [
+            "opp2p_self",
+            "opp2p_peerCount",
+            "opp2p_peers",
+            "opp2p_peerStats",
+            "opp2p_discoveryTable",
+            "opp2p_blockPeer",
+            "opp2p_unblockPeer",
+            "opp2p_listBlockedPeers",
+            "opp2p_blockAddr",
+            "opp2p_unblockAddr",
+            "opp2p_listBlockedAddrs",
+            "opp2p_blockSubnet",
+            "opp2p_unblockSubnet",
+            "opp2p_listBlockedSubnets",
+            "opp2p_protectPeer",
+            "opp2p_unprotectPeer",
+            "opp2p_connectPeer",
+            "opp2p_disconnectPeer",
+            "admin_postUnsafePayload",
+        ] {
+            kona_macros::set!(gauge, Self::RPC_CALLS, "method", method, 0);
+        }
 
-        // Gossip Events
-        kona_macros::set!(gauge, Self::GOSSIP_EVENT, "type", "message", 0);
-        kona_macros::set!(gauge, Self::GOSSIP_EVENT, "type", "subscribed", 0);
-        kona_macros::set!(gauge, Self::GOSSIP_EVENT, "type", "unsubscribed", 0);
+        // The other three types also carry a `topic`, and for `subscribed`/`unsubscribed` that
+        // topic comes from remote peers, so their value set is not knowable here.
         kona_macros::set!(gauge, Self::GOSSIP_EVENT, "type", "slow_peer", 0);
         kona_macros::set!(gauge, Self::GOSSIP_EVENT, "type", "not_supported", 0);
 
         // Peer dials
         kona_macros::set!(gauge, Self::DIAL_PEER, 0);
-        kona_macros::set!(gauge, Self::DIAL_PEER_ERROR, 0);
+
+        // The reasons emitted by `driver.rs` and `gater.rs`.
+        for reason in [
+            "invalid_enr",
+            "invalid_multiaddr",
+            "already_connected",
+            "already_dialing",
+            "connection_error",
+            "threshold_reached",
+            "blocked_peer",
+            "blocked_address",
+            "blocked_subnet",
+        ] {
+            kona_macros::set!(gauge, Self::DIAL_PEER_ERROR, "type", reason, 0);
+        }
 
         // Unsafe Blocks
         kona_macros::set!(gauge, Self::UNSAFE_BLOCK_PUBLISHED, 0);
@@ -187,57 +204,119 @@ impl Metrics {
         kona_macros::set!(gauge, Self::GOSSIP_PEER_COUNT, 0);
 
         // Connection
-        kona_macros::set!(gauge, Self::GOSSIPSUB_CONNECTION, "type", "connected", 0);
-        kona_macros::set!(gauge, Self::GOSSIPSUB_CONNECTION, "type", "outgoing_error", 0);
-        kona_macros::set!(gauge, Self::GOSSIPSUB_CONNECTION, "type", "incoming_error", 0);
-        kona_macros::set!(gauge, Self::GOSSIPSUB_CONNECTION, "type", "closed", 0);
+        for event in ["connected", "outgoing_error", "incoming_error", "closed"] {
+            kona_macros::set!(gauge, Self::GOSSIPSUB_CONNECTION, "type", event, 0);
+        }
 
-        // Gossipsub Events
-        kona_macros::set!(gauge, Self::GOSSIPSUB_EVENT, "type", "subscribed", 0);
-        kona_macros::set!(gauge, Self::GOSSIPSUB_EVENT, "type", "unsubscribed", 0);
-        kona_macros::set!(gauge, Self::GOSSIPSUB_EVENT, "type", "gossipsub_not_supported", 0);
-        kona_macros::set!(gauge, Self::GOSSIPSUB_EVENT, "type", "slow_peer", 0);
-        kona_macros::set!(gauge, Self::GOSSIPSUB_EVENT, "type", "message_received", 0);
-
-        // Banned Peers
-        kona_macros::set!(gauge, Self::BANNED_PEERS, 0);
+        // `BANNED_PEERS` is absent: its emit carries `peer_id`, so there is no finite series set.
 
         // Block validation metrics
         kona_macros::set!(counter, Self::BLOCK_VALIDATION_TOTAL, 0);
         kona_macros::set!(counter, Self::BLOCK_VALIDATION_SUCCESS, 0);
 
-        // Block validation failures by reason
-        kona_macros::set!(counter, Self::BLOCK_VALIDATION_FAILED, "reason", "timestamp_future", 0);
-        kona_macros::set!(counter, Self::BLOCK_VALIDATION_FAILED, "reason", "timestamp_past", 0);
-        kona_macros::set!(counter, Self::BLOCK_VALIDATION_FAILED, "reason", "invalid_hash", 0);
-        kona_macros::set!(counter, Self::BLOCK_VALIDATION_FAILED, "reason", "invalid_signature", 0);
-        kona_macros::set!(counter, Self::BLOCK_VALIDATION_FAILED, "reason", "invalid_signer", 0);
-        kona_macros::set!(counter, Self::BLOCK_VALIDATION_FAILED, "reason", "too_many_blocks", 0);
-        kona_macros::set!(counter, Self::BLOCK_VALIDATION_FAILED, "reason", "block_seen", 0);
-        kona_macros::set!(counter, Self::BLOCK_VALIDATION_FAILED, "reason", "invalid_block", 0);
-        kona_macros::set!(
-            counter,
-            Self::BLOCK_VALIDATION_FAILED,
-            "reason",
-            "parent_beacon_root",
-            0
-        );
-        kona_macros::set!(counter, Self::BLOCK_VALIDATION_FAILED, "reason", "blob_gas_used", 0);
-        kona_macros::set!(counter, Self::BLOCK_VALIDATION_FAILED, "reason", "excess_blob_gas", 0);
-        kona_macros::set!(counter, Self::BLOCK_VALIDATION_FAILED, "reason", "withdrawals_root", 0);
+        // The reasons come from the `match` in `BlockValidator::block_valid`.
+        for reason in [
+            "timestamp_future",
+            "timestamp_past",
+            "invalid_hash",
+            "invalid_signature",
+            "invalid_signer",
+            "too_many_blocks",
+            "block_seen",
+            "invalid_block",
+            "blob_gas_used",
+            "excess_blob_gas",
+            "withdrawals_root",
+        ] {
+            kona_macros::set!(counter, Self::BLOCK_VALIDATION_FAILED, "reason", reason, 0);
+        }
 
         // Block versions
-        kona_macros::set!(counter, Self::BLOCK_VERSION, "version", "v1", 0);
-        kona_macros::set!(counter, Self::BLOCK_VERSION, "version", "v2", 0);
-        kona_macros::set!(counter, Self::BLOCK_VERSION, "version", "v3", 0);
-        kona_macros::set!(counter, Self::BLOCK_VERSION, "version", "v4", 0);
+        for version in ["v1", "v2", "v3", "v4"] {
+            kona_macros::set!(counter, Self::BLOCK_VERSION, "version", version, 0);
+        }
 
         // Messages rejected by the block handler before validation, by reason
-        kona_macros::set!(counter, Self::INVALID_MESSAGE, "reason", "invalid_snappy_length", 0);
-        kona_macros::set!(counter, Self::INVALID_MESSAGE, "reason", "decode_error", 0);
-        kona_macros::set!(counter, Self::INVALID_MESSAGE, "reason", "unknown_topic", 0);
+        for reason in ["invalid_snappy_length", "decode_error", "unknown_topic"] {
+            kona_macros::set!(counter, Self::INVALID_MESSAGE, "reason", reason, 0);
+        }
 
         // Malformed frames caught in the message-id function (per receipt, before dedup)
         kona_macros::set!(counter, Self::MESSAGE_ID_INVALID_SNAPPY, 0);
+    }
+}
+
+#[cfg(all(test, feature = "metrics"))]
+mod tests {
+    use super::Metrics;
+    use metrics_util::debugging::DebuggingRecorder;
+    use std::collections::BTreeSet;
+
+    /// The `label` values that `zero()` pre-creates for `metric`, or `None` for a series with no
+    /// such label.
+    fn zeroed(metric: &str, label: &str) -> BTreeSet<Option<String>> {
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+        metrics::with_local_recorder(&recorder, Metrics::zero);
+
+        snapshotter
+            .snapshot()
+            .into_vec()
+            .into_iter()
+            .map(|(ckey, ..)| ckey)
+            .filter(|ckey| ckey.key().name() == metric)
+            .map(|ckey| {
+                ckey.key().labels().find(|l| l.key() == label).map(|l| l.value().to_string())
+            })
+            .collect()
+    }
+
+    fn expect(metric: &str, label: &str, values: &[&str]) {
+        let expected: BTreeSet<_> = values.iter().map(|v| Some(v.to_string())).collect();
+        assert_eq!(zeroed(metric, label), expected, "{metric} pre-created the wrong {label} set");
+    }
+
+    #[test]
+    fn dial_peer_errors_are_pre_created_per_reason() {
+        // The nine reasons emitted by `driver.rs` and `gater.rs`.
+        expect(
+            Metrics::DIAL_PEER_ERROR,
+            "type",
+            &[
+                "invalid_enr",
+                "invalid_multiaddr",
+                "already_connected",
+                "already_dialing",
+                "connection_error",
+                "threshold_reached",
+                "blocked_peer",
+                "blocked_address",
+                "blocked_subnet",
+            ],
+        );
+    }
+
+    #[test]
+    fn gossip_events_pre_create_only_the_topic_free_types() {
+        expect(Metrics::GOSSIP_EVENT, "type", &["slow_peer", "not_supported"]);
+    }
+
+    #[test]
+    fn block_validation_failures_omit_the_unreachable_reason() {
+        // `BlockInvalidError` has no variant that yields `parent_beacon_root`.
+        assert!(
+            !zeroed(Metrics::BLOCK_VALIDATION_FAILED, "reason")
+                .contains(&Some("parent_beacon_root".to_string()))
+        );
+    }
+
+    #[test]
+    fn banned_peers_is_not_pre_created() {
+        assert!(zeroed(Metrics::BANNED_PEERS, "peer_id").is_empty());
+    }
+
+    #[test]
+    fn no_series_is_pre_created_without_an_emit() {
+        assert!(zeroed("kona_node_gossipsub_events", "type").is_empty());
     }
 }

--- a/rust/kona/crates/node/rpc/Cargo.toml
+++ b/rust/kona/crates/node/rpc/Cargo.toml
@@ -63,6 +63,9 @@ metrics = { workspace = true, optional = true }
 
 [dev-dependencies]
 serde_json.workspace = true
+metrics-util = { workspace = true, features = ["debugging"] }
+alloy-primitives.workspace = true
+alloy-consensus.workspace = true
 
 [features]
 default = []

--- a/rust/kona/crates/node/rpc/src/p2p.rs
+++ b/rust/kona/crates/node/rpc/src/p2p.rs
@@ -58,6 +58,7 @@ impl OpP2PApiServer for P2pRpc {
     }
 
     async fn opp2p_peer_stats(&self) -> RpcResult<PeerStats> {
+        kona_macros::inc!(gauge, kona_gossip::Metrics::RPC_CALLS, "method" => "opp2p_peerStats");
         let (tx, rx) = tokio::sync::oneshot::channel();
         self.sender
             .send(P2pRpcRequest::PeerStats(tx))
@@ -313,5 +314,127 @@ mod tests {
             libp2p::multiaddr::Protocol::Ip4(std::net::Ipv4Addr::new(127, 0, 0, 1))
         );
         assert_eq!(components[1], libp2p::multiaddr::Protocol::Udt);
+    }
+
+    /// Never called; `AdminRpc` needs a concrete type parameter even when it holds `None`.
+    #[cfg(feature = "metrics")]
+    #[derive(Debug)]
+    struct NoSequencer;
+
+    #[cfg(feature = "metrics")]
+    #[async_trait::async_trait]
+    impl crate::SequencerAdminAPIClient for NoSequencer {
+        async fn is_sequencer_active(&self) -> Result<bool, crate::SequencerAdminAPIError> {
+            unreachable!("the admin rpc holds no sequencer client")
+        }
+        async fn is_conductor_enabled(&self) -> Result<bool, crate::SequencerAdminAPIError> {
+            unreachable!("the admin rpc holds no sequencer client")
+        }
+        async fn is_recovery_mode(&self) -> Result<bool, crate::SequencerAdminAPIError> {
+            unreachable!("the admin rpc holds no sequencer client")
+        }
+        async fn start_sequencer(&self) -> Result<(), crate::SequencerAdminAPIError> {
+            unreachable!("the admin rpc holds no sequencer client")
+        }
+        async fn stop_sequencer(
+            &self,
+        ) -> Result<alloy_primitives::B256, crate::SequencerAdminAPIError> {
+            unreachable!("the admin rpc holds no sequencer client")
+        }
+        async fn set_recovery_mode(
+            &self,
+            _mode: bool,
+        ) -> Result<(), crate::SequencerAdminAPIError> {
+            unreachable!("the admin rpc holds no sequencer client")
+        }
+        async fn override_leader(&self) -> Result<(), crate::SequencerAdminAPIError> {
+            unreachable!("the admin rpc holds no sequencer client")
+        }
+        async fn reset_derivation_pipeline(&self) -> Result<(), crate::SequencerAdminAPIError> {
+            unreachable!("the admin rpc holds no sequencer client")
+        }
+    }
+
+    /// The pre-created `kona_node_rpc_calls` series must be exactly the ones these handlers emit.
+    ///
+    /// `kona-gossip` owns the metric and cannot see these emit sites, so this is the only place
+    /// the two halves can be compared.
+    #[cfg(feature = "metrics")]
+    #[test]
+    fn rpc_call_metric_is_pre_created_for_every_emitted_method() {
+        use crate::{AdminApiServer, AdminRpc, OpP2PApiServer, net::P2pRpc};
+        use metrics_util::debugging::DebuggingRecorder;
+        use std::collections::BTreeSet;
+
+        fn methods_of(f: impl FnOnce()) -> BTreeSet<String> {
+            let recorder = DebuggingRecorder::new();
+            let snapshotter = recorder.snapshotter();
+            metrics::with_local_recorder(&recorder, f);
+
+            snapshotter
+                .snapshot()
+                .into_vec()
+                .into_iter()
+                .map(|(ckey, ..)| ckey)
+                .filter(|ckey| ckey.key().name() == kona_gossip::Metrics::RPC_CALLS)
+                .map(|ckey| {
+                    ckey.key()
+                        .labels()
+                        .find(|l| l.key() == "method")
+                        .map(|l| l.value().to_string())
+                        .expect("every emit carries a `method` label")
+                })
+                .collect()
+        }
+
+        // The receivers are dropped, so each handler's first send fails and it returns early.
+        // Every one emits before that send.
+        // `_`, not `_rx`: a named binding keeps the receiver alive and the handler blocks for
+        // ever awaiting a reply.
+        let (p2p_tx, _) = tokio::sync::mpsc::channel(1);
+        let (admin_tx, _) = tokio::sync::mpsc::channel(1);
+        let p2p = P2pRpc::new(p2p_tx);
+        let admin = AdminRpc::<NoSequencer>::new(None, admin_tx);
+
+        let runtime = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
+        let emitted = methods_of(|| {
+            runtime.block_on(async {
+                let localhost = std::net::IpAddr::from([127, 0, 0, 1]);
+                let subnet: ipnet::IpNet = "127.0.0.0/8".parse().unwrap();
+
+                let _ = p2p.opp2p_self().await;
+                let _ = p2p.opp2p_peer_count().await;
+                let _ = p2p.opp2p_peers(true).await;
+                let _ = p2p.opp2p_peer_stats().await;
+                let _ = p2p.opp2p_discovery_table().await;
+                let _ = p2p.opp2p_block_peer(String::new()).await;
+                let _ = p2p.opp2p_unblock_peer(String::new()).await;
+                let _ = p2p.opp2p_list_blocked_peers().await;
+                let _ = p2p.opp2p_block_addr(localhost).await;
+                let _ = p2p.opp2p_unblock_addr(localhost).await;
+                let _ = p2p.opp2p_list_blocked_addrs().await;
+                let _ = p2p.opp2p_block_subnet(subnet).await;
+                let _ = p2p.opp2p_unblock_subnet(subnet).await;
+                let _ = p2p.opp2p_list_blocked_subnets().await;
+                let _ = p2p.opp2p_protect_peer(String::new()).await;
+                let _ = p2p.opp2p_unprotect_peer(String::new()).await;
+                let _ = p2p.opp2p_connect_peer(String::new()).await;
+                let _ = p2p.opp2p_disconnect_peer(String::new()).await;
+
+                let payload = op_alloy_rpc_types_engine::OpExecutionPayloadEnvelope::V1(
+                    alloy_rpc_types_engine::ExecutionPayloadV1::from_block_slow(
+                        &alloy_consensus::Block::<op_alloy_consensus::OpTxEnvelope>::default(),
+                    ),
+                );
+                let _ = admin.admin_post_unsafe_payload(payload).await;
+            });
+        });
+
+        let pre_created = methods_of(kona_gossip::Metrics::zero);
+
+        assert_eq!(
+            emitted, pre_created,
+            "every emitted `method` must be pre-created, and nothing else"
+        );
     }
 }

--- a/rust/kona/crates/node/service/src/metrics/mod.rs
+++ b/rust/kona/crates/node/service/src/metrics/mod.rs
@@ -14,7 +14,7 @@ impl Metrics {
     /// Identifier for the counter of critical derivation errors (strictly for alerting.)
     pub const DERIVATION_CRITICAL_ERROR: &str = "kona_node_derivation_critical_errors";
 
-    /// Identifier for the counter that tracks sequencer state flags.
+    /// Identifier for the gauge that tracks sequencer state flags.
     pub const SEQUENCER_STATE: &str = "kona_node_sequencer_state";
 
     /// Gauge for the sequencer's attributes builder duration.
@@ -63,8 +63,8 @@ impl Metrics {
             "Critical errors in the derivation pipeline"
         );
 
-        // Sequencer state
-        metrics::describe_counter!(Self::SEQUENCER_STATE, "Tracks sequencer state flags");
+        // Emitted with `metrics::gauge!`.
+        metrics::describe_gauge!(Self::SEQUENCER_STATE, "Tracks sequencer state flags");
 
         // Sequencer attributes builder duration
         metrics::describe_gauge!(

--- a/rust/kona/crates/protocol/derive/src/metrics/mod.rs
+++ b/rust/kona/crates/protocol/derive/src/metrics/mod.rs
@@ -17,9 +17,6 @@ impl Metrics {
     /// Identifier to track the amount of time it takes to advance the pipeline origin.
     pub const PIPELINE_ORIGIN_ADVANCE: &str = "kona_derive_pipeline_origin_advance";
 
-    /// Identifier for the histogram that tracks when the system config is updated.
-    pub const SYSTEM_CONFIG_UPDATE: &str = "kona_derive_system_config_update";
-
     /// Identifier for the number of frames in the frame queue pipeline stage.
     pub const PIPELINE_FRAME_QUEUE_BUFFER: &str = "kona_derive_frame_queue_buffer";
 
@@ -169,10 +166,6 @@ impl Metrics {
         metrics::describe_histogram!(
             Self::PIPELINE_ORIGIN_ADVANCE,
             "The amount of time it takes to advance the pipeline origin"
-        );
-        metrics::describe_histogram!(
-            Self::SYSTEM_CONFIG_UPDATE,
-            "The time it takes to update the system config"
         );
         metrics::describe_gauge!(
             Self::PIPELINE_FRAME_QUEUE_BUFFER,

--- a/rust/kona/crates/providers/providers-alloy/Cargo.toml
+++ b/rust/kona/crates/providers/providers-alloy/Cargo.toml
@@ -65,6 +65,7 @@ default = []
 metrics = [ "dep:metrics", "kona-derive/metrics", "kona-providers-local/metrics" ]
 
 [dev-dependencies]
+metrics-util = { workspace = true, features = ["debugging"] }
 tokio.workspace = true
 kona-protocol = { workspace = true, features = ["test-utils"] }
 alloy-rpc-types-eth.workspace = true

--- a/rust/kona/crates/providers/providers-alloy/src/metrics.rs
+++ b/rust/kona/crates/providers/providers-alloy/src/metrics.rs
@@ -35,14 +35,8 @@ impl Metrics {
     /// Identifier for the gauge that tracks blob fetch errors.
     pub const BLOB_FETCH_ERRORS: &str = "kona_providers_blob_fetch_errors";
 
-    /// Identifier for the histogram that tracks provider request duration.
-    pub const PROVIDER_REQUEST_DURATION: &str = "kona_providers_request_duration";
-
     /// Identifier for the gauge that tracks active cache entries.
     pub const CACHE_ENTRIES: &str = "kona_providers_cache_entries";
-
-    /// Identifier for the gauge that tracks cache memory usage.
-    pub const CACHE_MEMORY_USAGE: &str = "kona_providers_cache_memory_bytes";
 
     /// Initializes metrics for the Alloy providers.
     ///
@@ -92,17 +86,9 @@ impl Metrics {
         );
         metrics::describe_gauge!(Self::BLOB_FETCHES, "Number of blob sidecar fetches");
         metrics::describe_gauge!(Self::BLOB_FETCH_ERRORS, "Number of blob sidecar fetch errors");
-        metrics::describe_histogram!(
-            Self::PROVIDER_REQUEST_DURATION,
-            "Duration of provider requests in seconds"
-        );
         metrics::describe_gauge!(
             Self::CACHE_ENTRIES,
             "Number of active entries in provider caches"
-        );
-        metrics::describe_gauge!(
-            Self::CACHE_MEMORY_USAGE,
-            "Memory usage of provider caches in bytes"
         );
     }
 
@@ -110,98 +96,99 @@ impl Metrics {
     /// metrics.
     #[cfg(feature = "metrics")]
     pub fn zero() {
-        // Chain provider cache metrics
-        kona_macros::set!(gauge, Self::CHAIN_PROVIDER_CACHE_HITS, "cache", "header_by_hash", 0);
-        kona_macros::set!(gauge, Self::CHAIN_PROVIDER_CACHE_HITS, "cache", "receipts_by_hash", 0);
-        kona_macros::set!(gauge, Self::CHAIN_PROVIDER_CACHE_HITS, "cache", "block_info_and_tx", 0);
+        for cache in ["header_by_hash", "receipts_by_hash", "block_info_and_tx"] {
+            kona_macros::set!(gauge, Self::CHAIN_PROVIDER_CACHE_HITS, "cache", cache, 0);
+            kona_macros::set!(gauge, Self::CHAIN_PROVIDER_CACHE_MISSES, "cache", cache, 0);
+            kona_macros::set!(gauge, Self::CACHE_ENTRIES, "cache", cache, 0);
+        }
 
-        kona_macros::set!(gauge, Self::CHAIN_PROVIDER_CACHE_MISSES, "cache", "header_by_hash", 0);
-        kona_macros::set!(gauge, Self::CHAIN_PROVIDER_CACHE_MISSES, "cache", "receipts_by_hash", 0);
-        kona_macros::set!(
-            gauge,
-            Self::CHAIN_PROVIDER_CACHE_MISSES,
-            "cache",
-            "block_info_and_tx",
-            0
-        );
+        // Per method emitted by `chain_provider.rs`.
+        for method in [
+            "header_by_hash",
+            "receipts_by_hash",
+            "block_by_hash",
+            "block_by_number",
+            "block_number",
+        ] {
+            kona_macros::set!(gauge, Self::CHAIN_PROVIDER_RPC_CALLS, "method", method, 0);
+            kona_macros::set!(gauge, Self::CHAIN_PROVIDER_RPC_ERRORS, "method", method, 0);
+        }
 
-        // RPC call metrics
-        kona_macros::set!(gauge, Self::CHAIN_PROVIDER_RPC_CALLS, "method", "header_by_hash", 0);
-        kona_macros::set!(gauge, Self::CHAIN_PROVIDER_RPC_CALLS, "method", "receipts_by_hash", 0);
-        kona_macros::set!(gauge, Self::CHAIN_PROVIDER_RPC_CALLS, "method", "block_by_hash", 0);
-        kona_macros::set!(gauge, Self::CHAIN_PROVIDER_RPC_CALLS, "method", "block_number", 0);
+        // Per method emitted by `beacon_client.rs`.
+        for method in ["spec", "genesis", "blobs"] {
+            kona_macros::set!(gauge, Self::BEACON_CLIENT_REQUESTS, "method", method, 0);
+            kona_macros::set!(gauge, Self::BEACON_CLIENT_ERRORS, "method", method, 0);
+        }
 
-        // RPC error metrics
-        kona_macros::set!(gauge, Self::CHAIN_PROVIDER_RPC_ERRORS, "method", "header_by_hash", 0);
-        kona_macros::set!(gauge, Self::CHAIN_PROVIDER_RPC_ERRORS, "method", "receipts_by_hash", 0);
-        kona_macros::set!(gauge, Self::CHAIN_PROVIDER_RPC_ERRORS, "method", "block_by_hash", 0);
-        kona_macros::set!(gauge, Self::CHAIN_PROVIDER_RPC_ERRORS, "method", "block_number", 0);
+        // Per method emitted by `l2_chain_provider.rs`.
+        for method in ["l2_block_by_hash", "l2_block_ref_by_number"] {
+            kona_macros::set!(gauge, Self::L2_CHAIN_PROVIDER_REQUESTS, "method", method, 0);
+            kona_macros::set!(gauge, Self::L2_CHAIN_PROVIDER_ERRORS, "method", method, 0);
+        }
 
-        // Beacon client metrics
-        kona_macros::set!(gauge, Self::BEACON_CLIENT_REQUESTS, "method", "spec", 0);
-        kona_macros::set!(gauge, Self::BEACON_CLIENT_REQUESTS, "method", "genesis", 0);
-        kona_macros::set!(gauge, Self::BEACON_CLIENT_REQUESTS, "method", "blob_sidecars", 0);
-
-        kona_macros::set!(gauge, Self::BEACON_CLIENT_ERRORS, "method", "spec", 0);
-        kona_macros::set!(gauge, Self::BEACON_CLIENT_ERRORS, "method", "genesis", 0);
-        kona_macros::set!(gauge, Self::BEACON_CLIENT_ERRORS, "method", "blob_sidecars", 0);
-
-        // L2 chain provider metrics
-        kona_macros::set!(
-            gauge,
-            Self::L2_CHAIN_PROVIDER_REQUESTS,
-            "method",
-            "l2_block_ref_by_label",
-            0
-        );
-        kona_macros::set!(
-            gauge,
-            Self::L2_CHAIN_PROVIDER_REQUESTS,
-            "method",
-            "l2_block_ref_by_hash",
-            0
-        );
-        kona_macros::set!(
-            gauge,
-            Self::L2_CHAIN_PROVIDER_REQUESTS,
-            "method",
-            "l2_block_ref_by_number",
-            0
-        );
-
-        kona_macros::set!(
-            gauge,
-            Self::L2_CHAIN_PROVIDER_ERRORS,
-            "method",
-            "l2_block_ref_by_label",
-            0
-        );
-        kona_macros::set!(
-            gauge,
-            Self::L2_CHAIN_PROVIDER_ERRORS,
-            "method",
-            "l2_block_ref_by_hash",
-            0
-        );
-        kona_macros::set!(
-            gauge,
-            Self::L2_CHAIN_PROVIDER_ERRORS,
-            "method",
-            "l2_block_ref_by_number",
-            0
-        );
-
-        // Blob sidecar metrics
         kona_macros::set!(gauge, Self::BLOB_FETCHES, 0);
         kona_macros::set!(gauge, Self::BLOB_FETCH_ERRORS, 0);
+    }
+}
 
-        // Cache metrics
-        kona_macros::set!(gauge, Self::CACHE_ENTRIES, "cache", "header_by_hash", 0);
-        kona_macros::set!(gauge, Self::CACHE_ENTRIES, "cache", "receipts_by_hash", 0);
-        kona_macros::set!(gauge, Self::CACHE_ENTRIES, "cache", "block_info_and_tx", 0);
+#[cfg(all(test, feature = "metrics"))]
+mod tests {
+    use super::Metrics;
+    use metrics_util::debugging::DebuggingRecorder;
+    use std::collections::BTreeSet;
 
-        kona_macros::set!(gauge, Self::CACHE_MEMORY_USAGE, "cache", "header_by_hash", 0);
-        kona_macros::set!(gauge, Self::CACHE_MEMORY_USAGE, "cache", "receipts_by_hash", 0);
-        kona_macros::set!(gauge, Self::CACHE_MEMORY_USAGE, "cache", "block_info_and_tx", 0);
+    fn zeroed(metric: &str, label: &str) -> BTreeSet<Option<String>> {
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+        metrics::with_local_recorder(&recorder, Metrics::zero);
+
+        snapshotter
+            .snapshot()
+            .into_vec()
+            .into_iter()
+            .map(|(ckey, ..)| ckey)
+            .filter(|ckey| ckey.key().name() == metric)
+            // `map`, not `filter_map`: a label-free series must show up as `None` and break
+            // equality.
+            .map(|ckey| {
+                ckey.key().labels().find(|l| l.key() == label).map(|l| l.value().to_string())
+            })
+            .collect()
+    }
+
+    fn expect(metric: &str, label: &str, values: &[&str]) {
+        let expected: BTreeSet<_> = values.iter().map(|v| Some(v.to_string())).collect();
+        assert_eq!(zeroed(metric, label), expected, "{metric} pre-created the wrong {label} set");
+    }
+
+    #[test]
+    fn chain_provider_methods_match_the_emits() {
+        let methods = [
+            "header_by_hash",
+            "receipts_by_hash",
+            "block_by_hash",
+            "block_by_number",
+            "block_number",
+        ];
+        expect(Metrics::CHAIN_PROVIDER_RPC_CALLS, "method", &methods);
+        expect(Metrics::CHAIN_PROVIDER_RPC_ERRORS, "method", &methods);
+    }
+
+    #[test]
+    fn beacon_client_methods_match_the_emits() {
+        expect(Metrics::BEACON_CLIENT_REQUESTS, "method", &["spec", "genesis", "blobs"]);
+        expect(Metrics::BEACON_CLIENT_ERRORS, "method", &["spec", "genesis", "blobs"]);
+    }
+
+    #[test]
+    fn l2_chain_provider_methods_match_the_emits() {
+        let methods = ["l2_block_by_hash", "l2_block_ref_by_number"];
+        expect(Metrics::L2_CHAIN_PROVIDER_REQUESTS, "method", &methods);
+        expect(Metrics::L2_CHAIN_PROVIDER_ERRORS, "method", &methods);
+    }
+
+    #[test]
+    fn no_series_is_pre_created_without_an_emit() {
+        assert!(zeroed("kona_providers_cache_memory_bytes", "cache").is_empty());
     }
 }

--- a/rust/kona/crates/providers/providers-local/Cargo.toml
+++ b/rust/kona/crates/providers/providers-local/Cargo.toml
@@ -39,6 +39,7 @@ thiserror.workspace = true
 metrics = { workspace = true, optional = true }
 
 [dev-dependencies]
+metrics-util = { workspace = true, features = ["debugging"] }
 tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread"] }
 rstest.workspace = true
 

--- a/rust/kona/crates/providers/providers-local/src/metrics.rs
+++ b/rust/kona/crates/providers/providers-local/src/metrics.rs
@@ -23,9 +23,6 @@ impl Metrics {
     /// Identifier for the gauge that tracks active cache entries.
     pub const CACHE_ENTRIES: &str = "kona_providers_local_cache_entries";
 
-    /// Identifier for the gauge that tracks cache capacity.
-    pub const CACHE_CAPACITY: &str = "kona_providers_local_cache_capacity";
-
     /// Identifier for the gauge that tracks reorg depth.
     pub const REORG_DEPTH: &str = "kona_providers_local_reorg_depth";
 
@@ -61,7 +58,6 @@ impl Metrics {
         );
         metrics::describe_gauge!(Self::BLOCKS_ADDED, "Number of blocks added to cache");
         metrics::describe_gauge!(Self::CACHE_ENTRIES, "Number of active entries in cache");
-        metrics::describe_gauge!(Self::CACHE_CAPACITY, "Total capacity of cache");
         metrics::describe_gauge!(Self::REORG_DEPTH, "Maximum depth of reorganization observed");
         metrics::describe_gauge!(Self::CACHE_CLEARS, "Number of times cache was cleared");
     }
@@ -69,62 +65,78 @@ impl Metrics {
     /// Initializes metrics to `0` so they can be queried immediately.
     #[cfg(feature = "metrics")]
     pub fn zero() {
-        // Cache hit/miss metrics
-        kona_macros::set!(
-            gauge,
-            Self::BUFFERED_PROVIDER_CACHE_HITS,
-            "method",
-            "block_by_number",
-            0
-        );
-        kona_macros::set!(gauge, Self::BUFFERED_PROVIDER_CACHE_HITS, "method", "block_by_hash", 0);
-        kona_macros::set!(gauge, Self::BUFFERED_PROVIDER_CACHE_HITS, "method", "l2_block_info", 0);
-        kona_macros::set!(gauge, Self::BUFFERED_PROVIDER_CACHE_HITS, "method", "system_config", 0);
+        // Per method emitted by `buffered.rs`.
+        for method in ["block_by_number", "l2_block_info", "l2_block_info_by_hash", "system_config"]
+        {
+            kona_macros::set!(gauge, Self::BUFFERED_PROVIDER_CACHE_HITS, "method", method, 0);
+            kona_macros::set!(gauge, Self::BUFFERED_PROVIDER_CACHE_MISSES, "method", method, 0);
+        }
 
-        kona_macros::set!(
-            gauge,
-            Self::BUFFERED_PROVIDER_CACHE_MISSES,
-            "method",
-            "block_by_number",
-            0
-        );
-        kona_macros::set!(
-            gauge,
-            Self::BUFFERED_PROVIDER_CACHE_MISSES,
-            "method",
-            "block_by_hash",
-            0
-        );
-        kona_macros::set!(
-            gauge,
-            Self::BUFFERED_PROVIDER_CACHE_MISSES,
-            "method",
-            "l2_block_info",
-            0
-        );
-        kona_macros::set!(
-            gauge,
-            Self::BUFFERED_PROVIDER_CACHE_MISSES,
-            "method",
-            "system_config",
-            0
-        );
-
-        // Chain event metrics
-        kona_macros::set!(gauge, Self::CHAIN_EVENTS_PROCESSED, "event", "committed", 0);
-        kona_macros::set!(gauge, Self::CHAIN_EVENTS_PROCESSED, "event", "reorged", 0);
-        kona_macros::set!(gauge, Self::CHAIN_EVENTS_PROCESSED, "event", "reverted", 0);
-
-        kona_macros::set!(gauge, Self::CHAIN_EVENT_ERRORS, "event", "committed", 0);
-        kona_macros::set!(gauge, Self::CHAIN_EVENT_ERRORS, "event", "reorged", 0);
-        kona_macros::set!(gauge, Self::CHAIN_EVENT_ERRORS, "event", "reverted", 0);
+        // Per event emitted by `buffered.rs`.
+        for event in ["committed", "reorged", "reverted"] {
+            kona_macros::set!(gauge, Self::CHAIN_EVENTS_PROCESSED, "event", event, 0);
+            kona_macros::set!(gauge, Self::CHAIN_EVENT_ERRORS, "event", event, 0);
+        }
 
         // General metrics
         kona_macros::set!(gauge, Self::BLOCKS_ADDED, 0);
         kona_macros::set!(gauge, Self::CACHE_ENTRIES, "cache", "blocks_by_hash", 0);
         kona_macros::set!(gauge, Self::CACHE_ENTRIES, "cache", "blocks_by_number", 0);
-        kona_macros::set!(gauge, Self::CACHE_CAPACITY, 0);
         kona_macros::set!(gauge, Self::REORG_DEPTH, 0);
         kona_macros::set!(gauge, Self::CACHE_CLEARS, 0);
+    }
+}
+
+#[cfg(all(test, feature = "metrics"))]
+mod tests {
+    use super::Metrics;
+    use metrics_util::debugging::DebuggingRecorder;
+    use std::collections::BTreeSet;
+
+    fn zeroed(metric: &str, label: &str) -> BTreeSet<Option<String>> {
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+        metrics::with_local_recorder(&recorder, Metrics::zero);
+
+        snapshotter
+            .snapshot()
+            .into_vec()
+            .into_iter()
+            .map(|(ckey, ..)| ckey)
+            .filter(|ckey| ckey.key().name() == metric)
+            // `map`, not `filter_map`: a label-free series must show up as `None` and break
+            // equality.
+            .map(|ckey| {
+                ckey.key().labels().find(|l| l.key() == label).map(|l| l.value().to_string())
+            })
+            .collect()
+    }
+
+    #[test]
+    fn buffered_cache_methods_match_the_emits() {
+        // The four methods `buffered.rs` emits.
+        let expected: BTreeSet<_> =
+            ["block_by_number", "l2_block_info", "l2_block_info_by_hash", "system_config"]
+                .iter()
+                .map(|v| Some(v.to_string()))
+                .collect();
+
+        assert_eq!(zeroed(Metrics::BUFFERED_PROVIDER_CACHE_HITS, "method"), expected);
+        assert_eq!(zeroed(Metrics::BUFFERED_PROVIDER_CACHE_MISSES, "method"), expected);
+    }
+
+    #[test]
+    fn no_series_is_pre_created_without_an_emit() {
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+        metrics::with_local_recorder(&recorder, Metrics::zero);
+
+        assert!(
+            !snapshotter
+                .snapshot()
+                .into_vec()
+                .iter()
+                .any(|(ckey, ..)| ckey.key().name() == "kona_providers_local_cache_capacity")
+        );
     }
 }

--- a/rust/kona/docker/recipes/kona-node-dev/grafana/dashboards/overview.json
+++ b/rust/kona/docker/recipes/kona-node-dev/grafana/dashboards/overview.json
@@ -5533,17 +5533,17 @@
               },
               "disableTextWrap": false,
               "editorMode": "builder",
-              "expr": "kona_providers_blob_sidecar_fetches{instance=\"$instance\"}",
+              "expr": "kona_providers_blob_fetches{instance=\"$instance\"}",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
               "instant": false,
-              "legendFormat": "{{method}}",
+              "legendFormat": "__auto",
               "range": true,
               "refId": "A",
               "useBackend": false
             }
           ],
-          "title": "Beacon Provider RPC Calls",
+          "title": "Blob Fetches",
           "transparent": true,
           "type": "timeseries"
         },
@@ -5634,17 +5634,17 @@
               },
               "disableTextWrap": false,
               "editorMode": "builder",
-              "expr": "kona_providers_blob_sidecar_errors{instance=\"$instance\"}",
+              "expr": "kona_providers_blob_fetch_errors{instance=\"$instance\"}",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
               "instant": false,
-              "legendFormat": "{{method}}",
+              "legendFormat": "__auto",
               "range": true,
               "refId": "A",
               "useBackend": false
             }
           ],
-          "title": "Beacon Provider RPC Errors",
+          "title": "Blob Fetch Errors",
           "transparent": true,
           "type": "timeseries"
         },
@@ -5746,108 +5746,6 @@
             }
           ],
           "title": "Cache Entries",
-          "transparent": true,
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "description": "",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "barWidthFactor": 0.6,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 7,
-            "w": 12,
-            "x": 12,
-            "y": 40
-          },
-          "id": 113,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "disableTextWrap": false,
-              "editorMode": "builder",
-              "expr": "kona_providers_cache_memory_bytes{instance=\"$instance\"}",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
-              "instant": false,
-              "legendFormat": "{{cache}}",
-              "range": true,
-              "refId": "A",
-              "useBackend": false
-            }
-          ],
-          "title": "Cache Memory Usage",
           "transparent": true,
           "type": "timeseries"
         }

--- a/rust/kona/docker/recipes/kona-node/grafana/dashboards/overview.json
+++ b/rust/kona/docker/recipes/kona-node/grafana/dashboards/overview.json
@@ -5533,17 +5533,17 @@
               },
               "disableTextWrap": false,
               "editorMode": "builder",
-              "expr": "kona_providers_blob_sidecar_fetches{instance=\"$instance\"}",
+              "expr": "kona_providers_blob_fetches{instance=\"$instance\"}",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
               "instant": false,
-              "legendFormat": "{{method}}",
+              "legendFormat": "__auto",
               "range": true,
               "refId": "A",
               "useBackend": false
             }
           ],
-          "title": "Beacon Provider RPC Calls",
+          "title": "Blob Fetches",
           "transparent": true,
           "type": "timeseries"
         },
@@ -5634,17 +5634,17 @@
               },
               "disableTextWrap": false,
               "editorMode": "builder",
-              "expr": "kona_providers_blob_sidecar_errors{instance=\"$instance\"}",
+              "expr": "kona_providers_blob_fetch_errors{instance=\"$instance\"}",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
               "instant": false,
-              "legendFormat": "{{method}}",
+              "legendFormat": "__auto",
               "range": true,
               "refId": "A",
               "useBackend": false
             }
           ],
-          "title": "Beacon Provider RPC Errors",
+          "title": "Blob Fetch Errors",
           "transparent": true,
           "type": "timeseries"
         },
@@ -5746,108 +5746,6 @@
             }
           ],
           "title": "Cache Entries",
-          "transparent": true,
-          "type": "timeseries"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "description": "",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "barWidthFactor": 0.6,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 7,
-            "w": 12,
-            "x": 12,
-            "y": 40
-          },
-          "id": 113,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "disableTextWrap": false,
-              "editorMode": "builder",
-              "expr": "kona_providers_cache_memory_bytes{instance=\"$instance\"}",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
-              "instant": false,
-              "legendFormat": "{{cache}}",
-              "range": true,
-              "refId": "A",
-              "useBackend": false
-            }
-          ],
-          "title": "Cache Memory Usage",
           "transparent": true,
           "type": "timeseries"
         }


### PR DESCRIPTION
`Metrics::zero()` pre-creates one series per expected label tuple so Prometheus exposes it before the first event. Nothing links that list to the emit sites, and the two had drifted apart in both directions. A series no code can produce sits at 0 forever beside the real ones, and an emitted series is missing until its first event — which is the gap `zero()` exists to close. Three shipped dashboard panels are empty today because of it.

Every label list is now derived from the emit sites, and written as a loop over the emitted values rather than one call per series.

### Corrected in `zero()`

|metric|was|is|
|---|---|---|
|`kona_node_dial_peer_error`|one unlabelled series|the 9 `type` values emitted by `driver.rs`/`gater.rs`|
|`kona_node_find_node_requests`|one unlabelled series|the constant `find_node` label the emit carries|
|`kona_node_rpc_calls`|17 methods|19 — adds the emitted `opp2p_unblockPeer` and `admin_postUnsafePayload`|
|`kona_node_block_validation_failed`|12 reasons|11 — drops `parent_beacon_root`, which no `BlockInvalidError` variant produces|
|`kona_node_gossip_events`|5 `type` values|the 2 topic-free ones|
|`kona_node_banned_peers`|one unlabelled series|not pre-created|
|`kona_providers_chain_rpc_calls` / `_errors`|4 methods|5 — adds the emitted `block_by_number`|
|`kona_providers_beacon_requests` / `_errors`|`blob_sidecars`|`blobs`, which is what `beacon_client.rs` emits|
|`kona_providers_l2_chain_requests` / `_errors`|3 methods, 2 with no code path|the 2 emitted: `l2_block_by_hash`, `l2_block_ref_by_number`|
|`kona_providers_local_cache_hits` / `_misses`|included `block_by_hash`, omitted `l2_block_info_by_hash`|the 4 methods `buffered.rs` emits|

Two of these need a word on why the fix goes the way it does. `kona_node_gossip_events` pre-created five `type` values, but the `message`, `subscribed` and `unsubscribed` emits also carry `topic`; for the last two the topic is whatever a remote peer announces, so the value set is not knowable at startup. `kona_node_banned_peers` carries `peer_id` and `score`, so it has no finite series set either. Both keep their emits and drop the phantom pre-created series.

`opp2p_peerStats` was pre-created, but `P2pRpc::opp2p_peer_stats` was the one handler of eighteen with no emit at all. That reads as the omission, so the emit is added rather than the series removed.

`SEQUENCER_STATE` was declared with `describe_counter!` and is emitted with `metrics::gauge!`, so the description never attached to the series. Same class of defect, one line.

### Removed

Four metrics were declared and described but emitted by nothing anywhere in `rust/`. They are removed rather than left reporting a permanent 0: `kona_node_gossipsub_events` (duplicated `kona_node_gossip_events`, which carries the real data), `kona_providers_cache_memory_bytes`, `kona_providers_request_duration` and `kona_providers_local_cache_capacity`.

Only `kona_providers_cache_memory_bytes` had a consumer: the "Cache Memory Usage" panel on both kona-node dashboards, rendering the constant 0 from `zero()`. That panel is removed with it. The other three had none.

While checking consumers I found the dashboards querying two metric names that do not exist — `kona_providers_blob_sidecar_fetches` and `kona_providers_blob_sidecar_errors`, against emitted names `kona_providers_blob_fetches` and `kona_providers_blob_fetch_errors`. Same drift, other direction; those two panels now use the emitted names.

### Verification

13 new tests render `zero()` through a `DebuggingRecorder` and assert the pre-created label set for each corrected metric. All fail on `develop`. `cargo test --all-features` across kona-gossip, kona-disc, kona-providers-alloy, kona-providers-local, kona-derive, kona-node-service and kona-rpc passes, except `kona-disc driver::tests::test_online_discv5_driver_bootstrap_testnet`, which dials real testnet boot nodes and fails identically on `develop`. `clippy --all-features --all-targets -D warnings` clean over those crates plus kona-node. `cargo build -p kona-derive --target riscv32imac-unknown-none-elf --no-default-features` still builds.

### Deliberately not in scope

These are real defects found on the way. They are behavioural changes or separate work, so they are recorded here rather than folded in.

- Metrics with no `zero()` entry at all: 17 in kona-derive, 6 in kona-node-service. That is the pre-existing scope of `zero()`, not drift. Several are level gauges where publishing a fake 0 height is arguably worse than an absent series, so it needs a decision rather than a sweep.
- `kona_node_banned_peers` uses `inc!(gauge, ..)` per `peer_id`, so it is a one-shot 1 per peer rather than a count, and its cardinality is unbounded.
- `kona_derive_batch_validity` carries 26 free-text `BatchDropReason` sentences as label values.
- `kona_providers_cache_entries` uses `inc!` on insert against a bounded `LruCache`, so it grows without bound and never reflects the real entry count.
- `SEQUENCER_STATE` sets the current `active`/`recovery` combination to 1 and never clears the previous one, so two series read 1 after any flip.
- `RollupRpc::RPC_IDENT` is `"rollup_rpc"`: off-convention name, never described, never zeroed.
- Nothing prevents this drifting again. The structural fix is to make the label values constants that both the emit and `zero()` read, or to add a lint. `kona_node_engine_task_failure` in #22705 shows the shape, using `EngineTaskErrorSeverity::ALL`.

Split out of #22569, which found most of this while adding a chain dimension. It is independent of that work, and much easier to review on its own.