### PR TITLE
alloy-op-evm,op-revm,kona: cover SDM refund settlement and gas accounting

### DIFF
--- a/rust/alloy-op-evm/src/block/mod.rs
+++ b/rust/alloy-op-evm/src/block/mod.rs
@@ -563,11 +563,13 @@ where
         Ok(refund)
     }
 
-    /// Applies the post-exec refund to `total_gas_spent` so `tx_gas_used()` reports canonical gas.
+    /// Applies the post-exec refund to the result gas so `tx_gas_used()` reports canonical gas.
     ///
-    /// The EVM refund counter stays unchanged to avoid subtracting the refund twice. If the
-    /// EIP-7623 floor binds, `tx_gas_used()` remains clamped and may exceed canonical gas; whether
-    /// SDM rebates can reduce gas below that floor remains an open spec question.
+    /// The EVM refund counter stays unchanged to avoid subtracting the refund twice. EIP-7623 is
+    /// part of `evm_gas_used`, so SDM applies after its floor and may reduce canonical gas below
+    /// that floor. Reducing both `total_gas_spent` and `floor_gas` preserves this ordering in the
+    /// generic [`revm::context::result::ResultGas`] view used by receipts, tracing, and execution
+    /// observers.
     const fn canonicalize_result_gas(
         result: &mut ExecutionResult<E::HaltReason>,
         post_exec_refund: u64,
@@ -581,7 +583,8 @@ where
             ExecutionResult::Revert { gas, .. } |
             ExecutionResult::Halt { gas, .. } => {
                 *gas = gas
-                    .with_total_gas_spent(gas.total_gas_spent().saturating_sub(post_exec_refund));
+                    .with_total_gas_spent(gas.total_gas_spent().saturating_sub(post_exec_refund))
+                    .with_floor_gas(gas.floor_gas().saturating_sub(post_exec_refund));
             }
         }
     }

--- a/rust/alloy-op-evm/src/block/tests.rs
+++ b/rust/alloy-op-evm/src/block/tests.rs
@@ -149,7 +149,8 @@ fn build_executor<'a>(
 ) -> JovianTestExecutor<'a> {
     let ctx = Context::mainnet()
         .with_tx(crate::OpTx(OpTransaction::builder().build_fill()))
-        .with_cfg(CfgEnv::new_with_spec(OpSpecId::BEDROCK))
+        // Initialize directly at Jovian so `GasParams` includes Prague's EIP-7623 floor.
+        .with_cfg(CfgEnv::new_with_spec(OpSpecId::JOVIAN))
         .with_chain(L1BlockInfo::default())
         .with_db(db)
         .with_chain(L1BlockInfo {
@@ -163,8 +164,7 @@ fn build_executor<'a>(
             basefee: base_fee,
             beneficiary,
             ..Default::default()
-        })
-        .modify_cfg_chained(|cfg| cfg.spec = OpSpecId::JOVIAN);
+        });
 
     let evm = OpEvm::new(
         ctx.build_op_with_inspector(NoOpInspector {}),
@@ -553,6 +553,7 @@ fn test_none_parent_timestamp_skips_check() {
 }
 
 const OBSERVER_TEST_CONTRACT: Address = Address::with_last_byte(0x42);
+const CALLDATA_FLOOR_TEST_CONTRACT: Address = Address::with_last_byte(0x43);
 
 /// Bytecode that executes CREATE, CALL, and SELFDESTRUCT. Every opcode also drives `step`.
 const OBSERVER_TEST_BYTECODE: &[u8] = &[
@@ -572,6 +573,30 @@ fn prepare_observer_db() -> State<InMemoryDB> {
             code: Some(Bytecode::new_raw(code)),
             ..Default::default()
         },
+    );
+    db
+}
+
+/// Builds a state whose test contract both earns a native EVM refund and executes enough work to
+/// remain above the EIP-7623 floor before SDM is applied.
+fn prepare_calldata_floor_db() -> State<InMemoryDB> {
+    let mut db = prepare_jovian_db(0);
+    let mut raw_code = Vec::with_capacity(304);
+    for _ in 0..100 {
+        // Repeatedly read slot zero: PUSH0; SLOAD; POP.
+        raw_code.extend_from_slice(&[0x5f, 0x54, 0x50]);
+    }
+    // Clear the originally non-zero slot to earn a native EVM storage refund, then stop.
+    raw_code.extend_from_slice(&[0x5f, 0x5f, 0x55, 0x00]);
+    let code = Bytes::from(raw_code);
+    db.insert_account_with_storage(
+        CALLDATA_FLOOR_TEST_CONTRACT,
+        AccountInfo {
+            code_hash: keccak256(&code),
+            code: Some(Bytecode::new_raw(code)),
+            ..Default::default()
+        },
+        HashMap::from_iter([(U256::ZERO, U256::from(1))]),
     );
     db
 }
