### PR TITLE
contracts-bedrock: cover dispute game initialization

### DIFF
--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -280,7 +280,13 @@ contract Deploy is Deployer {
         artifacts.save("OPContractsManagerV2", address(dio.opcmV2));
         artifacts.save("DelayedWETHImpl", address(dio.delayedWETHImpl));
         artifacts.save("PreimageOracle", address(dio.preimageOracleSingleton));
+        artifacts.save("FaultDisputeGameImpl", address(dio.faultDisputeGameImpl));
+        artifacts.save("PermissionedDisputeGameImpl", address(dio.permissionedDisputeGameImpl));
         artifacts.save("PermissionedDisputeGame", address(dio.permissionedDisputeGameImpl));
+        if (address(dio.superFaultDisputeGameImpl) != address(0)) {
+            artifacts.save("SuperFaultDisputeGameImpl", address(dio.superFaultDisputeGameImpl));
+            artifacts.save("SuperPermissionedDisputeGameImpl", address(dio.superPermissionedDisputeGameImpl));
+        }
         if (address(dio.sp1PlonkAdapterSingleton) != address(0)) {
             artifacts.save("SP1PlonkAdapter", address(dio.sp1PlonkAdapterSingleton));
         }

--- a/packages/contracts-bedrock/scripts/libraries/ForgeArtifacts.sol
+++ b/packages/contracts-bedrock/scripts/libraries/ForgeArtifacts.sol
@@ -152,10 +152,14 @@ library ForgeArtifacts {
 
     /// @notice Pulls the `_initialized` storage slot information from the Forge artifacts for a given contract.
     function getInitializedSlot(string memory _contractName) internal returns (StorageSlot memory slot_) {
-        // FaultDisputeGame and PermissionedDisputeGame use a different name for the initialized storage slot.
+        // Dispute games use a different name for the initialized storage slot.
         string memory slotName = "_initialized";
         string memory slotType = "t_uint8";
-        if (LibString.eq(_contractName, "FaultDisputeGame") || LibString.eq(_contractName, "PermissionedDisputeGame")) {
+        if (
+            LibString.eq(_contractName, "FaultDisputeGame") || LibString.eq(_contractName, "PermissionedDisputeGame")
+                || LibString.eq(_contractName, "SuperFaultDisputeGame")
+                || LibString.eq(_contractName, "SuperPermissionedDisputeGame")
+        ) {
             slotName = "initialized";
             slotType = "t_bool";
         }

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -160,20 +160,20 @@
     "sourceCodeHash": "0xc8fe83b48139bbf192f3ed3a32ed99086a34047009b08c1aab61e5163d69b11f"
   },
   "src/dispute/FaultDisputeGame.sol:FaultDisputeGame": {
-    "initCodeHash": "0xb1f5751c6bd16ce44f8fb9dade40895f45777cb0595e607b6625a88b9e7cd71c",
-    "sourceCodeHash": "0x0946cc5be75eea9dd4e52eb08bf00d51dafc61736eee4cd195bad517050e89b4"
+    "initCodeHash": "0x089d14bd5f000be2dcba6938cd3515b0e36ffbe1cb1123351a6c833616ae811f",
+    "sourceCodeHash": "0xbc9c38206856c29efceab61fd795fffe6d626bebee9e9acabecedae836a8526c"
   },
   "src/dispute/PermissionedDisputeGame.sol:PermissionedDisputeGame": {
-    "initCodeHash": "0x940289cf9018b6b22b532a90ee1e731427d435d7982e4e78ea44f25e1cb874a2",
-    "sourceCodeHash": "0x8302f265145ebccb05d1dfb123a1176bb0b29a06167817b0020eac104da8a841"
+    "initCodeHash": "0xffee5a2d3a178bd9e08e90649caf919c23153bad4737c6fa331e7d8645f52784",
+    "sourceCodeHash": "0xb656d051bd976f326e49991560b2bdfc653083bf8c0f17758bca362c5e098ed9"
   },
   "src/dispute/SuperFaultDisputeGame.sol:SuperFaultDisputeGame": {
-    "initCodeHash": "0x3061dcde7a64107937c5e299ff07d5a59212e20432266977c4d5e21fd3abc6df",
-    "sourceCodeHash": "0xa63af3cce83c917c30ffd216ff371d6ffc829406c3d932ba038d0edf6e7ce921"
+    "initCodeHash": "0x9668963c991453ffcc2b8e3f47972080e697c858825ad73fdcfa3dd221c72bec",
+    "sourceCodeHash": "0x583a22cf2056ee2eb9dccf609b81804faa86dfafbc9988b63f28d7729b26c9a2"
   },
   "src/dispute/SuperPermissionedDisputeGame.sol:SuperPermissionedDisputeGame": {
-    "initCodeHash": "0x722d281f2c08158a95568d6842f266fd902a78a5fa3f4dd76125afc61c4382e4",
-    "sourceCodeHash": "0x89c8f9a57d8d671adb04ad87cd17324388abe65499b43a2a00bdd4692f54f6c8"
+    "initCodeHash": "0xb54e949c3f45a90bd5cebb98abeb2a3fab976af98f2e1cd921770049d230afd3",
+    "sourceCodeHash": "0xce6fd7891bc2aef25c2cfa0985e6e6eae66c8fc639fa6a590f24e929e52c3681"
   },
   "src/dispute/zk/SP1PlonkAdapter.sol:SP1PlonkAdapter": {
     "initCodeHash": "0x86e0b79d15c85268155e304dd1d68d1a26782303bb86d44387ee938b0ca45c5c",

--- a/packages/contracts-bedrock/src/dispute/FaultDisputeGame.sol
+++ b/packages/contracts-bedrock/src/dispute/FaultDisputeGame.sol
@@ -147,9 +147,9 @@ contract FaultDisputeGame is Clone, ISemver {
     uint256 internal constant HEADER_BLOCK_NUMBER_INDEX = 8;
 
     /// @notice Semantic version.
-    /// @custom:semver 2.4.2
+    /// @custom:semver 2.5.0
     function version() public pure virtual returns (string memory) {
-        return "2.4.2";
+        return "2.5.0";
     }
 
     /// @notice The starting timestamp of the game
@@ -235,6 +235,7 @@ contract FaultDisputeGame is Clone, ISemver {
         SPLIT_DEPTH = _params.splitDepth;
         CLOCK_EXTENSION = _params.clockExtension;
         MAX_CLOCK_DURATION = _params.maxClockDuration;
+        initialized = true;
     }
 
     /// @notice Initializes the contract.

--- a/packages/contracts-bedrock/src/dispute/PermissionedDisputeGame.sol
+++ b/packages/contracts-bedrock/src/dispute/PermissionedDisputeGame.sol
@@ -26,9 +26,9 @@ contract PermissionedDisputeGame is FaultDisputeGame {
     }
 
     /// @notice Semantic version.
-    /// @custom:semver 2.4.0
+    /// @custom:semver 2.5.0
     function version() public pure override returns (string memory) {
-        return "2.4.0";
+        return "2.5.0";
     }
 
     /// @param _params Parameters for creating a new FaultDisputeGame.

--- a/packages/contracts-bedrock/src/dispute/SuperFaultDisputeGame.sol
+++ b/packages/contracts-bedrock/src/dispute/SuperFaultDisputeGame.sol
@@ -163,9 +163,9 @@ contract SuperFaultDisputeGame is Clone, ISemver {
     uint256 internal constant GAME_IMPL_ARGS_BYTE_COUNT = 124;
 
     /// @notice Semantic version.
-    /// @custom:semver 0.8.0
+    /// @custom:semver 0.9.0
     function version() public pure virtual returns (string memory) {
-        return "0.8.0";
+        return "0.9.0";
     }
 
     /// @notice The starting timestamp of the game
@@ -244,6 +244,7 @@ contract SuperFaultDisputeGame is Clone, ISemver {
         SPLIT_DEPTH = _params.splitDepth;
         CLOCK_EXTENSION = _params.clockExtension;
         MAX_CLOCK_DURATION = _params.maxClockDuration;
+        initialized = true;
     }
 
     /// @notice Initializes the contract.

--- a/packages/contracts-bedrock/src/dispute/SuperPermissionedDisputeGame.sol
+++ b/packages/contracts-bedrock/src/dispute/SuperPermissionedDisputeGame.sol
@@ -18,14 +18,13 @@ import { ISemver } from "interfaces/universal/ISemver.sol";
 
 /// @title SuperPermissionedDisputeGame
 
-/// @custom:proxied
 /// @notice A simplified permissioned super-root dispute game. The proposer creates a super-root
 ///         proposal, and the proposal resolves in favor of the defender. Invalid proposals are
 ///         invalidated through the AnchorStateRegistry blacklist before finalization.
 contract SuperPermissionedDisputeGame is Clone, ISemver, IDisputeGame {
     /// @notice Semantic version.
-    /// @custom:semver 1.1.0
-    string public constant version = "1.1.0";
+    /// @custom:semver 1.2.0
+    string public constant version = "1.2.0";
 
     /// @notice The timestamp at which the game was created.
     Timestamp public createdAt;
@@ -42,7 +41,9 @@ contract SuperPermissionedDisputeGame is Clone, ISemver, IDisputeGame {
     /// @notice Prevents re-initialization.
     bool internal initialized;
 
-    constructor() { }
+    constructor() {
+        initialized = true;
+    }
 
     /// @notice Initializes the contract.
     function initialize() external payable {

--- a/packages/contracts-bedrock/test/vendor/Initializable.t.sol
+++ b/packages/contracts-bedrock/test/vendor/Initializable.t.sol
@@ -21,6 +21,8 @@ import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 import { IResourceMetering } from "interfaces/L1/IResourceMetering.sol";
 import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.sol";
 import { IDisputeGameFactory } from "interfaces/dispute/IDisputeGameFactory.sol";
+import { IFaultDisputeGame } from "interfaces/dispute/IFaultDisputeGame.sol";
+import { IInitializable } from "interfaces/dispute/IInitializable.sol";
 import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
 
 /// @title Initializer_Test
@@ -47,6 +49,7 @@ contract Initializer_Test is CommonTest {
 
     function setUp() public override {
         super.enableAltDA();
+        super.enableInterop();
         super.setUp();
 
         // Initialize the `contracts` array with the addresses of the contracts to test, the
@@ -102,6 +105,34 @@ contract Initializer_Test is CommonTest {
                 name: "DisputeGameFactoryProxy",
                 target: address(disputeGameFactory),
                 initCalldata: abi.encodeCall(disputeGameFactory.initialize, (address(0)))
+            })
+        );
+        contracts.push(
+            InitializeableContract({
+                name: "FaultDisputeGameImpl",
+                target: artifacts.mustGetAddress("FaultDisputeGameImpl"),
+                initCalldata: abi.encodeCall(IInitializable.initialize, ())
+            })
+        );
+        contracts.push(
+            InitializeableContract({
+                name: "PermissionedDisputeGameImpl",
+                target: artifacts.mustGetAddress("PermissionedDisputeGameImpl"),
+                initCalldata: abi.encodeCall(IInitializable.initialize, ())
+            })
+        );
+        contracts.push(
+            InitializeableContract({
+                name: "SuperFaultDisputeGameImpl",
+                target: artifacts.mustGetAddress("SuperFaultDisputeGameImpl"),
+                initCalldata: abi.encodeCall(IInitializable.initialize, ())
+            })
+        );
+        contracts.push(
+            InitializeableContract({
+                name: "SuperPermissionedDisputeGameImpl",
+                target: artifacts.mustGetAddress("SuperPermissionedDisputeGameImpl"),
+                initCalldata: abi.encodeCall(IInitializable.initialize, ())
             })
         );
         // DelayedWETHImpl
@@ -360,18 +391,9 @@ contract Initializer_Test is CommonTest {
     function test_cannotReinitialize_succeeds() public {
         // Collect exclusions.
         uint256 j;
-        string[] memory excludes = new string[](9);
+        string[] memory excludes = new string[](3);
         // Periphery contracts don't get deployed as part of the standard deployment script.
         excludes[j++] = "src/periphery/*";
-        // TODO: Deployment script is currently "broken" in the sense that it doesn't properly
-        //       label the FaultDisputeGame, PermissionedDisputeGame, SuperFaultDisputeGame, and
-        // SuperPermissionedDisputeGame
-        //       contracts and instead simply deploys them anonymously. Means that functions like "getInitializedSlot"
-        //       don't work properly. Remove these exclusions once the deployment script is fixed.
-        excludes[j++] = "src/dispute/FaultDisputeGame.sol";
-        excludes[j++] = "src/dispute/PermissionedDisputeGame.sol";
-        excludes[j++] = "src/dispute/SuperFaultDisputeGame.sol";
-        excludes[j++] = "src/dispute/SuperPermissionedDisputeGame.sol";
         excludes[j++] = "src/dispute/zk/ZKDisputeGame.sol";
         // L2 contract initialization is tested in Predeploys.t.sol
         excludes[j++] = "src/L2/*";
@@ -437,7 +459,11 @@ contract Initializer_Test is CommonTest {
             // Then, attempt to re-initialize the contract. This should fail.
             (bool success, bytes memory returnData) = _contract.target.call(_contract.initCalldata);
             assertFalse(success);
-            assertEq(_extractErrorString(returnData), "Initializable: contract is already initialized");
+            if (bytes4(returnData) == IFaultDisputeGame.AlreadyInitialized.selector) {
+                assertEq(returnData.length, 4);
+            } else {
+                assertEq(_extractErrorString(returnData), "Initializable: contract is already initialized");
+            }
         }
     }
 


### PR DESCRIPTION
Locks the four dispute-game singleton implementations against direct initialization and records their deployment artifacts so the initializer coverage test can include them. The test now covers FaultDisputeGame, PermissionedDisputeGame, SuperFaultDisputeGame, and SuperPermissionedDisputeGame; clone initialization is unchanged because clones have independent storage.

Stacked on #22766.