### PR TITLE
op-challenger: fix interop vm runner picking an unusable game L1 head

### DIFF
--- a/op-challenger/runner/game_inputs.go
+++ b/op-challenger/runner/game_inputs.go
@@ -248,6 +248,13 @@ func createGameInputsInterop(ctx context.Context, log log.Logger, client super.S
 			return utils.LocalGameInputs{}, fmt.Errorf("failed to get claim: %w", err)
 		}
 	}
+	// The trace provider returns this sentinel without error whenever the game L1 head can't
+	// support a real transition, because in a real game that is the honest claim. As a runner
+	// input it is worthless: the FPP proves it trivially and the run reports success having
+	// exercised no derivation.
+	if claim == eth.InvalidTransitionHash {
+		return utils.LocalGameInputs{}, errors.New("claim is the invalid transition sentinel")
+	}
 	localInputs := utils.LocalGameInputs{
 		L1Head:           l1Head.Hash,
 		AgreedPreState:   agreedPrestate,

--- a/op-challenger/runner/game_inputs.go
+++ b/op-challenger/runner/game_inputs.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/types"
 	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
 	"github.com/ethereum-optimism/optimism/op-node/node/safedb"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"github.com/ethereum/go-ethereum/common"
 	ethTypes "github.com/ethereum/go-ethereum/core/types"
@@ -40,7 +41,7 @@ func createGameInputs(ctx context.Context, log log.Logger, rollupClient *sources
 		if superRoots == nil {
 			return utils.LocalGameInputs{}, fmt.Errorf("game type %s requires super root RPC to be set", gameType)
 		}
-		return createGameInputsInterop(ctx, log, superRoots, typeName)
+		return createGameInputsInterop(ctx, log, superRoots, l1Client, typeName)
 	default:
 		if rollupClient == nil {
 			return utils.LocalGameInputs{}, fmt.Errorf("game type %s requires rollup rpc to be set", gameType)
@@ -170,7 +171,23 @@ func hasNonZeroSafeHead(ctx context.Context, client *sources.RollupClient, l1Num
 	return safeHead.SafeHead.Number > 0, nil
 }
 
-func createGameInputsInterop(ctx context.Context, log log.Logger, client super.SuperNodeRootProvider, typeName string) (utils.LocalGameInputs, error) {
+// fullyProcessedL1Head returns the highest L1 block the node has fully processed. Only blocks
+// strictly below CurrentL1 are fully processed, and the super root trace provider serves
+// claims only when the node's CurrentL1 is above the game's L1 head, so CurrentL1 itself is
+// never usable as one: every claim fails with ErrNotInSync however well synced the node is.
+func fullyProcessedL1Head(ctx context.Context, l1Client l1BlockHashSource, currentL1 eth.BlockID) (eth.BlockID, error) {
+	if currentL1.Number == 0 {
+		return eth.BlockID{}, errors.New("l1 head is 0")
+	}
+	headNum := currentL1.Number - 1
+	header, err := l1Client.HeaderByNumber(ctx, new(big.Int).SetUint64(headNum))
+	if err != nil {
+		return eth.BlockID{}, fmt.Errorf("failed to fetch l1 head at block %v: %w", headNum, err)
+	}
+	return eth.BlockID{Number: headNum, Hash: header.Hash()}, nil
+}
+
+func createGameInputsInterop(ctx context.Context, log log.Logger, client super.SuperNodeRootProvider, l1Client l1BlockHashSource, typeName string) (utils.LocalGameInputs, error) {
 	// superroot_atTimestamp carries the same finalized timestamp and L1 head as
 	// supernode_syncStatus, and is served by op-supernode and by op-node (which has no
 	// supernode namespace), so a single-chain rollup can be its own super root source.
@@ -186,11 +203,11 @@ func createGameInputsInterop(ctx context.Context, log log.Logger, client super.S
 	if claimTimestamp == 0 {
 		return utils.LocalGameInputs{}, errors.New("finalized timestamp is 0")
 	}
-	l1Head := status.CurrentL1
-	log.Info("Using L1 head", "head", l1Head, "type", typeName)
-	if l1Head.Number == 0 {
-		return utils.LocalGameInputs{}, errors.New("l1 head is 0")
+	l1Head, err := fullyProcessedL1Head(ctx, l1Client, status.CurrentL1)
+	if err != nil {
+		return utils.LocalGameInputs{}, err
 	}
+	log.Info("Using L1 head", "head", l1Head, "currentL1", status.CurrentL1, "type", typeName)
 
 	prestateProvider := super.NewSuperNodePrestateProvider(client, agreedTimestamp)
 	gameDepth := types.Depth(30)

--- a/op-challenger/runner/game_inputs.go
+++ b/op-challenger/runner/game_inputs.go
@@ -15,7 +15,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/node/safedb"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/ethclient"
+	ethTypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 )
 
@@ -29,7 +29,12 @@ const (
 	disputeL1OffsetBlocks = uint64(7 * 24 * 60 * 60 / 12)  // 50400
 )
 
-func createGameInputs(ctx context.Context, log log.Logger, rollupClient *sources.RollupClient, superRoots super.SuperNodeRootProvider, l1Client *ethclient.Client, typeName string, gameType gameTypes.GameType, ageGameInputs bool) (utils.LocalGameInputs, error) {
+// l1BlockHashSource resolves an L1 block number to its canonical block hash.
+type l1BlockHashSource interface {
+	HeaderByNumber(ctx context.Context, number *big.Int) (*ethTypes.Header, error)
+}
+
+func createGameInputs(ctx context.Context, log log.Logger, rollupClient *sources.RollupClient, superRoots super.SuperNodeRootProvider, l1Client l1BlockHashSource, typeName string, gameType gameTypes.GameType, ageGameInputs bool) (utils.LocalGameInputs, error) {
 	switch gameType {
 	case gameTypes.SuperCannonKonaGameType:
 		if superRoots == nil {
@@ -44,7 +49,7 @@ func createGameInputs(ctx context.Context, log log.Logger, rollupClient *sources
 	}
 }
 
-func createGameInputsSingle(ctx context.Context, log log.Logger, client *sources.RollupClient, l1Client *ethclient.Client, typeName string, ageGameInputs bool) (utils.LocalGameInputs, error) {
+func createGameInputsSingle(ctx context.Context, log log.Logger, client *sources.RollupClient, l1Client l1BlockHashSource, typeName string, ageGameInputs bool) (utils.LocalGameInputs, error) {
 	status, err := client.SyncStatus(ctx)
 	if err != nil {
 		return utils.LocalGameInputs{}, fmt.Errorf("failed to get rollup sync status: %w", err)

--- a/op-challenger/runner/game_inputs_test.go
+++ b/op-challenger/runner/game_inputs_test.go
@@ -178,10 +178,10 @@ func TestCreateGameInputsInteropBuildsInputsFromSyncedNode(t *testing.T) {
 }
 
 // The other edge of the window: an L1 head below the L1 data the disputed timestamps need
-// makes every claim the InvalidTransition sentinel. That builds inputs without error, so the
-// run goes green having proven nothing - the reason the assertion above checks the sentinel
-// rather than just a non-zero claim.
-func TestCreateGameInputsInteropClaimsSentinelWhenL1HeadBelowRequiredL1(t *testing.T) {
+// makes every claim the InvalidTransition sentinel, which the trace provider returns without
+// error. The FPP would prove it trivially, so the run must fail rather than pass having
+// verified nothing.
+func TestCreateGameInputsInteropRejectsSentinelClaim(t *testing.T) {
 	logger := testlog.Logger(t, log.LvlInfo)
 	currentL1 := eth.BlockID{Number: 5000, Hash: common.Hash{0xaa}}
 	client := &stubSyncedSuperNode{
@@ -190,10 +190,10 @@ func TestCreateGameInputsInteropClaimsSentinelWhenL1HeadBelowRequiredL1(t *testi
 		requiredL1:  eth.BlockID{Number: currentL1.Number + 5, Hash: common.Hash{0xcc}},
 	}
 
+	// Every one of the three random trace positions must be rejected.
 	for i := 0; i < 20; i++ {
-		inputs, err := createGameInputsInterop(context.Background(), logger, client, &stubL1Headers{}, "test")
-		require.NoError(t, err)
-		require.Equal(t, eth.InvalidTransitionHash, inputs.L2Claim)
+		_, err := createGameInputsInterop(context.Background(), logger, client, &stubL1Headers{}, "test")
+		require.ErrorContains(t, err, "invalid transition sentinel")
 	}
 }
 

--- a/op-challenger/runner/game_inputs_test.go
+++ b/op-challenger/runner/game_inputs_test.go
@@ -3,16 +3,37 @@ package runner
 import (
 	"context"
 	"errors"
+	"math/big"
 	"testing"
 	"time"
 
 	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/ethereum-optimism/optimism/op-service/bigs"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
 	"github.com/ethereum/go-ethereum/common"
+	ethTypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/stretchr/testify/require"
 )
+
+type stubL1Headers struct {
+	requested []uint64
+	err       error
+}
+
+func (s *stubL1Headers) header(number uint64) *ethTypes.Header {
+	return &ethTypes.Header{Number: new(big.Int).SetUint64(number)}
+}
+
+func (s *stubL1Headers) HeaderByNumber(_ context.Context, number *big.Int) (*ethTypes.Header, error) {
+	num := bigs.Uint64Strict(number)
+	s.requested = append(s.requested, num)
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.header(num), nil
+}
 
 type stubSuperRootProvider struct {
 	resp      eth.SuperRootAtTimestampResponse
@@ -35,7 +56,7 @@ func TestCreateGameInputsInteropReadsStatusFromSuperRoot(t *testing.T) {
 		CurrentL1:                 eth.BlockID{Number: 100, Hash: common.Hash{0xaa}},
 	}}
 
-	_, err := createGameInputsInterop(context.Background(), logger, client, "test")
+	_, err := createGameInputsInterop(context.Background(), logger, client, &stubL1Headers{}, "test")
 	require.ErrorContains(t, err, "finalized timestamp is 0")
 
 	require.Len(t, client.requested, 1, "should read status with a single super root call")
@@ -47,7 +68,7 @@ func TestCreateGameInputsInteropStatusFailure(t *testing.T) {
 	boom := errors.New("boom")
 	client := &stubSuperRootProvider{err: boom}
 
-	_, err := createGameInputsInterop(context.Background(), logger, client, "test")
+	_, err := createGameInputsInterop(context.Background(), logger, client, &stubL1Headers{}, "test")
 	require.ErrorIs(t, err, boom)
 	require.ErrorContains(t, err, "super root status")
 }
@@ -61,7 +82,7 @@ func TestCreateGameInputsInteropRejectsZeroFinalizedTimestamp(t *testing.T) {
 		CurrentL1:                 eth.BlockID{Number: 100},
 	}}
 
-	_, err := createGameInputsInterop(context.Background(), logger, client, "test")
+	_, err := createGameInputsInterop(context.Background(), logger, client, &stubL1Headers{}, "test")
 	require.ErrorContains(t, err, "finalized timestamp is 0")
 }
 
@@ -72,7 +93,7 @@ func TestCreateGameInputsInteropRejectsZeroL1Head(t *testing.T) {
 		CurrentL1:                 eth.BlockID{Number: 0},
 	}}
 
-	_, err := createGameInputsInterop(context.Background(), logger, client, "test")
+	_, err := createGameInputsInterop(context.Background(), logger, client, &stubL1Headers{}, "test")
 	require.ErrorContains(t, err, "l1 head is 0")
 }
 
@@ -90,4 +111,100 @@ func TestCreateGameInputsRequiresRollupClient(t *testing.T) {
 
 	_, err := createGameInputs(context.Background(), logger, nil, nil, nil, "test", gameTypes.CannonKonaGameType, false)
 	require.ErrorContains(t, err, "requires rollup rpc to be set")
+}
+
+// stubSyncedSuperNode answers like a fully synced single-chain op-node: a fixed CurrentL1
+// for every timestamp, super root data up to the finalized timestamp, and no chain data
+// beyond it.
+type stubSyncedSuperNode struct {
+	currentL1   eth.BlockID
+	finalizedTs uint64
+	// requiredL1 is the L1 data the disputed timestamps need. Defaults to well below
+	// currentL1, as it is for a finalized timestamp on a live chain.
+	requiredL1 eth.BlockID
+}
+
+func (s *stubSyncedSuperNode) SuperRootAtTimestamp(_ context.Context, timestamp uint64) (eth.SuperRootAtTimestampResponse, error) {
+	chainID := eth.ChainIDFromUInt64(10)
+	resp := eth.SuperRootAtTimestampResponse{
+		CurrentL1:                 s.currentL1,
+		CurrentFinalizedTimestamp: s.finalizedTs,
+		ChainIDs:                  []eth.ChainID{chainID},
+		OptimisticAtTimestamp:     map[eth.ChainID]eth.OutputWithRequiredL1{},
+	}
+	if timestamp > s.finalizedTs {
+		return resp, nil
+	}
+	output := &eth.OutputV0{BlockHash: common.Hash{byte(timestamp)}}
+	requiredL1 := s.requiredL1
+	if requiredL1 == (eth.BlockID{}) {
+		requiredL1 = eth.BlockID{Number: s.currentL1.Number - 100, Hash: common.Hash{0xbb}}
+	}
+	resp.OptimisticAtTimestamp[chainID] = eth.OutputWithRequiredL1{
+		Output:     output,
+		OutputRoot: eth.OutputRoot(output),
+		RequiredL1: requiredL1,
+	}
+	super := eth.NewSuperV1(timestamp, eth.ChainIDAndOutput{ChainID: chainID, Output: eth.OutputRoot(output)})
+	resp.Data = &eth.SuperRootResponseData{
+		VerifiedRequiredL1: requiredL1,
+		Super:              super,
+		SuperRoot:          eth.SuperRoot(super),
+	}
+	return resp, nil
+}
+
+// The game L1 head must be one the node has fully processed, otherwise the trace provider's
+// sync gate (which requires CurrentL1 > l1Head) rejects every claim as ErrNotInSync.
+func TestCreateGameInputsInteropBuildsInputsFromSyncedNode(t *testing.T) {
+	logger := testlog.Logger(t, log.LvlInfo)
+	currentL1 := eth.BlockID{Number: 5000, Hash: common.Hash{0xaa}}
+	client := &stubSyncedSuperNode{currentL1: currentL1, finalizedTs: 9000}
+
+	// The run picks one of three trace positions at random; all must build inputs.
+	for i := 0; i < 20; i++ {
+		l1 := &stubL1Headers{}
+		inputs, err := createGameInputsInterop(context.Background(), logger, client, l1, "test")
+		require.NoError(t, err)
+		require.NotEmpty(t, inputs.AgreedPreState)
+		require.NotEqual(t, common.Hash{}, inputs.L2Claim)
+		require.NotEqual(t, eth.InvalidTransitionHash, inputs.L2Claim,
+			"a sentinel claim means the FPP is asked to prove nothing")
+		require.Equal(t, new(big.Int).SetUint64(client.finalizedTs+10), inputs.L2SequenceNumber)
+		require.Equal(t, []uint64{currentL1.Number - 1}, l1.requested,
+			"game L1 head must be the highest fully processed block, not CurrentL1 itself")
+		require.Equal(t, l1.header(currentL1.Number-1).Hash(), inputs.L1Head)
+	}
+}
+
+// The other edge of the window: an L1 head below the L1 data the disputed timestamps need
+// makes every claim the InvalidTransition sentinel. That builds inputs without error, so the
+// run goes green having proven nothing - the reason the assertion above checks the sentinel
+// rather than just a non-zero claim.
+func TestCreateGameInputsInteropClaimsSentinelWhenL1HeadBelowRequiredL1(t *testing.T) {
+	logger := testlog.Logger(t, log.LvlInfo)
+	currentL1 := eth.BlockID{Number: 5000, Hash: common.Hash{0xaa}}
+	client := &stubSyncedSuperNode{
+		currentL1:   currentL1,
+		finalizedTs: 9000,
+		requiredL1:  eth.BlockID{Number: currentL1.Number + 5, Hash: common.Hash{0xcc}},
+	}
+
+	for i := 0; i < 20; i++ {
+		inputs, err := createGameInputsInterop(context.Background(), logger, client, &stubL1Headers{}, "test")
+		require.NoError(t, err)
+		require.Equal(t, eth.InvalidTransitionHash, inputs.L2Claim)
+	}
+}
+
+// The game L1 head needs a working L1 client to resolve its hash. A lookup failure must
+// surface, not leave the run to fall back on an unusable head.
+func TestCreateGameInputsInteropL1LookupFailure(t *testing.T) {
+	logger := testlog.Logger(t, log.LvlInfo)
+	client := &stubSyncedSuperNode{currentL1: eth.BlockID{Number: 5000}, finalizedTs: 9000}
+	boom := errors.New("l1 unavailable")
+
+	_, err := createGameInputsInterop(context.Background(), logger, client, &stubL1Headers{err: boom}, "test")
+	require.ErrorIs(t, err, boom)
+	require.ErrorContains(t, err, "failed to fetch l1 head at block 4999")
 }

--- a/op-challenger/runner/runner.go
+++ b/op-challenger/runner/runner.go
@@ -145,7 +145,7 @@ func (r *Runner) Start(ctx context.Context) error {
 	return nil
 }
 
-func (r *Runner) loop(ctx context.Context, runConfig RunConfig, rollupClient *sources.RollupClient, superRoots super.SuperNodeRootProvider, l1EthClient *ethclient.Client, caller *batching.MultiCaller) {
+func (r *Runner) loop(ctx context.Context, runConfig RunConfig, rollupClient *sources.RollupClient, superRoots super.SuperNodeRootProvider, l1EthClient l1BlockHashSource, caller *batching.MultiCaller) {
 	defer r.wg.Done()
 	t := time.NewTicker(1 * time.Minute)
 	defer t.Stop()
@@ -160,7 +160,7 @@ func (r *Runner) loop(ctx context.Context, runConfig RunConfig, rollupClient *so
 	}
 }
 
-func (r *Runner) runAndRecordOnce(ctx context.Context, rlog log.Logger, runConfig RunConfig, rollupClient *sources.RollupClient, superRoots super.SuperNodeRootProvider, l1EthClient *ethclient.Client, caller *batching.MultiCaller) {
+func (r *Runner) runAndRecordOnce(ctx context.Context, rlog log.Logger, runConfig RunConfig, rollupClient *sources.RollupClient, superRoots super.SuperNodeRootProvider, l1EthClient l1BlockHashSource, caller *batching.MultiCaller) {
 	recordError := func(err error, configName string, m Metricer, log log.Logger) {
 		if errors.Is(err, ErrUnexpectedStatusCode) {
 			log.Error("Incorrect status code", "type", runConfig.Name, "err", err)


### PR DESCRIPTION
The vm runner's interop (`super-cannon-kona`) game inputs took the game L1 head from the node's `CurrentL1`, then handed it to a trace provider that only serves claims when `CurrentL1` is strictly *above* the game L1 head. Every run therefore failed with `local node too far behind` unless an L1 block happened to land in the few milliseconds between the two RPCs.

This surfaced when the first interop prestate (`kona-v1.7.0-rc.1-interop`) was enabled on the mainnet and sepolia runners. The bug itself dates from #20687, which tightened the provider's sync gate from `<` to `<=` and deliberately left the runner's game-input generation alone, on the reasoning that its downstream logic compensated for an L1 head one block high. Nothing compensated — the interop run config just wasn't enabled anywhere until now.

## Changes

- Take the game L1 head from the block below `CurrentL1`, the highest one the node has fully processed, so the sync gate passes deterministically instead of by winning a race
- Narrow the runner's L1 client parameter to an `l1BlockHashSource` interface so the interop path is testable (structural, no behaviour change)
- Reject inputs whose claim is the `InvalidTransition` sentinel. The trace provider returns it *without error* when the L1 head cannot support a real transition, because in a real game that is the honest claim — but as a runner input it means the FPP proves it trivially and the run reports success having exercised no derivation

`TestCreateGameInputsInteropBuildsInputsFromSyncedNode` fails with `local node too far behind` against a perfectly synced stub node before the fix, and passes after.