@@ -614,7 +639,8 @@ where
 {
     let ctx = Context::mainnet()
         .with_tx(crate::OpTx(OpTransaction::builder().build_fill()))
-        .with_cfg(CfgEnv::new_with_spec(OpSpecId::BEDROCK))
+        // Initialize directly at Jovian so `GasParams` includes Prague's EIP-7623 floor.
+        .with_cfg(CfgEnv::new_with_spec(OpSpecId::JOVIAN))
         .with_chain(L1BlockInfo::default())
         .with_db(db)
         .with_block(BlockEnv {
@@ -623,8 +649,7 @@ where
             basefee: base_fee,
             beneficiary,
             ..Default::default()
-        })
-        .modify_cfg_chained(|cfg| cfg.spec = OpSpecId::JOVIAN);
+        });
 
     let evm: OpEvm<_, _, _, crate::OpTx, R> = OpEvm::new(
         ctx.build_op_with_inspector(NoOpInspector {}),
@@ -642,6 +667,16 @@ fn observer_test_tx() -> Recovered<OpTxEnvelope> {
     recovered_legacy(TxLegacy {
         to: TxKind::Call(OBSERVER_TEST_CONTRACT),
         gas_limit: 200_000,
+        ..Default::default()
+    })
+}
+
+/// An execution-heavy transaction with enough non-zero calldata for a meaningful EIP-7623 floor.
+fn calldata_floor_test_tx() -> Recovered<OpTxEnvelope> {
+    recovered_legacy(TxLegacy {
+        to: TxKind::Call(CALLDATA_FLOOR_TEST_CONTRACT),
+        gas_limit: 200_000,
+        input: Bytes::from(vec![0xff; 128]),
         ..Default::default()
     })
 }

--- a/rust/alloy-op-evm/src/block/tests/structural_tests.rs
+++ b/rust/alloy-op-evm/src/block/tests/structural_tests.rs
@@ -168,6 +168,80 @@ fn canonicalized_result_gas_applies_refund_exactly_once() {
 }
 
 #[test]
+fn sdm_refund_can_reduce_canonical_gas_across_eip7623_floor() {
+    let tx = calldata_floor_test_tx();
+    let (evm_gas_used, floor_gas, native_evm_refund) = {
+        let mut fixture =
+            JovianExecutorFixture::new(DEFAULT_DA_FOOTPRINT_GAS_SCALAR, 500_000, JOVIAN_TIMESTAMP);
+        fixture.db = prepare_calldata_floor_db();
+        let mut executor = fixture.executor();
+        let output =
+            executor.execute_transaction_without_commit(&tx).expect("floor probe executes");
+        let gas = output.inner.result.result.gas();
+        (output.evm_gas_used, gas.floor_gas(), gas.inner_refunded())
+    };
+    assert!(floor_gas > 0, "Jovian transaction must compute an EIP-7623 floor");
+    assert!(native_evm_refund > 0, "test transaction must earn a native EVM refund");
+    let gas_above_floor = evm_gas_used
+        .checked_sub(floor_gas)
+        .expect("test transaction executes above its calldata floor");
+    assert!(gas_above_floor > 1, "test needs room on both sides of the floor");
+
+    for (case, refund, expected_canonical_gas) in [
+        ("above floor", gas_above_floor - 1, floor_gas + 1),
+        ("at floor", gas_above_floor, floor_gas),
+        ("below floor", gas_above_floor + 1, floor_gas - 1),
+    ] {
+        let entries = vec![SDMGasEntry { index: 0, gas_refund: refund }];
+        let mut fixture =
+            JovianExecutorFixture::new(DEFAULT_DA_FOOTPRINT_GAS_SCALAR, 500_000, JOVIAN_TIMESTAMP);
+        fixture.db = prepare_calldata_floor_db();
+        let mut verifier = fixture.verifier(0, entries.clone());
+
+        let output = verifier
+            .execute_transaction_without_commit(&tx)
+            .unwrap_or_else(|err| panic!("{case}: refunded transaction executes: {err}"));
+        assert_eq!(output.evm_gas_used, evm_gas_used, "{case}: raw gas remains unchanged");
+        assert_eq!(
+            output.canonical_gas_used, expected_canonical_gas,
+            "{case}: canonical gas is raw EVM gas minus the complete SDM refund"
+        );
+        let result_gas = output.inner.result.result.gas();
+        assert_eq!(
+            result_gas.tx_gas_used(),
+            expected_canonical_gas,
+            "{case}: generic execution-result gas must agree with canonical gas"
+        );
+        assert_eq!(
+            result_gas.inner_refunded(),
+            native_evm_refund,
+            "{case}: SDM must not alter the EVM's own refund counter"
+        );
+        assert_eq!(
+            result_gas.floor_gas(),
+            floor_gas.saturating_sub(refund),
+            "{case}: the post-EVM SDM refund must discount the stored floor too"
+        );
+
+        verifier.commit_transaction(output);
+        let post_exec = recovered_post_exec(0, entries);
+        verifier.execute_transaction(&post_exec).expect("post-exec transaction verifies");
+        let (_, result) = verifier.finish().expect("floor-bound block finishes");
+        assert_eq!(result.gas_used, expected_canonical_gas, "{case}: block gas");
+        assert_eq!(
+            result.receipts[0].cumulative_gas_used(),
+            expected_canonical_gas,
+            "{case}: user receipt cumulative gas"
+        );
+        assert_eq!(
+            result.receipts[1].cumulative_gas_used(),
+            expected_canonical_gas,
+            "{case}: zero-gas PostExec receipt inherits canonical cumulative gas"
+        );
+    }
+}
+
+#[test]
 fn fixed_policy_producer_verifier_roundtrip() {
     let tx = observer_test_tx();
     let mut producer_db = prepare_observer_db();

--- a/rust/kona/crates/proof/executor/src/builder/core/tests.rs
+++ b/rust/kona/crates/proof/executor/src/builder/core/tests.rs
@@ -1,12 +1,22 @@
 use crate::{
-    ExecutorError,
-    test_utils::{execute_loaded_fixture, load_test_fixture, run_test_fixture},
+    BlockBuildingOutcome, ExecutorError, StatelessL2Builder,
+    test_utils::{
+        ExecutorTestFixture, LoadedExecutorTestFixture, execute_loaded_fixture, load_test_fixture,
+        run_test_fixture,
+    },
 };
-use alloy_consensus::Header;
+use alloy_consensus::{Header, Transaction};
 use alloy_eips::Encodable2718;
+use alloy_op_evm::OpEvmFactory;
+use alloy_primitives::{Address, Sealable, U256};
+use kona_mpt::NoopTrieHinter;
 use op_alloy_consensus::{OpReceiptEnvelope, SDMGasEntry, build_post_exec_tx};
+use op_revm::constants::{BASE_FEE_RECIPIENT, OPERATOR_FEE_RECIPIENT};
 use rstest::rstest;
-use std::path::PathBuf;
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    path::PathBuf,
+};
 
 /// Path to the fixture used by all post-exec tests.
 ///
@@ -41,6 +51,41 @@ fn assert_post_exec_validation_failure(err: ExecutorError, expected: &str) {
     let err = err.to_string();
     assert!(err.to_lowercase().contains("invalid post-exec payload"), "unexpected error: {err}");
     assert!(err.contains(expected), "expected {err:?} to contain {expected:?}");
+}
+
+/// Executes a fixture and reads selected balances from its resulting state trie.
+fn execute_loaded_fixture_with_balances(
+    loaded: LoadedExecutorTestFixture,
+    sdm_active_override: Option<bool>,
+    addresses: &BTreeSet<Address>,
+) -> (BlockBuildingOutcome<OpReceiptEnvelope>, BTreeMap<Address, U256>) {
+    let LoadedExecutorTestFixture { fixture_dir: _fixture_dir, fixture, provider } = loaded;
+    let ExecutorTestFixture { rollup_config, parent_header, executing_payload, .. } = fixture;
+
+    let mut executor = StatelessL2Builder::new(
+        &rollup_config,
+        OpEvmFactory::<alloy_op_evm::OpTx>::default(),
+        alloy_op_evm::block::OpAlloyReceiptBuilder::default(),
+        provider,
+        NoopTrieHinter,
+        parent_header.seal_slow(),
+    );
+    executor.set_sdm_active_override(sdm_active_override);
+    let outcome = executor.build_block(executing_payload).expect("fixture executes");
+    let balances = addresses
+        .iter()
+        .map(|address| {
+            let balance = executor
+                .trie_db
+                .get_trie_account(address)
+                .expect("account proof is available")
+                .unwrap_or_else(|| panic!("account {address} exists"))
+                .balance;
+            (*address, balance)
+        })
+        .collect();
+
+    (outcome, balances)
 }
 
 #[rstest]
@@ -135,6 +180,124 @@ async fn post_exec_valid_empty_payload_executes_without_state_or_gas_change() {
     ));
     assert_eq!(outcome.execution_result.gas_used, baseline.execution_result.gas_used);
     assert_eq!(outcome.header.state_root, baseline.header.state_root);
