### PR TITLE
op-devstack: support external L2 consensus-client slots

### DIFF
--- a/op-devstack/presets/minimal_from_runtime.go
+++ b/op-devstack/presets/minimal_from_runtime.go
@@ -29,10 +29,14 @@ func minimalFromRuntime(t devtest.T, runtime *sysgo.SingleChainRuntime) *Minimal
 	l2EL := newL2ELFrontend(t, "sequencer", l2ChainID, runtime.L2EL.UserRPC(), runtime.L2EL.EngineRPC(), runtime.L2EL.JWTPath(), runtime.L2Network.RollupConfig(), runtime.L2EL)
 	l2CL := newL2CLFrontend(t, "sequencer", l2ChainID, runtime.L2CL.UserRPC(), runtime.L2CL)
 	l2CL.attachEL(l2EL)
-	l2Batcher := newL2BatcherFrontend(t, "main", l2ChainID, runtime.L2Batcher.UserRPC())
 	l2Chain.AddL2ELNode(l2EL)
 	l2Chain.AddL2CLNode(l2CL)
-	l2Chain.AddL2Batcher(l2Batcher)
+	var l2BatcherDSL *dsl.L2Batcher
+	if runtime.L2Batcher != nil {
+		l2Batcher := newL2BatcherFrontend(t, "main", l2ChainID, runtime.L2Batcher.UserRPC())
+		l2Chain.AddL2Batcher(l2Batcher)
+		l2BatcherDSL = dsl.NewL2Batcher(l2Batcher)
+	}
 
 	var challengerCfg *challengerConfig.Config
 	if runtime.L2Challenger != nil {
@@ -55,7 +59,7 @@ func minimalFromRuntime(t devtest.T, runtime *sysgo.SingleChainRuntime) *Minimal
 		L1EL:             l1ELDSL,
 		L1CL:             l1CLDSL,
 		L2Chain:          dsl.NewL2Network(l2Chain, l2ELDSL, l2CLDSL, l1ELDSL, nil, nil),
-		L2Batcher:        dsl.NewL2Batcher(l2Batcher),
+		L2Batcher:        l2BatcherDSL,
 		L2EL:             l2ELDSL,
 		L2CL:             l2CLDSL,
 		Wallet:           dsl.NewRandomHDWallet(t, 30), // Random for test isolation
@@ -64,4 +68,10 @@ func minimalFromRuntime(t devtest.T, runtime *sysgo.SingleChainRuntime) *Minimal
 	out.FunderL1 = newFunderEOA(t, runtime.Keys, out.L1EL, out.Wallet)
 	out.FunderL2 = newFunderEOA(t, runtime.Keys, out.L2EL, out.Wallet)
 	return out
+}
+
+// MinimalFromRuntime projects a composable sysgo runtime into the standard
+// single-chain DSL before optional follower nodes are attached.
+func MinimalFromRuntime(t devtest.T, runtime *sysgo.SingleChainRuntime) *Minimal {
+	return minimalFromRuntime(t, runtime)
 }

--- a/op-devstack/presets/option_validation.go
+++ b/op-devstack/presets/option_validation.go
@@ -16,6 +16,7 @@ const (
 	optionKindProposer
 	optionKindOpReth
 	optionKindGlobalL2CL
+	optionKindL2CLFactory
 	optionKindGlobalSyncTesterEL
 	optionKindL1EL
 	optionKindAddedGameType
@@ -44,6 +45,7 @@ const allOptionKinds = optionKindDeployer |
 	optionKindProposer |
 	optionKindOpReth |
 	optionKindGlobalL2CL |
+	optionKindL2CLFactory |
 	optionKindGlobalSyncTesterEL |
 	optionKindL1EL |
 	optionKindAddedGameType |
@@ -75,6 +77,7 @@ var optionKindLabels = []struct {
 	{kind: optionKindProposer, label: "proposer options"},
 	{kind: optionKindOpReth, label: "op-reth options"},
 	{kind: optionKindGlobalL2CL, label: "L2 CL options"},
+	{kind: optionKindL2CLFactory, label: "L2 CL factory"},
 	{kind: optionKindGlobalSyncTesterEL, label: "sync tester EL options"},
 	{kind: optionKindL1EL, label: "L1 EL options"},
 	{kind: optionKindAddedGameType, label: "added game types"},
@@ -147,6 +150,7 @@ const minimalPresetSupportedOptionKinds = optionKindDeployer |
 	optionKindProposer |
 	optionKindOpReth |
 	optionKindGlobalL2CL |
+	optionKindL2CLFactory |
 	optionKindL1EL |
 	optionKindAddedGameType |
 	optionKindRespectedGameType |
@@ -155,11 +159,11 @@ const minimalPresetSupportedOptionKinds = optionKindDeployer |
 	optionKindProofValidation |
 	optionKindSkipHonestProposer
 
-const minimalWithConductorsPresetSupportedOptionKinds = minimalPresetSupportedOptionKinds
+const minimalWithConductorsPresetSupportedOptionKinds = minimalPresetSupportedOptionKinds &^ optionKindL2CLFactory
 
 // Builds on the minimal set, op-reth options included: the added node is a sync-tester EL, not a
 // sequencing candidate, so the sequencer-builds / stock-verifies split holds.
-const simpleWithSyncTesterPresetSupportedOptionKinds = minimalPresetSupportedOptionKinds |
+const simpleWithSyncTesterPresetSupportedOptionKinds = (minimalPresetSupportedOptionKinds &^ optionKindL2CLFactory) |
 	optionKindGlobalSyncTesterEL
 
 // singleSupernodeWithSyncTesterPresetSupportedOptionKinds covers exactly what
@@ -211,3 +215,11 @@ const twoL2SupernodeInteropPresetSupportedOptionKinds = optionKindDeployer |
 // option is accepted here and nowhere else to avoid a silent no-op.
 const twoL2SupernodeLightSequencerPresetSupportedOptionKinds = twoL2SupernodeInteropPresetSupportedOptionKinds |
 	optionKindGlobalL2CL
+
+const twoL2ExternalCLInteropPresetSupportedOptionKinds = optionKindDeployer |
+	optionKindBatcher |
+	optionKindOpReth |
+	optionKindTimeTravel |
+	optionKindL1EL |
+	optionKindGlobalL2CL |
+	optionKindL2CLFactory

--- a/op-devstack/presets/options.go
+++ b/op-devstack/presets/options.go
@@ -88,6 +88,13 @@ func collectPresetConfig(opts []Option) (sysgo.PresetConfig, CombinedOption) {
 	return cfg, combined
 }
 
+// PresetConfigFromOptions applies preset options for callers using lower-level
+// sysgo composition APIs. Frontend-only hooks are intentionally not run.
+func PresetConfigFromOptions(opts ...Option) sysgo.PresetConfig {
+	cfg, _ := collectPresetConfig(opts)
+	return cfg
+}
+
 func WithDeployerOptions(opts ...sysgo.DeployerOption) Option {
 	var kinds optionKinds
 	for _, opt := range opts {
@@ -151,6 +158,21 @@ func WithGlobalL2CLOption(opt sysgo.L2CLOption) Option {
 				return
 			}
 			cfg.GlobalL2CLOptions = append(cfg.GlobalL2CLOptions, opt)
+		},
+	}
+}
+
+// WithL2CLFactory injects an external, product-neutral L2 consensus-client
+// factory. The factory may decline individual slots to retain stock behavior.
+func WithL2CLFactory(factory sysgo.L2CLFactory) Option {
+	var kinds optionKinds
+	if factory != nil {
+		kinds = optionKindL2CLFactory
+	}
+	return option{
+		kinds: kinds,
+		applyFn: func(cfg *sysgo.PresetConfig) {
+			cfg.L2CLFactory = factory
 		},
 	}
 }

--- a/op-devstack/presets/options_test.go
+++ b/op-devstack/presets/options_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/stretchr/testify/require"
@@ -37,12 +38,22 @@ func TestOptionKindsFromCompositeOptions(t *testing.T) {
 		require.Zero(t, WithLocalContractSourcesAt("").optionKinds())
 		require.Zero(t, WithBatcherOption(nil).optionKinds())
 		require.Zero(t, WithGlobalL2CLOption(nil).optionKinds())
+		require.Zero(t, WithL2CLFactory(nil).optionKinds())
 		require.Zero(t, WithGlobalSyncTesterELOption(nil).optionKinds())
 		require.Zero(t, WithProposerOption(nil).optionKinds())
 		require.Zero(t, WithZKProposerOption(nil).optionKinds())
 		require.Zero(t, WithPreGenesisSuperGame().optionKinds())
 		require.Zero(t, AfterBuild(nil).optionKinds())
 	})
