### PR TITLE
op-batcher,op-node: drop the batcher's registry edge; build the display map without parsing configs

### DIFF
--- a/op-batcher/batcher/service.go
+++ b/op-batcher/batcher/service.go
@@ -16,7 +16,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-batcher/flags"
 	"github.com/ethereum-optimism/optimism/op-batcher/metrics"
 	"github.com/ethereum-optimism/optimism/op-batcher/rpc"
-	"github.com/ethereum-optimism/optimism/op-node/chaincfg"
 	"github.com/ethereum-optimism/optimism/op-node/params"
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/cliapp"
@@ -250,7 +249,10 @@ func (bs *BatcherService) initRollupConfig(ctx context.Context) error {
 	if err := bs.RollupConfig.Check(); err != nil {
 		return fmt.Errorf("invalid rollup config: %w", err)
 	}
-	bs.RollupConfig.LogDescription(bs.Log, chaincfg.L2ChainIDToNetworkDisplayName)
+	// No chain-ID→name map: the batcher deliberately keeps op-node/chaincfg (and with it the
+	// superchain-configs bundle) out of its build closure — see TestBundleReachability.
+	// l2_chain_id identifies the chain in the banner.
+	bs.RollupConfig.LogDescription(bs.Log, nil)
 	return nil
 }
 

