### PR TITLE
justfile: refactor `release-notes` to add `release-paths` which can be used by scripts and skills

### DIFF
--- a/justfile
+++ b/justfile
@@ -544,9 +544,10 @@ release-paths component:
     # Shared Go infrastructure linked into every Go binary.
     go_shared="shared=go.*,op-core/,op-service/"
     # kona-host's local-path dependency closure per `cargo metadata`, excluding
-    # rust/kona/crates/node/ because kona-node is a separate binary. Blind spot: a
-    # dependency bump touching only rust/Cargo.lock appears in no path here.
-    kona_host="kona-host=rust/kona/bin/host/,rust/kona/crates/proof/,rust/kona/crates/protocol/,rust/kona/crates/providers/,rust/kona/crates/utilities/,rust/alloy-op-evm/,rust/alloy-op-hardforks/,rust/op-alloy/,rust/op-revm/"
+    # rust/kona/crates/node/ because kona-node is a separate binary. rust/Cargo.toml
+    # is included because a dependency bump reaches the binary; a bump touching only
+    # rust/Cargo.lock still appears under no path here.
+    kona_host="kona-host=rust/Cargo.toml,rust/kona/bin/host/,rust/kona/crates/proof/,rust/kona/crates/protocol/,rust/kona/crates/providers/,rust/kona/crates/utilities/,rust/alloy-op-evm/,rust/alloy-op-hardforks/,rust/op-alloy/,rust/op-revm/"
     specs=()
     case "{{ component }}" in
         op-node|op-batcher|op-proposer|op-supernode|op-dispute-mon)
@@ -562,10 +563,10 @@ release-paths component:
             specs=("op-challenger/" "cannon/" "$kona_host" "$go_shared")
             ;;
         op-reth)
-            specs=("rust/{{ component }}/" "rust/Cargo.toml" "rust/op-alloy/" "rust/alloy-op*/")
+            specs=("rust/{{ component }}/" "rust/Cargo.toml" "rust/op-alloy/" "rust/alloy-op-evm/" "rust/alloy-op-hardforks/")
             ;;
         kona-*)
-            specs=("rust/kona/" "rust/Cargo.toml" "rust/op-alloy/" "rust/alloy-op*/" "rust/op-revm/")
+            specs=("rust/kona/" "rust/Cargo.toml" "rust/op-alloy/" "rust/alloy-op-evm/" "rust/alloy-op-hardforks/" "rust/op-revm/")
             ;;
         op-deployer)
             specs=("op-deployer/")
@@ -630,7 +631,7 @@ release-notes component from='latest' to='latest-rc' mode='':
     if [ -z "$from_tag" ]; then echo "error: could not resolve from tag '{{ from }}' for {{ component }}"; exit 1; fi
     # release-paths is the single source of truth for what ships in a component.
     # Assigning first (rather than piping) so `set -e` aborts on an unknown one.
-    component_paths="$({{ just_executable() }} release-paths "{{ component }}")"
+    component_paths="$({{ just_executable() }} --justfile {{ justfile() }} release-paths "{{ component }}")"
     include_path_args=()
     # Second column only — the label just names a section, which notes don't use.
     # Not `path`: this recipe is zsh, where $path is tied to $PATH and reading
@@ -641,10 +642,6 @@ release-notes component from='latest' to='latest-rc' mode='':
         case "$include_path" in */) include_path="${include_path}**/*" ;; esac
         include_path_args+=(--include-path "$include_path")
     done <<< "$component_paths"
