### PR TITLE
kona-sp1-proposer: right-size SPN submission parameters

### DIFF
--- a/rust/kona/sp1/README.md
+++ b/rust/kona/sp1/README.md
@@ -225,10 +225,10 @@ Optional core and operational configuration:
 | `KONA_SP1_PROPOSER_FETCH_INTERVAL` | loop interval in seconds (default `30`) |
 | `KONA_SP1_PROPOSER_METRICS_PORT` | `0` disables metrics; `auto` selects a free port (default `0`) |
 | `KONA_SP1_PROPOSER_SYNC_L1_CONFIRMATIONS` | L1 confirmation lag for pinned reads (default `0`) |
-| `KONA_SP1_PROPOSER_TX_CONFIRMATION_TIMEOUT` | transaction confirmation timeout in seconds (default `60`) |
+| `KONA_SP1_PROPOSER_TX_CONFIRMATION_TIMEOUT` | transaction confirmation timeout in seconds (default `180`) |
 | `KONA_SP1_PROPOSER_MAX_FEE_PER_GAS` | L1 max-fee cap in wei (default uncapped) |
 | `KONA_SP1_PROPOSER_MAX_PRIORITY_FEE_PER_GAS` | L1 priority-fee cap in wei (default uncapped) |
-| `KONA_SP1_PROPOSER_RANGE_SPLIT_COUNT` | chunks per defended span (default `1`, maximum `16`) |
+| `KONA_SP1_PROPOSER_RANGE_SPLIT_COUNT` | chunks per defended span (default and maximum `16`) |
 | `KONA_SP1_PROPOSER_MAX_CONCURRENT_RANGE_PROOFS` | child-proof concurrency per game (default `1`) |
 | `KONA_SP1_PROPOSER_MAX_CONCURRENT_DEFENSE_TASKS` | concurrent defended games (default `8`, minimum `1`) |
 | `KONA_SP1_PROPOSER_FAST_FINALITY_MODE` | prove signer-created owned games while unchallenged (default `false`) |