+    assert_ne!(outcome.header.transactions_root, baseline.header.transactions_root);
+    assert_ne!(outcome.header.receipts_root, baseline.header.receipts_root);
+}
+
+#[tokio::test]
+async fn post_exec_nonzero_payload_applies_refunds() {
+    let mut loaded = load_test_fixture(post_exec_fixture_path()).await;
+    let block_number = fixture_block_number(&loaded.fixture.parent_header);
+    let timestamp = loaded.fixture.executing_payload.payload_attributes.timestamp;
+    assert!(
+        !loaded.fixture.rollup_config.is_isthmus_active(timestamp),
+        "fixture must remain pre-Isthmus so operator-fee settlement is zero"
+    );
+
+    let recovered = loaded
+        .fixture
+        .executing_payload
+        .recovered_transactions()
+        .collect::<Result<Vec<_>, _>>()
+        .expect("fixture transactions recover");
+    assert_eq!(recovered.len(), 10, "fixture must contain ten pre-PostExec transactions");
+
+    // Leave the deposit at index 0 and the first regular transaction unrefunded, then refund one
+    // gas from each of the remaining eight transactions.
+    let refunded = &recovered[2..];
+    let refund_senders = refunded.iter().map(|tx| tx.signer()).collect::<BTreeSet<_>>();
+    let beneficiary = loaded.fixture.executing_payload.payload_attributes.suggested_fee_recipient;
+    assert_ne!(beneficiary, BASE_FEE_RECIPIENT);
+    assert_ne!(beneficiary, OPERATOR_FEE_RECIPIENT);
+    assert_ne!(BASE_FEE_RECIPIENT, OPERATOR_FEE_RECIPIENT);
+    assert!(
+        refund_senders.iter().all(|sender| ![
+            beneficiary,
+            BASE_FEE_RECIPIENT,
+            OPERATOR_FEE_RECIPIENT
+        ]
+        .contains(sender)),
+        "refund senders must not alias fee recipients"
+    );
+
+    let mut affected_accounts = refund_senders.clone();
+    affected_accounts.extend([beneficiary, BASE_FEE_RECIPIENT, OPERATOR_FEE_RECIPIENT]);
+    let (baseline, baseline_balances) = execute_loaded_fixture_with_balances(
+        load_test_fixture(post_exec_fixture_path()).await,
+        None,
+        &affected_accounts,
+    );
+
+    let transactions = loaded.fixture.executing_payload.transactions.as_mut().unwrap();
+    let gas_refund_entries = (2..transactions.len())
+        .map(|index| SDMGasEntry { index: index as u64, gas_refund: 1 })
+        .collect::<Vec<_>>();
+    let refund_total = gas_refund_entries.len() as u64;
+    assert_eq!(refund_total, 8);
+    append_post_exec_tx(transactions, block_number, gas_refund_entries);
+
+    let (outcome, refunded_balances) =
+        execute_loaded_fixture_with_balances(loaded, Some(true), &affected_accounts);
+    assert_eq!(
+        outcome.execution_result.receipts.len(),
+        baseline.execution_result.receipts.len() + 1
+    );
+    assert!(matches!(
+        outcome.execution_result.receipts.last(),
+        Some(OpReceiptEnvelope::PostExec(_))
+    ));
+    assert_eq!(
+        outcome.execution_result.gas_used,
+        baseline.execution_result.gas_used - refund_total
+    );
+    assert_eq!(outcome.header.gas_used, baseline.header.gas_used - refund_total);
+
+    let base_fee = baseline.header.base_fee_per_gas.expect("fixture has a base fee");
+    let mut expected_sender_credits = BTreeMap::<Address, U256>::new();
+    let mut expected_beneficiary_debit = U256::ZERO;
+    for tx in refunded {
+        let effective_gas_price = tx.inner().effective_gas_price(Some(base_fee));
+        *expected_sender_credits.entry(tx.signer()).or_default() += U256::from(effective_gas_price);
+        expected_beneficiary_debit +=
+            U256::from(effective_gas_price.saturating_sub(u128::from(base_fee)));
+    }
+    let expected_base_fee_debit = U256::from(base_fee) * U256::from(refund_total);
+
+    for (sender, expected_credit) in expected_sender_credits {
+        assert_eq!(
+            refunded_balances[&sender],
+            baseline_balances[&sender] + expected_credit,
+            "refunded sender {sender} must receive its exact effective-gas-price credit"
+        );
+    }
+    assert_eq!(
+        refunded_balances[&beneficiary],
+        baseline_balances[&beneficiary]
+            .checked_sub(expected_beneficiary_debit)
+            .expect("beneficiary funds the priority-fee refund"),
+        "beneficiary must fund the exact priority-fee share"
+    );
+    assert_eq!(
+        refunded_balances[&BASE_FEE_RECIPIENT],
+        baseline_balances[&BASE_FEE_RECIPIENT]
+            .checked_sub(expected_base_fee_debit)
+            .expect("base-fee recipient funds the base-fee refund"),
+        "base-fee recipient must fund the exact base-fee share"
+    );
+    assert_eq!(
+        refunded_balances[&OPERATOR_FEE_RECIPIENT], baseline_balances[&OPERATOR_FEE_RECIPIENT],
+        "pre-Isthmus settlement must not debit the operator-fee recipient"
+    );
+
+    let total = |balances: &BTreeMap<Address, U256>| {
+        balances.values().copied().fold(U256::ZERO, |total, balance| total + balance)
+    };
+    assert_eq!(
+        total(&refunded_balances),
+        total(&baseline_balances),
+        "settlement must only transfer value among affected accounts"
+    );
+    assert_ne!(outcome.header.state_root, baseline.header.state_root);
     assert_ne!(outcome.header.transactions_root, baseline.header.transactions_root);
     assert_ne!(outcome.header.receipts_root, baseline.header.receipts_root);
 }

