### PR TITLE
kona-sp1: make proposer task IDs nonzero

### DIFF
--- a/rust/kona/sp1/crates/proposer/src/proposer.rs
+++ b/rust/kona/sp1/crates/proposer/src/proposer.rs
@@ -10,6 +10,7 @@
 
 use std::{
     collections::{HashMap, HashSet},
+    num::NonZeroU64,
     sync::{
         Arc,
         atomic::{AtomicBool, AtomicU64, Ordering},
@@ -62,7 +63,25 @@ mod scenario;
 /// ensuring all actionable games are included under normal conditions.
 pub const MAX_GAME_DEADLINE_LAG: u64 = 60 * 60 * 24 * 14; // 14 days
 
-pub(crate) type TaskId = u64;
+/// Nonzero identifier assigned to a proposer task.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub(crate) struct TaskId(NonZeroU64);
+
+impl TaskId {
+    fn allocate(next_task_id: &AtomicU64) -> Self {
+        let task_id = next_task_id
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |task_id| {
+                if task_id == 0 { None } else { task_id.checked_add(1) }
+            })
+            .expect("task ID counter must be nonzero and not exhausted");
+        Self(NonZeroU64::new(task_id).expect("task ID was validated before allocation"))
+    }
+
+    const fn get(self) -> u64 {
+        self.0.get()
+    }
+}
+
 type TaskHandle = tokio::task::JoinHandle<Result<TaskSuccess>>;
 type TaskMap = HashMap<TaskId, (TaskHandle, OperationSummary)>;
 
@@ -2737,7 +2756,7 @@ impl Proposer {
         let mut scheduled = Vec::with_capacity(planned.len());
 
         for operation in planned {
-            let task_id = self.next_task_id.fetch_add(1, Ordering::Relaxed);
+            let task_id = TaskId::allocate(&self.next_task_id);
             let proposer = self.clone();
             let operation_for_task = operation.clone();
             let handle = tokio::spawn(async move {
@@ -2773,7 +2792,7 @@ impl Proposer {
                     }
                 }
             }
-            tracing::info!(task_id, ?operation, "Spawned proposer task");
+            tracing::info!(task_id = task_id.get(), ?operation, "Spawned proposer task");
             scheduled.push(ScheduledOperation { task_id, operation });
         }
         scheduled.sort_unstable_by(|left, right| {
@@ -3669,7 +3688,10 @@ impl PrestateCache {
 mod tests {
     use std::{
         collections::HashSet,
-        sync::{Arc, Mutex as StdMutex, atomic::Ordering as AtomicOrdering},
+        sync::{
+            Arc, Mutex as StdMutex,
+            atomic::{AtomicU64, Ordering as AtomicOrdering},
+        },
     };
 
     use alloy_eips::BlockId;
@@ -3687,7 +3709,7 @@ mod tests {
         ClaimPreflightDecision, CompactGameSummary, Cursor, DEADLINE_WARNING_DIVISOR,
         DeadlineStatus, Game, GameFetchResult, GameSyncAction, GameSyncFacts, GameSyncRetention,
         MAX_GAME_DEADLINE_LAG, OperationSummary, PrestateCache, Proposer, ProposerState,
-        ProvingPurpose, SyncDisposition, TaskDeduplicationKey, TaskSuccess, awaiting_proof,
+        ProvingPurpose, SyncDisposition, TaskDeduplicationKey, TaskId, TaskSuccess, awaiting_proof,
         check_deadline_status, classify_claim_preflight, classify_game_sync,
         next_proposal_timestamp,
     };
@@ -4359,9 +4381,17 @@ mod tests {
     }
 
     async fn insert_task(proposer: &Proposer, operation: OperationSummary) {
-        let task_id = proposer.next_task_id.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let task_id = TaskId::allocate(&proposer.next_task_id);
         let handle = tokio::spawn(async { Ok(TaskSuccess::Completed) });
         proposer.tasks.lock().await.insert(task_id, (handle, operation));
+    }
+
+    #[test]
+    fn task_id_allocation_rejects_exhaustion_without_wrapping() {
+        let next_task_id = AtomicU64::new(u64::MAX);
+
+        assert!(std::panic::catch_unwind(|| TaskId::allocate(&next_task_id)).is_err());
+        assert_eq!(next_task_id.load(AtomicOrdering::Relaxed), u64::MAX);
     }
 
     async fn active_task_keys(proposer: &Proposer) -> HashSet<TaskDeduplicationKey> {

--- a/rust/kona/sp1/crates/proposer/src/proposer/scenario/mod.rs
+++ b/rust/kona/sp1/crates/proposer/src/proposer/scenario/mod.rs
@@ -47,7 +47,6 @@ impl NamedBarrier {
     }
 
     pub(super) async fn park(&self, task_id: TaskId) {
-        assert_ne!(task_id, 0, "barriers cannot be reached by an unknown task");
         assert!(
             self.0.reached_by.set(task_id).is_ok(),
             "barrier '{}' cannot be reused",
@@ -167,7 +166,7 @@ impl ScenarioControl {
 
     fn classify_missing(&self, task_id: TaskId) -> ScenarioError {
         let next_task_id = self.proposer.next_task_id.load(std::sync::atomic::Ordering::Relaxed);
-        if task_id == 0 || task_id >= next_task_id {
+        if task_id.get() >= next_task_id {
             ScenarioError::UnknownTask { task_id }
         } else {
             ScenarioError::AlreadyFinalized { task_id }

--- a/rust/kona/sp1/crates/proposer/src/proposer/scenario/tests.rs
+++ b/rust/kona/sp1/crates/proposer/src/proposer/scenario/tests.rs
@@ -37,7 +37,7 @@ use crate::{
 
 use crate::proposer::{
     CompactGameSummary, InFlightCreation, OperationSummary, Proposer, ProvingPurpose,
-    SyncDisposition, TaskClass, TaskCompletionOutcome, TaskFailureClass, TaskSuccess,
+    SyncDisposition, TaskClass, TaskCompletionOutcome, TaskFailureClass, TaskId, TaskSuccess,
 };
 
 const HEAD_NUMBER: u64 = 1;
@@ -421,19 +421,19 @@ async fn insert_task(
     proposer: &Proposer,
     operation: OperationSummary,
     handle: tokio::task::JoinHandle<anyhow::Result<TaskSuccess>>,
-) -> u64 {
+) -> TaskId {
     let task_id = allocate_task_id(proposer);
     insert_allocated_task(proposer, task_id, operation, handle).await;
     task_id
 }
 
-fn allocate_task_id(proposer: &Proposer) -> u64 {
-    proposer.next_task_id.fetch_add(1, Ordering::Relaxed)
+fn allocate_task_id(proposer: &Proposer) -> TaskId {
+    TaskId::allocate(&proposer.next_task_id)
 }
 
 async fn insert_allocated_task(
     proposer: &Proposer,
-    task_id: u64,
+    task_id: TaskId,
     operation: OperationSummary,
     handle: tokio::task::JoinHandle<anyhow::Result<TaskSuccess>>,
 ) {
@@ -441,7 +441,7 @@ async fn insert_allocated_task(
 }
 
 struct ParkedTask {
-    task_id: u64,
+    task_id: TaskId,
     barrier: NamedBarrier,
 }
 
@@ -842,7 +842,8 @@ async fn settle_rejects_unknown_and_finalized_task_ids() {
         control.settle(&[success]).await.unwrap_err(),
         ScenarioError::AlreadyFinalized { task_id: success }
     );
-    let unknown = proposer.next_task_id.load(Ordering::Relaxed) + 10;
+    let unknown =
+        TaskId(NonZeroU64::new(proposer.next_task_id.load(Ordering::Relaxed) + 10).unwrap());
     assert_eq!(
         control.settle(&[unknown]).await.unwrap_err(),
         ScenarioError::UnknownTask { task_id: unknown }
@@ -1088,7 +1089,8 @@ async fn record_parked_requires_task_to_reach_matching_barrier() {
     let mut control = ScenarioControl::new(proposer.clone(), Duration::from_secs(1));
 
     let mismatched = NamedBarrier::new("different task barrier");
-    let mismatched_task = proposer.next_task_id.load(Ordering::Relaxed);
+    let mismatched_task =
+        TaskId(NonZeroU64::new(proposer.next_task_id.load(Ordering::Relaxed)).unwrap());
     let mismatched_worker = {
         let mismatched = mismatched.clone();
         tokio::spawn(async move { mismatched.park(mismatched_task).await })


### PR DESCRIPTION
## Summary

- Replace the proposer’s `u64` task ID alias with a `TaskId(NonZeroU64)` newtype.
- Centralize task ID allocation and prevent counter wraparound through zero.
- Update scenario helpers and tests to use the strongly typed ID.
- Preserve numeric task IDs in structured logs.

Follow-up to review feedback on #22503.