### PR TITLE
op-challenger: record a stuck VM run as a timeout, not a setup failure

### DIFF
--- a/op-challenger/runner/runner.go
+++ b/op-challenger/runner/runner.go
@@ -225,14 +225,27 @@ func (r *Runner) runOnce(ctx context.Context, logger log.Logger, name string, ga
 		ctx, cancel = context.WithTimeout(ctx, r.vmTimeout)
 		defer cancel()
 	}
+	// The VM timeout is enforced by killing the VM's process group, so exec reports an
+	// *exec.ExitError ("signal: killed") and Cmd.Wait discards the context error. Testing
+	// the returned error for context.DeadlineExceeded therefore never matches and a stuck
+	// run gets recorded as a setup failure. Classify on the deadline instead of the error.
+	asTimeout := func(err error) error {
+		if !errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return nil
+		}
+		return fmt.Errorf("%w after %v: %w", ErrVMTimeout, r.vmTimeout, errors.Join(err, ctx.Err()))
+	}
 	provider, err := r.traceProviderCreator(ctx, logger, metrics.NewTypedVmMetrics(r.m, name), r.cfg, prestateSource, gameType, localInputs, dir)
 	if err != nil {
+		if timedOut := asTimeout(err); timedOut != nil {
+			return timedOut
+		}
 		return fmt.Errorf("failed to create trace provider: %w", err)
 	}
 	hash, err := provider.Get(ctx, types.RootPosition)
 	if err != nil {
-		if errors.Is(err, context.DeadlineExceeded) {
-			return fmt.Errorf("%w: %w", ErrVMTimeout, err)
+		if timedOut := asTimeout(err); timedOut != nil {
+			return timedOut
 		}
 		return fmt.Errorf("failed to execute trace provider: %w", err)
 	}

--- a/op-challenger/runner/runner_test.go
+++ b/op-challenger/runner/runner_test.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -93,12 +94,16 @@ func (s *stubTraceProvider) GetL2BlockNumberChallenge(_ context.Context) (*types
 	return nil, types.ErrL2BlockNumberValid
 }
 
+// errVMKilled is what a real run reports when the VM timeout fires: the VM's process group
+// is killed, so exec surfaces an *exec.ExitError and Cmd.Wait discards the context error.
+var errVMKilled = errors.New("signal: killed")
+
 // slowTraceProvider blocks until context is done, simulating a slow VM
 type slowTraceProvider struct{}
 
 func (s *slowTraceProvider) Get(ctx context.Context, _ types.Position) (common.Hash, error) {
 	<-ctx.Done()
-	return common.Hash{}, ctx.Err()
+	return common.Hash{}, errVMKilled
 }
 
 func (s *slowTraceProvider) GetStepData(_ context.Context, _ types.Position) ([]byte, []byte, *types.PreimageOracleData, error) {
@@ -135,4 +140,54 @@ func TestRunOnceReturnsTimeoutError(t *testing.T) {
 	err := r.runOnce(context.Background(), log.New(), "test", gameTypes.CannonGameType, nil, utils.LocalGameInputs{}, "")
 	require.ErrorIs(t, err, ErrVMTimeout)
 	require.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestRunOnceReturnsTimeoutErrorWhenCreatingTraceProvider(t *testing.T) {
+	slowCreator := func(
+		ctx context.Context,
+		_ log.Logger,
+		_ vm.Metricer,
+		_ *config.Config,
+		_ prestateFetcher,
+		_ gameTypes.GameType,
+		_ utils.LocalGameInputs,
+		_ string,
+	) (types.TraceProvider, error) {
+		<-ctx.Done()
+		return nil, errVMKilled
+	}
+
+	r := &Runner{
+		vmTimeout:            50 * time.Millisecond,
+		traceProviderCreator: slowCreator,
+	}
+
+	err := r.runOnce(context.Background(), log.New(), "test", gameTypes.CannonGameType, nil, utils.LocalGameInputs{}, "")
+	require.ErrorIs(t, err, ErrVMTimeout)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestRunOnceDoesNotReportTimeoutForOtherFailures(t *testing.T) {
+	expectedErr := errors.New("boom")
+	failingCreator := func(
+		_ context.Context,
+		_ log.Logger,
+		_ vm.Metricer,
+		_ *config.Config,
+		_ prestateFetcher,
+		_ gameTypes.GameType,
+		_ utils.LocalGameInputs,
+		_ string,
+	) (types.TraceProvider, error) {
+		return nil, expectedErr
+	}
+
+	r := &Runner{
+		vmTimeout:            time.Minute,
+		traceProviderCreator: failingCreator,
+	}
+
+	err := r.runOnce(context.Background(), log.New(), "test", gameTypes.CannonGameType, nil, utils.LocalGameInputs{}, "")
+	require.ErrorIs(t, err, expectedErr)
+	require.NotErrorIs(t, err, ErrVMTimeout)
 }


### PR DESCRIPTION
## Description

A stuck VM run in the challenger runner was being recorded as a *setup* failure instead of a VM failure ([thread](https://github.com/ethereum-optimism/optimism/pull/22732)-adjacent report from @ajsutton: "this is getting stuck but being reported as a setup failure").

Root cause: `runOnce` mapped a timeout to `ErrVMTimeout` only when `errors.Is(err, context.DeadlineExceeded)`. That never matches in practice. The VM timeout cancels the run's context, `RunCmd` sets `cmd.Cancel` to kill the VM's whole process group, and `Cmd.Wait` prefers the process's own exit error — so `cmd.Run()` returns an `*exec.ExitError` ("signal: killed") and the context error is discarded. Exit code is `-1`, not `2`, so it isn't `ErrVMPanic` either, and it falls through to the catch-all `else if err != nil` in `recordError` → `RecordSetupFailure`.

That misclassification is why nobody got paged. `challenger-runner-vm-failure` fires on any increase in `vm_failures_total[1h]`; `challenger-runner-setup-failure` needs `consecutive_setup_failures_current > 10` sustained for 30m. With the default 3h `--vm-timeout`, 11 consecutive stuck runs is ~33h before the alert window even opens.

## Changes

- Classify on the context's deadline state (`errors.Is(ctx.Err(), context.DeadlineExceeded)`) rather than the identity of the returned error. The original error is joined in so it still appears in logs and `ErrorIs` checks.
- Apply the same check to `traceProviderCreator`, not just `provider.Get` — a hang fetching the prestate was also being counted as a setup failure.
- `runner_test.go`'s `slowTraceProvider` returned `ctx.Err()` directly, which no real provider does; that is why the old check looked covered. It now returns the error a killed VM actually produces, plus tests for the provider-creation timeout and for a non-timeout failure still being reported as-is.

## Tests

Unit tests in `op-challenger/runner/runner_test.go`. I could not run `go test` in this sandbox (no Go toolchain, ~1Gi disk), so CI is the first real execution of these tests.

## Additional context

Not changed here, but worth a follow-up: `challenger-runner-setup-failure` in `ethereum-optimism/k8s` (`grafana-cloud/terraform-rules/challenger.yaml`) is far less sensitive than the VM-failure alert, so genuine setup failures still take ~a day of 3h runs to notify.

## Metadata

Prompted by: @pauldowman