--- a/op-core/superchain/deps_test.go
+++ b/op-core/superchain/deps_test.go
@@ -60,12 +60,6 @@ var bundleAllowed = []string{
 	// networks, so the package is inherently about the registry.
 	"github.com/ethereum-optimism/optimism/op-service/flags",
 
-	// Uses chaincfg's registry-derived chain-ID→name map in its startup log
-	// banner only; its rollup config comes from the rollup node RPC. Slated to
-	// log the bare chain ID instead, which would remove these entries (#22678).
-	"github.com/ethereum-optimism/optimism/op-batcher/batcher",
-	"github.com/ethereum-optimism/optimism/op-batcher/cmd",
-
 	// Generates flag documentation for the registry consumers above.
 	"github.com/ethereum-optimism/optimism/docs/public-docs/scripts/gen-flags",
 

--- a/op-core/superchain/strict_decode_test.go
+++ b/op-core/superchain/strict_decode_test.go
@@ -13,9 +13,12 @@ import (
 // strict decoder. It fails if any config carries a key the Go structs do not model — the exact
 // drift that let keep_karst_upgrade_gas be silently dropped. A superchain-registry bump that adds a
 // field therefore cannot merge until the structs are updated to consume it.
+//
+// It also pins that each Chains index key equals the chain ID inside the config, so lookups keyed
+// by the index (e.g. chaincfg's display-name map) need not parse the TOMLs.
 func TestAllEmbeddedConfigsDecodeStrictly(t *testing.T) {
 	networks := map[string]struct{}{}
-	for _, ch := range BuiltInConfigs.Chains {
+	for chainID, ch := range BuiltInConfigs.Chains {
 		networks[ch.Network] = struct{}{}
 		t.Run(ch.Network+"/"+ch.Name, func(t *testing.T) {
 			f, err := BuiltInConfigs.configDataReader.Open(path.Join("configs", ch.Network, ch.Name+".toml"))
@@ -23,6 +26,7 @@ func TestAllEmbeddedConfigsDecodeStrictly(t *testing.T) {
 			defer f.Close()
 			var cfg ChainConfig
 			require.NoError(t, jsonutil.DecodeTOMLStrict(f, &cfg, nil))
+			require.Equal(t, cfg.ChainID, chainID, "chains.json index key must match the config's chain ID")
 		})
 	}
 

--- a/op-node/chaincfg/chains.go
+++ b/op-node/chaincfg/chains.go
@@ -23,14 +23,13 @@ func mustLoadRollupConfig(name string) *rollup.Config {
 	return cfg
 }
 
+// L2ChainIDToNetworkDisplayName maps chain IDs to registry chain names. It is built from the
+// registry's chain index alone — the index key is the chain ID (pinned by
+// TestAllEmbeddedConfigsDecodeStrictly) — so no chain config is parsed.
 var L2ChainIDToNetworkDisplayName = func() map[string]string {
 	out := make(map[string]string)
-	for _, netCfg := range registry.Chains {
-		cfg, err := netCfg.Config()
-		if err != nil {
-			panic(fmt.Errorf("failed to load chain config: %w", err))
-		}
-		out[fmt.Sprintf("%d", cfg.ChainID)] = netCfg.Name
+	for chainID, netCfg := range registry.Chains {
+		out[fmt.Sprintf("%d", chainID)] = netCfg.Name
 	}
 	return out
 }()

--- a/op-node/rollup/types.go
+++ b/op-node/rollup/types.go
@@ -828,7 +828,8 @@ func (c *Config) SyncLookback() uint64 {
 }
 
 // Description outputs a banner describing the important parts of rollup configuration in a human-readable form.
-// Optionally provide a mapping of L2 chain IDs to network names to label the L2 chain with if not unknown.
+// Optionally provide a mapping of L2 chain IDs to network names to label the L2 chain with; unlike
+// LogDescription, the human-readable banner always prints a name, falling back to "unknown L2".
 // The config should be config.Check()-ed before creating a description.
 func (c *Config) Description(l2Chains map[string]string) string {
 	// Find and report the network the user is running
@@ -867,17 +868,10 @@ func (c *Config) Description(l2Chains map[string]string) string {
 }
 
 // LogDescription outputs a banner describing the important parts of rollup configuration in a log format.
-// Optionally provide a mapping of L2 chain IDs to network names to label the L2 chain with if not unknown.
+// Optionally provide a mapping of L2 chain IDs to network names to label the L2 chain; without a
+// name for the chain, the l2_network field is omitted (l2_chain_id identifies the chain either way).
 // The config should be config.Check()-ed before creating a description.
 func (c *Config) LogDescription(log log.Logger, l2Chains map[string]string) {
-	// Find and report the network the user is running
-	networkL2 := ""
-	if l2Chains != nil {
-		networkL2 = l2Chains[c.L2ChainID.String()]
-	}
-	if networkL2 == "" {
-		networkL2 = "unknown L2"
-	}
 	networkL1 := params.NetworkNames[c.L1ChainID.String()]
 	if networkL1 == "" {
 		networkL1 = "unknown L1"
@@ -885,7 +879,11 @@ func (c *Config) LogDescription(log log.Logger, l2Chains map[string]string) {
 
 	ctx := []any{
 		"l2_chain_id", c.L2ChainID,
-		"l2_network", networkL2,
+	}
+	if networkL2 := l2Chains[c.L2ChainID.String()]; networkL2 != "" {
+		ctx = append(ctx, "l2_network", networkL2)
+	}
+	ctx = append(ctx,
 		"l1_chain_id", c.L1ChainID,
 		"l1_network", networkL1,
 		"l2_start_time", c.Genesis.L2Time,
@@ -893,7 +891,7 @@ func (c *Config) LogDescription(log log.Logger, l2Chains map[string]string) {
 		"l2_block_number", c.Genesis.L2.Number,
 		"l1_block_hash", c.Genesis.L1.Hash.String(),
 		"l1_block_number", c.Genesis.L1.Number,
-	}
+	)
 	c.forEachFork(func(_ string, logName string, time *uint64) {
 		ctx = append(ctx, logName, fmtForkTimeOrUnset(time))
 	})

--- a/op-node/rollup/types_test.go
+++ b/op-node/rollup/types_test.go
@@ -220,6 +220,27 @@ func TestCheckL1BlockRefByNumber(t *testing.T) {
 }
 
 // TestRandomConfigDescription tests that the description works for different variations of a random rollup config.
+func TestLogDescription(t *testing.T) {
+	config := randConfig()
+
+	t.Run("named L2", func(t *testing.T) {
+		lgr, logs := testlog.CaptureLogger(t, log.LevelInfo)
+		config.LogDescription(lgr, map[string]string{config.L2ChainID.String(): "foobar chain"})
+		rec := logs.FindLog(testlog.NewMessageFilter("Rollup Config"))
+		require.NotNil(t, rec)
+		require.Equal(t, "foobar chain", rec.AttrValue("l2_network"))
+	})
+
+	t.Run("unnamed L2", func(t *testing.T) {
+		lgr, logs := testlog.CaptureLogger(t, log.LevelInfo)
+		config.LogDescription(lgr, nil)
+		rec := logs.FindLog(testlog.NewMessageFilter("Rollup Config"))
+		require.NotNil(t, rec)
+		require.Nil(t, rec.AttrValue("l2_network"), "l2_network is omitted when no name is known")
+		require.Equal(t, "unknown L1", rec.AttrValue("l1_network"))
+	})
+}
+
 func TestRandomConfigDescription(t *testing.T) {
 	t.Run("named L2", func(t *testing.T) {
 		config := randConfig()


### PR DESCRIPTION
Cuts op-batcher's last edge into the `superchain-configs.zip` bundle and stops parsing every embedded chain config at op-node init. Stacked on #22709.

- **op-batcher**: the batcher imported `op-node/chaincfg` only to name the chain in its startup banner (its rollup config comes from the rollup node RPC). It now passes no name map; `LogDescription` omits the `l2_network` field when it has no name instead of printing `"unknown L2"` — `l2_chain_id` identifies the chain either way. `Description` (the human-readable banner) deliberately keeps its `unknown L2` fallback. New `TestLogDescription` pins both cases.
- **chaincfg**: `L2ChainIDToNetworkDisplayName` deflated and strict-parsed all ~53 chain TOMLs at package init just to read each config's chain ID — which is already the key of the registry's chain index. It now reads the index alone; `TestAllEmbeddedConfigsDecodeStrictly` pins index key == config chain ID (true by construction in `sync-superchain.sh`).
- The bundle guard's stale-entry check forced the removal of both op-batcher allowlist entries, exactly as designed.

Minor behavior notes: banners of chains without a registry name lose the `l2_network="unknown L2"` field (grep accordingly), and a corrupt embedded config now surfaces at first `Chain.Config()` call rather than at op-node init (decodability of every embedded config stays CI-enforced).

Part of #22678.

🤖 *Co-created with Claude Fable 5*
