### PR TITLE
op-devstack: add a two-L2 external-CL interop preset

### DIFF
--- a/op-devstack/presets/twol2_external_cl.go
+++ b/op-devstack/presets/twol2_external_cl.go
@@ -1,0 +1,128 @@
+package presets
+
+import (
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+	"github.com/ethereum-optimism/optimism/op-service/clock"
+)
+
+// TwoL2ExternalCLInterop is a two-chain interop setup without a supernode or
+// supervisor. Each chain has a stock sequencer and a dedicated verifier slot
+// supplied through WithL2CLFactory (or ordinary client selection as fallback).
+type TwoL2ExternalCLInterop struct {
+	TwoL2
+
+	TestSequencer *dsl.TestSequencer
+
+	L2ELA *dsl.L2ELNode
+	L2ELB *dsl.L2ELNode
+
+	L2AVerifierCL *dsl.L2CLNode
+	L2BVerifierCL *dsl.L2CLNode
+	L2AVerifierEL *dsl.L2ELNode
+	L2BVerifierEL *dsl.L2ELNode
+
+	L2BatcherA *dsl.L2Batcher
+	L2BatcherB *dsl.L2Batcher
+
+	Wallet  *dsl.HDWallet
+	FunderA *dsl.FunderEOA
+	FunderB *dsl.FunderEOA
+
+	GenesisTime           uint64
+	InteropActivationTime uint64
+	DelaySeconds          uint64
+
+	timeTravel *clock.AdvancingClock
+}
+
+func (s *TwoL2ExternalCLInterop) L2UserRPCURLs() []string {
+	return []string{s.L2ELA.Escape().UserRPC(), s.L2ELB.Escape().UserRPC()}
+}
+
+func (s *TwoL2ExternalCLInterop) AdvanceTime(amount time.Duration) {
+	s.T.Require().NotNil(s.timeTravel, "attempting to advance time on incompatible system")
+	s.L1EL.AdvanceTime(s.timeTravel, amount)
+}
+
+// NewTwoL2ExternalCLInterop constructs the no-supernode interop preset.
+func NewTwoL2ExternalCLInterop(t devtest.T, delaySeconds uint64, opts ...Option) *TwoL2ExternalCLInterop {
+	presetCfg, _ := collectSupportedPresetConfig(
+		t, "NewTwoL2ExternalCLInterop", opts, twoL2ExternalCLInteropPresetSupportedOptionKinds,
+	)
+	return twoL2ExternalCLInteropFromRuntime(
+		t, sysgo.NewTwoL2ExternalCLInteropRuntimeWithConfig(t, delaySeconds, presetCfg),
+	)
+}
+
+func twoL2ExternalCLInteropFromRuntime(t devtest.T, runtime *sysgo.MultiChainRuntime) *TwoL2ExternalCLInterop {
+	twoL2, components := twoL2FromRuntime(t, runtime)
+	chainA := runtime.Chains["l2a"]
+	chainB := runtime.Chains["l2b"]
+	t.Require().NotNil(chainA, "missing l2a runtime chain")
+	t.Require().NotNil(chainB, "missing l2b runtime chain")
+	verifierA := chainA.Followers["verifier"]
+	verifierB := chainB.Followers["verifier"]
+	t.Require().NotNil(verifierA, "missing l2a verifier node")
+	t.Require().NotNil(verifierB, "missing l2b verifier node")
+
+	l2AVerifierEL := newL2ELFrontend(
+		t, verifierA.Name, chainA.Network.ChainID(), verifierA.EL.UserRPC(), verifierA.EL.EngineRPC(),
+		verifierA.EL.JWTPath(), chainA.Network.RollupConfig(), verifierA.EL,
+	)
+	l2AVerifierCL := newL2CLFrontend(
+		t, verifierA.Name, chainA.Network.ChainID(), verifierA.CL.UserRPC(), verifierA.CL,
+	)
+	l2AVerifierCL.attachEL(l2AVerifierEL)
+
+	l2BVerifierEL := newL2ELFrontend(
+		t, verifierB.Name, chainB.Network.ChainID(), verifierB.EL.UserRPC(), verifierB.EL.EngineRPC(),
+		verifierB.EL.JWTPath(), chainB.Network.RollupConfig(), verifierB.EL,
+	)
+	l2BVerifierCL := newL2CLFrontend(
+		t, verifierB.Name, chainB.Network.ChainID(), verifierB.CL.UserRPC(), verifierB.CL,
+	)
+	l2BVerifierCL.attachEL(l2BVerifierEL)
+
+	l2ANet, ok := twoL2.L2A.Escape().(*presetL2Network)
+	t.Require().True(ok, "expected preset L2 network A")
+	l2ANet.AddL2ELNode(l2AVerifierEL)
+	l2ANet.AddL2CLNode(l2AVerifierCL)
+
+	l2BNet, ok := twoL2.L2B.Escape().(*presetL2Network)
+	t.Require().True(ok, "expected preset L2 network B")
+	l2BNet.AddL2ELNode(l2BVerifierEL)
+	l2BNet.AddL2CLNode(l2BVerifierCL)
+
+	testSequencer := newTestSequencerFrontend(
+		t,
+		runtime.TestSequencer.Name,
+		runtime.TestSequencer.AdminRPC,
+		runtime.TestSequencer.ControlRPC,
+		runtime.TestSequencer.JWTSecret,
+	)
+	genesisTime := twoL2.L2A.Escape().RollupConfig().Genesis.L2Time
+	out := &TwoL2ExternalCLInterop{
+		TwoL2:                 *twoL2,
+		TestSequencer:         dsl.NewTestSequencer(testSequencer),
+		L2ELA:                 dsl.NewL2ELNode(components.l2AEL),
+		L2ELB:                 dsl.NewL2ELNode(components.l2BEL),
+		L2AVerifierCL:         dsl.NewL2CLNode(l2AVerifierCL),
+		L2BVerifierCL:         dsl.NewL2CLNode(l2BVerifierCL),
+		L2AVerifierEL:         dsl.NewL2ELNode(l2AVerifierEL),
+		L2BVerifierEL:         dsl.NewL2ELNode(l2BVerifierEL),
+		L2BatcherA:            dsl.NewL2Batcher(components.l2ABatcher),
+		L2BatcherB:            dsl.NewL2Batcher(components.l2BBatcher),
+		Wallet:                dsl.NewRandomHDWallet(t, 30),
+		GenesisTime:           genesisTime,
+		InteropActivationTime: genesisTime + runtime.DelaySeconds,
+		DelaySeconds:          runtime.DelaySeconds,
+		timeTravel:            runtime.TimeTravel,
+	}
+	out.FunderA = newFunderEOA(t, runtime.Keys, out.L2ELA, out.Wallet)
+	out.FunderB = newFunderEOA(t, runtime.Keys, out.L2ELB, out.Wallet)
+	return out
+}