-    if [ ${#include_path_args[@]} -eq 0 ]; then
-        echo "error: no paths for component '{{ component }}'"
-        exit 1
-    fi
     tag_args=()
     if [ "{{ to }}" = "develop" ]; then
         tag_args=(--unreleased)

--- a/justfile
+++ b/justfile
@@ -518,6 +518,83 @@ latest-tag component:
 latest-rc-tag component:
     @git tag -l '{{ component }}/v*' --sort=-v:refname | grep -E '^[^/]+/v[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$' | head -1
 
+# Prints the repository paths that ship in a component — the single source of
+# truth for "what belongs to <component>", defined next to the code it describes.
+# Release notes read it, and so does the proofs release tooling, so a component's
+# paths are never restated anywhere else.
+#
+# Output is one `<label><TAB><path>` pair per line. Consecutive lines sharing a
+# label form a group: a set of paths that ship as one unit — a bundled binary's
+# dependency closure, or the shared infrastructure every Go component links.
+# Consumers that section their output group by label, keeping a closure from
+# swamping the component's own changes; consumers that only need the path set
+# read the second column. Emitting both in one stream means a component's paths
+# and their grouping cannot disagree.
+#
+# A directory is written as a plain prefix ("cannon/"), not a glob, because the
+# two disagree: as a git pathspec, `cannon/**/*` skips files sitting directly in
+# cannon/ (README.md, Dockerfile.diff) since `**/` needs an intervening
+# directory. Consumers needing a glob append `**/*` themselves — release-notes
+# does, for git-cliff.
+#
+#   just release-paths op-challenger
+[script('bash')]
+release-paths component:
+    set -euo pipefail
+    # Shared Go infrastructure linked into every Go binary.
+    go_shared="shared=go.*,op-core/,op-service/"
+    # kona-host's local-path dependency closure per `cargo metadata`, excluding
+    # rust/kona/crates/node/ because kona-node is a separate binary. Blind spot: a
+    # dependency bump touching only rust/Cargo.lock appears in no path here.
+    kona_host="kona-host=rust/kona/bin/host/,rust/kona/crates/proof/,rust/kona/crates/protocol/,rust/kona/crates/providers/,rust/kona/crates/utilities/,rust/alloy-op-evm/,rust/alloy-op-hardforks/,rust/op-alloy/,rust/op-revm/"
+    specs=()
+    case "{{ component }}" in
+        op-node|op-batcher|op-proposer|op-supernode|op-dispute-mon)
+            specs=("{{ component }}/" "$go_shared")
+            ;;
+        op-challenger)
+            # The op-challenger image ships three binaries, so all three are
+            # release-relevant: op-challenger itself, the cannon VM, and kona-host
+            # built from the in-repo rust/ workspace. See the op-challenger-target
+            # stage in ops/docker/op-stack-go/Dockerfile. A kona-host-only fix has
+            # no op-challenger/ diff yet still changes what operators run.
+            # kona-client is not in the image — it ships as a prestate hash.
+            specs=("op-challenger/" "cannon/" "$kona_host" "$go_shared")
+            ;;
+        op-reth)
+            specs=("rust/{{ component }}/" "rust/Cargo.toml" "rust/op-alloy/" "rust/alloy-op*/")
+            ;;
+        kona-*)
+            specs=("rust/kona/" "rust/Cargo.toml" "rust/op-alloy/" "rust/alloy-op*/" "rust/op-revm/")
+            ;;
+        op-deployer)
+            specs=("op-deployer/")
+            ;;
+        op-contracts)
+            specs=("packages/contracts-bedrock/")
+            ;;
+        *)
+            echo "error: component must be one of: op-node, op-batcher, op-proposer, op-challenger, op-dispute-mon, op-reth, op-deployer, op-contracts, op-supernode, kona-*; is {{ component }}" >&2
+            exit 1
+            ;;
+    esac
+    # `label=a,b` is private to this recipe: it is expanded to labelled pairs
+    # here, so no consumer ever has to know the separators.
+    for spec in "${specs[@]}"; do
+        if [[ "$spec" == *=* ]]; then
+            label="${spec%%=*}"
+            group="${spec#*=}"
+        else
+            # A lone path is its own section; "cannon/" reads as cannon.
+            label="${spec%/}"
+            group="$spec"
+        fi
+        IFS=',' read -r -a group_paths <<< "$group"
+        for p in "${group_paths[@]}"; do
+            printf '%s\t%s\n' "$label" "$p"
+        done
+    done
+
 # Generates release notes between two tags using git-cliff.
 # <from> and <to> can be explicit tags (e.g. v1.16.5), or:
 #   'latest'    - resolves to the latest stable tag (vX.Y.Z)
@@ -551,47 +628,23 @@ release-notes component from='latest' to='latest-rc' mode='':
     }
     from_tag=$(resolve_tag "{{ from }}")
     if [ -z "$from_tag" ]; then echo "error: could not resolve from tag '{{ from }}' for {{ component }}"; exit 1; fi
+    # release-paths is the single source of truth for what ships in a component.
+    # Assigning first (rather than piping) so `set -e` aborts on an unknown one.
+    component_paths="$({{ just_executable() }} release-paths "{{ component }}")"
     include_path_args=()
