### PR TITLE
kona-genesis: Add the genesis offset to the block number from a timestamp

### DIFF
--- a/rust/kona/crates/protocol/genesis/src/rollup.rs
+++ b/rust/kona/crates/protocol/genesis/src/rollup.rs
@@ -371,13 +371,14 @@ impl RollupConfig {
         self.hardforks
     }
 
-    /// Computes a block number from a timestamp, relative to the L2 genesis time and the block
-    /// time.
+    /// Computes the absolute L2 block number that a timestamp falls in.
     ///
-    /// This function assumes that the timestamp is aligned with the block time, and uses floor
-    /// division in its computation.
+    /// The computation uses floor division. A timestamp between two blocks therefore resolves
+    /// to the earlier block.
     pub const fn block_number_from_timestamp(&self, timestamp: u64) -> u64 {
-        timestamp.saturating_sub(self.genesis.l2_time).saturating_div(self.block_time)
+        self.genesis.l2.number.saturating_add(
+            timestamp.saturating_sub(self.genesis.l2_time).saturating_div(self.block_time),
+        )
     }
 
     /// Checks the scalar value in Ecotone.
@@ -481,7 +482,6 @@ impl OpHardforks for RollupConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
-    #[cfg(feature = "serde")]
     use alloy_eips::BlockNumHash;
     use alloy_primitives::address;
     #[cfg(feature = "serde")]
@@ -1056,6 +1056,28 @@ mod tests {
 
         assert_eq!(cfg.block_number_from_timestamp(20), 5);
         assert_eq!(cfg.block_number_from_timestamp(30), 10);
+    }
+
+    #[test]
+    fn test_compute_block_number_from_time_non_zero_genesis() {
+        // OP Mainnet, whose L2 genesis is the last block of the legacy OVM chain.
+        let cfg = RollupConfig {
+            genesis: ChainGenesis {
+                l2: BlockNumHash { number: 105235063, ..Default::default() },
+                l2_time: 1686068903,
+                ..Default::default()
+            },
+            block_time: 2,
+            ..Default::default()
+        };
+
+        assert_eq!(cfg.block_number_from_timestamp(1686068903), 105235063);
+        assert_eq!(cfg.block_number_from_timestamp(1686068905), 105235064);
+        // 1788303126 falls between two blocks.
+        assert_eq!(cfg.block_number_from_timestamp(1788303126), 156352174);
+        assert_eq!(cfg.block_number_from_timestamp(1788303127), 156352175);
+        // A timestamp before genesis clamps to the genesis block.
+        assert_eq!(cfg.block_number_from_timestamp(0), 105235063);
     }
 
     #[cfg(feature = "rollup_config_override")]


### PR DESCRIPTION
`RollupConfig::block_number_from_timestamp` returned the count of L2 blocks elapsed since L2 genesis, not the absolute L2 block number. It was therefore wrong by `genesis.l2.number` on every chain migrated from a legacy chain. Its only caller is the interop host's `L2OutputRoot` hint handler, which resolves the agreed super root to an L2 block and then asks the L2 node for that block's header and message-passer proof.

On OP Mainnet the helper returns a pre-Bedrock block number. `eth_getProof` for such a block fails with "no state found", so the host retries the hint for ever and the proof never advances. This hangs every interop run of the op-challenger VM runner against OP Mainnet today, and it would break interop fault proofs on any migrated chain in the same way. Both the derivation sub-transition and the consolidation step reach this hint, so no interop sub-problem can be proven. Chains whose genesis block number is 0 — every devnet and test chain — are unaffected, which is why the existing unit test could not see the fault.

The helper now matches `Config.TargetBlockNumber` in `op-node/rollup/types.go`.

Reviewer notes. Two non-blocking findings from review that I left alone as out of scope:

- Unlike the Go reference, the helper stays infallible and clamps a pre-genesis timestamp to the genesis block instead of returning an error. The previous code clamped to 0, so this is not a regression, and keeping a `const fn` is worth more than the error.
- `saturating_div` still panics when `block_time` is 0. Only a default-constructed config produces that.

Conflict warning: the draft PR #22671 changes this same function to return `Option<u64>` and keeps the missing genesis offset. Whoever rebases second must keep both changes.