+}
+
+func TestWithL2CLFactory(t *testing.T) {
+	factory := sysgo.L2CLFactoryFn(func(devtest.T, sysgo.L2CLLaunchContext) (sysgo.L2CLNode, bool) {
+		return nil, false
+	})
+	cfg, combined := collectPresetConfig([]Option{WithL2CLFactory(factory)})
+	require.Equal(t, optionKindL2CLFactory, combined.optionKinds())
+	require.NotNil(t, cfg.L2CLFactory)
 }
 
 func TestWithLocalContractSourcesAt(t *testing.T) {
@@ -82,6 +93,9 @@ func TestWithZKProposerOption(t *testing.T) {
 }
 
 func TestUnsupportedPresetOptionKinds(t *testing.T) {
+	factory := sysgo.L2CLFactoryFn(func(devtest.T, sysgo.L2CLLaunchContext) (sysgo.L2CLNode, bool) {
+		return nil, false
+	})
 	tests := []struct {
 		name      string
 		supported optionKinds
@@ -114,6 +128,33 @@ func TestUnsupportedPresetOptionKinds(t *testing.T) {
 			supported: minimalWithConductorsPresetSupportedOptionKinds,
 			opts:      WithOpRethOption(sysgo.OpRethWithBinary("op-reth-superset")),
 			want:      0,
+		},
+		{
+			name:      "minimal allows external L2 CL factory",
+			supported: minimalPresetSupportedOptionKinds,
+			opts:      WithL2CLFactory(factory),
+			want:      0,
+		},
+		{
+			name:      "conductors reject external L2 CL factory",
+			supported: minimalWithConductorsPresetSupportedOptionKinds,
+			opts:      WithL2CLFactory(factory),
+			want:      optionKindL2CLFactory,
+		},
+		{
+			name:      "sync tester rejects external L2 CL factory",
+			supported: simpleWithSyncTesterPresetSupportedOptionKinds,
+			opts:      WithL2CLFactory(factory),
+			want:      optionKindL2CLFactory,
+		},
+		{
+			name:      "two L2 external CL allows factory and op-reth options",
+			supported: twoL2ExternalCLInteropPresetSupportedOptionKinds,
+			opts: Combine(
+				WithL2CLFactory(factory),
+				WithOpRethOption(sysgo.OpRethWithInteropURL("http://127.0.0.1:1")),
+			),
+			want: 0,
 		},
 		{
 			name:      "shared supernode proofs reject pre-genesis super game",

--- a/op-devstack/presets/singlechain_from_runtime.go
+++ b/op-devstack/presets/singlechain_from_runtime.go
@@ -85,7 +85,7 @@ func singleChainMultiNodeFromRuntime(t devtest.T, runtime *sysgo.SingleChainRunt
 		L2ELB:   dsl.NewL2ELNode(l2ELB),
 		L2CLB:   dsl.NewL2CLNode(l2CLB),
 	}
-	if runtime.P2PEnabled {
+	if shouldManageSingleChainCLPeer(runtime, nodeB) {
 		preset.L2CLB.ManagePeer(preset.L2CL)
 	}
 	if runSyncChecks {
@@ -117,6 +117,18 @@ func singleChainMultiNodeFromRuntime(t devtest.T, runtime *sysgo.SingleChainRunt
 		)
 	}
 	return preset
+}
+
+func shouldManageSingleChainCLPeer(runtime *sysgo.SingleChainRuntime, follower *sysgo.SingleChainNodeRuntime) bool {
+	if runtime == nil || follower == nil || !runtime.P2PEnabled {
+		return false
+	}
+	primary := runtime.Nodes["sequencer"]
+	return shouldManageSingleChainCLPeerEdge(primary, follower)
+}
+
+func shouldManageSingleChainCLPeerEdge(source, target *sysgo.SingleChainNodeRuntime) bool {
+	return source != nil && target != nil && !source.FactoryHandledCL && !target.FactoryHandledCL
 }
 
 // runInitialSyncChecks runs the initial-sync DSL checks. On failure in ELSync
@@ -155,6 +167,18 @@ func dumpVerifierELSyncing(t devtest.T, verifierEL *dsl.L2ELNode) {
 	t.Logger().Warn("Verifier EL eth_syncing snapshot at sync-check failure", "eth_syncing", string(raw))
 }
 
+// SingleChainMultiNodeFromRuntime projects a composed sysgo runtime into the
+// standard DSL surface.
+func SingleChainMultiNodeFromRuntime(t devtest.T, runtime *sysgo.SingleChainRuntime, runSyncChecks bool) *SingleChainMultiNode {
+	return singleChainMultiNodeFromRuntime(t, runtime, runSyncChecks)
+}
+
+// SingleChainMultiNodeWithTestSeqFromRuntime projects a composed runtime with
+// its test sequencer attached.
+func SingleChainMultiNodeWithTestSeqFromRuntime(t devtest.T, runtime *sysgo.SingleChainRuntime) *SingleChainMultiNodeWithTestSeq {
+	return singleChainMultiNodeWithTestSeqFromRuntime(t, runtime)
+}
+
 func singleChainMultiNodeWithTestSeqFromRuntime(t devtest.T, runtime *sysgo.SingleChainRuntime) *SingleChainMultiNodeWithTestSeq {
 	preset := singleChainMultiNodeFromRuntime(t, runtime, false)
 	testSequencer := newTestSequencerFrontend(
@@ -173,7 +197,9 @@ func singleChainMultiNodeWithTestSeqFromRuntime(t devtest.T, runtime *sysgo.Sing
 func singleChainTwoVerifiersFromRuntime(t devtest.T, runtime *sysgo.SingleChainRuntime) *SingleChainTwoVerifiers {
 	base := singleChainMultiNodeFromRuntime(t, runtime, false)
 	l2ChainID := runtime.L2Network.ChainID()
+	nodeB := runtime.Nodes["b"]
 	nodeC := runtime.Nodes["c"]
+	t.Require().NotNil(nodeB, "missing single-chain node b")
 	t.Require().NotNil(nodeC, "missing single-chain node c")
 
 	l2ELC := newL2ELFrontend(
@@ -211,8 +237,12 @@ func singleChainTwoVerifiersFromRuntime(t devtest.T, runtime *sysgo.SingleChainR
 		L2CLC:                dsl.NewL2CLNode(l2CLC),
 		TestSequencer:        dsl.NewTestSequencer(testSequencer),
 	}
-	preset.L2CLC.ManagePeer(preset.L2CL)
-	preset.L2CLC.ManagePeer(preset.L2CLB)
+	if shouldManageSingleChainCLPeerEdge(runtime.Nodes["sequencer"], nodeC) {
+		preset.L2CLC.ManagePeer(preset.L2CL)
+	}
+	if shouldManageSingleChainCLPeerEdge(nodeB, nodeC) {
+		preset.L2CLC.ManagePeer(preset.L2CLB)
+	}
 	return preset
 }
 

--- a/op-devstack/presets/singlechain_from_runtime_test.go
+++ b/op-devstack/presets/singlechain_from_runtime_test.go
@@ -1,0 +1,30 @@
+package presets
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSingleChainProjectionManagesOnlyStockCLPeerEdges(t *testing.T) {
+	primary := &sysgo.SingleChainNodeRuntime{}
+	follower := &sysgo.SingleChainNodeRuntime{}
+	runtime := &sysgo.SingleChainRuntime{
+		Nodes:      map[string]*sysgo.SingleChainNodeRuntime{"sequencer": primary},
+		P2PEnabled: true,
+	}
+
+	require.True(t, shouldManageSingleChainCLPeer(runtime, follower))
+	require.True(t, shouldManageSingleChainCLPeerEdge(primary, follower))
+	primary.FactoryHandledCL = true
+	require.False(t, shouldManageSingleChainCLPeer(runtime, follower))
+	require.False(t, shouldManageSingleChainCLPeerEdge(primary, follower))
+	primary.FactoryHandledCL = false
+	follower.FactoryHandledCL = true
+	require.False(t, shouldManageSingleChainCLPeer(runtime, follower))
+	require.False(t, shouldManageSingleChainCLPeerEdge(primary, follower))
+	follower.FactoryHandledCL = false
+	runtime.P2PEnabled = false
+	require.False(t, shouldManageSingleChainCLPeer(runtime, follower))
+}

--- a/op-devstack/sysgo/l2_cl.go
+++ b/op-devstack/sysgo/l2_cl.go
@@ -3,14 +3,82 @@ package sysgo
 import (
 	"time"
 
+	"github.com/ethereum-optimism/optimism/op-core/interop/depset"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	nodeSync "github.com/ethereum-optimism/optimism/op-node/rollup/sync"
+	"github.com/ethereum/go-ethereum/core"
 )
 
 type L2CLNode interface {
 	stack.Lifecycle
 	UserRPC() string
+}
+
+// L2CLRole describes the responsibility of a consensus-layer node slot.
+type L2CLRole string
+
+const (
+	L2CLRoleSequencer L2CLRole = "sequencer"
+	L2CLRoleVerifier  L2CLRole = "verifier"
+)
+
+// L2CLLaunchContext is the product-neutral input required to launch an
+// externally implemented L2 consensus client. It contains stable endpoints
+// and immutable network configuration, rather than concrete sysgo backends.
+type L2CLLaunchContext struct {
+	Target ComponentTarget
+	Role   L2CLRole
+
+	L1UserRPC   string
+	L1BeaconRPC string
+	L2UserRPC   string
+	L2EngineRPC string
+	L2JWTPath   string
+
+	L1Genesis    *core.Genesis
+	L2Genesis    *core.Genesis
+	RollupConfig *rollup.Config
+	FollowSource string
+
+	// UnsafeSource* identifies the complete EL selected as a verifier's
+	// unsafe source when the runtime owns that EL.
+	UnsafeSourceUserRPC   string
+	UnsafeSourceEngineRPC string
+	UnsafeSourceJWTPath   string
+
+	Config        L2CLConfig
+	DependencySet depset.DependencySet
+
+	// RegisterMetrics is nil in classic and staged runtimes because they do not
+	// own a metrics collector. External clients must treat nil as registration
+	// being unavailable; their Prometheus endpoint may still be scraped directly.
+	RegisterMetrics func(serviceName string, endpoints ...PrometheusMetricsTarget)
+}
+
+// L2CLFactory may provide an external implementation for an individual L2 CL
+// slot. For a handled slot, the factory must return a non-nil lifecycle/RPC
+// handle whose UserRPC address is stable. The factory owns readiness and the
+// external process lifecycle, including starting the process and registering
+// cleanup with devtest.T. Launch may be deferred until the factory has enough
+// slots to start one shared process. The runtime deliberately does not call
+// Start, wait for readiness, or register Stop. Supplying a factory may require
+// endpoint providers to start before CL selection and resolves L2CLOptions
+// before CreateL2CL, even when the factory declines. A decline must return
+// (nil, false) without starting resources; the runtime immediately selects its
+// fallback. Returning handled=false preserves the configured fallback client
+// kind, not factory-free start order or option side effects.
+type L2CLFactory interface {
+	CreateL2CL(t devtest.T, ctx L2CLLaunchContext) (node L2CLNode, handled bool)
+}
+
+type L2CLFactoryFn func(t devtest.T, ctx L2CLLaunchContext) (node L2CLNode, handled bool)
+
+var _ L2CLFactory = L2CLFactoryFn(nil)
+
+func (fn L2CLFactoryFn) CreateL2CL(t devtest.T, ctx L2CLLaunchContext) (L2CLNode, bool) {
+	return fn(t, ctx)
 }
 
 type L2CLConfig struct {
@@ -23,6 +91,9 @@ type L2CLConfig struct {
 	SafeDBPath string
 
 	IsSequencer bool
+	// SequencerStopped starts a sequencer without producing blocks until its
+	// admin start method is called.
+	SequencerStopped bool
 
 	// EnableReqRespSync enables/disables the req-resp sync server (serving payloads to peers).
 	EnableReqRespSync bool
@@ -43,6 +114,12 @@ type L2CLConfig struct {
 func L2CLSequencer() L2CLOption {
 	return L2CLOptionFn(func(p devtest.T, _ ComponentTarget, cfg *L2CLConfig) {
 		cfg.IsSequencer = true
+	})
+}
+
+func L2CLSequencerStopped() L2CLOption {
+	return L2CLOptionFn(func(_ devtest.T, _ ComponentTarget, cfg *L2CLConfig) {
+		cfg.SequencerStopped = true
 	})
 }
 

--- a/op-devstack/sysgo/l2_cl_factory_test.go
+++ b/op-devstack/sysgo/l2_cl_factory_test.go
@@ -1,0 +1,191 @@
+package sysgo
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-core/interop/depset"
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	nodeSync "github.com/ethereum-optimism/optimism/op-node/rollup/sync"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeExternalL2CL struct {
+	starts int
+	stops  int
+	rpc    string
+}
+
+type fakeFactoryL2EL struct {
+	rpc string
+}
+
+func (n *fakeFactoryL2EL) Start()            {}
+func (n *fakeFactoryL2EL) Stop()             {}
+func (n *fakeFactoryL2EL) UserRPC() string   { return n.rpc }
+func (n *fakeFactoryL2EL) EngineRPC() string { return "http://127.0.0.1:8551" }
+func (n *fakeFactoryL2EL) JWTPath() string   { return "/tmp/fake-jwt" }
+
+func (n *fakeExternalL2CL) Start() { n.starts++ }
+func (n *fakeExternalL2CL) Stop()  { n.stops++ }
+func (n *fakeExternalL2CL) UserRPC() string {
+	if n.rpc != "" {
+		return n.rpc
+	}
+	return "http://127.0.0.1:9545"
+}
+
+func TestL2CLFactoryOwnsDeferredSharedProcessLifecycle(t *testing.T) {
+	shared := &fakeExternalL2CL{}
+	var seen []L2CLLaunchContext
+
+	t.Run("factory lifetime", func(t *testing.T) {
+		dt := devtest.SerialT(t)
+		externalSlots := 0
+		factory := L2CLFactoryFn(func(t devtest.T, ctx L2CLLaunchContext) (L2CLNode, bool) {
+			seen = append(seen, ctx)
+			if ctx.Target.Name == "stock" {
+				return nil, false
+			}
+			externalSlots++
+			if externalSlots == 2 {
+				shared.Start()
+				t.Cleanup(shared.Stop)
+			}
+			return shared, true
+		})
+
+		sequencer, handled := factory.CreateL2CL(dt, L2CLLaunchContext{
+			Target: NewComponentTarget("sequencer", eth.ChainIDFromUInt64(901)),
+			Role:   L2CLRoleSequencer,
+		})
+		require.True(t, handled)
+		require.Zero(t, shared.starts, "the factory may defer a shared launch until all slots arrive")
+		require.Equal(t, "http://127.0.0.1:9545", sequencer.UserRPC(), "the pre-launch RPC address is stable")
+
+		verifier, handled := factory.CreateL2CL(dt, L2CLLaunchContext{
+			Target: NewComponentTarget("late-verifier", eth.ChainIDFromUInt64(901)),
+			Role:   L2CLRoleVerifier,
+		})
+		require.True(t, handled)
+		require.Same(t, sequencer, verifier, "slot handles may share one backing process")
+
+		_, handled = factory.CreateL2CL(dt, L2CLLaunchContext{
+			Target: NewComponentTarget("stock", eth.ChainIDFromUInt64(901)),
+			Role:   L2CLRoleVerifier,
+		})
+		require.False(t, handled)
+
+		require.Equal(t, []string{"sequencer", "late-verifier", "stock"}, []string{
+			seen[0].Target.Name,
+			seen[1].Target.Name,
+			seen[2].Target.Name,
+		})
+		require.Equal(t, 1, shared.starts, "the factory starts the shared process once after its final slot")
+		require.Zero(t, shared.stops, "the factory defers cleanup until the test ends")
+	})
+
+	require.Equal(t, 1, shared.stops, "factory-owned cleanup stops the shared process once")
+}
+
+func TestResolveL2CLNodeConfigAppliesOptionsOnce(t *testing.T) {
+	dt := devtest.SerialT(t)
+	applications := 0
+	target := NewComponentTarget("verifier", eth.ChainIDFromUInt64(901))
+	cfg := resolveL2CLNodeConfig(dt, target, l2CLNodeStartConfig{
+		Key:              target.Name,
+		IsSequencer:      true,
+		NoDiscovery:      true,
+		EnableReqResp:    true,
+		L2FollowSource:   "http://source.invalid",
+		SyncMode:         nodeSync.ELSync,
+		SequencerStopped: true,
+		L2CLOptions: []L2CLOption{L2CLOptionFn(func(_ devtest.T, got ComponentTarget, cfg *L2CLConfig) {
+			applications++
+			require.Equal(t, target, got)
+			cfg.FollowSource = "http://proxy.invalid"
+			cfg.SequencerSyncMode = nodeSync.CLSync
+		})},
+	})
+
+	require.Equal(t, 1, applications)
+	require.True(t, cfg.IsSequencer)
+	require.True(t, cfg.NoDiscovery)
+	require.True(t, cfg.EnableReqRespSync)
+	require.True(t, cfg.SequencerStopped)
+	require.Equal(t, nodeSync.ELSync, cfg.SequencerSyncMode, "direct start state overrides an option")
+	require.Equal(t, nodeSync.ELSync, cfg.VerifierSyncMode)
+	require.Equal(t, "http://proxy.invalid", cfg.FollowSource)
+}
+
+func TestSingleChainFactoryHandlingControlsPeering(t *testing.T) {
+	stock := &SingleChainNodeRuntime{}
+	external := &SingleChainNodeRuntime{FactoryHandledCL: true}
+
+	require.True(t, shouldConnectSingleChainCLPeers(stock, stock),
+		"stock slots retain op-node admin P2P peering")
+	require.False(t, shouldConnectSingleChainCLPeers(stock, external))
+	require.False(t, shouldConnectSingleChainCLPeers(external, stock))
+	require.False(t, shouldConnectSingleChainCLPeers(external, external))
+}
+
+func TestSingleChainNodeSourcesKeepFollowAndUnsafeSourceConsistent(t *testing.T) {
+	source := &SingleChainNodeRuntime{
+		EL: &fakeFactoryL2EL{rpc: "http://127.0.0.1:8545"},
+		CL: &fakeExternalL2CL{rpc: "http://127.0.0.1:9545"},
+	}
+
+	follow, unsafeEL := singleChainNodeSources(source, "")
+	require.Empty(t, follow, "stock-to-stock nodes retain P2P-only unsafe sync")
+	require.Same(t, source.EL, unsafeEL)
+
+	source.FactoryHandledCL = true
+	follow, unsafeEL = singleChainNodeSources(source, "")
+	require.Equal(t, source.CL.UserRPC(), follow,
+		"a declined stock verifier follows an external source through its rollup RPC")
+	require.Same(t, source.EL, unsafeEL)
+
+	follow, unsafeEL = singleChainNodeSources(source, "http://explicit-stock-rollup.invalid")
+	require.Equal(t, "http://explicit-stock-rollup.invalid", follow)
+	require.Same(t, source.EL, unsafeEL,
+		"an explicit source node supplies matching execution endpoints to the external factory")
+}
+
+func TestSingleChainInteropPrimaryRetainsOpNodeFallback(t *testing.T) {
+	t.Setenv("DEVSTACK_L2CL_KIND", string(MixedL2CLKona))
+	require.Equal(t, MixedL2CLKona, singleChainPrimaryFallbackKind(singleChainRuntimeWorld{}))
+	require.Equal(t, MixedL2CLOpNode, singleChainPrimaryFallbackKind(singleChainRuntimeWorld{
+		Interop: &SingleChainInteropSupport{},
+	}))
+}
+
+func TestSingleChainAddedNodeDependencySetPreservesNilFactoryBehavior(t *testing.T) {
+	chainID := eth.ChainIDFromUInt64(901)
+	depSet, err := depset.NewStaticConfigDependencySet(map[eth.ChainID]*depset.StaticConfigDependency{
+		chainID: {},
+	})
+	require.NoError(t, err)
+	runtime := &SingleChainRuntime{Interop: &SingleChainInteropSupport{DependencySet: depSet}}
+
+	require.Nil(t, singleChainAddedNodeDependencySet(runtime),
+		"without a factory, added nodes retain their historical nil dependency set")
+	runtime.L2CLFactory = L2CLFactoryFn(func(devtest.T, L2CLLaunchContext) (L2CLNode, bool) {
+		return nil, false
+	})
+	require.Same(t, depSet, singleChainAddedNodeDependencySet(runtime),
+		"a factory receives the interop dependency set for added-node slots")
+}
+
+func TestDeclinedKonaFallbackRejectsFactoryHandledSource(t *testing.T) {
+	require.NoError(t, validateDeclinedL2CLFallback(MixedL2CLOpNode, true, "http://external-rollup.invalid"))
+	require.NoError(t, validateDeclinedL2CLFallback(MixedL2CLKona, false, ""),
+		"factory-declines-all keeps the ordinary Kona fallback")
+	require.NoError(t,
+		validateDeclinedL2CLFallback(MixedL2CLKona, false, "http://explicit-rollup.invalid"),
+		"a pre-existing explicit follow source is not evidence of a factory-handled source",
+	)
+	require.EqualError(t,
+		validateDeclinedL2CLFallback(MixedL2CLKona, true, "http://external-rollup.invalid"),
+		`Kona fallback cannot follow external source "http://external-rollup.invalid"; handle the slot or select op-node`,
+	)
+}

--- a/op-devstack/sysgo/mixed_runtime.go
+++ b/op-devstack/sysgo/mixed_runtime.go
@@ -185,7 +185,13 @@ type MixedSingleChainNodeSpec struct {
 }
 
 type MixedSingleChainPresetConfig struct {
-	NodeSpecs                  []MixedSingleChainNodeSpec
+	NodeSpecs []MixedSingleChainNodeSpec
+	// L2CLFactory optionally supplies an external consensus client for each
+	// mixed-EL slot. Supplying it opts into an all-EL-first launch phase and
+	// sequencer-first CL selection so verifier source endpoints are available
+	// independent of NodeSpecs order. A declined slot retains its explicit
+	// CLKind fallback, but not the factory-free interleaved start order.
+	L2CLFactory                L2CLFactory
 	WithTestSequencer          bool
 	TestSequencerName          string
 	LocalContractArtifactsPath string
@@ -199,9 +205,10 @@ type MixedSingleChainPresetConfig struct {
 }
 
 type mixedSingleChainNode struct {
-	spec MixedSingleChainNodeSpec
-	el   L2ELNode
-	cl   L2CLNode
+	spec             MixedSingleChainNodeSpec
+	el               L2ELNode
+	cl               L2CLNode
+	factoryHandledCL bool
 }
 
 type MixedSingleChainRuntime struct {
@@ -246,58 +253,104 @@ func NewMixedSingleChainRuntime(t devtest.T, cfg MixedSingleChainPresetConfig) *
 	metricsRegistrar := mixedNoopMetricsRegistrar{}
 
 	nodes := make([]mixedSingleChainNode, 0, len(cfg.NodeSpecs))
-	for _, spec := range cfg.NodeSpecs {
-		identity := NewELNodeIdentity(0)
+	if cfg.L2CLFactory == nil {
+		// Keep the ordinary mixed-runtime launch path interleaved exactly as it
+		// was before the optional factory seam.
+		for _, spec := range cfg.NodeSpecs {
+			identity := NewELNodeIdentity(0)
 
-		// Shared options first, then this node's per-spec options (so a per-node flag can
-		// override or extend the shared set without leaking to other nodes).
-		nodeOpRethOpts := append(append([]OpRethOption{}, cfg.OpRethOptions...), spec.OpRethOpts...)
+			// Shared options first, then this node's per-spec options (so a per-node flag can
+			// override or extend the shared set without leaking to other nodes).
+			nodeOpRethOpts := append(append([]OpRethOption{}, cfg.OpRethOptions...), spec.OpRethOpts...)
 
-		var el L2ELNode
-		switch spec.ELKind {
-		case MixedL2ELOpGeth:
-			el = startL2ELNode(t, l2Net, jwtPath, jwtSecret, spec.ELKey, identity)
-		case MixedL2ELOpReth:
-			el = startMixedOpRethNode(t, l2Net, spec.ELKey, jwtPath, jwtSecret, metricsRegistrar, "v1", nodeOpRethOpts...)
-		case MixedL2ELOpRethV2:
-			el = startMixedOpRethNode(t, l2Net, spec.ELKey, jwtPath, jwtSecret, metricsRegistrar, "v2", nodeOpRethOpts...)
-		default:
-			require.FailNowf("unsupported EL kind", "unsupported mixed EL kind %q", spec.ELKind)
-		}
+			var el L2ELNode
+			switch spec.ELKind {
+			case MixedL2ELOpGeth:
+				el = startL2ELNode(t, l2Net, jwtPath, jwtSecret, spec.ELKey, identity)
+			case MixedL2ELOpReth:
+				el = startMixedOpRethNode(t, l2Net, spec.ELKey, jwtPath, jwtSecret, metricsRegistrar, "v1", nodeOpRethOpts...)
+			case MixedL2ELOpRethV2:
+				el = startMixedOpRethNode(t, l2Net, spec.ELKey, jwtPath, jwtSecret, metricsRegistrar, "v2", nodeOpRethOpts...)
+			default:
+				require.FailNowf("unsupported EL kind", "unsupported mixed EL kind %q", spec.ELKind)
+			}
 
-		var cl L2CLNode
-		switch spec.CLKind {
-		case MixedL2CLOpNode:
-			cl = startL2CLNode(t, keys, l1Net, l2Net, l1EL, l1CL, el, jwtSecret, l2CLNodeStartConfig{
-				Key:           spec.CLKey,
-				IsSequencer:   spec.IsSequencer,
-				NoDiscovery:   true,
-				EnableReqResp: true,
-				DependencySet: depSet,
+			var cl L2CLNode
+			switch spec.CLKind {
+			case MixedL2CLOpNode:
+				cl = startL2CLNode(t, keys, l1Net, l2Net, l1EL, l1CL, el, jwtSecret, l2CLNodeStartConfig{
+					Key:           spec.CLKey,
+					IsSequencer:   spec.IsSequencer,
+					NoDiscovery:   true,
+					EnableReqResp: true,
+					DependencySet: depSet,
+				})
+			case MixedL2CLKona:
+				cl = startMixedKonaNode(
+					t,
+					keys,
+					l1Net,
+					l2Net,
+					l1EL,
+					l1CL,
+					el,
+					spec.CLKey,
+					spec.ELKey,
+					spec.IsSequencer,
+					depSet,
+				)
+			default:
+				require.FailNowf("unsupported CL kind", "unsupported mixed CL kind %q", spec.CLKind)
+			}
+
+			nodes = append(nodes, mixedSingleChainNode{
+				spec: spec,
+				el:   el,
+				cl:   cl,
 			})
-		case MixedL2CLKona:
-			cl = startMixedKonaNode(
-				t,
-				keys,
-				l1Net,
-				l2Net,
-				l1EL,
-				l1CL,
-				el,
-				spec.CLKey,
-				spec.ELKey,
-				spec.IsSequencer,
-				depSet,
-			)
-		default:
-			require.FailNowf("unsupported CL kind", "unsupported mixed CL kind %q", spec.CLKind)
+		}
+	} else {
+		// Build every EL before consulting the factory so a verifier can identify
+		// its sequencer source regardless of NodeSpecs ordering.
+		for _, spec := range cfg.NodeSpecs {
+			switch spec.CLKind {
+			case MixedL2CLOpNode, MixedL2CLKona:
+			default:
+				require.FailNowf("unsupported CL kind", "unsupported mixed CL kind %q", spec.CLKind)
+			}
+			identity := NewELNodeIdentity(0)
+			nodeOpRethOpts := append(append([]OpRethOption{}, cfg.OpRethOptions...), spec.OpRethOpts...)
+			var el L2ELNode
+			switch spec.ELKind {
+			case MixedL2ELOpGeth:
+				el = startL2ELNode(t, l2Net, jwtPath, jwtSecret, spec.ELKey, identity)
+			case MixedL2ELOpReth:
+				el = startMixedOpRethNode(t, l2Net, spec.ELKey, jwtPath, jwtSecret, metricsRegistrar, "v1", nodeOpRethOpts...)
+			case MixedL2ELOpRethV2:
+				el = startMixedOpRethNode(t, l2Net, spec.ELKey, jwtPath, jwtSecret, metricsRegistrar, "v2", nodeOpRethOpts...)
+			default:
+				require.FailNowf("unsupported EL kind", "unsupported mixed EL kind %q", spec.ELKind)
+			}
+			nodes = append(nodes, mixedSingleChainNode{spec: spec, el: el})
 		}
 
-		nodes = append(nodes, mixedSingleChainNode{
-			spec: spec,
-			el:   el,
-			cl:   cl,
-		})
+		for _, i := range mixedCLStartOrder(nodes) {
+			spec := nodes[i].spec
+			source := mixedUnsafeSourceNode(nodes, spec)
+			var unsafeSourceEL L2ELNode
+			if source != nil {
+				unsafeSourceEL = source.el
+			}
+			stockFollowSource := mixedNodeFollowSource(source)
+			result := startL2CLForKeyWithKind(
+				t, keys, l1Net, l2Net, l1EL, l1CL, nodes[i].el, jwtSecret,
+				spec.CLKey, spec.ELKey, spec.IsSequencer, stockFollowSource,
+				depSet, nil, cfg.L2CLFactory, unsafeSourceEL,
+				source != nil && source.factoryHandledCL, spec.CLKind,
+			)
+			nodes[i].cl = result.Node
+			nodes[i].factoryHandledCL = result.FactoryHandled
+		}
 	}
 
 	for i := range nodes {
@@ -307,7 +360,9 @@ func NewMixedSingleChainRuntime(t devtest.T, cfg MixedSingleChainPresetConfig) *
 			if nodes[i].spec.IsolateFromL2P2P || nodes[j].spec.IsolateFromL2P2P {
 				continue
 			}
-			connectL2CLPeers(t, t.Logger(), nodes[i].cl, nodes[j].cl)
+			if shouldConnectMixedCLPeers(nodes[i], nodes[j]) {
+				connectL2CLPeers(t, t.Logger(), nodes[i].cl, nodes[j].cl)
+			}
 			connectL2ELPeers(t, t.Logger(), nodes[i].el.UserRPC(), nodes[j].el.UserRPC())
 		}
 	}
@@ -353,6 +408,49 @@ func NewMixedSingleChainRuntime(t devtest.T, cfg MixedSingleChainPresetConfig) *
 		L2Batcher:     l2Batcher,
 		TestSequencer: newTestSequencerRuntime(testSequencer, cfg.TestSequencerName),
 	}
+}
+
+func shouldConnectMixedCLPeers(a, b mixedSingleChainNode) bool {
+	return !a.factoryHandledCL && !b.factoryHandledCL
+}
+
+func mixedCLStartOrder(nodes []mixedSingleChainNode) []int {
+	order := make([]int, 0, len(nodes))
+	for i := range nodes {
+		if nodes[i].spec.IsSequencer {
+			order = append(order, i)
+		}
+	}
+	for i := range nodes {
+		if !nodes[i].spec.IsSequencer {
+			order = append(order, i)
+		}
+	}
+	return order
+}
+
+func mixedNodeFollowSource(source *mixedSingleChainNode) string {
+	if source == nil {
+		return ""
+	}
+	if source.factoryHandledCL {
+		// This stock fallback cannot form an op-node admin P2P edge with its
+		// external source, so follow the source's rollup RPC.
+		return source.cl.UserRPC()
+	}
+	return ""
+}
+
+func mixedUnsafeSourceNode(nodes []mixedSingleChainNode, spec MixedSingleChainNodeSpec) *mixedSingleChainNode {
+	if spec.IsSequencer || spec.IsolateFromL2P2P {
+		return nil
+	}
+	for i := range nodes {
+		if nodes[i].spec.IsSequencer && !nodes[i].spec.IsolateFromL2P2P {
+			return &nodes[i]
+		}
+	}
+	return nil
 }
 
 func mixedNodeRefs(nodes []mixedSingleChainNode) []MixedSingleChainNodeRefs {

--- a/op-devstack/sysgo/mixed_runtime_test.go
+++ b/op-devstack/sysgo/mixed_runtime_test.go
@@ -66,3 +66,62 @@ func TestResolveMixedL2ELOptsReadsEnv(t *testing.T) {
 	require.Equal(t, []string{"--extra.bind=127.0.0.1:0"}, cfg.ExtraArgs)
 	require.True(t, cfg.DisableProofsHistory)
 }
+
+func TestMixedCLPeeringTracksFactoryHandlingPerSlot(t *testing.T) {
+	stock := mixedSingleChainNode{}
+	external := mixedSingleChainNode{factoryHandledCL: true}
+
+	require.True(t, shouldConnectMixedCLPeers(stock, stock),
+		"no factory, or a factory that declines every slot, preserves stock peering")
+	require.False(t, shouldConnectMixedCLPeers(stock, external),
+		"a mixed stock/external edge must not assume the external CL implements op-node admin RPCs")
+	require.False(t, shouldConnectMixedCLPeers(external, stock))
+	require.False(t, shouldConnectMixedCLPeers(external, external))
+}
+
+func TestMixedUnsafeSourceIsIndependentOfSpecOrder(t *testing.T) {
+	verifier := MixedSingleChainNodeSpec{CLKey: "verifier"}
+	sequencer := MixedSingleChainNodeSpec{CLKey: "sequencer", IsSequencer: true}
+	nodes := []mixedSingleChainNode{
+		{spec: verifier},
+		{spec: sequencer},
+	}
+
+	source := mixedUnsafeSourceNode(nodes, verifier)
+	require.NotNil(t, source)
+	require.Equal(t, "sequencer", source.spec.CLKey)
+	require.Nil(t, mixedUnsafeSourceNode(nodes, sequencer))
+
+	isolatedVerifier := verifier
+	isolatedVerifier.IsolateFromL2P2P = true
+	require.Nil(t, mixedUnsafeSourceNode(nodes, isolatedVerifier))
+
+	isolatedSequencer := sequencer
+	isolatedSequencer.IsolateFromL2P2P = true
+	nodes[1].spec = isolatedSequencer
+	require.Nil(t, mixedUnsafeSourceNode(nodes, verifier),
+		"an isolated sequencer cannot become another node's unsafe source")
+}
+
+func TestMixedFactoryStartsSequencersBeforeVerifiers(t *testing.T) {
+	nodes := []mixedSingleChainNode{
+		{spec: MixedSingleChainNodeSpec{CLKey: "verifier-a"}},
+		{spec: MixedSingleChainNodeSpec{CLKey: "sequencer", IsSequencer: true}},
+		{spec: MixedSingleChainNodeSpec{CLKey: "verifier-b"}},
+	}
+
+	require.Equal(t, []int{1, 0, 2}, mixedCLStartOrder(nodes))
+}
+
+func TestMixedDeclinedVerifierFollowsOnlyExternalSourceCL(t *testing.T) {
+	source := &mixedSingleChainNode{
+		el: &fakeFactoryL2EL{rpc: "http://127.0.0.1:8545"},
+		cl: &fakeExternalL2CL{rpc: "http://127.0.0.1:9545"},
+	}
+
+	require.Empty(t, mixedNodeFollowSource(source),
+		"a factory that declines all slots retains stock P2P-only follow behavior")
+	source.factoryHandledCL = true
+	require.Equal(t, source.cl.UserRPC(), mixedNodeFollowSource(source),
+		"a declined stock verifier follows an external source through its rollup RPC")
+}

--- a/op-devstack/sysgo/preset_config.go
+++ b/op-devstack/sysgo/preset_config.go
@@ -45,6 +45,7 @@ type PresetConfig struct {
 	ProposerOptions            []ProposerOption
 	OpRethOptions              []OpRethOption
 	GlobalL2CLOptions          []L2CLOption
+	L2CLFactory                L2CLFactory
 	GlobalSyncTesterELOptions  []SyncTesterELOption
 	L1ELKind                   string
 	L1GethExecPath             string

--- a/op-devstack/sysgo/runtime_state.go
+++ b/op-devstack/sysgo/runtime_state.go
@@ -42,10 +42,11 @@ func newTestSequencerRuntime(ts *testSequencer, name string) *TestSequencerRunti
 }
 
 type SingleChainNodeRuntime struct {
-	Name        string
-	IsSequencer bool
-	EL          L2ELNode
-	CL          L2CLNode
+	Name             string
+	IsSequencer      bool
+	EL               L2ELNode
+	CL               L2CLNode
+	FactoryHandledCL bool
 }
 
 type SyncTesterRuntime struct {
@@ -66,6 +67,9 @@ type SingleChainInteropSupport struct {
 
 type SingleChainRuntime struct {
 	Keys devkeys.Keys
+	// L2CLFactory is retained so delayed and additional node slots use the
+	// same explicit client selection as the primary.
+	L2CLFactory L2CLFactory
 
 	L1Network *L1Network
 	L2Network *L2Network
@@ -89,6 +93,9 @@ type SingleChainRuntime struct {
 	SyncTester *SyncTesterRuntime
 	Conductors map[string]*Conductor
 	Interop    *SingleChainInteropSupport
+	// P2PEnabled records whether the stock primary/follower CL peer edge was
+	// established. EL peering may still be active when an external CL handles
+	// either slot and this is false.
 	P2PEnabled bool
 }
 

--- a/op-devstack/sysgo/singlechain_build.go
+++ b/op-devstack/sysgo/singlechain_build.go
@@ -1,7 +1,6 @@
 package sysgo
 
 import (
-	"context"
 	"encoding/hex"
 	"flag"
 	"fmt"
@@ -10,9 +9,7 @@ import (
 	"github.com/urfave/cli/v2"
 
 	altda "github.com/ethereum-optimism/optimism/op-alt-da"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
@@ -27,29 +24,13 @@ import (
 	nodeSync "github.com/ethereum-optimism/optimism/op-node/rollup/sync"
 	"github.com/ethereum-optimism/optimism/op-service/clock"
 	"github.com/ethereum-optimism/optimism/op-service/dial"
-	"github.com/ethereum-optimism/optimism/op-service/endpoint"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 	opmetrics "github.com/ethereum-optimism/optimism/op-service/metrics"
 	"github.com/ethereum-optimism/optimism/op-service/oppprof"
 	"github.com/ethereum-optimism/optimism/op-service/retry"
 	oprpc "github.com/ethereum-optimism/optimism/op-service/rpc"
 	"github.com/ethereum-optimism/optimism/op-service/sources"
-	sequencerConfig "github.com/ethereum-optimism/optimism/op-test-sequencer/config"
-	testmetrics "github.com/ethereum-optimism/optimism/op-test-sequencer/metrics"
 	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer"
-	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work"
-	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work/builders/fakepos"
-	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work/builders/standardbuilder"
-	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work/committers/noopcommitter"
-	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work/committers/standardcommitter"
-	workconfig "github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work/config"
-	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work/publishers/nooppublisher"
-	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work/publishers/standardpublisher"
-	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work/sequencers/fullseq"
-	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work/signers/localkey"
-	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/backend/work/signers/noopsigner"
-	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
 )
 
 type testSequencer struct {
@@ -147,12 +128,18 @@ func startL2ELForKey(t devtest.T, l2Net *L2Network, jwtPath string, jwtSecret [3
 	}
 }
 
-// startL2CLForKey starts an L2 CL node for the given key, respecting DEVSTACK_L2CL_KIND.
-// This is the env-aware dispatch point for preset runtimes that don't build explicit node
-// specs. Runtimes constructed from explicit MixedSingleChainNodeSpec.CLKind values (e.g.
-// NewMixedSingleChainRuntime) don't route through here; they resolve the env up front via
-// ResolveMixedL2CLKind instead.
-func startL2CLForKey(
+type l2CLStartResult struct {
+	Node           L2CLNode
+	FactoryHandled bool
+}
+
+// startL2CLForKeyWithKind is the explicit-fallback form used by mixed-client
+// runtimes. FactoryHandled lets callers avoid assuming that an external CL
+// implements op-node's devp2p admin RPCs while preserving ordinary peering
+// when the factory declines a slot. A non-nil factory receives fully resolved
+// L2CLOptions before it selects or declines the slot; only a nil-factory Kona
+// fallback retains Kona's historical behavior of ignoring those options.
+func startL2CLForKeyWithKind(
 	t devtest.T,
 	keys devkeys.Keys,
 	l1Net *L1Network,
@@ -164,21 +151,80 @@ func startL2CLForKey(
 	clKey, elKey string,
 	isSequencer bool,
 	followSource string,
+	depSet depset.DependencySet,
 	l2CLOpts []L2CLOption,
-) L2CLNode {
-	switch devstackL2CLKind() {
-	case MixedL2CLKona:
-		return startMixedKonaNode(t, keys, l1Net, l2Net, l1EL, l1CL, l2EL, clKey, elKey, isSequencer, nil)
-	default: // op-node
-		return startL2CLNode(t, keys, l1Net, l2Net, l1EL, l1CL, l2EL, jwtSecret, l2CLNodeStartConfig{
-			Key:            clKey,
-			IsSequencer:    isSequencer,
-			NoDiscovery:    true,
-			EnableReqResp:  true,
-			L2FollowSource: followSource,
-			L2CLOptions:    l2CLOpts,
-		})
+	factory L2CLFactory,
+	unsafeSourceEL L2ELNode,
+	fallbackSourceFactoryHandled bool,
+	fallbackKind MixedL2CLKind,
+) l2CLStartResult {
+	startCfg := l2CLNodeStartConfig{
+		Key:            clKey,
+		IsSequencer:    isSequencer,
+		NoDiscovery:    true,
+		EnableReqResp:  true,
+		L2FollowSource: followSource,
+		DependencySet:  depSet,
+		L2CLOptions:    l2CLOpts,
 	}
+	target := NewComponentTarget(clKey, l2Net.ChainID())
+	var resolvedCfg *L2CLConfig
+	if factory != nil {
+		resolvedCfg = resolveL2CLNodeConfig(t, target, startCfg)
+		role := L2CLRoleVerifier
+		if resolvedCfg.IsSequencer {
+			role = L2CLRoleSequencer
+		}
+		launchCtx := L2CLLaunchContext{
+			Target:        target,
+			Role:          role,
+			L1UserRPC:     l1EL.UserRPC(),
+			L1BeaconRPC:   l1CL.BeaconHTTPAddr(),
+			L2UserRPC:     l2EL.UserRPC(),
+			L2EngineRPC:   l2EL.EngineRPC(),
+			L2JWTPath:     l2EL.JWTPath(),
+			L1Genesis:     l1Net.Genesis(),
+			L2Genesis:     l2Net.genesis,
+			RollupConfig:  l2Net.RollupConfig(),
+			FollowSource:  resolvedCfg.FollowSource,
+			Config:        *resolvedCfg,
+			DependencySet: depSet,
+		}
+		if unsafeSourceEL != nil {
+			launchCtx.UnsafeSourceUserRPC = unsafeSourceEL.UserRPC()
+			launchCtx.UnsafeSourceEngineRPC = unsafeSourceEL.EngineRPC()
+			launchCtx.UnsafeSourceJWTPath = unsafeSourceEL.JWTPath()
+		}
+		node, handled := factory.CreateL2CL(t, launchCtx)
+		if handled {
+			t.Require().NotNil(node, "L2 CL factory handled %s but returned a nil node", target)
+			return l2CLStartResult{Node: node, FactoryHandled: true}
+		}
+		t.Require().Nil(node, "L2 CL factory declined %s but returned a node", target)
+		t.Require().NoError(validateDeclinedL2CLFallback(fallbackKind, fallbackSourceFactoryHandled, resolvedCfg.FollowSource),
+			"unsupported partial external L2 CL topology for %s", target)
+	}
+	switch fallbackKind {
+	case MixedL2CLKona:
+		return l2CLStartResult{Node: startMixedKonaNode(
+			t, keys, l1Net, l2Net, l1EL, l1CL, l2EL, clKey, elKey, isSequencer, depSet,
+		)}
+	default: // op-node
+		if resolvedCfg == nil {
+			resolvedCfg = resolveL2CLNodeConfig(t, target, startCfg)
+		}
+		startCfg.ResolvedConfig = resolvedCfg
+		return l2CLStartResult{Node: startL2CLNode(
+			t, keys, l1Net, l2Net, l1EL, l1CL, l2EL, jwtSecret, startCfg,
+		)}
+	}
+}
+
+func validateDeclinedL2CLFallback(kind MixedL2CLKind, sourceFactoryHandled bool, followSource string) error {
+	if kind == MixedL2CLKona && sourceFactoryHandled {
+		return fmt.Errorf("Kona fallback cannot follow external source %q; handle the slot or select op-node", followSource)
+	}
+	return nil
 }
 
 func startSequencerEL(t devtest.T, l2Net *L2Network, jwtPath string, jwtSecret [32]byte, identity *ELNodeIdentity, opts ...OpRethOption) L2ELNode {
@@ -250,20 +296,6 @@ func connectL2CLPeers(t devtest.T, logger log.Logger, l2CL1, l2CL2 L2CLNode) {
 	require.True(ok2, "peer register invalid (cl2 missing cl1)")
 }
 
-func startSequencerCL(
-	t devtest.T,
-	keys devkeys.Keys,
-	l1Net *L1Network,
-	l2Net *L2Network,
-	l1EL L1ELNode,
-	l1CL *L1CLNode,
-	l2EL L2ELNode,
-	jwtSecret [32]byte,
-	l2CLOpts []L2CLOption,
-) L2CLNode {
-	return startL2CLForKey(t, keys, l1Net, l2Net, l1EL, l1CL, l2EL, jwtSecret, "sequencer", "sequencer", true, "", l2CLOpts)
-}
-
 type l2CLNodeStartConfig struct {
 	Key            string
 	IsSequencer    bool
@@ -272,11 +304,34 @@ type l2CLNodeStartConfig struct {
 	L2FollowSource string
 	DependencySet  depset.DependencySet
 	L2CLOptions    []L2CLOption
+	// ResolvedConfig, when set, is used instead of resolving defaults and
+	// options again. This keeps side-effecting options at one application per
+	// slot across factory selection and stock fallback.
+	ResolvedConfig *L2CLConfig
 	// SyncMode overrides the sequencer and verifier sync modes; defaults to CLSync if unset.
 	SyncMode nodeSync.Mode
 	// SequencerStopped starts the sequencer in the stopped state (it must be
 	// activated later via the StartSequencer RPC). Only meaningful when IsSequencer.
 	SequencerStopped bool
+}
+
+func resolveL2CLNodeConfig(t devtest.T, target ComponentTarget, startCfg l2CLNodeStartConfig) *L2CLConfig {
+	cfg := DefaultL2CLConfig()
+	cfg.IsSequencer = startCfg.IsSequencer
+	cfg.NoDiscovery = startCfg.NoDiscovery
+	cfg.EnableReqRespSync = startCfg.EnableReqResp
+	cfg.FollowSource = startCfg.L2FollowSource
+	for _, opt := range startCfg.L2CLOptions {
+		if opt != nil {
+			opt.Apply(t, target, cfg)
+		}
+	}
+	if startCfg.SyncMode != 0 {
+		cfg.SequencerSyncMode = startCfg.SyncMode
+		cfg.VerifierSyncMode = startCfg.SyncMode
+	}
+	cfg.SequencerStopped = startCfg.SequencerStopped || cfg.SequencerStopped
+	return cfg
 }
 
 func startL2CLNode(
@@ -291,24 +346,9 @@ func startL2CLNode(
 	startCfg l2CLNodeStartConfig,
 ) *OpNode {
 	require := t.Require()
-	cfg := DefaultL2CLConfig()
-	cfg.IsSequencer = startCfg.IsSequencer
-	cfg.NoDiscovery = startCfg.NoDiscovery
-	cfg.EnableReqRespSync = startCfg.EnableReqResp
-	cfg.FollowSource = startCfg.L2FollowSource
-	if len(startCfg.L2CLOptions) > 0 {
-		l2CLTarget := NewComponentTarget(startCfg.Key, l2Net.ChainID())
-		for _, opt := range startCfg.L2CLOptions {
-			if opt == nil {
-				continue
-			}
-			opt.Apply(t, l2CLTarget, cfg)
-		}
-	}
-
-	if startCfg.SyncMode != 0 {
-		cfg.SequencerSyncMode = startCfg.SyncMode
-		cfg.VerifierSyncMode = startCfg.SyncMode
+	cfg := startCfg.ResolvedConfig
+	if cfg == nil {
+		cfg = resolveL2CLNodeConfig(t, NewComponentTarget(startCfg.Key, l2Net.ChainID()), startCfg)
 	}
 
 	syncMode := cfg.VerifierSyncMode
@@ -384,7 +424,7 @@ func startL2CLNode(
 		},
 		Driver: driver.Config{
 			SequencerEnabled:    cfg.IsSequencer,
-			SequencerStopped:    startCfg.SequencerStopped,
+			SequencerStopped:    cfg.SequencerStopped,
 			SequencerConfDepth:  2,
 			SequencerMaxSafeLag: cfg.SequencerMaxSafeLag,
 		},
@@ -434,204 +474,6 @@ func startL2CLNode(
 	l2CL.Start()
 	t.Cleanup(l2CL.Stop)
 	return l2CL
-}
-
-func startTestSequencer(
-	t devtest.T,
-	keys devkeys.Keys,
-	jwtPath string,
-	jwtSecret [32]byte,
-	l1Net *L1Network,
-	l1EL *L1Geth,
-	l1CL *L1CLNode,
-	l2EL L2ELNode,
-	l2Net *L2Network,
-	l2CL *OpNode,
-) *testSequencer {
-	require := t.Require()
-	logger := t.Logger().New("component", "test-sequencer")
-
-	l1ELClient, err := ethclient.DialContext(t.Ctx(), l1EL.UserRPC())
-	require.NoError(err, "failed to dial L1 EL RPC for test-sequencer")
-	t.Cleanup(l1ELClient.Close)
-
-	engineCl, err := dialEngine(t.Ctx(), l1EL.AuthRPC(), jwtSecret)
-	require.NoError(err, "failed to dial L1 engine API for test-sequencer")
-	t.Cleanup(func() {
-		engineCl.inner.Close()
-	})
-
-	l1ChainID := l1Net.ChainID()
-	l2ChainID := l2Net.ChainID()
-
-	// L1 sequencer components: fakepos builder + noop signer/committer/publisher.
-	bidL1 := seqtypes.BuilderID("test-l1-builder")
-	cidL1 := seqtypes.CommitterID("test-noop-committer")
-	sidL1 := seqtypes.SignerID("test-noop-signer")
-	pidL1 := seqtypes.PublisherID("test-noop-publisher")
-	seqIDL1 := seqtypes.SequencerID(fmt.Sprintf("test-seq-%s", l1ChainID))
-
-	ensemble := &workconfig.Ensemble{
-		Builders: map[seqtypes.BuilderID]*workconfig.BuilderEntry{
-			bidL1: {
-				L1: &fakepos.Config{
-					ChainConfig:       l1Net.genesis.Config,
-					EngineAPI:         engineCl,
-					Backend:           l1ELClient,
-					Beacon:            l1CL.beacon,
-					FinalizedDistance: 20,
-					SafeDistance:      10,
-					BlockTime:         6,
-				},
-			},
-		},
-		Signers: map[seqtypes.SignerID]*workconfig.SignerEntry{
-			sidL1: {
-				Noop: &noopsigner.Config{},
-			},
-		},
-		Committers: map[seqtypes.CommitterID]*workconfig.CommitterEntry{
-			cidL1: {
-				Noop: &noopcommitter.Config{},
-			},
-		},
-		Publishers: map[seqtypes.PublisherID]*workconfig.PublisherEntry{
-			pidL1: {
-				Noop: &nooppublisher.Config{},
-			},
-		},
-		Sequencers: map[seqtypes.SequencerID]*workconfig.SequencerEntry{
-			seqIDL1: {
-				Full: &fullseq.Config{
-					ChainID:   l1ChainID,
-					Builder:   bidL1,
-					Signer:    sidL1,
-					Committer: cidL1,
-					Publisher: pidL1,
-				},
-			},
-		},
-	}
-
-	// L2 sequencer components: standard builder/committer/publisher + local signer.
-	bidL2 := seqtypes.BuilderID("test-standard-builder")
-	cidL2 := seqtypes.CommitterID("test-standard-committer")
-	sidL2 := seqtypes.SignerID("test-local-signer")
-	pidL2 := seqtypes.PublisherID("test-standard-publisher")
-	seqIDL2 := seqtypes.SequencerID(fmt.Sprintf("test-seq-%s", l2ChainID))
-
-	p2pKey, err := keys.Secret(devkeys.SequencerP2PRole.Key(l2ChainID.ToBig()))
-	require.NoError(err, "need p2p key for test sequencer")
-	rawKey := hexutil.Bytes(crypto.FromECDSA(p2pKey))
-
-	ensemble.Builders[bidL2] = &workconfig.BuilderEntry{
-		Standard: &standardbuilder.Config{
-			L1ChainConfig: l1Net.genesis.Config,
-			L1EL: endpoint.MustRPC{
-				Value: endpoint.HttpURL(l1EL.UserRPC()),
-			},
-			L2EL: endpoint.MustRPC{
-				Value: endpoint.HttpURL(l2EL.UserRPC()),
-			},
-			L2CL: endpoint.MustRPC{
-				Value: endpoint.HttpURL(l2CL.UserRPC()),
-			},
-		},
-	}
-	ensemble.Signers[sidL2] = &workconfig.SignerEntry{
-		LocalKey: &localkey.Config{
-			RawKey:  &rawKey,
-			ChainID: l2ChainID,
-		},
-	}
-	ensemble.Committers[cidL2] = &workconfig.CommitterEntry{
-		Standard: &standardcommitter.Config{
-			RPC: endpoint.MustRPC{
-				Value: endpoint.HttpURL(l2CL.UserRPC()),
-			},
-		},
-	}
-	ensemble.Publishers[pidL2] = &workconfig.PublisherEntry{
-		Standard: &standardpublisher.Config{
-			RPC: endpoint.MustRPC{
-				Value: endpoint.HttpURL(l2CL.UserRPC()),
-			},
-		},
-	}
-	ensemble.Sequencers[seqIDL2] = &workconfig.SequencerEntry{
-		Full: &fullseq.Config{
-			ChainID:             l2ChainID,
-			Builder:             bidL2,
-			Signer:              sidL2,
-			Committer:           cidL2,
-			Publisher:           pidL2,
-			SequencerConfDepth:  2,
-			SequencerEnabled:    true,
-			SequencerStopped:    false,
-			SequencerMaxSafeLag: 0,
-		},
-	}
-
-	sequencerIDs := map[eth.ChainID]seqtypes.SequencerID{
-		l1ChainID: seqIDL1,
-		l2ChainID: seqIDL2,
-	}
-
-	jobs := work.NewJobRegistry()
-	startedEnsemble, err := ensemble.Start(t.Ctx(), &work.StartOpts{
-		Log:     logger,
-		Metrics: &testmetrics.NoopMetrics{},
-		Jobs:    jobs,
-	})
-	require.NoError(err, "failed to start test-sequencer ensemble")
-
-	cfg := &sequencerConfig.Config{
-		MetricsConfig: opmetrics.CLIConfig{
-			Enabled: false,
-		},
-		PprofConfig: oppprof.CLIConfig{
-			ListenEnabled: false,
-		},
-		LogConfig: oplog.CLIConfig{
-			Level:  log.LevelDebug,
-			Format: oplog.FormatText,
-		},
-		RPC: oprpc.CLIConfig{
-			ListenAddr:  "127.0.0.1",
-			ListenPort:  0,
-			EnableAdmin: true,
-		},
-		Ensemble:      startedEnsemble,
-		JWTSecretPath: jwtPath,
-		Version:       "dev",
-		MockRun:       false,
-	}
-
-	sq, err := sequencer.FromConfig(t.Ctx(), cfg, logger)
-	require.NoError(err, "failed to initialize test-sequencer service")
-	require.NoError(sq.Start(t.Ctx()), "failed to start test-sequencer service")
-
-	t.Cleanup(func() {
-		ctx, cancel := context.WithCancel(t.Ctx())
-		cancel()
-		logger.Info("Closing test-sequencer service")
-		closeErr := sq.Stop(ctx)
-		logger.Info("Closed test-sequencer service", "err", closeErr)
-	})
-
-	adminRPC := sq.RPC()
-	controlRPCs := make(map[eth.ChainID]string, len(sequencerIDs))
-	for chainID, seqID := range sequencerIDs {
-		controlRPCs[chainID] = adminRPC + "/sequencers/" + seqID.String()
-	}
-
-	return &testSequencer{
-		name:       "test-sequencer",
-		adminRPC:   adminRPC,
-		jwtSecret:  jwtSecret,
-		controlRPC: controlRPCs,
-		service:    sq,
-	}
 }
 
 func copyControlRPCMap(in map[eth.ChainID]string) map[eth.ChainID]string {

--- a/op-devstack/sysgo/singlechain_runtime.go
+++ b/op-devstack/sysgo/singlechain_runtime.go
@@ -39,13 +39,23 @@ type singleChainRuntimeWorld struct {
 }
 
 type singleChainPrimaryRuntime struct {
-	EL L2ELNode
-	CL L2CLNode
+	EL               L2ELNode
+	CL               L2CLNode
+	FactoryHandledCL bool
 }
 
 type singleChainRuntimeSpec struct {
 	BuildWorld      func(t devtest.T, keys devkeys.Keys, cfg PresetConfig) singleChainRuntimeWorld
 	StartPrimary    func(t devtest.T, keys devkeys.Keys, world singleChainRuntimeWorld, l1EL *L1Geth, l1CL *L1CLNode, jwtPath string, jwtSecret [32]byte, cfg PresetConfig) singleChainPrimaryRuntime
+	StartBatcher    bool
+	StartProposer   bool
+	StartChallenger bool
+	TestSequencer   string
+}
+
+// SingleChainRuntimeOptions controls which product-neutral services surround
+// the primary L2 node. Additional nodes can be attached with AddSingleChainNode.
+type SingleChainRuntimeOptions struct {
 	StartBatcher    bool
 	StartProposer   bool
 	StartChallenger bool
@@ -101,22 +111,31 @@ func startDefaultSingleChainPrimary(
 	// Env-resolved options come first so an explicit binary from the test overrides the env one.
 	sequencerELOpts := append(append([]OpRethOption{}, ResolveMixedL2ELOpts(t)...), cfg.OpRethOptions...)
 	l2EL := startSequencerEL(t, world.L2Network, jwtPath, jwtSecret, NewELNodeIdentity(0), sequencerELOpts...)
+	var depSet depset.DependencySet
 	if world.Interop != nil {
-		l2CL := startL2CLNode(t, keys, world.L1Network, world.L2Network, l1EL, l1CL, l2EL, jwtSecret, l2CLNodeStartConfig{
-			Key:           "sequencer",
-			IsSequencer:   true,
-			NoDiscovery:   true,
-			EnableReqResp: true,
-			DependencySet: world.Interop.DependencySet,
-			L2CLOptions:   l2CLOptions,
-		})
-		return singleChainPrimaryRuntime{EL: l2EL, CL: l2CL}
+		depSet = world.Interop.DependencySet
 	}
-	l2CL := startSequencerCL(t, keys, world.L1Network, world.L2Network, l1EL, l1CL, l2EL, jwtSecret, l2CLOptions)
+	fallbackKind := singleChainPrimaryFallbackKind(world)
+	result := startL2CLForKeyWithKind(
+		t, keys, world.L1Network, world.L2Network, l1EL, l1CL, l2EL, jwtSecret,
+		"sequencer", "sequencer", true, "", depSet, l2CLOptions, cfg.L2CLFactory,
+		nil, false, fallbackKind,
+	)
 	return singleChainPrimaryRuntime{
-		EL: l2EL,
-		CL: l2CL,
+		EL:               l2EL,
+		CL:               result.Node,
+		FactoryHandledCL: result.FactoryHandled,
 	}
+}
+
+func singleChainPrimaryFallbackKind(world singleChainRuntimeWorld) MixedL2CLKind {
+	if world.Interop != nil {
+		// Interop primaries were explicitly op-node before the external factory
+		// seam and must not become env-selected Kona nodes when the factory is
+		// absent or declines.
+		return MixedL2CLOpNode
+	}
+	return devstackL2CLKind()
 }
 
 func newSingleChainRuntimeWithConfig(t devtest.T, cfg PresetConfig, spec singleChainRuntimeSpec) *SingleChainRuntime {
@@ -138,6 +157,7 @@ func newSingleChainRuntimeWithConfig(t devtest.T, cfg PresetConfig, spec singleC
 
 	primary := spec.StartPrimary(t, keys, world, l1EL, l1CL, jwtPath, jwtSecret, cfg)
 	primaryNode := newSingleChainNodeRuntime("sequencer", true, primary.EL, primary.CL)
+	primaryNode.FactoryHandledCL = primary.FactoryHandledCL
 
 	var l2Batcher *L2Batcher
 	if spec.StartBatcher {
@@ -162,6 +182,7 @@ func newSingleChainRuntimeWithConfig(t devtest.T, cfg PresetConfig, spec singleC
 
 	return &SingleChainRuntime{
 		Keys:                          keys,
+		L2CLFactory:                   cfg.L2CLFactory,
 		L1Network:                     world.L1Network,
 		L2Network:                     world.L2Network,
 		L1EL:                          l1EL,
@@ -195,6 +216,19 @@ func NewMinimalRuntimeWithConfig(t devtest.T, cfg PresetConfig) *SingleChainRunt
 		StartBatcher:    true,
 		StartProposer:   true,
 		StartChallenger: true,
+	})
+}
+
+// NewSingleChainRuntime constructs a composable single-chain runtime using
+// the default world and primary-node builders.
+func NewSingleChainRuntime(t devtest.T, cfg PresetConfig, opts SingleChainRuntimeOptions) *SingleChainRuntime {
+	return newSingleChainRuntimeWithConfig(t, cfg, singleChainRuntimeSpec{
+		BuildWorld:      newDefaultSingleChainWorld,
+		StartPrimary:    startDefaultSingleChainPrimary,
+		StartBatcher:    opts.StartBatcher,
+		StartProposer:   opts.StartProposer,
+		StartChallenger: opts.StartChallenger,
+		TestSequencer:   opts.TestSequencer,
 	})
 }
 

--- a/op-devstack/sysgo/singlechain_variants.go
+++ b/op-devstack/sysgo/singlechain_variants.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	opconductor "github.com/ethereum-optimism/optimism/op-conductor/conductor"
+	"github.com/ethereum-optimism/optimism/op-core/interop/depset"
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-service/endpoint"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -30,9 +31,8 @@ func NewSingleChainMultiNodeRuntimeWithConfig(t devtest.T, withP2P bool, cfg Pre
 	runtime := NewMinimalRuntimeWithConfig(t, cfg)
 	nodeB := addSingleChainOpNode(t, runtime, "b", false, "", cfg.GlobalL2CLOptions...)
 	if withP2P {
-		connectSingleChainNodes(t, runtime.L2EL, runtime.L2CL, nodeB)
+		runtime.P2PEnabled = connectSingleChainNodes(t, runtime.Nodes["sequencer"], nodeB)
 	}
-	runtime.P2PEnabled = withP2P
 	return runtime
 }
 
@@ -44,10 +44,12 @@ func NewSingleChainTwoVerifiersRuntimeWithConfig(t devtest.T, cfg PresetConfig) 
 	runtime := NewSingleChainMultiNodeRuntimeWithConfig(t, true, cfg)
 	nodeB := runtime.Nodes["b"]
 	t.Require().NotNil(nodeB, "missing single-chain node b")
-	nodeC := addSingleChainOpNode(t, runtime, "c", false, nodeB.CL.UserRPC(), cfg.GlobalL2CLOptions...)
+	nodeC := addSingleChainOpNodeWithSource(
+		t, runtime, "c", false, nodeB, nodeB.CL.UserRPC(), cfg.GlobalL2CLOptions...,
+	)
 
-	connectSingleChainNodes(t, runtime.L2EL, runtime.L2CL, nodeC)
-	connectSingleChainNodes(t, nodeB.EL, nodeB.CL, nodeC)
+	connectSingleChainNodes(t, runtime.Nodes["sequencer"], nodeC)
+	connectSingleChainNodes(t, nodeB, nodeC)
 
 	// Follow legacy behavior: test-sequencer is wired against node "b".
 	replaceSingleChainTestSequencer(t, runtime, "dev", nodeB)
@@ -118,14 +120,14 @@ func NewMinimalWithConductorsRuntimeWithConfig(t devtest.T, cfg PresetConfig) *S
 	// apply to all of them or it would silently stop taking effect on transfer. The primary already
 	// received these options from startDefaultSingleChainPrimary.
 	candidateELOpts := append(append([]OpRethOption{}, ResolveMixedL2ELOpts(t)...), cfg.OpRethOptions...)
-	nodeB := addSingleChainOpNodeWithELOpts(t, runtime, "b", true, "", candidateELOpts, cfg.GlobalL2CLOptions...)
-	nodeC := addSingleChainOpNodeWithELOpts(t, runtime, "c", true, "", candidateELOpts, cfg.GlobalL2CLOptions...)
+	nodeB := addSingleChainOpNodeWithELOpts(t, runtime, "b", true, nil, "", candidateELOpts, cfg.GlobalL2CLOptions...)
+	nodeC := addSingleChainOpNodeWithELOpts(t, runtime, "c", true, nil, "", candidateELOpts, cfg.GlobalL2CLOptions...)
 
 	// A non-candidate node, always stock: it never sequences, so it independently validates every
 	// block the candidates build. Without it an overridden binary on all three members could accept
 	// its own invalid blocks and the run would still pass.
 	nodeVerifier := addSingleChainOpNode(t, runtime, "verifier", false, "", cfg.GlobalL2CLOptions...)
-	connectSingleChainNodes(t, runtime.L2EL, runtime.L2CL, nodeVerifier)
+	connectSingleChainNodes(t, runtime.Nodes["sequencer"], nodeVerifier)
 
 	conductorA := startConductorNode(t, "sequencer", runtime.L2Network, runtime.L2CL.(*OpNode), runtime.L2EL, true, false)
 	conductorB := startConductorNode(t, "b", runtime.L2Network, nodeB.CL.(*OpNode), nodeB.EL, false, true)
@@ -140,9 +142,19 @@ func NewMinimalWithConductorsRuntimeWithConfig(t devtest.T, cfg PresetConfig) *S
 	return runtime
 }
 
-func connectSingleChainNodes(t devtest.T, sourceEL L2ELNode, sourceCL L2CLNode, target *SingleChainNodeRuntime) {
-	connectL2ELPeers(t, t.Logger(), sourceEL.UserRPC(), target.EL.UserRPC())
-	connectSingleChainCLPeer(t, sourceCL, target.CL)
+func connectSingleChainNodes(t devtest.T, source, target *SingleChainNodeRuntime) bool {
+	t.Require().NotNil(source, "single-chain P2P source is required")
+	t.Require().NotNil(target, "single-chain P2P target is required")
+	connectL2ELPeers(t, t.Logger(), source.EL.UserRPC(), target.EL.UserRPC())
+	if shouldConnectSingleChainCLPeers(source, target) {
+		connectSingleChainCLPeer(t, source.CL, target.CL)
+		return true
+	}
+	return false
+}
+
+func shouldConnectSingleChainCLPeers(source, target *SingleChainNodeRuntime) bool {
+	return !source.FactoryHandledCL && !target.FactoryHandledCL
 }
 
 func connectSingleChainCLPeer(t devtest.T, sourceCL, targetCL L2CLNode) {
@@ -150,19 +162,18 @@ func connectSingleChainCLPeer(t devtest.T, sourceCL, targetCL L2CLNode) {
 }
 
 func replaceSingleChainTestSequencer(t devtest.T, runtime *SingleChainRuntime, name string, node *SingleChainNodeRuntime) {
-	l2CL, ok := node.CL.(*OpNode)
-	t.Require().True(ok, "single-chain test sequencer requires an op-node CL node")
-	testSequencer := startTestSequencer(
+	testSequencer := startTestSequencerForRPCs(
 		t,
 		runtime.Keys,
+		name,
 		runtime.L2EL.JWTPath(),
 		readJWTSecretFromPath(t, runtime.L2EL.JWTPath()),
 		runtime.L1Network,
 		runtime.L1EL,
 		runtime.L1CL,
-		node.EL,
-		runtime.L2Network,
-		l2CL,
+		runtime.L2Network.ChainID(),
+		node.EL.UserRPC(),
+		node.CL.UserRPC(),
 	)
 	runtime.TestSequencer = newTestSequencerRuntime(testSequencer, name)
 }
@@ -175,7 +186,23 @@ func addSingleChainOpNode(
 	followSource string,
 	l2Opts ...L2CLOption,
 ) *SingleChainNodeRuntime {
-	return addSingleChainOpNodeWithELOpts(t, runtime, name, isSequencer, followSource, nil, l2Opts...)
+	var source *SingleChainNodeRuntime
+	if !isSequencer && followSource == "" {
+		source = runtime.Nodes["sequencer"]
+	}
+	return addSingleChainOpNodeWithELOpts(t, runtime, name, isSequencer, source, followSource, nil, l2Opts...)
+}
+
+func addSingleChainOpNodeWithSource(
+	t devtest.T,
+	runtime *SingleChainRuntime,
+	name string,
+	isSequencer bool,
+	source *SingleChainNodeRuntime,
+	followSource string,
+	l2Opts ...L2CLOption,
+) *SingleChainNodeRuntime {
+	return addSingleChainOpNodeWithELOpts(t, runtime, name, isSequencer, source, followSource, nil, l2Opts...)
 }
 
 // addSingleChainOpNodeWithELOpts adds a node whose EL takes op-reth options. Passing none yields a
@@ -186,17 +213,58 @@ func addSingleChainOpNodeWithELOpts(
 	runtime *SingleChainRuntime,
 	name string,
 	isSequencer bool,
+	source *SingleChainNodeRuntime,
 	followSource string,
 	elOpts []OpRethOption,
 	l2Opts ...L2CLOption,
 ) *SingleChainNodeRuntime {
 	jwtPath := runtime.L2EL.JWTPath()
 	jwtSecret := readJWTSecretFromPath(t, jwtPath)
+	depSet := singleChainAddedNodeDependencySet(runtime)
 	l2EL := startL2ELForKey(t, runtime.L2Network, jwtPath, jwtSecret, name, NewELNodeIdentity(0), elOpts...)
-	l2CL := startL2CLForKey(t, runtime.Keys, runtime.L1Network, runtime.L2Network, runtime.L1EL, runtime.L1CL, l2EL, jwtSecret, name, name, isSequencer, followSource, l2Opts)
-	node := newSingleChainNodeRuntime(name, isSequencer, l2EL, l2CL)
+	stockFollowSource, unsafeSourceEL := singleChainNodeSources(source, followSource)
+	result := startL2CLForKeyWithKind(
+		t, runtime.Keys, runtime.L1Network, runtime.L2Network, runtime.L1EL, runtime.L1CL,
+		l2EL, jwtSecret, name, name, isSequencer, stockFollowSource, depSet, l2Opts,
+		runtime.L2CLFactory, unsafeSourceEL,
+		source != nil && source.FactoryHandledCL, devstackL2CLKind(),
+	)
+	node := newSingleChainNodeRuntime(name, isSequencer, l2EL, result.Node)
+	node.FactoryHandledCL = result.FactoryHandled
 	runtime.Nodes[name] = node
 	return node
+}
+
+func singleChainAddedNodeDependencySet(runtime *SingleChainRuntime) depset.DependencySet {
+	if runtime.L2CLFactory == nil || runtime.Interop == nil {
+		return nil
+	}
+	return runtime.Interop.DependencySet
+}
+
+func singleChainNodeSources(source *SingleChainNodeRuntime, requested string) (string, L2ELNode) {
+	if source == nil {
+		return requested, nil
+	}
+	if requested == "" && source.FactoryHandledCL {
+		// A declined stock verifier cannot use op-node admin peering when its
+		// source CL is external, so follow the source's rollup RPC.
+		return source.CL.UserRPC(), source.EL
+	}
+	return requested, source.EL
+}
+
+// AddSingleChainNode adds a sequencer or verifier slot to an existing runtime.
+// The runtime's L2CLFactory is consulted for the new slot.
+func AddSingleChainNode(
+	t devtest.T,
+	runtime *SingleChainRuntime,
+	name string,
+	isSequencer bool,
+	followSource string,
+	l2Opts ...L2CLOption,
+) *SingleChainNodeRuntime {
+	return addSingleChainOpNode(t, runtime, name, isSequencer, followSource, l2Opts...)
 }
 
 func startSyncTesterService(t devtest.T, chainRPCs map[eth.ChainID]string) *SyncTesterService {


### PR DESCRIPTION
op-devstack currently makes alternate L2 consensus-client testing depend on a downstream fork because stock CL construction is embedded in its runtimes. This adds a product-neutral factory contract for single-chain and mixed-client slots while preserving existing behavior when no factory is configured.

Supplying a factory intentionally opts into EL-first, sequencer-first CL selection so verifier source endpoints exist before a slot is selected; unsupported partial fallback from an external source to Kona fails closed. This is the first PR in the stack for #22756; follow-ups add the no-supernode two-L2 topology and staged startup API.