-    case "{{ component }}" in
-        op-node|op-batcher|op-proposer|op-challenger|op-supernode)
-            include_path_args=(
-                --include-path "{{ component }}/**/*"
-                --include-path "go.*"
-                --include-path "op-core/**/*"
-                --include-path "op-service/**/*"
-            )
-            ;;
-        op-reth)
-            include_path_args=(
-                --include-path "rust/{{ component }}/**/*"
-                --include-path "rust/Cargo.toml"
-                --include-path "rust/op-alloy/**/*"
-                --include-path "rust/alloy-op*/**/*"
-            )
-            ;;
-        kona-*)
-            include_path_args=(
-                --include-path "rust/kona/**/*"
-                --include-path "rust/Cargo.toml"
-                --include-path "rust/op-alloy/**/*"
-                --include-path "rust/alloy-op*/**/*"
-            )
-            ;;
-        op-deployer)
-            include_path_args=(
-                --include-path "op-deployer/**/*"
-            )
-            ;;
-        op-contracts)
-            include_path_args=(
-                --include-path "packages/contracts-bedrock/**/*"
-            )
-            ;;
-        *)
-            echo "error: component must be one of: op-node, op-batcher, op-proposer, op-challenger, op-reth, op-deployer, op-contracts, op-supernode, kona-*; is {{ component }}"
-            exit 1
-            ;;
-    esac
+    # Second column only — the label just names a section, which notes don't use.
+    # Not `path`: this recipe is zsh, where $path is tied to $PATH and reading
+    # into it empties PATH, so every later command silently vanishes.
+    while IFS=$'\t' read -r _label include_path; do
+        [ -z "$include_path" ] && continue
+        # release-paths yields directories as prefixes; git-cliff wants globs.
+        case "$include_path" in */) include_path="${include_path}**/*" ;; esac
+        include_path_args+=(--include-path "$include_path")
+    done <<< "$component_paths"
+    if [ ${#include_path_args[@]} -eq 0 ]; then
+        echo "error: no paths for component '{{ component }}'"
+        exit 1
+    fi
     tag_args=()
     if [ "{{ to }}" = "develop" ]; then
         tag_args=(--unreleased)


### PR DESCRIPTION
## Description

`just release-notes <component>` held an inline `case` mapping each component to git-cliff `--include-path` args. The proofs release tooling had duplication of this list. 

This extracts the list into a `release-paths <component>` recipe, so it is defined once, here, next to the code it describes. `release-notes` reads it; so does the external tooling, which stops keeping a copy.

Output is one `<label><TAB><path>` pair per line. Consecutive lines sharing a label are a group — a set of paths that ship as one unit, such as a bundled binary's dependency closure or the shared Go infrastructure. A consumer that sections its output groups by label; one that only needs the path set reads column 2. Both views come from one stream, so a component's paths and their grouping cannot disagree.

### Behavior changes

| component | change |
|---|---|
| op-node, op-batcher, op-proposer, op-supernode, op-reth, op-deployer, op-contracts | **none** |
| **op-dispute-mon** | now supported — previously fell through to the error branch, and its release notes were assembled by hand |
| **op-challenger** | gains `cannon/` and kona-host's dependency closure |
| **`kona-*`** | gains `rust/op-revm/` |

op-challenger's is the substantive fix. Its image ships three binaries — `op-challenger`, `cannon`, and `kona-host` built from the in-repo `rust/` workspace (see the `op-challenger-target` stage in `ops/docker/op-stack-go/Dockerfile`) — but only the first was in its include paths. A kona-host-only fix has no `op-challenger/` diff and so could never appear in its release notes, while still changing what operators run. #22732 was exactly that shape: a genesis-offset bug that hung every interop VM-runner run against OP Mainnet. For `v1.9.3..v1.9.4` the notes go from 66 PRs to 111.

The `kona-*` arms stay deliberately wide (all of `rust/kona/`) so this PR does not narrow kona's own notes; the precise per-binary closure is used only where it is needed, for op-challenger's bundled kona-host.

## Tests

- For every component that existed before, the reconstructed `--include-path` args are character-for-character identical to the old `case` output.
- `just release-notes op-node v1.19.3 v1.19.4` is byte-identical to `develop`.
- `just release-notes op-dispute-mon v1.5.2 v1.5.3` now produces notes instead of an error.
- An unknown component exits non-zero and lists the valid ones.

## Additional context

The external consumer is the `proofs-release-rc` / `proofs-release-finalize` tooling, which reads this recipe rather than keeping its own list, and drops both its op-dispute-mon workaround and the per-release step that reconciled the two lists by hand.