--- a/op-devstack/sysgo/twol2_external_cl_interop.go
+++ b/op-devstack/sysgo/twol2_external_cl_interop.go
@@ -1,0 +1,131 @@
+package sysgo
+
+import (
+	"github.com/ethereum-optimism/optimism/op-chain-ops/devkeys"
+	"github.com/ethereum-optimism/optimism/op-core/interop/depset"
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-service/clock"
+)
+
+const twoL2VerifierNodeKey = "verifier"
+
+// NewTwoL2ExternalCLInteropRuntime builds a two-chain interop world with a
+// stock sequencer and batcher per chain plus a dedicated verifier EL/CL slot.
+// It deliberately starts no supernode or supervisor.
+func NewTwoL2ExternalCLInteropRuntime(t devtest.T, delaySeconds uint64) *MultiChainRuntime {
+	return NewTwoL2ExternalCLInteropRuntimeWithConfig(t, delaySeconds, PresetConfig{})
+}
+
+// NewTwoL2ExternalCLInteropRuntimeWithConfig is the configured form of
+// NewTwoL2ExternalCLInteropRuntime. L2CLFactory is consulted for each verifier
+// slot and ordinary client selection is used when it is nil or declines.
+func NewTwoL2ExternalCLInteropRuntimeWithConfig(t devtest.T, delaySeconds uint64, cfg PresetConfig) *MultiChainRuntime {
+	require := t.Require()
+
+	keys, err := devkeys.NewMnemonicDevKeys(devkeys.TestMnemonic)
+	require.NoError(err, "failed to derive dev keys from mnemonic")
+
+	wb, l1Net, l2ANet, l2BNet := buildTwoL2RuntimeWorld(
+		t, keys, true, delaySeconds, cfg.LocalContractArtifactsPath, cfg.DeployerOptions...,
+	)
+	migration := newInteropMigrationState(wb)
+	jwtPath, jwtSecret := writeJWTSecret(t)
+	l1Clock := clock.SystemClock
+	var timeTravelClock *clock.AdvancingClock
+	if cfg.EnableTimeTravel {
+		timeTravelClock = clock.NewAdvancingClock()
+		l1Clock = timeTravelClock
+	}
+	l1EL, l1CL := startInProcessL1WithClockConfig(t, l1Net, jwtPath, l1Clock, cfg)
+
+	runtimeDepSet := wb.outFullCfgSet.DependencySet
+	require.NotNil(runtimeDepSet, "two-L2 interop world must provide a dependency set")
+
+	startChain := func(l2Net *L2Network) *MultiChainNodeRuntime {
+		// Apply target-scoped op-reth options before either EL starts. This is
+		// where callers attach stable interop-admission proxies without an EL
+		// restart/reconfiguration hook.
+		elOpts := append(append([]OpRethOption{}, ResolveMixedL2ELOpts(t)...), cfg.OpRethOptions...)
+		seqEL := startSequencerEL(t, l2Net, jwtPath, jwtSecret, NewELNodeIdentity(0), elOpts...)
+		seqCL := startL2CLNode(t, keys, l1Net, l2Net, l1EL, l1CL, seqEL, jwtSecret, l2CLNodeStartConfig{
+			Key:           "sequencer",
+			IsSequencer:   true,
+			NoDiscovery:   true,
+			EnableReqResp: true,
+			DependencySet: runtimeDepSet,
+			L2CLOptions:   cfg.GlobalL2CLOptions,
+		})
+		batcher := startMinimalBatcher(t, keys, l2Net, l1EL, seqCL, seqEL, cfg.BatcherOptions...)
+
+		verifierEL := startL2ELForKey(
+			t, l2Net, jwtPath, jwtSecret, twoL2VerifierNodeKey, NewELNodeIdentity(0), elOpts...,
+		)
+		// The stock follow path imports forkchoice from the sequencer CL but
+		// still needs the paired execution peer for block bodies. Keep the same
+		// edge for external verifiers so handled and fallback slots share one
+		// topology.
+		connectL2ELPeers(t, t.Logger(), seqEL.UserRPC(), verifierEL.UserRPC())
+		verifierCL := startInteropVerifierCL(
+			t, keys, l1Net, l2Net, l1EL, l1CL, verifierEL, jwtSecret,
+			seqEL, seqCL, runtimeDepSet, cfg.GlobalL2CLOptions, cfg.L2CLFactory,
+		)
+
+		return &MultiChainNodeRuntime{
+			Name:    l2Net.Name(),
+			Network: l2Net,
+			EL:      seqEL,
+			CL:      seqCL,
+			Batcher: batcher,
+			Followers: map[string]*SingleChainNodeRuntime{
+				twoL2VerifierNodeKey: newSingleChainNodeRuntime(twoL2VerifierNodeKey, false, verifierEL, verifierCL),
+			},
+		}
+	}
+
+	chainA := startChain(l2ANet)
+	chainB := startChain(l2BNet)
+	base := &MultiChainRuntime{
+		Keys:          keys,
+		Migration:     migration,
+		FullConfigSet: wb.outFullCfgSet,
+		DependencySet: runtimeDepSet,
+		L1Network:     l1Net,
+		L1EL:          l1EL,
+		L1CL:          l1CL,
+		Chains: map[string]*MultiChainNodeRuntime{
+			"l2a": chainA,
+			"l2b": chainB,
+		},
+		TimeTravel:   timeTravelClock,
+		DelaySeconds: delaySeconds,
+	}
+	attachTestSequencerToRuntime(t, base, "test-sequencer-2l2-external-cl")
+	return base
+}
+
+func startInteropVerifierCL(
+	t devtest.T,
+	keys devkeys.Keys,
+	l1Net *L1Network,
+	l2Net *L2Network,
+	l1EL L1ELNode,
+	l1CL *L1CLNode,
+	verifierEL L2ELNode,
+	jwtSecret [32]byte,
+	unsafeSourceEL L2ELNode,
+	unsafeSourceCL L2CLNode,
+	depSet depset.DependencySet,
+	l2CLOpts []L2CLOption,
+	factory L2CLFactory,
+) L2CLNode {
+	stockFollowSource := interopVerifierFollowSource(unsafeSourceCL)
+	return startL2CLForKeyWithKind(
+		t, keys, l1Net, l2Net, l1EL, l1CL, verifierEL, jwtSecret,
+		twoL2VerifierNodeKey, twoL2VerifierNodeKey, false, stockFollowSource,
+		depSet, l2CLOpts, factory, unsafeSourceEL, false, MixedL2CLOpNode,
+	).Node
+}
+
+func interopVerifierFollowSource(unsafeSourceCL L2CLNode) string {
+	return unsafeSourceCL.UserRPC()
+}

