### PR TITLE
op-interop-mon: propagate the caller's context into job updates

### DIFF
--- a/op-interop-mon/monitor/updater.go
+++ b/op-interop-mon/monitor/updater.go
@@ -98,14 +98,14 @@ func (t *RPCUpdater) Run(ctx context.Context) {
 			t.jobs.Store(job.ID(), job)
 		case <-processTicker.C:
 			t.log.Trace("processing jobs")
-			t.processJobs()
+			t.processJobs(ctx)
 			t.log.Trace("processed jobs done")
 		}
 	}
 }
 
 // processJobs handles updating all jobs in the map
-func (t *RPCUpdater) processJobs() {
+func (t *RPCUpdater) processJobs(ctx context.Context) {
 	var toUpdate []*Job
 	var toExpire []JobID
 
@@ -126,7 +126,7 @@ func (t *RPCUpdater) processJobs() {
 
 	// Update jobs that need updating
 	for _, job := range toUpdate {
-		err := t.UpdateJob(job)
+		err := t.UpdateJob(ctx, job)
 		if err != nil {
 			t.log.Error("error updating job", "error", err, "job", job.String())
 		}
@@ -184,15 +184,15 @@ func (t *RPCUpdater) ShouldExpire(job *Job) bool {
 	return false
 }
 
-func (t *RPCUpdater) UpdateJob(job *Job) error {
-	t.UpdateJobStatus(job)
+func (t *RPCUpdater) UpdateJob(ctx context.Context, job *Job) error {
+	t.UpdateJobStatus(ctx, job)
 	job.UpdateLastEvaluated(time.Now())
 	t.log.Debug("updated job", "job", job.String())
 	return nil
 }
 
-func (t *RPCUpdater) UpdateJobStatus(job *Job) {
-	blockInfo, receipts, err := t.client.FetchReceiptsByNumber(context.Background(), job.initiating.BlockNumber)
+func (t *RPCUpdater) UpdateJobStatus(ctx context.Context, job *Job) {
+	blockInfo, receipts, err := t.client.FetchReceiptsByNumber(ctx, job.initiating.BlockNumber)
 	if err != nil {
 		t.log.Error("error getting block receipts", "error", err)
 		job.UpdateStatus(jobStatusUnknown)

--- a/op-interop-mon/monitor/updater_test.go
+++ b/op-interop-mon/monitor/updater_test.go
@@ -288,7 +288,7 @@ func TestUpdaterJobStatusUpdate(t *testing.T) {
 			}
 
 			// Update job status
-			updater.UpdateJobStatus(job)
+			updater.UpdateJobStatus(context.Background(), job)
 
 			// Verify status
 			require.Equal(t, tt.expectedStatus, job.status, "job status mismatch")
@@ -412,8 +412,44 @@ func TestUpdaterValidityInvariants(t *testing.T) {
 				executingTimestamp: tt.execTimestamp,
 			}
 
-			updater.UpdateJobStatus(job)
+			updater.UpdateJobStatus(context.Background(), job)
 			require.Equal(t, tt.expectedStatus, job.status)
 		})
 	}
+}
+
+// TestUpdaterPropagatesContext asserts the caller's context reaches the RPC.
+//
+// UpdateJobStatus previously fetched with context.Background(), so a cancelled
+// context could not stop an in-flight receipts fetch. processJobs runs inline in
+// Run's select loop, so a fetch that does not observe cancellation keeps Run from
+// reaching the <-t.closed case.
+func TestUpdaterPropagatesContext(t *testing.T) {
+	updater, client := setupTestUpdater(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	var gotErr error
+	var called bool
+	client.fetchReceiptsByNumber = func(ctx context.Context, number uint64) (eth.BlockInfo, optypes.Receipts, error) {
+		called = true
+		gotErr = ctx.Err()
+		return nil, nil, ctx.Err()
+	}
+
+	job := &Job{
+		initiating: &messages.Identifier{
+			BlockNumber: 100,
+			Timestamp:   1000,
+		},
+		executingBlock: eth.BlockID{Number: 100},
+		executingChain: eth.ChainIDFromUInt64(2),
+	}
+
+	updater.UpdateJobStatus(ctx, job)
+
+	require.True(t, called, "client was not called")
+	require.ErrorIs(t, gotErr, context.Canceled,
+		"the cancelled context did not reach the receipts fetch")
 }


### PR DESCRIPTION
`RPCUpdater` is handed a context and drops it before the RPC.

## The bug

`Run(ctx)` receives a context, but nothing between it and the receipts fetch carries one. `processJobs`, `UpdateJob` and `UpdateJobStatus` all took no `ctx`, so a fresh background context was substituted at the RPC boundary:

```go
func (t *RPCUpdater) UpdateJobStatus(job *Job) {
    blockInfo, receipts, err := t.client.FetchReceiptsByNumber(context.Background(), ...)
```

The fetch is therefore uncancellable. That matters because `processJobs` runs **inline in `Run`'s select loop**, not in its own goroutine:

```go
case <-processTicker.C:
    t.processJobs()
```

So a fetch that hangs against an unresponsive L2 RPC blocks `Run` from ever reaching its `<-t.closed` case. `Stop()` closes that channel and returns `nil` immediately, so shutdown reports success while the updater goroutine is still parked in a fetch nothing can interrupt.

## The sibling already does this correctly

`RPCFinder`, in the same package, has the same shape (`Start(ctx)` -> `go Run(ctx)`, a ticker loop selecting on `t.closed`) and threads the context into the identical client call:

```go
blockInfo, receipts, err := t.client.FetchReceiptsByNumber(ctx, t.next)
```

Both are constructed over the same `*sources.EthClient` in `service.go`, so the two components behaved differently against the same connection.

## The change

Thread the context `Run` already has down through `processJobs`, `UpdateJob` and `UpdateJobStatus` to the fetch, matching `RPCFinder`. No behaviour change on the success path; a cancelled context now aborts the fetch instead of being ignored.

`UpdateJob` and `UpdateJobStatus` are exported, so their signatures change. They are not part of the `Updater` interface and have no callers outside this file and its test, so nothing else in the tree is affected. Flagging it in case that surface is considered load-bearing.

## Tests

`TestUpdaterPropagatesContext` fetches with an already-cancelled context and asserts the client observes `context.Canceled`. Against the unmodified `UpdateJobStatus` it fails; with the change it passes.

## Verification

`go build`, `go vet`, `gofmt` and `go test -race` all pass for `./op-interop-mon/...`.

**One gate I could not run, disclosed per AGENTS.md:** `mise exec -- just lint-go`. Neither `mise` nor `just` is installed in my environment and I did not want to install unpinned tooling, so the repo's custom golangci-lint build (including the `bigint` plugin) has not run against this diff. AGENTS.md asks that a skipped review be stated rather than skipped silently, so I am stating it. Happy to fix anything it flags in CI.
