### PR TITLE
docs: update flashblocks spec links to subblocks

### DIFF
--- a/docs/public-docs/app-developers/guides/transactions/integrating-subblocks.mdx
+++ b/docs/public-docs/app-developers/guides/transactions/integrating-subblocks.mdx
@@ -79,7 +79,7 @@ The difference is using the "pending" tag in some of them to explicitly query th
     </Expandable>
 
     Other methods, like `eth_getTransactionReceipt`, `eth_getTransactionByHash` or `eth_simulateV1`, return data from pre-confirmed transactions without requiring the `pending` tag.
-    Consult the [Flashblocks specification](https://specs.optimism.io/protocol/flashblocks.html#flashblock-json-rpc-apis) for more details on each of these methods.
+    Consult the [Subblocks specification](https://specs.optimism.io/protocol/subblocks.html#json-rpc) for the supported methods and pending-state behavior.
 
 ## Libraries
 
@@ -149,5 +149,5 @@ console.log('Transaction receipt:', receipt);
 
 *   Understand how subblocks affect [gas usage and large transactions](/app-developers/guides/transactions/subblocks-and-gas-usage).
 *   Learn how subblocks work in the [Subblocks explainer](/op-stack/features/subblocks).
-*   Review the [technical specs](https://specs.optimism.io/protocol/flashblocks.html) for architecture details.
+*   Review the [Subblocks specification](https://specs.optimism.io/protocol/subblocks.html) for wire-format and JSON-RPC details.
 *   Join our [community](https://discord.gg/jPQhHTdemH) to share best practices and get support!

--- a/docs/public-docs/notices/subblocks.mdx
+++ b/docs/public-docs/notices/subblocks.mdx
@@ -30,7 +30,7 @@ The stream keeps its existing wire format, and the payload type is still named `
 
 ## What this means
 
-*   **The interval drops from 250 ms to 200 ms.** This brings OP Sepolia and OP Mainnet to `FLASHBLOCKS_TIME = 200ms`, the default in the [Flashblocks specification](https://specs.optimism.io/protocol/flashblocks.html).
+*   **The interval drops from 250 ms to 200 ms.** This brings OP Sepolia and OP Mainnet to `FLASHBLOCKS_TIME = 200ms`.
 *   **Four payload fields are set to their zero value.** All four remain present in `ExecutionPayloadFlashblockDeltaV1`. Nothing is removed from the wire format.
 *   **Every other field, including `receipts_root` and `logs_bloom`, continues to carry a real value.**
 
@@ -69,6 +69,6 @@ Both dates are targets and may move.
 
 | Resource | Link |
 | --- | --- |
-| Flashblocks specification | [specs.optimism.io](https://specs.optimism.io/protocol/flashblocks.html) |
+| Subblocks specification | [specs.optimism.io](https://specs.optimism.io/protocol/subblocks.html) |
 | Subblocks explainer | [How Subblocks work](/op-stack/features/subblocks) |
 | App integration guide | [Integrate Subblocks in your app](/app-developers/guides/transactions/integrating-subblocks) |


### PR DESCRIPTION
## Summary

- Update public documentation links from the retired Flashblocks specification to the canonical Subblocks specification.
- Point RPC guidance to the new `#json-rpc` section.
- Preserve the planned 200 ms rollout timing while removing its link to the retired Flashblocks specification.
- Update surrounding terminology to match the replacement specification.