### PR TITLE
kona-sp1-proposer: raise range split ceiling to 128

### DIFF
--- a/rust/kona/sp1/README.md
+++ b/rust/kona/sp1/README.md
@@ -228,7 +228,7 @@ Optional core and operational configuration:
 | `KONA_SP1_PROPOSER_TX_CONFIRMATION_TIMEOUT` | transaction confirmation timeout in seconds (default `180`) |
 | `KONA_SP1_PROPOSER_MAX_FEE_PER_GAS` | L1 max-fee cap in wei (default uncapped) |
 | `KONA_SP1_PROPOSER_MAX_PRIORITY_FEE_PER_GAS` | L1 priority-fee cap in wei (default uncapped) |
-| `KONA_SP1_PROPOSER_RANGE_SPLIT_COUNT` | chunks per defended span (default and maximum `16`) |
+| `KONA_SP1_PROPOSER_RANGE_SPLIT_COUNT` | chunks per defended span (default `16`, maximum `128`) |
 | `KONA_SP1_PROPOSER_MAX_CONCURRENT_RANGE_PROOFS` | child-proof concurrency per game (default `1`) |
 | `KONA_SP1_PROPOSER_MAX_CONCURRENT_DEFENSE_TASKS` | concurrent defended games (default `8`, minimum `1`) |
 | `KONA_SP1_PROPOSER_FAST_FINALITY_MODE` | prove signer-created owned games while unchallenged (default `false`) |
@@ -264,10 +264,20 @@ arrival (3-10s) and no more. It must leave assignment margin under
 `AUCTION_TIMEOUT`; cancellation retries the unfinished request while completed
 chunks remain cached when the proving inputs are unchanged.
 
-A defended span produces up to 16 chunks. Each sufficiently large chunk can
-require a range proof and a consolidation proof, for up to 32 compressed child
-proofs before the final PLONK aggregation proof. `SP1_TIMEOUT_SECONDS` applies
-independently to each proof request, not to the complete defense.
+A defended span produces up to 128 chunks, with 16 by default. Each
+sufficiently large chunk can require a range proof and a consolidation proof,
+for up to 256 compressed child proofs before the final PLONK aggregation proof.
+`SP1_TIMEOUT_SECONDS` applies independently to each proof request, not to the
+complete defense.
+
+At the default one-hour interval, an OP Mainnet span contains about 1,800
+two-second blocks. The default 16 chunks average 112.5 blocks each; configuring
+18 targets 100 blocks per chunk. Configuring the maximum produces 125 chunks
+averaging 14.4 blocks because ceil division may yield fewer chunks than
+requested. Higher counts reduce per-request work but increase witness
+collection, fixed proving overhead, SPN request count, and aggregation input
+size. `RANGE_GAS_LIMIT` limits each range request, not the total work of the
+defense.
 
 Transaction signing requires one of these configurations:
 

--- a/rust/kona/sp1/README.md
+++ b/rust/kona/sp1/README.md
@@ -264,20 +264,17 @@ arrival (3-10s) and no more. It must leave assignment margin under
 `AUCTION_TIMEOUT`; cancellation retries the unfinished request while completed
 chunks remain cached when the proving inputs are unchanged.
 
-A defended span produces up to 128 chunks, with 16 by default. Each
-sufficiently large chunk can require a range proof and a consolidation proof,
-for up to 256 compressed child proofs before the final PLONK aggregation proof.
-`SP1_TIMEOUT_SECONDS` applies independently to each proof request, not to the
-complete defense.
+A defended span is split into up to the configured number of chunks. Each sufficiently
+large chunk can require a range proof and a consolidation proof before the final
+PLONK aggregation proof. `SP1_TIMEOUT_SECONDS` applies independently to each
+proof request, not to the complete defense.
 
 At the default one-hour interval, an OP Mainnet span contains about 1,800
 two-second blocks. The default 16 chunks average 112.5 blocks each; configuring
