### PR TITLE
kona-engine: isolate metrics recorder in tests

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6959,7 +6959,7 @@ dependencies = [
  "kona-protocol",
  "kona-registry",
  "metrics",
- "metrics-exporter-prometheus",
+ "metrics-util",
  "op-alloy-consensus",
  "op-alloy-network",
  "op-alloy-provider",

--- a/rust/kona/crates/node/engine/Cargo.toml
+++ b/rust/kona/crates/node/engine/Cargo.toml
@@ -57,7 +57,7 @@ kona-registry.workspace = true
 rand = {workspace = true, features = ["thread_rng"]}
 arbitrary.workspace = true
 op-alloy-rpc-types = {workspace = true, features = ["arbitrary", "k256"]}
-metrics-exporter-prometheus.workspace = true
+metrics-util = { workspace = true, features = ["debugging"] }
 rstest.workspace = true
 
 [features]

--- a/rust/kona/crates/node/engine/src/state/core.rs
+++ b/rust/kona/crates/node/engine/src/state/core.rs
@@ -159,8 +159,24 @@ mod test {
     use super::*;
     use crate::Metrics;
     use kona_protocol::BlockInfo;
-    use metrics_exporter_prometheus::PrometheusBuilder;
+    use metrics_util::debugging::{DebugValue, DebuggingRecorder};
     use rstest::rstest;
+
+    #[cfg(feature = "metrics")]
+    fn chain_label_value(
+        snapshot: metrics_util::debugging::Snapshot,
+        label_name: &str,
+    ) -> Option<f64> {
+        for (ckey, _unit, _description, value) in snapshot.into_vec() {
+            let key = ckey.key();
+            let is_match = key.name() == Metrics::BLOCK_LABELS &&
+                key.labels().any(|label| label.key() == "label" && label.value() == label_name);
+            if is_match && let DebugValue::Gauge(value) = value {
+                return Some(value.into_inner());
+            }
+        }
+        None
+    }
 
     impl EngineState {
         /// Set the unsafe head.
@@ -207,20 +223,21 @@ mod test {
         #[case] label_name: &str,
         #[case] number: u64,
     ) {
-        let handle = PrometheusBuilder::new().install_recorder().unwrap();
-        crate::Metrics::init();
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+        metrics::with_local_recorder(&recorder, || {
+            crate::Metrics::init();
 
-        let mut state = EngineState::default();
-        set_fn(
-            &mut state,
-            L2BlockInfo {
-                block_info: BlockInfo { number, ..Default::default() },
-                ..Default::default()
-            },
-        );
+            let mut state = EngineState::default();
+            set_fn(
+                &mut state,
+                L2BlockInfo {
+                    block_info: BlockInfo { number, ..Default::default() },
+                    ..Default::default()
+                },
+            );
+        });
 
-        assert!(handle.render().contains(
-            format!("kona_node_block_labels{{label=\"{label_name}\"}} {number}").as_str()
-        ));
+        assert_eq!(chain_label_value(snapshotter.snapshot(), label_name), Some(number as f64));
     }
 }


### PR DESCRIPTION
**Description**

Fixes `test_chain_label_metrics` installing a process-global metrics recorder independently in each of its four `rstest` cases. Under plain `cargo test`, only the first installation succeeded and the remaining cases failed with `FailedToSetGlobalRecorder`.

Each case now uses an isolated `DebuggingRecorder` through `metrics::with_local_recorder`. The test asserts the metric name, label, gauge type, and recorded value directly from the recorder snapshot.

The Prometheus exporter dev dependency is replaced with the workspace-pinned `metrics-util` debugging feature.

**Tests**

- `mise exec -- cargo test -p kona-engine --all-features`
- `mise exec -- cargo test -p kona-engine -p kona-node test_chain_label_metrics -- --nocapture`
- `RUSTFLAGS="-D warnings" mise exec -- cargo clippy -p kona-engine --all-features --all-targets --locked`
- `cargo +nightly fmt --all`

All four parameterized cases now pass in the same plain Cargo test process, including when `kona-node` enables `kona-engine`'s metrics feature through feature unification.

**Additional context**

This only changes test infrastructure and has no effect on production metrics behavior. It also removes reliance on Prometheus exposition formatting from a unit test intended to verify Kona's metric updates.

**Metadata**

- Fixes #22687