@@ -243,24 +243,31 @@ SP1 network configuration applies when `KONA_SP1_PROPOSER_PROOF_PROVIDER=network
 | `KONA_SP1_PROPOSER_USE_KMS_REQUESTER` | use AWS KMS for request signing (default `false`) |
 | `KONA_SP1_PROPOSER_RANGE_PROOF_STRATEGY` | range fulfillment strategy (default `auction`) |
 | `KONA_SP1_PROPOSER_AGG_PROOF_STRATEGY` | aggregation fulfillment strategy (default `auction`) |
-| `KONA_SP1_PROPOSER_SP1_TIMEOUT_SECONDS` | overall proof timeout (default `14400`) |
+| `KONA_SP1_PROPOSER_SP1_TIMEOUT_SECONDS` | per-proof request deadline and client wait (default `7200`) |
 | `KONA_SP1_PROPOSER_NETWORK_CALLS_TIMEOUT` | individual network-call timeout (default `15`) |
 | `KONA_SP1_PROPOSER_AUCTION_TIMEOUT` | unassigned mainnet request timeout (default `300`) |
 | `KONA_SP1_PROPOSER_RANGE_CYCLE_LIMIT` | range request cycle limit (default `1e12`) |
-| `KONA_SP1_PROPOSER_RANGE_GAS_LIMIT` | range request gas limit (default `1e12`) |
+| `KONA_SP1_PROPOSER_RANGE_GAS_LIMIT` | range request gas limit (default `200000000000`) |
 | `KONA_SP1_PROPOSER_AGG_CYCLE_LIMIT` | aggregation request cycle limit (default `1e12`) |
-| `KONA_SP1_PROPOSER_AGG_GAS_LIMIT` | aggregation request gas limit (default `1e12`) |
-| `KONA_SP1_PROPOSER_MAX_PRICE_PER_PGU` | maximum price per proving gas unit (default `1e9`, i.e. 1.0 PROVE per billion PGU) |
+| `KONA_SP1_PROPOSER_AGG_GAS_LIMIT` | aggregation request gas limit (default `1000000000`) |
+| `KONA_SP1_PROPOSER_MAX_PRICE_PER_PGU` | optional maximum price per proving gas unit; unset, empty, or `0` uses mainnet auction pricing |
 | `KONA_SP1_PROPOSER_MIN_AUCTION_PERIOD` | minimum auction period in seconds (default `30`) |
 
-`MAX_PRICE_PER_PGU` is a ceiling, not the price paid: the auction settles at the
-winning bid, which tracks the network's clearing price. A ceiling *below* that
-price leaves a request unbid until its deadline. Expiry makes the request
-retryable, so the next game attempt may submit a new auction.
+For mainnet auctions, the SP1 SDK derives the request ceiling from the network's
+published price with its 120% buffer and auction-tick rounding. A positive
+`MAX_PRICE_PER_PGU` replaces that dynamic ceiling exactly. It remains a ceiling,
+not the price paid: the auction settles at the winning bid. A ceiling below the
+clearing price leaves a request unbid until its deadline. Expiry makes the
+request retryable, so the next game attempt may submit a new auction.
 `MIN_AUCTION_PERIOD` is a floor every request waits out, so it needs to cover bid
 arrival (3-10s) and no more. It must leave assignment margin under
 `AUCTION_TIMEOUT`; cancellation retries the unfinished request while completed
 chunks remain cached when the proving inputs are unchanged.
+
+A defended span produces up to 16 chunks. Each sufficiently large chunk can
+require a range proof and a consolidation proof, for up to 32 compressed child
+proofs before the final PLONK aggregation proof. `SP1_TIMEOUT_SECONDS` applies
+independently to each proof request, not to the complete defense.
 
 Transaction signing requires one of these configurations:
 

--- a/rust/kona/sp1/crates/proposer/src/config.rs
+++ b/rust/kona/sp1/crates/proposer/src/config.rs
@@ -225,7 +225,7 @@ impl ProposerConfig {
     /// Parses the configuration from environment variables, applying defaults
     /// for optional settings and failing on missing or invalid required ones.
     pub fn from_env() -> Result<Self> {
-        let tx_confirmation_timeout = parsed_env_or("TX_CONFIRMATION_TIMEOUT", 60u64)?;
+        let tx_confirmation_timeout = parsed_env_or("TX_CONFIRMATION_TIMEOUT", 180u64)?;
         anyhow::ensure!(
             tx_confirmation_timeout > 0,
             "{} must be positive (0 would time out every transaction immediately)",
@@ -267,7 +267,11 @@ impl ProposerConfig {
                 .map(|list| list.split(',').map(|path| PathBuf::from(path.trim())).collect()),
             l1_config_path: optional_env("L1_CONFIG_PATH").map(PathBuf::from),
             dependency_set_path: optional_env("DEPENDENCY_SET_PATH").map(PathBuf::from),
-            range_split_count: parsed_env_or("RANGE_SPLIT_COUNT", RangeSplitCount::one())?,
+            range_split_count: parsed_env_or(
+                "RANGE_SPLIT_COUNT",
+                RangeSplitCount::new(RangeSplitCount::MAX)
+                    .expect("maximum is a valid range split count"),
+            )?,
             max_concurrent_range_proofs: parsed_env_or(
                 "MAX_CONCURRENT_RANGE_PROOFS",
                 NonZeroUsize::MIN,
@@ -305,12 +309,9 @@ fn parse_url_list(value: &str) -> Result<Vec<Url>> {
     Ok(urls)
 }
 
-const DEFAULT_PROOF_LIMIT: u64 = 1_000_000_000_000;
-
-/// Ceiling for one request, in wei of PROVE per PGU (1e9 = 1.0 PROVE per bPGU).
-/// A ceiling under the network's clearing price draws no bids at all, and that
-/// price moves, so this sits well above it rather than near it.
-const DEFAULT_MAX_PRICE_PER_PGU: u64 = 1_000_000_000;
+const DEFAULT_PROOF_CYCLE_LIMIT: u64 = 1_000_000_000_000;
+const DEFAULT_RANGE_GAS_LIMIT: u64 = 200_000_000_000;
+const DEFAULT_AGG_GAS_LIMIT: u64 = 1_000_000_000;
 
 /// Floor on how long an auction stays open, so the field can bid and undercut
 /// rather than the fastest poller winning at the ceiling. Observed arrivals are
@@ -331,8 +332,8 @@ const AUCTION_ASSIGNMENT_MARGIN_SECONDS: u64 = 30;
 /// `KONA_SP1_PROPOSER_NETWORK_PRIVATE_KEY` is read only when the network provider is built.
 #[derive(Debug, Clone)]
 pub struct ProofProviderConfig {
-    /// Overall per-proof timeout in seconds: the server-side deadline for
-    /// proof requests and the client-side maximum wait.
+    /// Per-proof timeout in seconds: the server-side deadline for proof
+    /// requests and the client-side maximum wait.
     pub timeout: u64,
     /// Timeout in seconds for individual network API calls (calls exceeding
     /// it are retried).
@@ -352,8 +353,8 @@ pub struct ProofProviderConfig {
     pub agg_cycle_limit: u64,
     /// Gas limit for the aggregation proof request.
     pub agg_gas_limit: u64,
-    /// Maximum price per proving gas unit.
-    pub max_price_per_pgu: u64,
+    /// Optional maximum price per proving gas unit.
+    pub max_price_per_pgu: Option<NonZeroU64>,
     /// Minimum auction period in seconds.
     pub min_auction_period: u64,
 }
@@ -361,7 +362,7 @@ pub struct ProofProviderConfig {
 impl ProofProviderConfig {
     /// Reads proof-provider settings from environment variables.
     pub fn from_env() -> Result<Self> {
-        let timeout = parsed_env_or("SP1_TIMEOUT_SECONDS", 14_400u64)?;
+        let timeout = parsed_env_or("SP1_TIMEOUT_SECONDS", 7_200u64)?;
         anyhow::ensure!(
             timeout > 0,
             "{} must be positive: 0 would stop every proof polling attempt immediately after \
@@ -401,11 +402,12 @@ impl ProofProviderConfig {
             .with_context(|| format!("invalid {}", env_var("RANGE_PROOF_STRATEGY")))?,
             agg_proof_strategy: parse_fulfillment_strategy(env_or("AGG_PROOF_STRATEGY", "auction"))
                 .with_context(|| format!("invalid {}", env_var("AGG_PROOF_STRATEGY")))?,
-            range_cycle_limit: parsed_env_or("RANGE_CYCLE_LIMIT", DEFAULT_PROOF_LIMIT)?,
-            range_gas_limit: parsed_env_or("RANGE_GAS_LIMIT", DEFAULT_PROOF_LIMIT)?,
-            agg_cycle_limit: parsed_env_or("AGG_CYCLE_LIMIT", DEFAULT_PROOF_LIMIT)?,
-            agg_gas_limit: parsed_env_or("AGG_GAS_LIMIT", DEFAULT_PROOF_LIMIT)?,
-            max_price_per_pgu: parsed_env_or("MAX_PRICE_PER_PGU", DEFAULT_MAX_PRICE_PER_PGU)?,
+            range_cycle_limit: parsed_env_or("RANGE_CYCLE_LIMIT", DEFAULT_PROOF_CYCLE_LIMIT)?,
+            range_gas_limit: parsed_env_or("RANGE_GAS_LIMIT", DEFAULT_RANGE_GAS_LIMIT)?,
+            agg_cycle_limit: parsed_env_or("AGG_CYCLE_LIMIT", DEFAULT_PROOF_CYCLE_LIMIT)?,
+            agg_gas_limit: parsed_env_or("AGG_GAS_LIMIT", DEFAULT_AGG_GAS_LIMIT)?,
+            max_price_per_pgu: parsed_optional_env::<u64>("MAX_PRICE_PER_PGU")?
+                .and_then(NonZeroU64::new),
             min_auction_period,
         })
     }
@@ -800,11 +802,12 @@ mod tests {
             assert_eq!(config.superroot_rpcs.len(), 2);
             assert_eq!(config.l2_rpcs.len(), 2);
             assert!(config.rollup_config_paths.is_none());
-            assert_eq!(config.range_split_count, RangeSplitCount::one());
+            assert_eq!(config.tx_confirmation_timeout, 180);
+            assert_eq!(config.range_split_count.to_usize(), 16);
             assert_eq!(config.max_concurrent_defense_tasks.get(), 8);
             assert!(!config.fast_finality_mode);
             assert_eq!(config.fast_finality_proving_limit.get(), 1);
-            assert_eq!(config.proof_provider_config.timeout, 14_400);
+            assert_eq!(config.proof_provider_config.timeout, 7_200);
             assert_eq!(
                 config.proof_provider_config.range_proof_strategy,
                 FulfillmentStrategy::Auction
@@ -812,6 +815,25 @@ mod tests {
             assert_eq!(
                 config.proof_provider_config.agg_proof_strategy,
                 FulfillmentStrategy::Auction
+            );
+            assert_eq!(config.proof_provider_config.range_cycle_limit, 1_000_000_000_000);
+            assert_eq!(config.proof_provider_config.range_gas_limit, 200_000_000_000);
+            assert_eq!(config.proof_provider_config.agg_cycle_limit, 1_000_000_000_000);
+            assert_eq!(config.proof_provider_config.agg_gas_limit, 1_000_000_000);
+            assert_eq!(config.proof_provider_config.max_price_per_pgu, None);
+        }
+
+        /// Zero disables the explicit SPN price ceiling while positive values
+        /// are preserved. Safe under nextest's process-per-test model.
+        #[test]
+        fn max_price_per_pgu_zero_disables_explicit_ceiling() {
+            set_proposer_env("MAX_PRICE_PER_PGU", "0");
+            assert_eq!(ProofProviderConfig::from_env().unwrap().max_price_per_pgu, None);
+
+            set_proposer_env("MAX_PRICE_PER_PGU", "123");
+            assert_eq!(
+                ProofProviderConfig::from_env().unwrap().max_price_per_pgu,
+                NonZeroU64::new(123)
             );
         }
 

--- a/rust/kona/sp1/crates/proposer/src/proposer.rs
+++ b/rust/kona/sp1/crates/proposer/src/proposer.rs
@@ -4060,7 +4060,7 @@ mod tests {
                 range_gas_limit: 1,
                 agg_cycle_limit: 1,
                 agg_gas_limit: 1,
-                max_price_per_pgu: 1,
+                max_price_per_pgu: Some(std::num::NonZeroU64::MIN),
                 min_auction_period: 1,
             },
         }

--- a/rust/kona/sp1/crates/proposer/src/prover/spn.rs
+++ b/rust/kona/sp1/crates/proposer/src/prover/spn.rs
@@ -1,6 +1,6 @@
 //! Succinct Prover Network request submission, polling, and verification.
 
-use std::{future::Future, sync::Arc, time::Duration};
+use std::{future::Future, num::NonZeroU64, sync::Arc, time::Duration};
 
 use anyhow::{Result, bail};
 use async_trait::async_trait;
@@ -14,6 +14,7 @@ use sp1_sdk::{
             GetProofRequestStatusResponse,
             types::{ExecutionStatus, FulfillmentStatus, ProofRequest},
         },
+        prove::NetworkProveBuilder,
     },
 };
 use tokio::time::sleep;
@@ -79,18 +80,17 @@ impl NetworkProverApi for Sp1NetworkProverApi {
         stdin: SP1Stdin,
         config: &ProofProviderConfig,
     ) -> Result<ProofId> {
-        self.prover
+        let request = self
+            .prover
             .prove(proving_key, stdin)
             .compressed()
             .skip_simulation(true)
             .strategy(config.range_proof_strategy)
             .timeout(Duration::from_secs(config.timeout))
             .min_auction_period(config.min_auction_period)
-            .max_price_per_pgu(config.max_price_per_pgu)
             .cycle_limit(config.range_cycle_limit)
-            .gas_limit(config.range_gas_limit)
-            .request()
-            .await
+            .gas_limit(config.range_gas_limit);
+        Self::with_max_price(request, config.max_price_per_pgu).request().await
     }
 
     async fn request_aggregation_proof(
@@ -99,17 +99,16 @@ impl NetworkProverApi for Sp1NetworkProverApi {
         stdin: SP1Stdin,
         config: &ProofProviderConfig,
     ) -> Result<ProofId> {
-        self.prover
+        let request = self
+            .prover
             .prove(proving_key, stdin)
             .mode(SP1ProofMode::Plonk)
             .strategy(config.agg_proof_strategy)
             .timeout(Duration::from_secs(config.timeout))
             .min_auction_period(config.min_auction_period)
-            .max_price_per_pgu(config.max_price_per_pgu)
             .cycle_limit(config.agg_cycle_limit)
-            .gas_limit(config.agg_gas_limit)
-            .request()
-            .await
+            .gas_limit(config.agg_gas_limit);
+        Self::with_max_price(request, config.max_price_per_pgu).request().await
     }
 
     async fn get_proof_status(
@@ -135,6 +134,19 @@ impl NetworkProverApi for Sp1NetworkProverApi {
         Prover::verify(self.prover.as_ref(), proof, verifying_key, None).map_err(anyhow::Error::new)
     }
 }
+
+impl Sp1NetworkProverApi {
+    fn with_max_price(
+        request: NetworkProveBuilder<'_>,
+        max_price_per_pgu: Option<NonZeroU64>,
+    ) -> NetworkProveBuilder<'_> {
+        match max_price_per_pgu {
+            Some(max_price_per_pgu) => request.max_price_per_pgu(max_price_per_pgu.get()),
+            None => request,
+        }
+    }
+}
+
 /// Network-based proof provider using the SP1 prover network.
 #[derive(Clone)]
 pub struct NetworkProofProvider {
@@ -236,10 +248,10 @@ impl NetworkProofProvider {
             "proving timeout exceeded"
         );
         ProposerGauge::ProvingTimeoutError.increment(1.0);
-        let range_split_count = crate::env_var("RANGE_SPLIT_COUNT");
+        let proof_timeout = crate::env_var("SP1_TIMEOUT_SECONDS");
         Err(ProofWaitError::Uncertain(anyhow::anyhow!(
             "proving timeout: proof_id={proof_id}, elapsed={elapsed_secs}s, timeout={}s \
-             (consider increasing {range_split_count} to shrink per-proof workloads)",
+             (consider increasing {proof_timeout} or reducing the per-proof workload)",
             self.config.timeout
         )))
     }
@@ -691,7 +703,7 @@ mod tests {
                 range_gas_limit: 1,
                 agg_cycle_limit: 1,
                 agg_gas_limit: 1,
-                max_price_per_pgu: 1,
+                max_price_per_pgu: Some(NonZeroU64::MIN),
                 min_auction_period: 1,
             },
             network_mode,


### PR DESCRIPTION
This changes the following `kona-sp1-proposer` defaults:

- `KONA_SP1_PROPOSER_RANGE_SPLIT_COUNT`: `1` → `16`
- `KONA_SP1_PROPOSER_RANGE_GAS_LIMIT`: `1_000_000_000_000` → `200_000_000_000` PGU
- `KONA_SP1_PROPOSER_AGG_GAS_LIMIT`: `1_000_000_000_000` → `1_000_000_000` PGU
- `KONA_SP1_PROPOSER_SP1_TIMEOUT_SECONDS`: `14_400` → `7_200` seconds per proof request
- `KONA_SP1_PROPOSER_TX_CONFIRMATION_TIMEOUT`: `60` → `180` seconds
- `KONA_SP1_PROPOSER_MAX_PRICE_PER_PGU`: fixed `1_000_000_000` default → no explicit default ceiling. In mainnet auctions, unset, empty, or `0` now uses the server ceiling with the SDK 120% buffer and tick rounding; a positive value remains an exact operator ceiling.

The auction strategies, `1_000_000_000_000` cycle limits, 300-second auction timeout, and 3,600-second proposal interval are unchanged.

With 16 sufficiently large chunks, one defense can submit up to 32 compressed child proofs (range plus consolidation per chunk), followed by one PLONK aggregation proof. The 7,200-second timeout applies independently to each proof request, not to the complete defense.

The new gas caps retain about 3.05x and 126x headroom over the maxima in the complete current requester history: 65,575,018,481 PGU across 94 compressed requests and 7,933,081 PGU for the observed PLONK request. Checked-in deployment configurations do not override the new timeout, gas, or pricing defaults; they only pin the unchanged auction strategies and the matching split count of 16.