### PR TITLE
docs: update node101 testnet support

### DIFF
--- a/docs/public-docs/app-developers/reference/rpc-providers.mdx
+++ b/docs/public-docs/app-developers/reference/rpc-providers.mdx
@@ -173,7 +173,7 @@ The following providers offer production-grade RPC access to OP Stack networks. 
 
 **Description**: [node101](https://node101.io/en/rpc/optimism) offers managed RPC access for the following [networks](https://node101.io/en/rpc):
 
-**Supported Testnets**: n/a
+**Supported Testnets**: OP Sepolia, Base Sepolia, Unichain Sepolia, World Sepolia
 
 **Supported Mainnets**: OP Mainnet, Base, Unichain, World
 


### PR DESCRIPTION
## Description

Updates node101's OP Stack RPC directory entry to include the testnets now documented on its network-specific service pages:

- OP Sepolia
- Base Sepolia
- Unichain Sepolia
- World Sepolia

This is a provider-submitted factual correction. The existing mainnet list is unchanged.

## Evidence

- Optimism: https://node101.io/en/rpc/optimism
- Base: https://node101.io/en/rpc/base
- Unichain: https://node101.io/en/rpc/unichain
- World Chain: https://node101.io/en/rpc/worldchain

Each page lists Testnet RPC Support as an available service.

## Validation

- `git diff --check`
- `./node_modules/.bin/tsx scripts/lint/validate-nav.ts`
- `./node_modules/.bin/tsx scripts/lint/validate-redirects.ts`