### PR TITLE
ci: enable renovate security automation cadence and automerge config

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -2,7 +2,7 @@ name: Renovate
 
 on:
   schedule:
-    - cron: "0 6 * * *" # daily 06:00 UTC
+    - cron: "27 * * * *" # hourly, staggered minute to avoid org-wide thundering herd
   workflow_dispatch:
     inputs:
       logLevel:

--- a/renovate.json
+++ b/renovate.json
@@ -32,7 +32,6 @@
   "vulnerabilityAlerts": {
     "automerge": true
   },
-  "automergeType": "pr",
-  "platformAutomerge": false,
+  "platformAutomerge": true,
   "rebaseWhen": "behind-base-branch"
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,21 +1,38 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>ethereum-optimism/factory:renovate-config"],
+  "extends": [
+    "github>ethereum-optimism/factory:renovate-config"
+  ],
   "packageRules": [
     {
       "description": "Group version-locked OpenTelemetry deps (Rust crates + Go modules) so coupled versions bump together in one buildable PR.",
-      "matchPackageNames": ["/^opentelemetry/", "/^tracing-opentelemetry$/", "/^go\\.opentelemetry\\.io\\//"],
+      "matchPackageNames": [
+        "/^opentelemetry/",
+        "/^tracing-opentelemetry$/",
+        "/^go\\.opentelemetry\\.io\\//"
+      ],
       "groupName": "opentelemetry"
     },
     {
       "description": "Group Alloy crates so coupled versions bump together.",
-      "matchPackageNames": ["/^alloy/", "/^op-alloy/"],
+      "matchPackageNames": [
+        "/^alloy/",
+        "/^op-alloy/"
+      ],
       "groupName": "alloy"
     },
     {
       "description": "Group libp2p crates so coupled versions bump together.",
-      "matchPackageNames": ["/^libp2p/"],
+      "matchPackageNames": [
+        "/^libp2p/"
+      ],
       "groupName": "libp2p"
     }
-  ]
+  ],
+  "vulnerabilityAlerts": {
+    "automerge": true
+  },
+  "automergeType": "pr",
+  "platformAutomerge": false,
+  "rebaseWhen": "behind-base-branch"
 }


### PR DESCRIPTION
## Summary

- Renovate schedule: daily 06:00 → hourly (staggered minute)
- adds the standard security-automerge configuration (vulnerability-fix PRs only; generic version updates stay disabled by the shared preset)

## Behavior on this repo (merge-queue aware)

`develop` is governed by a merge queue, so this uses GitHub **native auto-merge** (`platformAutomerge`) rather than a direct merge: Renovate enables auto-merge on a green security-fix PR, which enters the merge queue and lands only after the queue runs its serialized CI against the latest develop. The Renovate app is a review-bypass actor on the review ruleset so no human approval is needed to enter the queue; every human-authored PR keeps its normal review requirements (approvals, contracts-bedrock reviewers, required checks).

Broken fix PRs stay open for a human; Renovate's anti-flapping safety declines to auto-merge a branch name that merged before (one-click manual merge).

## Validation

- config additive over the shared preset + grouping rules (opentelemetry/alloy/libp2p preserved)
- schema-valid JSON; cron staggered against the other repositories
- the exact bypass + queue + auto-merge interaction is worth confirming on the first live security PR

Part of https://github.com/ethereum-optimism/cloud-security/issues/384
Closes https://github.com/ethereum-optimism/cloud-security/issues/395