--- a/rust/op-revm/src/l1block.rs
+++ b/rust/op-revm/src/l1block.rs
@@ -172,6 +172,12 @@ impl L1BlockInfo {
     ///
     /// Introduced in isthmus. Prior to isthmus, the operator fee is always zero.
     pub fn operator_fee_charge(&self, input: &[u8], gas_limit: U256, spec_id: OpSpecId) -> U256 {
+        // Operator fees do not exist before Isthmus. Guard the fork before reading the
+        // Isthmus-only L1 block fields so callers replaying older blocks cannot panic.
+        if !spec_id.is_enabled_in(OpSpecId::ISTHMUS) {
+            return U256::ZERO;
+        }
+
         // If the input is a deposit transaction or empty, the default value is zero.
         if input.is_empty() || input.first() == Some(&0x7E) {
             return U256::ZERO;
@@ -641,6 +647,13 @@ mod tests {
         };
 
         let input = [0x01u8];
+
+        let pre_isthmus_fee = L1BlockInfo::default().operator_fee_charge(
+            &input,
+            U256::from(1_000u64),
+            OpSpecId::FJORD,
+        );
+        assert_eq!(pre_isthmus_fee, U256::ZERO);
 
         let isthmus_fee =
             l1_block_info.operator_fee_charge(&input, U256::from(1_000u64), OpSpecId::ISTHMUS);


### PR DESCRIPTION
Re-opens #22613, closed after an unrelated force-push. Content is unchanged from that PR (verified byte-identical), rebased onto current `develop`.

## Changes

- **`alloy-op-evm`**: SDM refunds apply after EIP-7623's calldata floor, so a refund can legitimately push canonical gas below it. `canonicalize_result_gas` now discounts the stored `floor_gas` alongside `total_gas_spent`, keeping the generic `ResultGas` view used by receipts, tracing, and execution observers consistent with canonical block and receipt gas — previously `tx_gas_used()` stayed clamped at the original floor and diverged. Receipt and block gas have always been taken from `canonical_gas_used`, never from `ResultGas`, so this is **not a consensus change**.
- **`op-revm`**: `operator_fee_charge` returns zero before Isthmus, before reading the Isthmus-only `operator_fee_scalar` / `operator_fee_constant` — mirroring the guard `operator_fee_refund` already has. This is **defensive parity, not a production fix**: both clients gate SDM on Lagoon (kona `is_sdm_active`, op-reth `is_sdm_active_at_timestamp`), which is after Isthmus, so no production path reaches the guard. It unlocks pre-Isthmus SDM test fixtures — including the proptests in #22617, which hit the same `Option::expect`.
- **Tests**: a kona executor test for successful non-empty SDM settlement (receipt shape, gas accounting, exact sender / beneficiary / base-fee-vault balance transfers, ETH-supply conservation over the affected set), and an `alloy-op-evm` test crossing above, at, and below the calldata floor while preserving the native EVM refund counter.

### Reviewer note: the test harness gas schedule moved

`build_executor` / `build_policy_executor` switch from `CfgEnv::new_with_spec(BEDROCK)` plus a later `cfg.spec = JOVIAN` poke to initializing at `JOVIAN` directly. These are **not** equivalent: `new_with_spec` derives `gas_params` from the spec, so overwriting only the `spec` field left every test in `block/tests*` running with MERGE gas params and therefore no EIP-7623 floor at all. The harness now matches production, which builds `CfgEnv` via `with_spec_and_mainnet_gas_params`. Gas numbers across that file move as a result, and the pre-existing floor guard in `canonicalized_result_gas_applies_refund_exactly_once` stops being vacuous.

## Known gaps, raised in review and not addressed here

- The floor-crossing test runs at `JOVIAN → PRAGUE`, where the EIP-7623 floor is 10 gas/token. SDM activates at Lagoon → `OSAKA`, where EIP-7976 raises it to 16 gas/token and drops the zero-byte discount. The new arithmetic is therefore pinned under a floor formula that never coexists with SDM in production.
- No case covers a natively floor-bound transaction (`floor_gas > total_gas_spent - refunded`), which is the other half of the same divergence.
- `execute_loaded_fixture_with_balances` duplicates the `StatelessL2Builder` construction in `test_utils::execute_loaded_fixture` instead of extending it.

## Testing

- `cargo nextest run --release -p kona-executor` — 40/40 pass
- `cargo nextest run -p alloy-op-evm -p op-revm` — 174/174 pass
- `cargo clippy -p alloy-op-evm -p op-revm --all-targets --all-features -- -D warnings`
- `cargo check -p alloy-op-evm --no-default-features`
- `just lint` (`fmt-check` + workspace clippy + `lint-docs`)
