### PR TITLE
kona-client: Skip consolidation when interop is inactive

### DIFF
--- a/rust/kona/bin/client/src/interop/consolidate.rs
+++ b/rust/kona/bin/client/src/interop/consolidate.rs
@@ -13,7 +13,7 @@ use kona_executor::TrieDBProvider;
 use kona_preimage::{HintWriterClient, PreimageOracleClient};
 use kona_proof::{CachingOracle, l2::OracleL2ChainProvider};
 use kona_proof_interop::{
-    BootInfo, HintType, OracleInteropProvider, PreState, SuperchainConsolidator,
+    BootInfo, HintType, OracleInteropProvider, PreState, SuperchainConsolidator, TransitionState,
 };
 use kona_registry::{HashMap, ROLLUP_CONFIGS, RollupConfig};
 use op_alloy_consensus::{OpReceiptEnvelope, OpTxEnvelope};
@@ -26,6 +26,9 @@ use tracing::{error, info};
 ///
 /// This phase is responsible for checking the dependencies between [OptimisticBlock]s in the
 /// superchain and ensuring that all dependencies are satisfied.
+///
+/// Consolidation only applies once the Lagoon (interop) hardfork is active. Before activation the
+/// optimistic outputs pass through unchanged and the super root is finalized directly.
 ///
 /// [OptimisticBlock]: kona_proof_interop::OptimisticBlock
 pub(crate) async fn consolidate_dependencies<P, H, Evm>(
@@ -46,14 +49,32 @@ where
             Receipt = OpReceiptEnvelope,
         >,
 {
-    info!(target: "client_interop", "Deriving local-safe headers from prestate");
-
     // Ensure that the pre-state is a transition state. It is invalid to pass a non-transition state
     // to this function, as it will not have the required information to derive the local-safe
     // headers for the next super root.
-    let PreState::TransitionState(ref transition_state) = boot.agreed_pre_state else {
+    let PreState::TransitionState(transition_state) = &boot.agreed_pre_state else {
         return Err(FaultProofProgramError::StateTransitionFailed);
     };
+
+    let consolidation_timestamp = transition_state.pre_state.timestamp + 1;
+
+    // An optimisation: the CrossL2Inbox predeploy has no code before interop activates, so no
+    // executing message can exist. Keeps in-development interop code fully off.
+    if !interop_active_for_consolidation(
+        &boot.rollup_configs,
+        transition_state,
+        consolidation_timestamp,
+    ) {
+        info!(
+            target: "client_interop",
+            timestamp = consolidation_timestamp,
+            chains = transition_state.pending_progress.len(),
+            "Interop inactive on every chain in the transition state; skipping consolidation",
+        );
+        return finalize_super_root(boot);
+    }
+
+    info!(target: "client_interop", "Deriving local-safe headers from prestate");
 
     // Collect the cross-safe output roots and local-safe block hashes from the transition state.
     let transition_meta = transition_state
@@ -75,9 +96,7 @@ where
         .await?;
 
         // Fetch the rollup config for the given L2 chain ID.
-        let rollup_config = ROLLUP_CONFIGS
-            .get(&cross_safe_output.chain_id)
-            .or_else(|| boot.rollup_configs.get(&cross_safe_output.chain_id))
+        let rollup_config = rollup_config_for(&boot.rollup_configs, cross_safe_output.chain_id)
             .ok_or(FaultProofProgramError::MissingRollupConfig(cross_safe_output.chain_id))?;
 
         // Initialize the local provider for the current L2 chain.
@@ -122,6 +141,12 @@ where
         .consolidate()
         .await?;
 
+    finalize_super_root(boot)
+}
+
+/// Finalizes a saturated transition state into the super root at the next timestamp, and validates
+/// it against the claimed post-state.
+fn finalize_super_root(boot: BootInfo) -> Result<(), FaultProofProgramError> {
     // Transition to the Super Root at the next timestamp.
     let post = boot
         .agreed_pre_state
@@ -146,4 +171,151 @@ where
         "Super root validation succeeded"
     );
     Ok(())
+}
+
+/// Resolves the [`RollupConfig`] for `chain_id`, preferring the bundled superchain registry.
+///
+/// Matches the order the message validity rules use, so the gate reads the config they read.
+fn rollup_config_for(
+    local_configs: &HashMap<u64, RollupConfig>,
+    chain_id: u64,
+) -> Option<&RollupConfig> {
+    ROLLUP_CONFIGS.get(&chain_id).or_else(|| local_configs.get(&chain_id))
+}
+
+/// Returns `true` when the Lagoon (interop) hardfork is active at `timestamp` on any chain in the
+/// transition state.
+///
+/// A chain with no resolvable config counts as active, so consolidation proceeds and reports the
+/// missing config exactly where it did before.
+fn interop_active_for_consolidation(
+    local_configs: &HashMap<u64, RollupConfig>,
+    transition_state: &TransitionState,
+    timestamp: u64,
+) -> bool {
+    transition_state.pre_state.output_roots.iter().any(|output_root| {
+        rollup_config_for(local_configs, output_root.chain_id)
+            .is_none_or(|config| config.is_interop_active(timestamp))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec::Vec;
+    use alloy_primitives::B256;
+    use kona_genesis::HardForkConfig;
+    use kona_interop::{OutputRootWithChain, SuperRoot};
+    use kona_proof_interop::{OptimisticBlock, TRANSITION_STATE_MAX_STEPS};
+
+    /// Chain IDs absent from the bundled superchain registry, so the tests set their own
+    /// activation times.
+    const CHAIN_A: u64 = 0xdead_0001;
+    const CHAIN_B: u64 = 0xdead_0002;
+
+    /// The pre-state timestamp. Consolidation finalizes the root at `PRE_TIMESTAMP + 1`.
+    const PRE_TIMESTAMP: u64 = 99;
+
+    fn configs(
+        entries: impl IntoIterator<Item = (u64, Option<u64>)>,
+    ) -> HashMap<u64, RollupConfig> {
+        entries
+            .into_iter()
+            .map(|(chain_id, lagoon_time)| {
+                let config = RollupConfig {
+                    hardforks: HardForkConfig { lagoon_time, ..Default::default() },
+                    ..Default::default()
+                };
+                (chain_id, config)
+            })
+            .collect()
+    }
+
+    /// Builds the saturated transition state that consolidation always receives.
+    fn saturated_transition_state(chain_ids: impl IntoIterator<Item = u64>) -> TransitionState {
+        let output_roots = chain_ids
+            .into_iter()
+            .map(|chain_id| OutputRootWithChain::new(chain_id, B256::ZERO))
+            .collect::<Vec<_>>();
+        let pending_progress =
+            output_roots.iter().map(|_| OptimisticBlock::new(B256::ZERO, B256::ZERO)).collect();
+        TransitionState::new(
+            SuperRoot::new(PRE_TIMESTAMP, output_roots),
+            pending_progress,
+            TRANSITION_STATE_MAX_STEPS,
+        )
+    }
+
+    fn interop_active(
+        local: &HashMap<u64, RollupConfig>,
+        chain_ids: impl IntoIterator<Item = u64>,
+        timestamp: u64,
+    ) -> bool {
+        interop_active_for_consolidation(local, &saturated_transition_state(chain_ids), timestamp)
+    }
+
+    #[test]
+    fn test_inactive_when_lagoon_unscheduled() {
+        // `lagoon_time = None` is never active, at any timestamp.
+        let local = configs([(CHAIN_A, None), (CHAIN_B, None)]);
+        assert!(!interop_active(&local, [CHAIN_A, CHAIN_B], u64::MAX));
+    }
+
+    #[test]
+    fn test_inactive_before_activation() {
+        let local = configs([(CHAIN_A, Some(PRE_TIMESTAMP + 2))]);
+        assert!(!interop_active(&local, [CHAIN_A], PRE_TIMESTAMP + 1));
+    }
+
+    #[test]
+    fn test_active_at_activation_timestamp() {
+        // The activation timestamp must still consolidate, so the per-message rules can reject it
+        // via `is_first_interop_block`.
+        let local = configs([(CHAIN_A, Some(PRE_TIMESTAMP + 1))]);
+        assert!(interop_active(&local, [CHAIN_A], PRE_TIMESTAMP + 1));
+    }
+
+    #[test]
+    fn test_active_after_activation() {
+        let local = configs([(CHAIN_A, Some(PRE_TIMESTAMP))]);
+        assert!(interop_active(&local, [CHAIN_A], PRE_TIMESTAMP + 1));
+    }
+
+    #[test]
+    fn test_active_when_any_chain_is_active() {
+        // An active chain can hold a message referencing the inactive one. Both orderings assert
+        // the result does not depend on which chain is read first.
+        let local = configs([(CHAIN_A, None), (CHAIN_B, Some(PRE_TIMESTAMP))]);
+        assert!(interop_active(&local, [CHAIN_A, CHAIN_B], PRE_TIMESTAMP + 1));
+        assert!(interop_active(&local, [CHAIN_B, CHAIN_A], PRE_TIMESTAMP + 1));
+    }
+
+    #[test]
+    fn test_unresolvable_config_counts_as_active() {
+        // Consolidating raises `MissingRollupConfig`; skipping would swallow it.
+        let local = configs([(CHAIN_A, None)]);
+        assert!(interop_active(&local, [CHAIN_A, CHAIN_B], PRE_TIMESTAMP + 1));
+    }
+
+    #[test]
+    fn test_empty_transition_state_is_inactive() {
+        assert!(!interop_active(&configs([]), [], PRE_TIMESTAMP + 1));
+    }
+
+    #[test]
+    fn test_rollup_config_prefers_the_bundled_registry() {
+        // The registry entry must win over a conflicting oracle-supplied config.
+        let registry_chain = *ROLLUP_CONFIGS.keys().next().expect("registry is not empty");
+        let local = configs([(registry_chain, Some(1))]);
+
+        let resolved = rollup_config_for(&local, registry_chain).unwrap();
+        assert_eq!(resolved, ROLLUP_CONFIGS.get(&registry_chain).unwrap());
+    }
+
+    #[test]
+    fn test_rollup_config_falls_back_to_oracle_supplied_config() {
+        let local = configs([(CHAIN_A, Some(42))]);
+        let config = rollup_config_for(&local, CHAIN_A).unwrap();
+        assert_eq!(config.hardforks.lagoon_time, Some(42));
+    }
 }


### PR DESCRIPTION
The interop consolidation step dispatched purely on the transition state's step counter, so it built a `MessageGraph` and walked every local-safe receipts trie through the preimage oracle even when the Lagoon hardfork was not active on any chain. This gates the graph on interop activation at the timestamp being finalized; when no covered chain is active it transitions the saturated state to the next super root and checks it against the claim.

This is an optimisation and a clean off-switch, not a fix. No behaviour change is expected: the `CrossL2Inbox` predeploy has no code before interop activates, so no block can emit an executing message and the graph has nothing to find. Interop is still in development, so keeping its code fully off removes any risk of bugs in it affecting chains that have not activated. The skip path issues no oracle reads at all — on op-sepolia, which has no `lagoon_time`, the consolidate step drops from ~6.22e6 MIPS steps to nothing. I found this running `op-challenger run-trace` against a kona-interop prestate there: every consolidate run walked the receipts trie to discover there was nothing to consolidate.

The gate uses `is_interop_active`, not the stricter `interop_active_for_full_block`, so the activation timestamp itself still consolidates and the per-message rules keep rejecting via `is_first_interop_block`. A chain whose rollup config cannot be resolved counts as active, so consolidation proceeds and raises `MissingRollupConfig` from the same place it always did.

**Effect on users:** none expected. The interop-active path is untouched. This changes the FPP, so it needs a new absolute prestate.

Worth a reviewer's attention: the skip path no longer fetches the cross-safe output-root preimages or the local-safe headers, so a prestate with unavailable block data now returns `Ok` where it previously errored. Those values never feed the finalized super root, and the pre-state is jointly agreed, so this is unreachable for an honestly agreed prestate — but it is a state-transition change, not purely a speed-up.

`transition_and_check` is now reused for the post-state check instead of the near-identical copy `consolidate_dependencies` carried, so the two cannot drift. It is `pub(super)`, the minimum needed for the sibling module.

For context, the op-program implementation this replaced (`RunConsolidation`, removed in #21271) had no activation gate either, so this logic is new rather than restored.

Ran the `rust-code-reviewer` agent and an adversarial correctness review; neither found a blocking issue. Folded in: the comments originally claimed the pre-activation graph was "edgeless", which is false; the missing-config handling was simplified so the error surfaces from the pre-existing call site rather than the gate; added registry-precedence and post-state-check tests.

Not run: full-workspace `just l`, which fails on pristine `develop` with `missing_const_for_fn` in `kona-derive`, and the full `kona-client` suite, blocked by the pre-existing slow `fpvm_evm::precompiles::bls12_*` tests. Verified instead: `cargo clippy -p kona-client --all-targets --no-deps -- -D warnings` green, nightly fmt clean, and 11 new tests plus `interop_trace_extension` (6), `kona-proof-interop` and `kona-interop` (84) passing.