-18 targets 100 blocks per chunk. Configuring the maximum produces 125 chunks
-averaging 14.4 blocks because ceil division may yield fewer chunks than
-requested. Higher counts reduce per-request work but increase witness
-collection, fixed proving overhead, SPN request count, and aggregation input
-size. `RANGE_GAS_LIMIT` limits each range request, not the total work of the
-defense.
+18 targets 100 blocks per chunk. Higher counts reduce per-request work but
+increase witness collection, fixed proving overhead, SPN request count, and
+aggregation input size. `RANGE_GAS_LIMIT` limits each range request, not the
+total work of the defense.
 
 Transaction signing requires one of these configurations:
 

--- a/rust/kona/sp1/crates/proposer/src/config.rs
+++ b/rust/kona/sp1/crates/proposer/src/config.rs
@@ -267,11 +267,7 @@ impl ProposerConfig {
                 .map(|list| list.split(',').map(|path| PathBuf::from(path.trim())).collect()),
             l1_config_path: optional_env("L1_CONFIG_PATH").map(PathBuf::from),
             dependency_set_path: optional_env("DEPENDENCY_SET_PATH").map(PathBuf::from),
-            range_split_count: parsed_env_or(
-                "RANGE_SPLIT_COUNT",
-                RangeSplitCount::new(RangeSplitCount::DEFAULT)
-                    .expect("default is a valid range split count"),
-            )?,
+            range_split_count: parsed_env_or("RANGE_SPLIT_COUNT", RangeSplitCount::default())?,
             max_concurrent_range_proofs: parsed_env_or(
                 "MAX_CONCURRENT_RANGE_PROOFS",
                 NonZeroUsize::MIN,
@@ -418,9 +414,6 @@ impl ProofProviderConfig {
 pub struct RangeSplitCount(NonZeroU8);
 
 impl RangeSplitCount {
-    /// Default chunk count when the operator does not configure one.
-    pub const DEFAULT: u8 = 16;
-
     /// Maximum accepted chunk count.
     pub const MAX: u8 = 128;
 
@@ -485,6 +478,11 @@ impl RangeSplitCount {
         }
 
         Ok(ranges)
+    }
+}
+impl Default for RangeSplitCount {
+    fn default() -> Self {
+        Self::new(16).expect("default is a valid range split count")
     }
 }
 
@@ -730,7 +728,7 @@ mod tests {
             assert!(RangeSplitCount::new(0).is_err());
             assert!(RangeSplitCount::new(129).is_err());
             assert_eq!(RangeSplitCount::one().to_usize(), 1);
-            assert_eq!(RangeSplitCount::new(RangeSplitCount::DEFAULT).unwrap().to_usize(), 16);
+            assert_eq!(RangeSplitCount::default().to_usize(), 16);
             assert_eq!(RangeSplitCount::new(RangeSplitCount::MAX).unwrap().to_usize(), 128);
         }
 

--- a/rust/kona/sp1/crates/proposer/src/config.rs
+++ b/rust/kona/sp1/crates/proposer/src/config.rs
@@ -269,8 +269,8 @@ impl ProposerConfig {
             dependency_set_path: optional_env("DEPENDENCY_SET_PATH").map(PathBuf::from),
             range_split_count: parsed_env_or(
                 "RANGE_SPLIT_COUNT",
-                RangeSplitCount::new(RangeSplitCount::MAX)
-                    .expect("maximum is a valid range split count"),
+                RangeSplitCount::new(RangeSplitCount::DEFAULT)
+                    .expect("default is a valid range split count"),
             )?,
             max_concurrent_range_proofs: parsed_env_or(
                 "MAX_CONCURRENT_RANGE_PROOFS",
@@ -413,13 +413,16 @@ impl ProofProviderConfig {
     }
 }
 
-/// Splits defended super-root timestamp spans into 1 to 16 chunks.
+/// Splits defended super-root timestamp spans into 1 to 128 chunks.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct RangeSplitCount(NonZeroU8);
 
 impl RangeSplitCount {
+    /// Default chunk count when the operator does not configure one.
+    pub const DEFAULT: u8 = 16;
+
     /// Maximum accepted chunk count.
-    pub const MAX: u8 = 16;
+    pub const MAX: u8 = 128;
 
     /// Creates a new `RangeSplitCount`, rejecting 0 and values above
     /// [`Self::MAX`].
@@ -725,9 +728,10 @@ mod tests {
         #[test]
         fn range_split_bounds() {
             assert!(RangeSplitCount::new(0).is_err());
-            assert!(RangeSplitCount::new(17).is_err());
+            assert!(RangeSplitCount::new(129).is_err());
             assert_eq!(RangeSplitCount::one().to_usize(), 1);
-            assert_eq!(RangeSplitCount::new(16).unwrap().to_usize(), 16);
+            assert_eq!(RangeSplitCount::new(RangeSplitCount::DEFAULT).unwrap().to_usize(), 16);
+            assert_eq!(RangeSplitCount::new(RangeSplitCount::MAX).unwrap().to_usize(), 128);
         }
 
         #[test]
@@ -745,10 +749,22 @@ mod tests {
                 RangeSplitCount::new(16).unwrap().split(0, 4).unwrap(),
                 vec![(0, 1), (1, 2), (2, 3), (3, 4)]
             );
+            // A long enough span can use the full supported chunk count.
+            assert_eq!(
+                RangeSplitCount::new(RangeSplitCount::MAX)
+                    .unwrap()
+                    .split(0, u64::from(RangeSplitCount::MAX))
+                    .unwrap()
+                    .len(),
+                128
+            );
+            // Ceil division produces fewer than 128 chunks for a one-hour timestamp span.
+            let chunks =
+                RangeSplitCount::new(RangeSplitCount::MAX).unwrap().split(0, 3_600).unwrap();
+            assert_eq!(chunks.len(), 125);
+            assert_eq!(chunks.first(), Some(&(0, 29)));
+            assert_eq!(chunks.last(), Some(&(3_596, 3_600)));
             // Chunks exactly cover (start, end] with no gaps or overlaps.
-            let chunks = RangeSplitCount::new(7).unwrap().split(10, 55).unwrap();
-            assert_eq!(chunks.first().unwrap().0, 10);
-            assert_eq!(chunks.last().unwrap().1, 55);
             for pair in chunks.windows(2) {
                 assert_eq!(pair[0].1, pair[1].0);
             }
@@ -804,6 +820,11 @@ mod tests {
             assert!(config.rollup_config_paths.is_none());
             assert_eq!(config.tx_confirmation_timeout, 180);
             assert_eq!(config.range_split_count.to_usize(), 16);
+            set_proposer_env("RANGE_SPLIT_COUNT", "128");
+            assert_eq!(ProposerConfig::from_env().unwrap().range_split_count.to_usize(), 128);
+            set_proposer_env("RANGE_SPLIT_COUNT", "129");
+            let err = ProposerConfig::from_env().unwrap_err().to_string();
+            assert!(err.contains("range splits must be between 1 and 128"), "unexpected: {err}");
             assert_eq!(config.max_concurrent_defense_tasks.get(), 8);
             assert!(!config.fast_finality_mode);
             assert_eq!(config.fast_finality_proving_limit.get(), 1);


### PR DESCRIPTION
The inherited 16-chunk ceiling is an application guard rather than a protocol or SP1 limit, and it prevents operators from experimenting with smaller proof ranges. This raises the configurable ceiling to 128 while preserving the default at 16, so existing deployments do not take on additional witness collection, proof requests, or aggregation fanout; a standard one-hour OP Mainnet span produces 125 range and 125 consolidation proofs at the maximum because of ceil division. Operator documentation now calls out that higher counts trade smaller requests for greater fixed proving overhead and total work.

NOTE: Using too high values for the range split count will waste PROVE tokens due to fixed per-proof overhead and make way too many proof requests. After we're done experimenting and know a better operational ceiling we will want to lower the max back to a more reasonable value.