--- a/op-devstack/sysgo/twol2_external_cl_interop_test.go
+++ b/op-devstack/sysgo/twol2_external_cl_interop_test.go
@@ -1,0 +1,134 @@
+package sysgo
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-core/interop/depset"
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	_ func(devtest.T, uint64) *MultiChainRuntime               = NewTwoL2ExternalCLInteropRuntime
+	_ func(devtest.T, uint64, PresetConfig) *MultiChainRuntime = NewTwoL2ExternalCLInteropRuntimeWithConfig
+)
+
+type fakeInteropL1EL struct{}
+
+func (fakeInteropL1EL) l1ELNode()       {}
+func (fakeInteropL1EL) UserRPC() string { return "http://127.0.0.1:8545" }
+func (fakeInteropL1EL) AuthRPC() string { return "http://127.0.0.1:8551" }
+
+type fakeInteropL2EL struct {
+	user   string
+	engine string
+	jwt    string
+}
+
+func (fakeInteropL2EL) Start()              {}
+func (fakeInteropL2EL) Stop()               {}
+func (n fakeInteropL2EL) UserRPC() string   { return n.user }
+func (n fakeInteropL2EL) EngineRPC() string { return n.engine }
+func (n fakeInteropL2EL) JWTPath() string   { return n.jwt }
+
+func TestTwoL2ExternalCLInteropVerifierSlotsUseFactory(t *testing.T) {
+	dt := devtest.SerialT(t)
+	chainAID := eth.ChainIDFromUInt64(901)
+	chainBID := eth.ChainIDFromUInt64(902)
+	depSet, err := depset.NewStaticConfigDependencySet(map[eth.ChainID]*depset.StaticConfigDependency{
+		chainAID: {},
+		chainBID: {},
+	})
+	require.NoError(t, err)
+
+	l1Net := &L1Network{name: "l1", chainID: eth.ChainIDFromUInt64(900), genesis: &core.Genesis{}}
+	l1CL := &L1CLNode{name: "l1", beaconHTTPAddr: "http://127.0.0.1:4000"}
+	l1EL := fakeInteropL1EL{}
+	newL2Net := func(name string, id eth.ChainID) *L2Network {
+		return &L2Network{
+			name:      name,
+			chainID:   id,
+			l1ChainID: l1Net.ChainID(),
+			genesis:   &core.Genesis{},
+			rollupCfg: &rollup.Config{L2ChainID: id.ToBig()},
+		}
+	}
+	l2ANet := newL2Net("l2a", chainAID)
+	l2BNet := newL2Net("l2b", chainBID)
+	verifierAEL := fakeInteropL2EL{user: "http://127.0.0.1:9001", engine: "http://127.0.0.1:9002", jwt: "/jwt/a"}
+	verifierBEL := fakeInteropL2EL{user: "http://127.0.0.1:9101", engine: "http://127.0.0.1:9102", jwt: "/jwt/b"}
+	sequencerAEL := fakeInteropL2EL{user: "http://127.0.0.1:9545", engine: "http://127.0.0.1:9551", jwt: "/jwt/seq-a"}
+	sequencerBEL := fakeInteropL2EL{user: "http://127.0.0.1:9645", engine: "http://127.0.0.1:9651", jwt: "/jwt/seq-b"}
+	sequencerACL := &fakeExternalL2CL{rpc: "http://127.0.0.1:7545"}
+	sequencerBCL := &fakeExternalL2CL{rpc: "http://127.0.0.1:7645"}
+
+	var seen []L2CLLaunchContext
+	factory := L2CLFactoryFn(func(_ devtest.T, ctx L2CLLaunchContext) (L2CLNode, bool) {
+		seen = append(seen, ctx)
+		return &fakeExternalL2CL{}, true
+	})
+	optionApplications := 0
+	opt := L2CLOptionFn(func(_ devtest.T, _ ComponentTarget, cfg *L2CLConfig) {
+		optionApplications++
+		cfg.SequencerMaxSafeLag = 7
+	})
+
+	verifierACL := startInteropVerifierCL(
+		dt, nil, l1Net, l2ANet, l1EL, l1CL, verifierAEL, [32]byte{}, sequencerAEL, sequencerACL,
+		depSet, []L2CLOption{opt}, factory,
+	)
+	verifierBCL := startInteropVerifierCL(
+		dt, nil, l1Net, l2BNet, l1EL, l1CL, verifierBEL, [32]byte{}, sequencerBEL, sequencerBCL,
+		depSet, []L2CLOption{opt}, factory,
+	)
+
+	require.NotNil(t, verifierACL)
+	require.NotNil(t, verifierBCL)
+	require.Len(t, seen, 2)
+	require.Equal(t, 2, optionApplications, "each slot resolves options exactly once")
+	for _, ctx := range seen {
+		require.Equal(t, L2CLRoleVerifier, ctx.Role)
+		require.Equal(t, twoL2VerifierNodeKey, ctx.Target.Name)
+		require.False(t, ctx.Config.IsSequencer)
+		require.Equal(t, uint64(7), ctx.Config.SequencerMaxSafeLag)
+		require.Same(t, depSet, ctx.DependencySet)
+		require.True(t, ctx.DependencySet.HasChain(chainAID))
+		require.True(t, ctx.DependencySet.HasChain(chainBID))
+		require.NotNil(t, ctx.L1Genesis)
+		require.NotNil(t, ctx.L2Genesis)
+		require.NotNil(t, ctx.RollupConfig)
+		require.Equal(t, ctx.Config.FollowSource, ctx.FollowSource,
+			"external and fallback selection share one rollup-RPC follow configuration")
+		require.Nil(t, ctx.RegisterMetrics, "classic runtime has no metrics registrar")
+	}
+
+	require.Equal(t, chainAID, seen[0].Target.ChainID)
+	require.Equal(t, verifierAEL.user, seen[0].L2UserRPC)
+	require.Equal(t, verifierAEL.engine, seen[0].L2EngineRPC)
+	require.Equal(t, verifierAEL.jwt, seen[0].L2JWTPath)
+	require.Equal(t, sequencerACL.UserRPC(), seen[0].FollowSource)
+	require.Equal(t, sequencerAEL.user, seen[0].UnsafeSourceUserRPC)
+	require.Equal(t, sequencerAEL.engine, seen[0].UnsafeSourceEngineRPC)
+	require.Equal(t, sequencerAEL.jwt, seen[0].UnsafeSourceJWTPath)
+
+	require.Equal(t, chainBID, seen[1].Target.ChainID)
+	require.Equal(t, verifierBEL.user, seen[1].L2UserRPC)
+	require.Equal(t, verifierBEL.engine, seen[1].L2EngineRPC)
+	require.Equal(t, verifierBEL.jwt, seen[1].L2JWTPath)
+	require.Equal(t, sequencerBCL.UserRPC(), seen[1].FollowSource)
+	require.Equal(t, sequencerBEL.user, seen[1].UnsafeSourceUserRPC)
+	require.Equal(t, sequencerBEL.engine, seen[1].UnsafeSourceEngineRPC)
+	require.Equal(t, sequencerBEL.jwt, seen[1].UnsafeSourceJWTPath)
+}
+
+func TestTwoL2ExternalCLInteropVerifierFollowSources(t *testing.T) {
+	sequencerCL := &fakeExternalL2CL{rpc: "http://127.0.0.1:7545"}
+
+	stock := interopVerifierFollowSource(sequencerCL)
+
+	require.Equal(t, sequencerCL.UserRPC(), stock,
+		"a nil or declining factory falls back to op-node's rollup-RPC follow source")
+}


### PR DESCRIPTION
The existing two-L2 presets put a stock supernode in the correctness path, so they cannot isolate an alternate per-chain consensus implementation. This adds a two-L2 interop runtime and preset with independent sequencer and verifier CL slots and no supernode, while keeping stock fallback follow-source and execution-source semantics distinct.

This is the second PR for #22756, stacked on #22757. The final PR adds deliberately staged startup for restart and sequencing tests.
