### PR TITLE
kona!: add a chain_id label to every metric, from an ambient scope

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6886,20 +6886,23 @@ dependencies = [
 
 [[package]]
 name = "kona-cli"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
  "clap",
  "kona-genesis",
+ "kona-metrics",
  "kona-registry",
  "libc",
  "libp2p",
+ "metrics",
  "metrics-exporter-prometheus",
  "metrics-process",
  "rstest",
  "serde",
  "thiserror 2.0.18",
+ "tokio",
  "tracing",
  "tracing-appender",
  "tracing-subscriber 0.3.23",
@@ -6985,6 +6988,7 @@ dependencies = [
  "kona-cli",
  "kona-genesis",
  "kona-macros",
+ "kona-metrics",
  "kona-peers",
  "libp2p",
  "metrics",
@@ -7253,6 +7257,15 @@ name = "kona-macros"
 version = "0.1.2"
 
 [[package]]
+name = "kona-metrics"
+version = "0.1.0"
+dependencies = [
+ "metrics",
+ "metrics-util",
+ "tokio",
+]
+
+[[package]]
 name = "kona-mpt"
 version = "0.3.0"
 dependencies = [
@@ -7301,6 +7314,7 @@ dependencies = [
  "kona-genesis",
  "kona-gossip",
  "kona-interop",
+ "kona-metrics",
  "kona-node-service",
  "kona-peers",
  "kona-protocol",
@@ -7363,6 +7377,7 @@ dependencies = [
  "kona-gossip",
  "kona-interop",
  "kona-macros",
+ "kona-metrics",
  "kona-peers",
  "kona-protocol",
  "kona-providers-alloy",
@@ -7372,6 +7387,7 @@ dependencies = [
  "libp2p",
  "libp2p-stream",
  "metrics",
+ "metrics-util",
  "mockall",
  "op-alloy-consensus",
  "op-alloy-network",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -305,9 +305,10 @@ kona-std-fpvm-proc = { path = "kona/crates/proof/std-fpvm-proc", version = "0.2.
 kona-proof-interop = { path = "kona/crates/proof/proof-interop", version = "0.2.0", default-features = false }
 
 # Utilities
-kona-cli = { path = "kona/crates/utilities/cli", version = "0.3.2", default-features = false }
+kona-cli = { path = "kona/crates/utilities/cli", version = "0.4.0", default-features = false }
 kona-serde = { path = "kona/crates/utilities/serde", version = "0.2.2", default-features = false }
 kona-macros = { path = "kona/crates/utilities/macros", version = "0.1.2", default-features = false }
+kona-metrics = { path = "kona/crates/utilities/metrics", version = "0.1.0", default-features = false }
 
 # ==================== KONA SP1 INTERNAL CRATES ====================
 kona-sp1-client-utils = { path = "kona/sp1/crates/client" }

--- a/rust/kona/bin/node/Cargo.toml
+++ b/rust/kona/bin/node/Cargo.toml
@@ -25,6 +25,7 @@ kona-interop = { workspace = true, features = ["serde"] }
 kona-protocol.workspace = true
 
 kona-cli = { workspace = true, features = ["secrets"] }
+kona-metrics.workspace = true
 kona-gossip = { workspace = true, features = ["metrics"] }
 kona-disc = { workspace = true, features = ["metrics"] }
 kona-derive = { workspace = true, features = ["metrics"] }

--- a/rust/kona/bin/node/src/cli.rs
+++ b/rust/kona/bin/node/src/cli.rs
@@ -62,7 +62,7 @@ impl Cli {
         }
 
         // Initialize unified metrics
-        init_unified_metrics(&self.global.metrics)?;
+        init_unified_metrics(&self.global, self.metrics_chain_id()?)?;
 
         // Allow subcommands to initialize cli metrics.
         match self.subcommand {
@@ -79,6 +79,17 @@ impl Cli {
             Commands::Registry(registry) => registry.run(&self.global),
             Commands::Bootstore(bootstore) => bootstore.run(&self.global),
             Commands::Info(info) => info.run(&self.global),
+        }
+    }
+
+    /// The chain the metrics recorder labels this process with.
+    ///
+    /// `node --l2-config-file` overrides `--chain`, and the actors scope themselves from that
+    /// file, so the recorder has to agree.
+    fn metrics_chain_id(&self) -> Result<u64> {
+        match &self.subcommand {
+            Commands::Node(node) => Ok(node.get_l2_config(&self.global)?.l2_chain_id.id()),
+            _ => Ok(self.global.l2_chain_id.id()),
         }
     }
 

--- a/rust/kona/bin/node/src/commands/net.rs
+++ b/rust/kona/bin/node/src/commands/net.rs
@@ -92,14 +92,16 @@ impl NetCommand {
         );
 
         // Spawn the actor; the loop below polls the p2p RPC interface on an interval.
-        tokio::spawn(async move {
+        // `tokio::spawn` inherits no scope, so this loop needs its own.
+        let chain = kona_metrics::chain_label(rollup_config.l2_chain_id.id());
+        tokio::spawn(kona_metrics::scoped(chain.clone(), async move {
             loop {
                 if let Err(e) = network.step().await {
                     error!(target: "net", "Network actor error: {e:?}");
                     return;
                 }
             }
-        });
+        }));
 
         info!(target: "net", "Network started, receiving blocks.");
 
@@ -113,7 +115,14 @@ impl NetCommand {
             let mut launcher = RpcModule::new(());
             launcher.merge(P2pRpc::new(rpc.clone()).into_rpc())?;
 
-            let server = Server::builder().build(config.socket).await?;
+            // `P2pRpc`'s handlers emit metrics, and jsonrpsee runs them on its own tasks.
+            let server = Server::builder()
+                .set_rpc_middleware(
+                    jsonrpsee::server::middleware::rpc::RpcServiceBuilder::new()
+                        .layer_fn(kona_node_service::ChainScope::layer(chain)),
+                )
+                .build(config.socket)
+                .await?;
             Some(server.start(launcher))
         } else {
             info!(target: "net", "RPC server disabled");

--- a/rust/kona/bin/node/src/flags/metrics.rs
+++ b/rust/kona/bin/node/src/flags/metrics.rs
@@ -2,16 +2,18 @@
 //!
 //! Specifies the available flags for prometheus metric configuration inside CLI
 
-use kona_cli::MetricsArgs;
+use super::GlobalArgs;
 use metrics::gauge;
 
 /// Initializes metrics for a Kona application, including Prometheus and node-specific metrics.
 /// Initialize the tracing stack and Prometheus metrics recorder.
 ///
 /// This function should be called at the beginning of the program.
-pub fn init_unified_metrics(args: &MetricsArgs) -> anyhow::Result<()> {
-    args.init_metrics()?;
-    if args.enabled {
+pub fn init_unified_metrics(args: &GlobalArgs, chain_id: u64) -> anyhow::Result<()> {
+    // One chain per process, so the recorder can label what no scope owns.
+    args.metrics.init_metrics(Some(chain_id))?;
+
+    if args.metrics.enabled {
         kona_gossip::Metrics::init();
         kona_disc::Metrics::init();
         kona_engine::Metrics::init();
@@ -37,8 +39,8 @@ pub fn init_unified_metrics(args: &MetricsArgs) -> anyhow::Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use clap::Parser;
+    use kona_cli::MetricsArgs;
     use std::net::IpAddr;
 
     /// A mock command that uses the `MetricsArgs`.

--- a/rust/kona/crates/node/disc/Cargo.toml
+++ b/rust/kona/crates/node/disc/Cargo.toml
@@ -19,6 +19,7 @@ workspace = true
 # Kona
 kona-peers.workspace = true
 kona-macros.workspace = true
+kona-metrics.workspace = true
 kona-genesis.workspace = true
 
 # Alloy

--- a/rust/kona/crates/node/disc/src/driver.rs
+++ b/rust/kona/crates/node/disc/src/driver.rs
@@ -152,7 +152,8 @@ impl Discv5Driver {
         let (req_sender, mut req_recv) = channel::<HandlerRequest>(1024);
         let (enr_sender, enr_recv) = channel::<Enr>(1024);
 
-        tokio::spawn(async move {
+        // `tokio::spawn` inherits no scope, so this loop needs its own.
+        tokio::spawn(kona_metrics::scoped(kona_metrics::chain_label(chain_id), async move {
             let remove = self.remove_interval.is_some();
             let remove_dur = self.remove_interval.unwrap_or(std::time::Duration::from_secs(600));
             let mut removal_interval = tokio::time::interval(remove_dur);
@@ -359,7 +360,7 @@ impl Discv5Driver {
                     }
                 }
             }
-        });
+        }));
 
         (Discv5Handler::new(chain_id, req_sender), enr_recv)
     }

--- a/rust/kona/crates/node/service/Cargo.toml
+++ b/rust/kona/crates/node/service/Cargo.toml
@@ -27,6 +27,7 @@ kona-providers-alloy.workspace = true
 kona-rpc = { workspace = true, features = ["client"] }
 kona-peers.workspace = true
 kona-macros.workspace = true
+kona-metrics.workspace = true
 
 # alloy
 alloy-chains.workspace = true
@@ -81,6 +82,7 @@ alloy-rpc-types-engine = { workspace = true, features = ["arbitrary"] }
 alloy-consensus = { workspace = true, features = ["arbitrary"] }
 op-alloy-consensus = { workspace = true, features = ["arbitrary", "k256"] }
 kona-derive = {workspace = true, features = ["test-utils"]}
+metrics-util = { workspace = true, features = ["debugging"] }
 
 [features]
 default = []

--- a/rust/kona/crates/node/service/src/actors/mod.rs
+++ b/rust/kona/crates/node/service/src/actors/mod.rs
@@ -14,8 +14,8 @@ pub use engine::{
 
 pub(crate) mod rpc;
 pub use rpc::{
-    JsonrpseeServerLauncher, QueuedEngineRpcClient, QueuedSequencerAdminAPIClient, RpcActor,
-    RpcActorError, RpcServerHandle, RpcServerLauncher,
+    ChainScope, JsonrpseeServerLauncher, QueuedEngineRpcClient, QueuedSequencerAdminAPIClient,
+    RpcActor, RpcActorError, RpcServerHandle, RpcServerLauncher,
 };
 
 mod derivation;

--- a/rust/kona/crates/node/service/src/actors/rpc/launcher.rs
+++ b/rust/kona/crates/node/service/src/actors/rpc/launcher.rs
@@ -7,10 +7,17 @@
 use async_trait::async_trait;
 use jsonrpsee::{
     RpcModule,
-    server::{Server, ServerHandle, middleware::http::ProxyGetRequestLayer},
+    server::{
+        Server, ServerHandle,
+        middleware::{
+            http::ProxyGetRequestLayer,
+            rpc::{Batch, Notification, Request, RpcServiceBuilder, RpcServiceT},
+        },
+    },
 };
+use kona_metrics::Label;
 use kona_rpc::RpcBuilder;
-use std::time::Duration;
+use std::{future::Future, sync::Arc, time::Duration};
 
 /// A handle to a running RPC server.
 ///
@@ -57,12 +64,15 @@ impl RpcServerHandle for ServerHandle {
 #[derive(Debug, Clone)]
 pub struct JsonrpseeServerLauncher {
     config: RpcBuilder,
+    chain: Label,
 }
 
 impl JsonrpseeServerLauncher {
     /// Wraps an [`RpcBuilder`] for use as a launcher.
-    pub const fn new(config: RpcBuilder) -> Self {
-        Self { config }
+    ///
+    /// `chain` labels the metrics the RPC handlers emit, via a [`ChainScope`] middleware.
+    pub const fn new(config: RpcBuilder, chain: Label) -> Self {
+        Self { config, chain }
     }
 }
 
@@ -71,7 +81,67 @@ impl RpcServerLauncher for JsonrpseeServerLauncher {
     type Handle = ServerHandle;
 
     async fn launch(&self, modules: RpcModule<()>) -> Result<Self::Handle, std::io::Error> {
-        launch(&self.config, modules).await
+        launch(&self.config, self.chain.clone(), modules).await
+    }
+}
+
+/// An RPC middleware that puts a chain scope around every call jsonrpsee serves, which it
+/// otherwise serves on tasks that inherit no scope.
+///
+/// Register with `RpcServiceBuilder::new().layer_fn(ChainScope::layer(chain))`.
+///
+/// Covers every `#[method]` handler. It does not cover a subscription or a blocking method, which
+/// jsonrpsee runs under `tokio::spawn` and `spawn_blocking`; one that emits a metric would need
+/// its own [`kona_metrics::scoped`].
+#[derive(Debug, Clone)]
+pub struct ChainScope<S> {
+    // The returned future is bound to the request lifetime, not `&self`, so the inner service
+    // must be owned rather than borrowed.
+    inner: Arc<S>,
+    chain: Label,
+}
+
+impl<S> ChainScope<S> {
+    /// A `layer_fn` closure that wraps an inner service in this scope.
+    pub fn layer(chain: Label) -> impl Fn(S) -> Self + Clone {
+        move |inner| Self { inner: Arc::new(inner), chain: chain.clone() }
+    }
+}
+
+impl<S> RpcServiceT for ChainScope<S>
+where
+    S: RpcServiceT + Send + Sync + 'static,
+{
+    type MethodResponse = S::MethodResponse;
+    type NotificationResponse = S::NotificationResponse;
+    type BatchResponse = S::BatchResponse;
+
+    fn call<'a>(
+        &self,
+        request: Request<'a>,
+    ) -> impl Future<Output = Self::MethodResponse> + Send + 'a {
+        let inner = self.inner.clone();
+        kona_metrics::scoped(self.chain.clone(), async move { inner.call(request).await })
+    }
+
+    // jsonrpsee dispatches a batch through its own `call`, not ours.
+    fn batch<'a>(
+        &self,
+        requests: Batch<'a>,
+    ) -> impl Future<Output = Self::BatchResponse> + Send + 'a {
+        let inner = self.inner.clone();
+        kona_metrics::scoped(self.chain.clone(), async move { inner.batch(requests).await })
+    }
+
+    fn notification<'a>(
+        &self,
+        notification: Notification<'a>,
+    ) -> impl Future<Output = Self::NotificationResponse> + Send + 'a {
+        let inner = self.inner.clone();
+        kona_metrics::scoped(
+            self.chain.clone(),
+            async move { inner.notification(notification).await },
+        )
     }
 }
 
@@ -82,15 +152,21 @@ impl RpcServerLauncher for JsonrpseeServerLauncher {
 /// - [`std::io::Error`] if the server fails to start.
 async fn launch(
     config: &RpcBuilder,
+    chain: Label,
     module: RpcModule<()>,
 ) -> Result<ServerHandle, std::io::Error> {
-    let middleware = tower::ServiceBuilder::new()
+    let http_middleware = tower::ServiceBuilder::new()
         .layer(
             ProxyGetRequestLayer::new([("/healthz", "healthz")])
                 .expect("Critical: Failed to build GET method proxy"),
         )
         .timeout(Duration::from_secs(2));
-    let server = Server::builder().set_http_middleware(middleware).build(config.socket).await?;
+    let rpc_middleware = RpcServiceBuilder::new().layer_fn(ChainScope::layer(chain));
+    let server = Server::builder()
+        .set_http_middleware(http_middleware)
+        .set_rpc_middleware(rpc_middleware)
+        .build(config.socket)
+        .await?;
 
     if let Ok(addr) = server.local_addr() {
         info!(target: "rpc", addr = ?addr, "RPC server bound to address");
@@ -99,4 +175,76 @@ async fn launch(
     }
 
     Ok(server.start(module))
+}
+
+#[cfg(all(test, feature = "metrics"))]
+mod tests {
+    use super::{JsonrpseeServerLauncher, RpcServerLauncher};
+    use crate::test_metrics::chains_of;
+    use jsonrpsee::{RpcModule, core::client::ClientT, http_client::HttpClientBuilder, rpc_params};
+    use kona_rpc::RpcBuilder;
+
+    const METRIC: &str = "kona_test_rpc_calls";
+
+    const fn builder(socket: std::net::SocketAddr) -> RpcBuilder {
+        RpcBuilder {
+            no_restart: true,
+            socket,
+            enable_admin: false,
+            admin_persistence: None,
+            ws_enabled: false,
+            dev_enabled: false,
+        }
+    }
+
+    /// The RPC handlers run on jsonrpsee's own tasks, so the middleware is the only thing that
+    /// can put them in a chain scope.
+    #[tokio::test]
+    async fn rpc_handler_metrics_carry_the_launcher_chain() {
+        // Installs the recorder before anything registers.
+        assert!(chains_of(METRIC).is_empty());
+
+        let mut module = RpcModule::new(());
+        module
+            .register_method(METRIC, |_, _, _| {
+                metrics::counter!(METRIC).increment(1);
+                ""
+            })
+            .expect("the method registers");
+
+        // `launch` returns only a `ServerHandle`, so probe for a free port first. The port is
+        // free between the probe and the bind, so retry if something else takes it.
+        let mut launched = None;
+        for _ in 0..8 {
+            let socket = std::net::TcpListener::bind("127.0.0.1:0")
+                .expect("a port is free")
+                .local_addr()
+                .expect("the listener reports its address");
+
+            let launcher =
+                JsonrpseeServerLauncher::new(builder(socket), kona_metrics::chain_label(901));
+            match launcher.launch(module.clone()).await {
+                Ok(handle) => {
+                    launched = Some((socket, handle));
+                    break;
+                }
+                Err(e) if e.kind() != std::io::ErrorKind::AddrInUse => {
+                    panic!("the server must start: {e}")
+                }
+                Err(_) => {}
+            }
+        }
+        let (socket, _handle) = launched.expect("a port stayed free for one bind in eight");
+
+        let client = HttpClientBuilder::default()
+            .build(format!("http://{socket}"))
+            .expect("the client builds");
+        let _: String = client.request(METRIC, rpc_params![]).await.expect("the call succeeds");
+
+        assert_eq!(
+            chains_of(METRIC),
+            vec![Some("901".to_string())],
+            "the RPC call must be attributed"
+        );
+    }
 }

--- a/rust/kona/crates/node/service/src/actors/rpc/mod.rs
+++ b/rust/kona/crates/node/service/src/actors/rpc/mod.rs
@@ -2,7 +2,7 @@ mod actor;
 pub use actor::RpcActor;
 
 mod launcher;
-pub use launcher::{JsonrpseeServerLauncher, RpcServerHandle, RpcServerLauncher};
+pub use launcher::{ChainScope, JsonrpseeServerLauncher, RpcServerHandle, RpcServerLauncher};
 
 mod engine_rpc_client;
 pub use engine_rpc_client::QueuedEngineRpcClient;

--- a/rust/kona/crates/node/service/src/lib.rs
+++ b/rust/kona/crates/node/service/src/lib.rs
@@ -16,7 +16,7 @@ pub use service::{
 
 mod actors;
 pub use actors::{
-    BlockStream, BuildRequest, Conductor, ConductorClient, ConductorError,
+    BlockStream, BuildRequest, ChainScope, Conductor, ConductorClient, ConductorError,
     DelayedL1OriginSelectorProvider, DelegateDerivationActor, DerivationActor,
     DerivationActorRequest, DerivationClientError, DerivationClientResult,
     DerivationDelegateClient, DerivationDelegateClientError, DerivationDelegateProvider,
@@ -38,6 +38,9 @@ pub use actors::{
 
 mod metrics;
 pub use metrics::Metrics;
+
+#[cfg(all(test, feature = "metrics"))]
+mod test_metrics;
 
 #[cfg(test)]
 pub use actors::{

--- a/rust/kona/crates/node/service/src/service/node.rs
+++ b/rust/kona/crates/node/service/src/service/node.rs
@@ -422,7 +422,10 @@ impl RollupNode {
         }
 
         let restarts_remaining = config.restart_count();
-        let launcher = JsonrpseeServerLauncher::new(config);
+        let launcher = JsonrpseeServerLauncher::new(
+            config,
+            kona_metrics::chain_label(self.config.l2_chain_id.id()),
+        );
         let handle = launcher
             .launch(modules.clone())
             .await
@@ -542,6 +545,7 @@ impl RollupNode {
 
         crate::service::spawn_and_wait!(
             cancellation,
+            chain = kona_metrics::chain_label(self.config.l2_chain_id.id()),
             actors = [
                 rpc,
                 sequencer_actor,

--- a/rust/kona/crates/node/service/src/service/util.rs
+++ b/rust/kona/crates/node/service/src/service/util.rs
@@ -11,13 +11,15 @@
 /// This macro also handles OS shutdown signals (SIGTERM, SIGINT) and triggers graceful shutdown
 /// when received.
 macro_rules! spawn_and_wait {
-    ($cancellation:expr, actors = [$($actor:expr),* $(,)?]) => {
+    ($cancellation:expr, chain = $chain:expr, actors = [$($actor:expr),* $(,)?]) => {
         let mut task_handles = tokio::task::JoinSet::new();
+        let chain = $chain;
 
         $(
             if let Some(mut actor) = $actor {
                 let cancellation = $cancellation.clone();
-                task_handles.spawn(async move {
+                // A task the actor spawns for itself does not inherit this scope.
+                task_handles.spawn(kona_metrics::scoped(chain.clone(), async move {
                     // This guard ensures that the cancellation token is cancelled when the actor
                     // task exits for any reason. This ensures peer actors observe shutdown on
                     // their next macro-level `select!`.
@@ -35,7 +37,7 @@ macro_rules! spawn_and_wait {
                             }
                         }
                     }
-                });
+                }));
             }
         )*
 
@@ -102,5 +104,52 @@ pub(crate) async fn shutdown_signal() {
         _ = terminate => {
             tracing::info!(target: "rollup_node", "Received SIGTERM");
         },
+    }
+}
+
+#[cfg(all(test, feature = "metrics"))]
+mod tests {
+    use crate::{NodeActor, test_metrics::chains_of};
+    use async_trait::async_trait;
+    use tokio_util::sync::CancellationToken;
+
+    const METRIC: &str = "kona_test_actor_steps";
+
+    /// Emits `METRIC` on its first step, then stops the supervision loop.
+    struct EmittingActor;
+
+    #[async_trait]
+    impl NodeActor for EmittingActor {
+        type Error = &'static str;
+
+        async fn step(&mut self) -> Result<(), Self::Error> {
+            // Await first, so the emit cannot have run on the spawning task.
+            tokio::task::yield_now().await;
+            metrics::counter!(METRIC).increment(1);
+            Err("done")
+        }
+    }
+
+    async fn run_actor(chain_id: u64) -> Result<(), String> {
+        let cancellation = CancellationToken::new();
+        crate::service::spawn_and_wait!(
+            cancellation,
+            chain = kona_metrics::chain_label(chain_id),
+            actors = [Some(EmittingActor)]
+        );
+        Ok(())
+    }
+
+    /// Actors are spawned, not awaited inline, so `spawn_and_wait!` is the one place that can
+    /// scope all seven of them.
+    #[tokio::test]
+    async fn actor_metrics_carry_the_chain_the_supervisor_was_given() {
+        // Installs the recorder before anything registers.
+        assert!(chains_of(METRIC).is_empty());
+
+        let error = run_actor(11155420).await.expect_err("the actor stops the loop");
+        assert_eq!(error, "\"done\"");
+
+        assert_eq!(chains_of(METRIC), vec![Some("11155420".to_string())]);
     }
 }

--- a/rust/kona/crates/node/service/src/test_metrics.rs
+++ b/rust/kona/crates/node/service/src/test_metrics.rs
@@ -1,0 +1,35 @@
+//! One process-global metrics recorder, shared by the tests that need one.
+//!
+//! Both seams this crate scopes run on spawned tasks, which a thread-local recorder cannot reach.
+//! `metrics::set_global_recorder` succeeds once per process, hence the single install.
+
+use metrics_util::debugging::{DebuggingRecorder, Snapshotter};
+use std::sync::LazyLock;
+
+static SNAPSHOTTER: LazyLock<Snapshotter> = LazyLock::new(|| {
+    let inner = DebuggingRecorder::new();
+    let snapshotter = inner.snapshotter();
+
+    // `None`, so an unscoped emit stays unlabelled and the tests can tell a scope from a fallback.
+    metrics::set_global_recorder(kona_metrics::ChainLabelRecorder::new(inner, None))
+        .expect("no other test installs a global recorder");
+
+    snapshotter
+});
+
+/// The `chain_id` label of every series recorded so far for `metric`, or `None` where a series
+/// carries none. Call it first in a test too, to install the recorder.
+pub(crate) fn chains_of(metric: &str) -> Vec<Option<String>> {
+    SNAPSHOTTER
+        .snapshot()
+        .into_vec()
+        .into_iter()
+        .filter(|(ckey, ..)| ckey.key().name() == metric)
+        .map(|(ckey, ..)| {
+            ckey.key()
+                .labels()
+                .find(|label| label.key() == kona_metrics::CHAIN_ID_LABEL)
+                .map(|label| label.value().to_string())
+        })
+        .collect()
+}

--- a/rust/kona/crates/utilities/cli/Cargo.toml
+++ b/rust/kona/crates/utilities/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kona-cli"
-version = "0.3.2"
+version = "0.4.0"
 description = "Shared CLI utilities for Kona crates"
 edition.workspace = true
 license.workspace = true
@@ -14,6 +14,7 @@ workspace = true
 [dependencies]
 # Workspace
 kona-genesis.workspace = true
+kona-metrics.workspace = true
 kona-registry.workspace = true
 
 # Alloy
@@ -27,6 +28,8 @@ tracing-subscriber = { workspace = true, features = ["fmt", "env-filter", "json"
 tracing-appender.workspace = true
 metrics-exporter-prometheus = { workspace = true, features = ["http-listener"] }
 metrics-process.workspace = true
+metrics.workspace = true
+tokio = { workspace = true, features = ["rt"] }
 thiserror.workspace = true
 
 # `secrets` feature

--- a/rust/kona/crates/utilities/cli/src/error.rs
+++ b/rust/kona/crates/utilities/cli/src/error.rs
@@ -4,6 +4,7 @@ use thiserror::Error;
 
 /// Errors that can occur in CLI operations.
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum CliError {
     /// Error when no chain config is found for the given chain ID.
     #[error("No chain config found for chain ID: {0}")]
@@ -20,6 +21,14 @@ pub enum CliError {
     /// Error initializing metrics.
     #[error("Failed to initialize metrics")]
     MetricsInitialization(#[from] metrics_exporter_prometheus::BuildError),
+
+    /// Error installing the metrics recorder or its exporter thread.
+    #[error("Failed to install the metrics recorder: {0}")]
+    Metrics(String),
+
+    /// Error spawning the thread that drives the metrics exporter.
+    #[error("Failed to start the metrics exporter: {0}")]
+    MetricsExporter(#[from] std::io::Error),
 }
 
 /// Type alias for CLI results.

--- a/rust/kona/crates/utilities/cli/src/flags/metrics.rs
+++ b/rust/kona/crates/utilities/cli/src/flags/metrics.rs
@@ -39,12 +39,15 @@ impl Default for MetricsArgs {
 }
 
 impl MetricsArgs {
-    /// Initialize the tracing stack and Prometheus metrics recorder.
+    /// Installs the Prometheus metrics recorder and starts its HTTP endpoint.
     ///
     /// This function should be called at the beginning of the program.
-    pub fn init_metrics(&self) -> CliResult<()> {
+    ///
+    /// `chain_id` labels every metric of a single-chain process. A multi-chain process passes
+    /// `None` and scopes each chain's work with [`kona_metrics::scoped`] instead.
+    pub fn init_metrics(&self, chain_id: Option<u64>) -> CliResult<()> {
         if self.enabled {
-            init_prometheus_server(self.addr, self.port)?;
+            init_prometheus_server(self.addr, self.port, chain_id)?;
         }
 
         Ok(())

--- a/rust/kona/crates/utilities/cli/src/prometheus.rs
+++ b/rust/kona/crates/utilities/cli/src/prometheus.rs
@@ -1,6 +1,8 @@
 //! Utilities for spinning up a prometheus metrics server.
 
-use metrics_exporter_prometheus::{BuildError, PrometheusBuilder};
+use crate::{CliError, CliResult};
+use kona_metrics::ChainLabelRecorder;
+use metrics_exporter_prometheus::PrometheusBuilder;
 use metrics_process::Collector;
 use std::{
     net::{IpAddr, SocketAddr},
@@ -10,11 +12,41 @@ use std::{
 use tracing::info;
 
 /// Start a Prometheus metrics server on the given port.
-pub fn init_prometheus_server(addr: IpAddr, metrics_port: u16) -> Result<(), BuildError> {
+///
+/// `chain_id` labels every metric of a single-chain process, including those emitted outside any
+/// [`kona_metrics::scoped`] scope. A multi-chain process passes `None`.
+pub fn init_prometheus_server(
+    addr: IpAddr,
+    metrics_port: u16,
+    chain_id: Option<u64>,
+) -> CliResult<()> {
     let prometheus_addr = SocketAddr::from((addr, metrics_port));
     let builder = PrometheusBuilder::new().with_http_listener(prometheus_addr);
 
-    builder.install()?;
+    // `PrometheusBuilder::install` installs the recorder itself, leaving no seam to wrap it in.
+    // This is that method's body with the wrapper added.
+    let recorder = if let Ok(handle) = tokio::runtime::Handle::try_current() {
+        let (recorder, exporter) = {
+            let _guard = handle.enter();
+            builder.build()?
+        };
+        handle.spawn(exporter);
+        recorder
+    } else {
+        let runtime = tokio::runtime::Builder::new_current_thread().enable_all().build()?;
+        let (recorder, exporter) = {
+            let _guard = runtime.enter();
+            builder.build()?
+        };
+        thread::Builder::new()
+            .name("metrics-exporter-prometheus-http-listener".to_string())
+            .spawn(move || runtime.block_on(exporter))?;
+        recorder
+    };
+
+    let recorder = ChainLabelRecorder::new(recorder, chain_id.map(kona_metrics::chain_label));
+    metrics::set_global_recorder(recorder)
+        .map_err(|e| CliError::Metrics(format!("failed to install the metrics recorder: {e}")))?;
 
     // Initialise collector for system metrics e.g. CPU, memory, etc.
     let collector = Collector::default();

--- a/rust/kona/crates/utilities/metrics/Cargo.toml
+++ b/rust/kona/crates/utilities/metrics/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "kona-metrics"
+description = "The chain dimension for kona's metrics"
+version = "0.1.0"
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+metrics.workspace = true
+tokio = { workspace = true, features = ["rt"] }
+
+[dev-dependencies]
+metrics-util = { workspace = true, features = ["debugging"] }
+tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }

--- a/rust/kona/crates/utilities/metrics/README.md
+++ b/rust/kona/crates/utilities/metrics/README.md
@@ -1,0 +1,16 @@
+# `kona-metrics`
+
+<a href="https://github.com/ethereum-optimism/optimism/actions/workflows/rust_ci.yaml"><img src="https://github.com/ethereum-optimism/optimism/actions/workflows/rust_ci.yaml/badge.svg?label=ci" alt="CI"></a>
+<a href="https://github.com/ethereum-optimism/optimism/blob/develop/LICENSE-MIT"><img src="https://img.shields.io/badge/License-MIT-d1d1f6.svg?label=license&labelColor=2a2f35" alt="MIT License"></a>
+
+The chain dimension for kona's metrics.
+
+kona resolves every metric through the process-wide `metrics` recorder, so a metric's chain is not
+knowable at the emit site. This crate carries the chain in an ambient scope and adds it as a label
+in a wrapping `Recorder`, so no emit site needs to know about it.
+
+- `scoped` and `sync_scoped` bind a chain to the work that emits its metrics.
+- `ChainLabelRecorder` wraps the real recorder and reads that binding on every emit.
+
+The binding is a `tokio::task_local`, so it survives `.await` and thread migration but is not
+inherited by a spawned task. Every task that emits kona metrics needs its own scope.

--- a/rust/kona/crates/utilities/metrics/src/lib.rs
+++ b/rust/kona/crates/utilities/metrics/src/lib.rs
@@ -1,0 +1,268 @@
+//! The chain dimension for kona's metrics.
+//!
+//! kona resolves every metric through the process-wide `metrics` recorder, so a metric's chain is
+//! not knowable at the emit site. In a process that runs several chains, every chain's series
+//! collapse into one. This crate carries the chain in an ambient scope instead, and adds it as a
+//! label in a wrapping [`Recorder`], so no emit site changes.
+//!
+//! * [`scoped`] and [`sync_scoped`] bind a chain to the work that emits its metrics.
+//! * [`ChainLabelRecorder`] wraps the real recorder and reads that binding on every emit.
+//!
+//! # The scope does not propagate
+//!
+//! The binding is a [`tokio::task_local`], carried by the future [`scoped`] returns. It survives
+//! `.await` and thread migration, but a new task inherits nothing, so every task that emits kona
+//! metrics needs its own scope. `spawn_blocking` closures and library-spawned tasks likewise.
+//!
+//! [`ChainLabelRecorder::new`]'s `fallback` covers what no scope owns: the process's only chain
+//! for a single-chain process, `None` for a multi-chain one, where no chain can be attributed.
+
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/ethereum-optimism/optimism/develop/rust/kona/assets/square.png",
+    html_favicon_url = "https://raw.githubusercontent.com/ethereum-optimism/optimism/develop/rust/kona/assets/favicon.ico",
+    issue_tracker_base_url = "https://github.com/ethereum-optimism/optimism/issues/"
+)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
+use metrics::{Counter, Gauge, Histogram, Key, KeyName, Metadata, Recorder, SharedString, Unit};
+use std::{borrow::Cow, future::Future, sync::Arc};
+
+// So a dependent can hold a label without taking `metrics`, which most kona crates make optional.
+pub use metrics::Label;
+
+/// The label key that carries the chain id.
+pub const CHAIN_ID_LABEL: &str = "chain_id";
+
+tokio::task_local! {
+    /// The chain bound to the current task, if any.
+    static CHAIN: Label;
+}
+
+/// Builds the [`Label`] for a chain.
+///
+/// Build once per chain and clone it: the value is shared, so a clone is a refcount bump. The
+/// recorder clones it on every emit.
+pub fn chain_label(chain_id: u64) -> Label {
+    Label::new(CHAIN_ID_LABEL, Arc::<str>::from(chain_id.to_string()))
+}
+
+/// Runs `fut` with `chain` labelling every metric emitted while it is polled.
+///
+/// The scope does not reach a task the future spawns. See the crate docs.
+pub fn scoped<F: Future>(chain: Label, fut: F) -> impl Future<Output = F::Output> {
+    CHAIN.scope(chain, fut)
+}
+
+/// [`scoped`] for synchronous work, such as the `Metrics::init` calls at start-up.
+///
+/// Needs no runtime, so it is usable before one is built.
+pub fn sync_scoped<R>(chain: Label, f: impl FnOnce() -> R) -> R {
+    CHAIN.sync_scope(chain, f)
+}
+
+/// The chain bound to the current task, if any.
+pub fn current_chain() -> Option<Label> {
+    CHAIN.try_with(Clone::clone).ok()
+}
+
+/// A [`Recorder`] that labels each metric with the chain of the scope that emitted it.
+///
+/// Every `metrics::counter!`/`gauge!`/`histogram!` resolves its key through the recorder on every
+/// emit, so this sees all of them. An emit that already carries a [`CHAIN_ID_LABEL`] is passed
+/// through untouched, for a component that serves more than one chain from one task.
+#[derive(Debug, Clone)]
+pub struct ChainLabelRecorder<R> {
+    inner: R,
+    fallback: Option<Label>,
+}
+
+impl<R> ChainLabelRecorder<R> {
+    /// Wraps `inner`.
+    ///
+    /// `fallback` labels emits that arrive with no scope bound: the process's only chain when it
+    /// serves one, `None` when it serves several.
+    pub const fn new(inner: R, fallback: Option<Label>) -> Self {
+        Self { inner, fallback }
+    }
+
+    /// `key`, with the chain label added when the emit did not carry one and a chain is known.
+    fn labelled<'k>(&self, key: &'k Key) -> Cow<'k, Key> {
+        // An explicit label wins.
+        if key.labels().any(|label| label.key() == CHAIN_ID_LABEL) {
+            return Cow::Borrowed(key);
+        }
+
+        let Some(chain) = current_chain().or_else(|| self.fallback.clone()) else {
+            return Cow::Borrowed(key);
+        };
+
+        Cow::Owned(key.with_extra_labels(vec![chain]))
+    }
+}
+
+impl<R: Recorder> Recorder for ChainLabelRecorder<R> {
+    fn describe_counter(&self, key: KeyName, unit: Option<Unit>, description: SharedString) {
+        self.inner.describe_counter(key, unit, description);
+    }
+
+    fn describe_gauge(&self, key: KeyName, unit: Option<Unit>, description: SharedString) {
+        self.inner.describe_gauge(key, unit, description);
+    }
+
+    fn describe_histogram(&self, key: KeyName, unit: Option<Unit>, description: SharedString) {
+        self.inner.describe_histogram(key, unit, description);
+    }
+
+    fn register_counter(&self, key: &Key, metadata: &Metadata<'_>) -> Counter {
+        self.inner.register_counter(&self.labelled(key), metadata)
+    }
+
+    fn register_gauge(&self, key: &Key, metadata: &Metadata<'_>) -> Gauge {
+        self.inner.register_gauge(&self.labelled(key), metadata)
+    }
+
+    fn register_histogram(&self, key: &Key, metadata: &Metadata<'_>) -> Histogram {
+        self.inner.register_histogram(&self.labelled(key), metadata)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CHAIN_ID_LABEL, ChainLabelRecorder, chain_label, scoped, sync_scoped};
+    use metrics_util::debugging::DebuggingRecorder;
+    use std::collections::BTreeSet;
+
+    /// The `chain_id` label of every series `f` emits, or `None` where a series has none.
+    fn chains_of(
+        fallback: Option<u64>,
+        f: impl FnOnce(&ChainLabelRecorder<DebuggingRecorder>),
+    ) -> BTreeSet<Option<String>> {
+        let inner = DebuggingRecorder::new();
+        let snapshotter = inner.snapshotter();
+        let recorder = ChainLabelRecorder::new(inner, fallback.map(chain_label));
+
+        f(&recorder);
+
+        snapshotter
+            .snapshot()
+            .into_vec()
+            .into_iter()
+            .map(|(ckey, ..)| {
+                ckey.key()
+                    .labels()
+                    .find(|label| label.key() == CHAIN_ID_LABEL)
+                    .map(|label| label.value().to_string())
+            })
+            .collect()
+    }
+
+    fn emit() {
+        metrics::counter!("kona_test_metric").increment(1);
+    }
+
+    // Every test drives its runtime on one thread inside `with_local_recorder`, which binds a
+    // *thread*-local recorder that a second worker could not see. A harness constraint, not one on
+    // the scope, which rides the future.
+    #[test]
+    fn concurrent_chains_get_one_series_each() {
+        let chains = chains_of(None, |recorder| {
+            metrics::with_local_recorder(recorder, || {
+                // The same metric with the same labels: without the scope, one series.
+                let runtime = tokio::runtime::Builder::new_current_thread().build().unwrap();
+                runtime.block_on(async {
+                    tokio::join!(
+                        scoped(chain_label(901), async {
+                            tokio::task::yield_now().await;
+                            emit();
+                        }),
+                        scoped(chain_label(902), async {
+                            tokio::task::yield_now().await;
+                            emit();
+                        }),
+                    );
+                });
+            });
+        });
+
+        assert_eq!(
+            chains,
+            BTreeSet::from([Some("901".to_string()), Some("902".to_string())]),
+            "each chain must get its own series"
+        );
+    }
+
+    #[test]
+    fn a_scope_survives_an_await() {
+        let chains = chains_of(None, |recorder| {
+            metrics::with_local_recorder(recorder, || {
+                let runtime = tokio::runtime::Builder::new_current_thread().build().unwrap();
+                runtime.block_on(scoped(chain_label(10), async {
+                    tokio::task::yield_now().await;
+                    emit();
+                }));
+            });
+        });
+
+        assert_eq!(chains, BTreeSet::from([Some("10".to_string())]));
+    }
+
+    #[test]
+    fn sync_work_can_be_scoped_without_a_runtime() {
+        let chains = chains_of(None, |recorder| {
+            metrics::with_local_recorder(recorder, || sync_scoped(chain_label(10), emit));
+        });
+
+        assert_eq!(chains, BTreeSet::from([Some("10".to_string())]));
+    }
+
+    #[test]
+    fn an_unscoped_emit_takes_the_fallback() {
+        let chains = chains_of(Some(10), |recorder| {
+            metrics::with_local_recorder(recorder, emit);
+        });
+
+        assert_eq!(chains, BTreeSet::from([Some("10".to_string())]));
+    }
+
+    #[test]
+    fn an_unscoped_emit_stays_unlabelled_without_a_fallback() {
+        let chains = chains_of(None, |recorder| {
+            metrics::with_local_recorder(recorder, emit);
+        });
+
+        assert_eq!(chains, BTreeSet::from([None]), "a process-wide emit must not claim a chain");
+    }
+
+    #[test]
+    fn an_explicit_label_wins() {
+        let chains = chains_of(Some(10), |recorder| {
+            metrics::with_local_recorder(recorder, || {
+                sync_scoped(chain_label(901), || {
+                    metrics::counter!("kona_test_metric", CHAIN_ID_LABEL => "902").increment(1);
+                });
+            });
+        });
+
+        assert_eq!(
+            chains,
+            BTreeSet::from([Some("902".to_string())]),
+            "a component that serves several chains labels its own emits"
+        );
+    }
+
+    #[test]
+    fn a_spawned_task_does_not_inherit_the_scope() {
+        // Pins the limit the crate docs describe, so a tokio change is caught here.
+        let chains = chains_of(None, |recorder| {
+            metrics::with_local_recorder(recorder, || {
+                let runtime = tokio::runtime::Builder::new_current_thread().build().unwrap();
+                runtime.block_on(scoped(chain_label(10), async {
+                    tokio::spawn(async { emit() }).await.unwrap();
+                }));
+            });
+        });
+
+        assert_eq!(chains, BTreeSet::from([None]));
+    }
+}


### PR DESCRIPTION
Closes #22529. **Replaces #22569** — same goal, different design. Please close that one in favour of this.

### Why replace it

#22569 threads `chain_id` to the emit: 59 files, ~20 constructors gain a parameter, every `Metrics::zero()` is rewritten, three public constants and `EngineSyncState::apply_update` change shape. It also accumulated 24 review comments, most of them about `zero()` drift that the label work dragged in.

The chain does not have to reach the emit. `metrics::counter!`/`gauge!`/`histogram!` call `Recorder::register_*` on **every** emit, and no kona emit site hoists a `Counter`/`Gauge`/`Histogram` into a field, `static` or `LazyLock` — I checked all ~320. So a wrapping recorder observes 100% of emits and can add the label itself. This is the same shape as op-supernode, which wraps a per-chain `prometheus.Registerer` with `WrapRegistererWith` (`op-node/metrics/metrics.go:160-176`) rather than labelling at each call site.

| | #22569 | this PR |
|---|---|---|
| files | 59 | 20 |
| emit sites changed | ~320 | 0 |
| `Metrics::zero()` bodies rewritten | 7 | 0 |
| constructors gaining a parameter | ~20 | 0 |

### Design

New crate `kona-metrics`, ~140 lines of production code:

- `scoped(chain, fut)` / `sync_scoped(chain, f)` bind a chain to the work that emits its metrics, via a `tokio::task_local`.
- `ChainLabelRecorder<R>` wraps the real recorder and reads that binding on each `register_*`.

The scope rides the future, so it survives `.await` and worker-thread migration, but a **new task inherits nothing**. Four places bind a chain, and between them they cover every kona emit:

1. `spawn_and_wait!` (`service/util.rs`) — one line covers all seven per-chain actors. The libp2p swarm is polled inside `NetworkActor::step`, so all gossip metrics are covered here too.
2. `Discv5Driver::start` — its event loop is a detached `tokio::spawn` and it emits the discovery metrics. The struct already held `chain_id`.
3. The jsonrpsee servers, through a `ChainScope` `RpcServiceT` middleware, because jsonrpsee serves each call on its own task. This is the only way to reach the 24 emits in `kona-rpc`. Installed by the node's launcher **and** by the `net` subcommand, which builds its own server.
4. The `net` subcommand's network actor, which it spawns directly rather than through `spawn_and_wait!`.

The remaining emitters own no chain: the `metrics_process` collector on its non-tokio thread, `kona_node_info`, and the start-up zero-fill, which runs on the main thread before the runtime exists. `ChainLabelRecorder::new`'s `fallback` covers those. kona-node serves one chain, so it passes that chain and **every** series is labelled. A multi-chain process passes `None`, so a process-wide emit stays unlabelled rather than claiming a chain it does not have — which also means a missed scope shows up there as a visible unlabelled series, not as a silently wrong one.

The fallback is taken from the **resolved rollup config**, not from `--chain`. `node --l2-config-file` overrides the flag, and the actors scope themselves with the chain from that file, so deriving the fallback from the flag would give a devnet two chain ids in one process: real series under the devnet and a full set of permanently-zero ones under OP Mainnet.

An emit that already carries `chain_id` is passed through untouched, so an explicit label remains available to a component that serves several chains from one task.

### Cost

The per-emit cost is a `task_local` `try_with` — one thread-local read plus a `RefCell` borrow — and, when a chain is known, one `Vec<Label>` allocation plus a key rehash inside `Key::with_extra_labels`. `PrometheusRecorder::register_*` already calls `key.to_retained()` and a sharded lookup per emit, so this is a constant factor on an existing cost rather than a new one, but it is a real one on the derivation hot path. The label value is a shared `Arc<str>` built once per chain, so cloning it is a refcount bump. Caching the extended `Key` per (scope, key) pair would remove the allocation; I left it out because a cache adds a lock and an eviction question for a cost that is not measured to matter.

`kona-metrics` is a hard dependency while the emits it serves are behind each crate's optional `metrics` feature, so the scope is established even when the feature is off. That is one code path instead of `#[cfg]` on a macro body and two spawn sites; the cost with the feature off is an `Option` swap per poll.

### Fit in the lokahi stack

#22599 ("lokahi: run N chains in one process") merged #22569's threading into its composition line and adds `Metrics::init(chain_id)` per chain plus ~26 `Arc<str>` label fields. Against this PR it needs none of that. What it needs instead is small and already has the seam: it composes each chain then flattens every chain's actors into one `run_actors` call, and `label_chain`/`ChainLabeledActor` already carries the chain id across that boundary — so `ChainLabeledActor::step_erased` wraps its inner step in `kona_metrics::scoped`, `init_prometheus_server` is called with `None`, and each chain's `Metrics::init` runs in a `sync_scoped`. Its multi-chain `L1WatcherActor` — the one component that serves N chains from a single task, and the case ambient scoping genuinely cannot handle — emits no metrics at all, so it needs nothing.

### Verification

**End to end, on the real binary.** kona-node built and run with `--metrics.enabled -c 11155420`, then `/metrics` scraped: **168 series, every one carrying `chain_id="11155420"`, none without.** That includes `process_cpu_seconds_total`, `kona_node_info`, `kona_node_rollup_config`, and the whole zero-fill — with zero emit-site changes.

**The config-file path too.** Run with `-c 10` but `--l2-config-file` naming chain `424242`: all 168 series carry `chain_id="424242"`. Before that fix they would have carried `10`.

**Both spawn seams are regression-tested, not asserted.**

- `actor_metrics_carry_the_chain_the_supervisor_was_given` drives `spawn_and_wait!` with a stub `NodeActor` that awaits and then emits. Remove the scope from the macro and it fails with `left: [None]`.
- `rpc_handler_metrics_carry_the_launcher_chain` launches a real jsonrpsee server through `JsonrpseeServerLauncher`, calls a method over HTTP, and asserts the label. Point the middleware at a different chain and it fails with `left: [Some("0")]`.

Both need the process-global recorder, since a thread-local one cannot reach a spawned task; `test_metrics.rs` owns the single install.

**7 tests in `kona-metrics`** cover the recorder and the scope semantics, including `a_spawned_task_does_not_inherit_the_scope`, which pins the limitation the design is built around so a change in tokio's behaviour is caught here rather than by a mislabelled dashboard.

244 tests pass across kona-metrics, kona-cli, kona-disc, kona-node-service, kona-node and kona-rpc. `clippy --all-features --all-targets -D warnings` clean. `cargo check` with default features clean for each package individually, not just in the workspace. `lint-docs` reproduced locally with CI's exact `RUSTDOCFLAGS` on the pinned nightly.

### Not in scope

- `kona_node_engine_task_failure`'s dynamic label key is fixed in #22705, and the `Metrics::zero()` drift in #22706. Both were found by #22569; neither needs the chain work, and splitting them keeps all three reviewable.
- `kona-metrics` is not wired into kona-host or the sp1 host. Neither is multi-chain, and the sp1 host installs its own recorder.
- jsonrpsee runs a subscription callback under `tokio::spawn` and a blocking method under `spawn_blocking`, so neither inherits the middleware's scope. kona registers four subscriptions and no blocking method, and none of the four emits a metric; the limitation is documented on `ChainScope`.
- Nothing forces a new spawn site to be scoped. The `None` fallback makes an unscoped emit visible in a multi-chain process rather than wrong, which is the cheap version; a lint or an assertion in lokahi's acceptance run would be the thorough one.

BREAKING CHANGE: three public items of `kona-cli` change, so it goes to 0.4.0. `MetricsArgs::init_metrics` and `init_prometheus_server` take a `chain_id: Option<u64>`, `init_prometheus_server` returns `CliResult` rather than `Result<(), BuildError>`, and `CliError` gains two variants. `CliError` is `#[non_exhaustive]` now, so later variants are additive. No in-repo caller outside `bin/node` is affected.
