### PR TITLE
op-alloy,op-reth,kona: reject non-canonical transaction encodings

### DIFF
--- a/rust/kona/crates/node/engine/src/attributes.rs
+++ b/rust/kona/crates/node/engine/src/attributes.rs
@@ -1,13 +1,14 @@
 //! Contains a utility method to check if attributes match a block.
 
-use alloy_eips::{Decodable2718, eip1559::BaseFeeParams};
+use alloy_eips::{Encodable2718, eip1559::BaseFeeParams};
 use alloy_network::TransactionResponse;
 use alloy_primitives::{Address, B256, Bytes};
 use alloy_rpc_types_eth::{Block, BlockTransactions, Withdrawals};
 use kona_genesis::RollupConfig;
 use kona_protocol::OpAttributesWithParent;
 use op_alloy_consensus::{
-    EIP1559ParamError, OpTxEnvelope, decode_holocene_extra_data, decode_jovian_extra_data,
+    EIP1559ParamError, OpTxEnvelope, decode_2718_canonical, decode_holocene_extra_data,
+    decode_jovian_extra_data,
 };
 use op_alloy_rpc_types::Transaction;
 
@@ -147,23 +148,22 @@ impl AttributesMatch {
                 block_tx_hash = %block_tx.tx_hash(),
                 "Checking attributes transaction against block transaction",
             );
-            // Let's try to deserialize the attributes transaction
-            let Ok(attr_tx) = OpTxEnvelope::decode_2718(&mut &attr_tx_bytes[..]) else {
-                error!(
-                    "Impossible to deserialize transaction from attributes. If we have stored these attributes it means the transactions where well formatted. This is a bug"
+            // Compare the raw bytes, as op-node does: bytes that merely decode to the same
+            // transaction are still a mismatch.
+            if attr_tx_bytes.as_ref() == block_tx.inner.inner.inner().encoded_2718().as_slice() {
+                continue;
+            }
+            let Ok(attr_tx) = decode_2718_canonical::<OpTxEnvelope>(attr_tx_bytes) else {
+                warn!(
+                    target: "engine",
+                    ?attr_tx_bytes,
+                    "Attributes transaction is not a canonically encoded transaction"
                 );
-
                 return AttributesMismatch::MalformedAttributesTransaction.into();
             };
-
-            if &attr_tx != block_tx.inner.inner.inner() {
-                warn!(target: "engine", ?attr_tx, ?block_tx, "Transaction mismatch in derived attributes");
-                return AttributesMismatch::TransactionContent(
-                    attr_tx.tx_hash(),
-                    block_tx.tx_hash(),
-                )
+            warn!(target: "engine", ?attr_tx, ?block_tx, "Transaction mismatch in derived attributes");
+            return AttributesMismatch::TransactionContent(attr_tx.tx_hash(), block_tx.tx_hash())
                 .into();
-            }
         }
 
         Self::Match
@@ -632,6 +632,28 @@ mod tests {
         let check = AttributesMatch::check(cfg, &attributes, &block);
         assert_eq!(check, expected);
         assert!(check.is_mismatch());
+    }
+
+    /// Attribute transaction bytes must equal the block transaction's encoding byte for byte, as
+    /// op-node compares. Bytes that merely decode to the same transaction (a typed body without
+    /// its type byte) are a mismatch.
+    #[test]
+    fn test_attributes_mismatch_non_canonical_transaction_encoding() {
+        let cfg = default_rollup_config();
+        // Retry until the random set contains a typed signed transaction to strip the tag from.
+        let (attributes, block, idx) = loop {
+            let (attributes, block) = test_transactions_match_helper();
+            let txs = attributes.attributes.transactions.as_ref().unwrap();
+            if let Some(idx) = txs.iter().position(|tx| matches!(tx[0], 0x01 | 0x02 | 0x04)) {
+                break (attributes, block, idx);
+            }
+        };
+        let mut attributes = attributes;
+        let txs = attributes.attributes.transactions.as_mut().unwrap();
+        txs[idx] = Bytes::copy_from_slice(&txs[idx][1..]);
+
+        let check = AttributesMatch::check(cfg, &attributes, &block);
+        assert_eq!(check, AttributesMismatch::MalformedAttributesTransaction.into());
     }
 
     /// Checks the edge case where the attributes array is empty.

--- a/rust/kona/crates/protocol/protocol/src/attributes.rs
+++ b/rust/kona/crates/protocol/protocol/src/attributes.rs
@@ -88,7 +88,7 @@ impl OpAttributesWithParent {
 
     /// Returns the number of transactions in the attributes.
     pub fn count_transactions(&self) -> u64 {
-        self.attributes().decoded_transactions().count().try_into().unwrap()
+        self.attributes().transactions.as_ref().map_or(0, |txs| txs.len()).try_into().unwrap()
     }
 }
 
@@ -109,6 +109,25 @@ mod tests {
         assert_eq!(op_attributes_with_parent.parent(), &parent);
         assert_eq!(op_attributes_with_parent.is_last_in_span(), is_last_in_span);
         assert_eq!(op_attributes_with_parent.derived_from(), None);
+    }
+
+    /// Every entry counts, decodable or not.
+    #[test]
+    fn count_transactions_counts_every_entry() {
+        let attributes = OpPayloadAttributes {
+            transactions: Some(vec![vec![OpTxType::Deposit as u8, 0xaa].into(), vec![0xff].into()]),
+            ..OpPayloadAttributes::default()
+        };
+        let with_parent =
+            OpAttributesWithParent::new(attributes, L2BlockInfo::default(), None, true);
+        assert_eq!(with_parent.count_transactions(), 2);
+        let empty = OpAttributesWithParent::new(
+            OpPayloadAttributes::default(),
+            L2BlockInfo::default(),
+            None,
+            true,
+        );
+        assert_eq!(empty.count_transactions(), 0);
     }
 
     /// Regression: `transactions` is `Option<Vec<Bytes>>`; `Option::iter` yields at most one

--- a/rust/op-alloy/crates/consensus/src/lib.rs
+++ b/rust/op-alloy/crates/consensus/src/lib.rs
@@ -26,7 +26,7 @@ pub use receipts::{
 pub mod transaction;
 pub use transaction::{
     DEPOSIT_TX_TYPE_ID, DepositTransaction, OpPooledTransaction, OpTransaction, OpTxEnvelope,
-    OpTxType, OpTypedTransaction, TxDeposit,
+    OpTxType, OpTypedTransaction, TxDeposit, decode_2718_canonical,
 };
 
 pub mod eip1559;

--- a/rust/op-alloy/crates/consensus/src/post_exec.rs
+++ b/rust/op-alloy/crates/consensus/src/post_exec.rs
@@ -278,6 +278,11 @@ impl TxPostExec {
         Address::ZERO
     }
 
+    /// Decodes the transaction from RLP bytes.
+    pub fn rlp_decode(data: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        Ok(Self::new(PostExecPayload::decode_checked(data)?))
+    }
+
     /// Encoded length of the transaction body.
     pub fn rlp_encoded_length(&self) -> usize {
         self.input.len()
@@ -416,11 +421,13 @@ impl Decodable2718 for TxPostExec {
         if ty != POST_EXEC_TX_TYPE_ID {
             return Err(Eip2718Error::UnexpectedType(ty));
         }
-        Ok(Self::new(PostExecPayload::decode_checked(data)?))
+        Ok(Self::rlp_decode(data)?)
     }
 
-    fn fallback_decode(data: &mut &[u8]) -> Eip2718Result<Self> {
-        Ok(Self::new(PostExecPayload::decode_checked(data)?))
+    fn fallback_decode(_data: &mut &[u8]) -> Eip2718Result<Self> {
+        // Post-exec transactions have no untyped form: reaching untyped dispatch means the 0x7D
+        // tag was absent, so reject rather than resurrect the type from the body.
+        Err(Eip2718Error::UnexpectedType(POST_EXEC_TX_TYPE_ID))
     }
 }
 
@@ -436,7 +443,7 @@ impl Encodable for TxPostExec {
 
 impl Decodable for TxPostExec {
     fn decode(data: &mut &[u8]) -> alloy_rlp::Result<Self> {
-        Ok(Self::new(PostExecPayload::decode_checked(data)?))
+        Self::rlp_decode(data)
     }
 }
 

--- a/rust/op-alloy/crates/consensus/src/transaction/canonical.rs
+++ b/rust/op-alloy/crates/consensus/src/transaction/canonical.rs
@@ -1,0 +1,194 @@
+//! Canonical EIP-2718 decoding.
+
+use alloy_eips::{
+    Decodable2718, Encodable2718,
+    eip2718::{Eip2718Error, Eip2718Result},
+};
+
+/// Decodes an EIP-2718 transaction and requires `bytes` to be its canonical encoding.
+///
+/// Plain `decode_2718_exact` accepts inputs that re-encode differently, such as a typed
+/// transaction body without its type byte or a legacy transaction carrying a `0x00` tag. Where the
+/// bytes are consensus input they must be rejected rather than normalised, so anything that does
+/// not round-trip is an error. The re-encode is one linear pass per transaction, far cheaper than
+/// the signer recovery that follows it.
+pub fn decode_2718_canonical<T: Decodable2718 + Encodable2718>(bytes: &[u8]) -> Eip2718Result<T> {
+    let tx = T::decode_2718_exact(bytes)?;
+    // Length first: it is free and skips the re-encode allocation on a mismatch.
+    if tx.encode_2718_len() != bytes.len() || tx.encoded_2718() != bytes {
+        return Err(Eip2718Error::RlpError(alloy_rlp::Error::Custom(
+            "non-canonical transaction encoding",
+        )));
+    }
+    Ok(tx)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{OpTxEnvelope, OpTxType, TxDeposit, build_post_exec_tx};
+    use alloc::{vec, vec::Vec};
+    use alloy_consensus::{SignableTransaction, TxEip1559, TxEip2930, TxEip7702, TxLegacy};
+    use alloy_eips::{Encodable2718, Typed2718};
+    use alloy_primitives::{Address, B256, Bytes, Signature, TxKind, U256};
+
+    /// Canonical encodings of every `OpTxEnvelope` variant.
+    fn canonical_encodings() -> Vec<(OpTxType, Vec<u8>)> {
+        let sig = Signature::test_signature();
+        let to = Address::repeat_byte(0x11);
+        vec![
+            (
+                OpTxType::Legacy,
+                TxLegacy {
+                    chain_id: Some(10),
+                    nonce: 1,
+                    gas_price: 2,
+                    gas_limit: 21_000,
+                    to: to.into(),
+                    value: U256::from(1u64),
+                    input: Bytes::new(),
+                }
+                .into_signed(sig)
+                .encoded_2718(),
+            ),
+            (
+                OpTxType::Legacy,
+                TxLegacy {
+                    chain_id: None,
+                    nonce: 1,
+                    gas_price: 2,
+                    gas_limit: 21_000,
+                    to: to.into(),
+                    value: U256::from(1u64),
+                    input: Bytes::new(),
+                }
+                .into_signed(sig)
+                .encoded_2718(),
+            ),
+            (
+                OpTxType::Eip2930,
+                TxEip2930 {
+                    chain_id: 10,
+                    nonce: 1,
+                    gas_price: 2,
+                    gas_limit: 21_000,
+                    to: to.into(),
+                    value: U256::from(1u64),
+                    access_list: Default::default(),
+                    input: Bytes::new(),
+                }
+                .into_signed(sig)
+                .encoded_2718(),
+            ),
+            (
+                OpTxType::Eip1559,
+                TxEip1559 {
+                    chain_id: 10,
+                    nonce: 1,
+                    gas_limit: 21_000,
+                    max_fee_per_gas: 2,
+                    max_priority_fee_per_gas: 1,
+                    to: to.into(),
+                    value: U256::from(1u64),
+                    access_list: Default::default(),
+                    input: Bytes::new(),
+                }
+                .into_signed(sig)
+                .encoded_2718(),
+            ),
+            (
+                OpTxType::Eip7702,
+                TxEip7702 {
+                    chain_id: 10,
+                    nonce: 1,
+                    gas_limit: 21_000,
+                    max_fee_per_gas: 2,
+                    max_priority_fee_per_gas: 1,
+                    to,
+                    value: U256::from(1u64),
+                    access_list: Default::default(),
+                    authorization_list: vec![],
+                    input: Bytes::new(),
+                }
+                .into_signed(sig)
+                .encoded_2718(),
+            ),
+            (
+                OpTxType::Deposit,
+                TxDeposit {
+                    source_hash: B256::with_last_byte(2),
+                    from: Address::repeat_byte(0x42),
+                    to: TxKind::Call(to),
+                    mint: 1,
+                    value: U256::from(1u64),
+                    gas_limit: 50_000,
+                    is_system_transaction: false,
+                    input: Bytes::new(),
+                }
+                .encoded_2718(),
+            ),
+            (
+                OpTxType::Deposit,
+                TxDeposit {
+                    source_hash: B256::with_last_byte(3),
+                    from: Address::repeat_byte(0x42),
+                    to: TxKind::Create,
+                    mint: 0,
+                    value: U256::ZERO,
+                    gas_limit: 50_000,
+                    is_system_transaction: true,
+                    input: Bytes::from(vec![0x60, 0x00]),
+                }
+                .encoded_2718(),
+            ),
+            (OpTxType::PostExec, build_post_exec_tx(1, vec![]).encoded_2718()),
+        ]
+    }
+
+    #[test]
+    fn accepts_canonical_encodings() {
+        for (ty, encoded) in canonical_encodings() {
+            let tx: OpTxEnvelope =
+                decode_2718_canonical(&encoded).unwrap_or_else(|e| panic!("{ty:?}: {e}"));
+            assert_eq!(tx.ty(), ty as u8);
+            assert_eq!(tx.encoded_2718(), encoded);
+        }
+    }
+
+    #[test]
+    fn rejects_typed_bodies_without_type_byte() {
+        for (ty, encoded) in canonical_encodings() {
+            if ty == OpTxType::Legacy {
+                continue;
+            }
+            assert_eq!(encoded[0], ty as u8);
+            let bare = &encoded[1..];
+            assert!(bare[0] > 0x7F, "{ty:?}: bare body must not start with a type byte");
+            assert!(
+                decode_2718_canonical::<OpTxEnvelope>(bare).is_err(),
+                "{ty:?}: body without its type byte must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_type_tagged_legacy() {
+        let legacies: Vec<_> =
+            canonical_encodings().into_iter().filter(|(ty, _)| *ty == OpTxType::Legacy).collect();
+        assert!(!legacies.is_empty());
+        for (_, legacy) in legacies {
+            assert!(legacy[0] > 0x7F);
+            let mut tagged = vec![OpTxType::Legacy as u8];
+            tagged.extend_from_slice(&legacy);
+            assert!(decode_2718_canonical::<OpTxEnvelope>(&tagged).is_err());
+        }
+    }
+
+    #[test]
+    fn rejects_trailing_bytes() {
+        for (ty, mut encoded) in canonical_encodings() {
+            encoded.push(0);
+            assert!(decode_2718_canonical::<OpTxEnvelope>(&encoded).is_err(), "{ty:?}");
+        }
+    }
+}

--- a/rust/op-alloy/crates/consensus/src/transaction/deposit.rs
+++ b/rust/op-alloy/crates/consensus/src/transaction/deposit.rs
@@ -300,9 +300,10 @@ impl Decodable2718 for TxDeposit {
         Ok(tx)
     }
 
-    fn fallback_decode(data: &mut &[u8]) -> Eip2718Result<Self> {
-        let tx = Self::decode(data)?;
-        Ok(tx)
+    fn fallback_decode(_data: &mut &[u8]) -> Eip2718Result<Self> {
+        // Deposits have no untyped form: reaching untyped dispatch means the 0x7E tag was absent,
+        // so reject rather than resurrect the type from the body.
+        Err(Eip2718Error::UnexpectedType(OpTxType::Deposit as u8))
     }
 }
 

--- a/rust/op-alloy/crates/consensus/src/transaction/envelope.rs
+++ b/rust/op-alloy/crates/consensus/src/transaction/envelope.rs
@@ -13,14 +13,6 @@ use alloy_primitives::{B256, Bytes, Signature, TxHash};
 
 /// The Ethereum [EIP-2718] Transaction Envelope, modified for OP Stack chains.
 ///
-/// # Note:
-///
-/// This enum distinguishes between tagged and untagged legacy transactions, as
-/// the in-protocol merkle tree may commit to EITHER 0-prefixed or raw.
-/// Therefore we must ensure that encoding returns the precise byte-array that
-/// was decoded, preserving the presence or absence of the `TransactionType`
-/// flag.
-///
 /// [EIP-2718]: https://eips.ethereum.org/EIPS/eip-2718
 #[derive(Debug, Clone, TransactionEnvelope)]
 #[envelope(tx_type_name = OpTxType, typed = OpTypedTransaction, serde_cfg(feature = "serde"))]
@@ -821,8 +813,78 @@ pub mod serde_bincode_compat {
 mod tests {
     use super::*;
     use alloc::vec;
-    use alloy_consensus::{SignableTransaction, Transaction};
+    use alloy_consensus::{SignableTransaction, Transaction, TxLegacy};
     use alloy_primitives::{Address, B256, Bytes, Signature, TxKind, U256, hex};
+    use alloy_rlp::Decodable;
+
+    /// A `TxDeposit` RLP body without its `0x7E` type byte must not decode as a deposit through
+    /// the envelope's untyped dispatch, on either the EIP-2718 or the network (RLP) entry point.
+    #[test]
+    fn bare_deposit_body_is_rejected() {
+        let canonical = TxDeposit {
+            source_hash: B256::with_last_byte(2),
+            from: Address::repeat_byte(0x42),
+            to: TxKind::Call(Address::repeat_byte(0x43)),
+            mint: u128::MAX,
+            value: U256::from(1_000_000_000_000_000_000u128),
+            gas_limit: 50_000,
+            is_system_transaction: false,
+            input: Bytes::new(),
+        }
+        .encoded_2718();
+        assert_eq!(canonical[0], 0x7E);
+        let bare = &canonical[1..];
+        assert_eq!(bare[0], 0xF8, "input really is an untyped RLP list");
+
+        assert!(
+            OpTxEnvelope::decode_2718_exact(bare).is_err(),
+            "a deposit body without its 0x7E type byte must be rejected"
+        );
+        assert!(OpTxEnvelope::decode(&mut &bare[..]).is_err(), "same via network decoding");
+
+        // The properly tagged deposit still decodes.
+        let tagged = OpTxEnvelope::decode_2718_exact(&canonical).expect("tagged deposit decodes");
+        assert!(tagged.is_deposit());
+    }
+
+    /// The same for the `0x7D` post-exec type.
+    #[test]
+    fn bare_post_exec_body_is_rejected() {
+        let canonical = crate::build_post_exec_tx(1, vec![]).encoded_2718();
+        assert_eq!(canonical[0], crate::POST_EXEC_TX_TYPE_ID);
+        let bare = &canonical[1..];
+        assert!(bare[0] > 0x7F, "bare payload must not look like a type byte");
+
+        assert!(
+            OpTxEnvelope::decode_2718_exact(bare).is_err(),
+            "a post-exec body without its 0x7D type byte must be rejected"
+        );
+        assert!(OpTxEnvelope::decode(&mut &bare[..]).is_err(), "same via network decoding");
+        assert!(
+            OpTxEnvelope::decode_2718_exact(&canonical).unwrap().as_post_exec().is_some(),
+            "the tagged post-exec transaction still decodes"
+        );
+    }
+
+    /// Legacy is the one variant with a genuine untyped form; it must keep decoding through the
+    /// untyped dispatch.
+    #[test]
+    fn untyped_legacy_still_decodes() {
+        let tx = TxLegacy {
+            chain_id: Some(1),
+            nonce: 2,
+            gas_price: 3,
+            gas_limit: 21_000,
+            to: Address::repeat_byte(0x11).into(),
+            value: U256::from(4u64),
+            input: Bytes::new(),
+        };
+        let encoded =
+            OpTxEnvelope::Legacy(tx.into_signed(Signature::test_signature())).encoded_2718();
+        assert!(encoded[0] > 0x7F, "legacy transactions are untyped");
+        let decoded = OpTxEnvelope::decode_2718_exact(&encoded).expect("legacy decodes");
+        assert!(matches!(decoded, OpTxEnvelope::Legacy(_)));
+    }
 
     #[test]
     fn test_tx_gas_limit() {

--- a/rust/op-alloy/crates/consensus/src/transaction/mod.rs
+++ b/rust/op-alloy/crates/consensus/src/transaction/mod.rs
@@ -1,5 +1,8 @@
 //! Transaction types for Optimism.
 
+mod canonical;
+pub use canonical::decode_2718_canonical;
+
 mod deposit;
 pub use deposit::{DepositTransaction, TxDeposit};
 

--- a/rust/op-alloy/crates/rpc-types-engine/src/attributes.rs
+++ b/rust/op-alloy/crates/rpc-types-engine/src/attributes.rs
@@ -2,7 +2,6 @@
 
 use alloc::vec::Vec;
 use alloy_eips::{
-    Decodable2718,
     eip1559::BaseFeeParams,
     eip2718::{Eip2718Result, WithEncoded},
 };
@@ -10,8 +9,8 @@ use alloy_primitives::{B64, B256, Bytes, keccak256};
 use alloy_rlp::{Encodable, Result};
 use alloy_rpc_types_engine::{PayloadAttributes, PayloadId};
 use op_alloy_consensus::{
-    EIP1559ParamError, OpTxEnvelope, decode_eip_1559_params, encode_holocene_extra_data,
-    encode_jovian_extra_data,
+    EIP1559ParamError, OpTxEnvelope, decode_2718_canonical, decode_eip_1559_params,
+    encode_holocene_extra_data, encode_jovian_extra_data,
 };
 use sha2::Digest;
 
@@ -152,14 +151,7 @@ impl OpPayloadAttributes {
     ///
     /// This iterator will be empty if there are no transactions in the attributes.
     pub fn decoded_transactions(&self) -> impl Iterator<Item = Eip2718Result<OpTxEnvelope>> + '_ {
-        self.transactions.iter().flatten().map(|tx_bytes| {
-            let mut buf = tx_bytes.as_ref();
-            let tx = OpTxEnvelope::decode_2718(&mut buf).map_err(alloy_rlp::Error::from)?;
-            if !buf.is_empty() {
-                return Err(alloy_rlp::Error::UnexpectedLength.into());
-            }
-            Ok(tx)
-        })
+        self.transactions.iter().flatten().map(|tx_bytes| decode_2718_canonical(tx_bytes))
     }
 
     /// Returns iterator over decoded transactions with their original encoded bytes.
@@ -479,5 +471,32 @@ mod test {
         let val = serde_json::to_value(&attributes).unwrap();
         let round_trip: OpPayloadAttributes = serde_json::from_value(val).unwrap();
         assert_eq!(attributes, round_trip);
+    }
+
+    /// A transaction that decodes but does not re-encode to the same bytes (here: an EIP-1559
+    /// body with its type byte stripped) must be rejected, not silently canonicalised.
+    #[test]
+    fn decoded_transactions_reject_non_canonical_encoding() {
+        use alloy_consensus::SignableTransaction;
+        use alloy_eips::Encodable2718;
+        let typed = alloy_consensus::TxEip1559 {
+            chain_id: 10,
+            nonce: 1,
+            gas_limit: 21_000,
+            max_fee_per_gas: 2,
+            max_priority_fee_per_gas: 1,
+            to: Address::ZERO.into(),
+            value: Default::default(),
+            access_list: Default::default(),
+            input: Default::default(),
+        }
+        .into_signed(alloy_primitives::Signature::test_signature())
+        .encoded_2718();
+        assert_eq!(typed[0], 0x02);
+        let bare = Bytes::copy_from_slice(&typed[1..]);
+
+        let attrs = OpPayloadAttributes { transactions: Some(vec![bare]), ..Default::default() };
+        let err = attrs.decoded_transactions().next().unwrap().unwrap_err();
+        assert!(err.to_string().contains("non-canonical"), "{err}");
     }
 }

--- a/rust/op-alloy/crates/rpc-types-engine/src/flashblock/payload.rs
+++ b/rust/op-alloy/crates/rpc-types-engine/src/flashblock/payload.rs
@@ -2,9 +2,10 @@
 
 use super::{OpFlashblockPayloadBase, OpFlashblockPayloadDelta};
 use crate::flashblock::metadata::OpFlashblockPayloadMetadata;
-use alloy_eips::{Decodable2718, eip2718::Eip2718Result};
+use alloy_eips::{Decodable2718, Encodable2718, eip2718::Eip2718Result};
 use alloy_primitives::{B256, Bytes};
 use alloy_rpc_types_engine::PayloadId;
+use op_alloy_consensus::decode_2718_canonical;
 
 /// Flashblock payload.
 ///
@@ -51,9 +52,9 @@ impl OpFlashblockPayload {
     /// This iterator will be empty if there are no transactions in this flashblock.
     pub fn decoded_transaction<T>(&self) -> impl Iterator<Item = Eip2718Result<T>> + '_
     where
-        T: Decodable2718,
+        T: Decodable2718 + Encodable2718,
     {
-        self.raw_transactions().iter().map(|tx| T::decode_2718_exact(tx))
+        self.raw_transactions().iter().map(|tx| decode_2718_canonical(tx))
     }
 
     /// Recovers transactions from flashblocks lazily.
@@ -69,10 +70,10 @@ impl OpFlashblockPayload {
         >,
     > + '_
     where
-        T: Decodable2718 + alloy_consensus::transaction::SignerRecoverable,
+        T: Decodable2718 + Encodable2718 + alloy_consensus::transaction::SignerRecoverable,
     {
         self.raw_transactions().iter().map(|raw| {
-            let tx = T::decode_2718_exact(raw)
+            let tx: T = decode_2718_canonical(raw)
                 .map_err(alloy_consensus::crypto::RecoveryError::from_source)?;
             tx.try_into_recovered().map(|tx| tx.into_encoded_with(raw.clone()))
         })
@@ -191,5 +192,38 @@ mod tests {
         assert_eq!(payload.base, None);
         assert_eq!(payload.diff, OpFlashblockPayloadDelta::default());
         assert_eq!(payload.metadata, OpFlashblockPayloadMetadata::default());
+    }
+
+    /// A transaction that decodes but does not re-encode to the same bytes (here: an EIP-1559
+    /// body with its type byte stripped) must be rejected, not silently canonicalised.
+    #[test]
+    fn decoded_transaction_rejects_non_canonical_encoding() {
+        use alloy_consensus::SignableTransaction;
+        use alloy_primitives::Address;
+        use op_alloy_consensus::OpTxEnvelope;
+        let typed = alloy_consensus::TxEip1559 {
+            chain_id: 10,
+            nonce: 1,
+            gas_limit: 21_000,
+            max_fee_per_gas: 2,
+            max_priority_fee_per_gas: 1,
+            to: Address::ZERO.into(),
+            value: Default::default(),
+            access_list: Default::default(),
+            input: Default::default(),
+        }
+        .into_signed(alloy_primitives::Signature::test_signature())
+        .encoded_2718();
+        assert_eq!(typed[0], 0x02);
+        let bare = Bytes::copy_from_slice(&typed[1..]);
+
+        let payload = OpFlashblockPayload {
+            diff: OpFlashblockPayloadDelta { transactions: vec![bare], ..Default::default() },
+            ..Default::default()
+        };
+        let err = payload.decoded_transaction::<OpTxEnvelope>().next().unwrap().unwrap_err();
+        assert!(err.to_string().contains("non-canonical"), "{err}");
+        #[cfg(feature = "k256")]
+        assert!(payload.recover_transactions::<OpTxEnvelope>().next().unwrap().is_err());
     }
 }

--- a/rust/op-reth/crates/cli/src/ovm_file_codec.rs
+++ b/rust/op-reth/crates/cli/src/ovm_file_codec.rs
@@ -278,7 +278,7 @@ impl Decodable2718 for OvmTransactionSigned {
                 TxDeposit::signature(),
             )),
             OpTxType::PostExec => Ok(Self::from_transaction_and_signature(
-                OpTypedTransaction::PostExec(TxPostExec::decode_2718(buf)?),
+                OpTypedTransaction::PostExec(TxPostExec::rlp_decode(buf)?),
                 TxPostExec::signature(),
             )),
         }
@@ -293,10 +293,35 @@ impl Decodable2718 for OvmTransactionSigned {
 mod tests {
     use crate::ovm_file_codec::OvmTransactionSigned;
     use alloy_consensus::Typed2718;
+    use alloy_eips::eip2718::{Decodable2718, Encodable2718};
     use alloy_primitives::{TxKind, U256, address, b256, hex};
-    use op_alloy_consensus::OpTypedTransaction;
+    use op_alloy_consensus::{
+        OpTypedTransaction, POST_EXEC_TX_TYPE_ID, SDMGasEntry, TxPostExec, build_post_exec_tx,
+    };
     const DEPOSIT_FUNCTION_SELECTOR: [u8; 4] = [0xb6, 0xb5, 0x5f, 0x25];
     use alloy_rlp::Decodable;
+
+    /// Regression: `typed_decode` is handed a buffer whose `0x7D` type byte has already been
+    /// consumed, so the post-exec arm must decode the RLP body. Routing back through
+    /// `decode_2718` re-dispatches on the body's first byte and lands in
+    /// `TxPostExec::fallback_decode`, which rejects untyped post-exec bodies.
+    #[test]
+    fn test_roundtrip_post_exec_transaction() {
+        let tx = OvmTransactionSigned::from_transaction_and_signature(
+            OpTypedTransaction::PostExec(build_post_exec_tx(
+                7,
+                vec![SDMGasEntry { index: 1, gas_refund: 21_000 }],
+            )),
+            TxPostExec::signature(),
+        );
+
+        let encoded = tx.encoded_2718();
+        assert_eq!(encoded[0], POST_EXEC_TX_TYPE_ID);
+
+        let decoded =
+            OvmTransactionSigned::decode_2718_exact(&encoded).expect("post-exec tx decodes");
+        assert_eq!(decoded, tx);
+    }
 
     #[test]
     fn test_decode_legacy_transactions() {

--- a/rust/op-reth/crates/flashblocks/src/service.rs
+++ b/rust/op-reth/crates/flashblocks/src/service.rs
@@ -404,7 +404,7 @@ where
         }
 
         if let Err(err) = self.sequences.insert_flashblock(flashblock) {
-            trace!(target: "flashblocks", %err, "Failed to insert flashblock");
+            debug!(target: "flashblocks", %err, "Failed to insert flashblock");
         }
     }
 

--- a/rust/op-reth/crates/payload/src/payload.rs
+++ b/rust/op-reth/crates/payload/src/payload.rs
@@ -4,7 +4,10 @@ use std::{fmt::Debug, sync::Arc};
 
 use alloy_consensus::{Block, BlockHeader};
 use alloy_eips::{
-    eip1559::BaseFeeParams, eip2718::Decodable2718, eip4895::Withdrawals, eip7685::Requests,
+    eip1559::BaseFeeParams,
+    eip2718::{Decodable2718, Encodable2718},
+    eip4895::Withdrawals,
+    eip7685::Requests,
 };
 use alloy_primitives::{Address, B64, B256, Bytes, U256, keccak256};
 use alloy_rlp::Encodable;
@@ -12,7 +15,9 @@ use alloy_rpc_types_engine::{
     BlobsBundleV1, ExecutionPayloadEnvelopeV2, ExecutionPayloadFieldV2, ExecutionPayloadV1,
     ExecutionPayloadV3, PayloadId,
 };
-use op_alloy_consensus::{EIP1559ParamError, encode_holocene_extra_data, encode_jovian_extra_data};
+use op_alloy_consensus::{
+    EIP1559ParamError, decode_2718_canonical, encode_holocene_extra_data, encode_jovian_extra_data,
+};
 use op_alloy_rpc_types_engine::{
     OpExecutionPayloadEnvelope, OpExecutionPayloadEnvelopeV3, OpExecutionPayloadEnvelopeV4,
     OpExecutionPayloadV4,
@@ -209,8 +214,8 @@ impl<T> serde::Serialize for OpPayloadBuilderAttributes<T> {
     }
 }
 
-impl<'de, T: Decodable2718 + Send + Sync + Debug + Unpin + 'static> serde::Deserialize<'de>
-    for OpPayloadBuilderAttributes<T>
+impl<'de, T: Decodable2718 + Encodable2718 + Send + Sync + Debug + Unpin + 'static>
+    serde::Deserialize<'de> for OpPayloadBuilderAttributes<T>
 {
     fn deserialize<D: serde::Deserializer<'de>>(_deserializer: D) -> Result<Self, D::Error> {
         // This type is never deserialized in practice; the PayloadAttributes trait bound
@@ -223,7 +228,7 @@ impl<'de, T: Decodable2718 + Send + Sync + Debug + Unpin + 'static> serde::Deser
     }
 }
 
-impl<T: Decodable2718 + Send + Sync + Debug + Clone + Unpin + 'static>
+impl<T: Decodable2718 + Encodable2718 + Send + Sync + Debug + Clone + Unpin + 'static>
     reth_payload_primitives::PayloadAttributes for OpPayloadBuilderAttributes<T>
 {
     fn payload_id(&self, _parent_hash: &B256) -> PayloadId {
@@ -292,7 +297,9 @@ impl<T> OpPayloadBuilderAttributes<T> {
     }
 }
 
-impl<T: Decodable2718 + Send + Sync + Debug + Unpin + 'static> OpPayloadBuilderAttributes<T> {
+impl<T: Decodable2718 + Encodable2718 + Send + Sync + Debug + Unpin + 'static>
+    OpPayloadBuilderAttributes<T>
+{
     /// Creates a new payload builder for the given parent block and the attributes.
     ///
     /// Derives the unique [`PayloadId`] for the given parent and attributes
@@ -302,30 +309,7 @@ impl<T: Decodable2718 + Send + Sync + Debug + Unpin + 'static> OpPayloadBuilderA
         version: u8,
     ) -> Result<Self, alloy_rlp::Error> {
         let id = payload_id_optimism(&parent, &attributes, version);
-
-        let transactions = attributes
-            .transactions
-            .unwrap_or_default()
-            .into_iter()
-            .map(|data| {
-                Decodable2718::decode_2718_exact(data.as_ref()).map(|tx| WithEncoded::new(data, tx))
-            })
-            .collect::<Result<_, _>>()?;
-
-        Ok(Self {
-            id,
-            parent,
-            timestamp: attributes.payload_attributes.timestamp,
-            suggested_fee_recipient: attributes.payload_attributes.suggested_fee_recipient,
-            prev_randao: attributes.payload_attributes.prev_randao,
-            withdrawals: attributes.payload_attributes.withdrawals.unwrap_or_default().into(),
-            parent_beacon_block_root: attributes.payload_attributes.parent_beacon_block_root,
-            no_tx_pool: attributes.no_tx_pool.unwrap_or_default(),
-            transactions,
-            gas_limit: attributes.gas_limit,
-            eip_1559_params: attributes.eip_1559_params,
-            min_base_fee: attributes.min_base_fee,
-        })
+        Self::from_rpc_attrs(parent, id, attributes)
     }
 
     /// Creates a new payload builder from RPC attributes with a pre-computed payload ID.
@@ -341,9 +325,7 @@ impl<T: Decodable2718 + Send + Sync + Debug + Unpin + 'static> OpPayloadBuilderA
             .transactions
             .unwrap_or_default()
             .into_iter()
-            .map(|data| {
-                Decodable2718::decode_2718_exact(data.as_ref()).map(|tx| WithEncoded::new(data, tx))
-            })
+            .map(|data| decode_2718_canonical(data.as_ref()).map(|tx| WithEncoded::new(data, tx)))
             .collect::<Result<_, _>>()?;
 
         Ok(Self {
@@ -832,5 +814,59 @@ mod tests {
             };
         let extra_data = attributes.get_jovian_extra_data(BaseFeeParams::new(80, 60));
         assert_eq!(extra_data.unwrap_err(), EIP1559ParamError::MinBaseFeeNotSet);
+    }
+
+    /// A transaction that decodes but does not re-encode to the same bytes (here: an EIP-1559
+    /// body with its type byte stripped) must be rejected, not silently canonicalised.
+    #[test]
+    fn try_new_rejects_non_canonical_transaction_encoding() {
+        use alloy_consensus::SignableTransaction;
+        use alloy_eips::eip2718::Encodable2718;
+        let typed = alloy_consensus::TxEip1559 {
+            chain_id: 10,
+            nonce: 1,
+            gas_limit: 21_000,
+            max_fee_per_gas: 2,
+            max_priority_fee_per_gas: 1,
+            to: Address::ZERO.into(),
+            value: Default::default(),
+            access_list: Default::default(),
+            input: Default::default(),
+        }
+        .into_signed(alloy_primitives::Signature::test_signature())
+        .encoded_2718();
+        assert_eq!(typed[0], 0x02);
+        let bare = Bytes::copy_from_slice(&typed[1..]);
+
+        let attrs = OpPayloadAttributes {
+            payload_attributes: PayloadAttributes {
+                timestamp: 1,
+                prev_randao: B256::ZERO,
+                suggested_fee_recipient: Address::ZERO,
+                withdrawals: Some(vec![]),
+                parent_beacon_block_root: Some(B256::ZERO),
+                slot_number: None,
+                target_gas_limit: None,
+            },
+            transactions: Some(vec![bare]),
+            no_tx_pool: Some(true),
+            gas_limit: Some(30_000_000),
+            eip_1559_params: None,
+            min_base_fee: None,
+        };
+        let err = OpPayloadBuilderAttributes::<OpTransactionSigned>::try_new(
+            B256::ZERO,
+            attrs.clone(),
+            3,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("non-canonical"), "{err}");
+        let err = OpPayloadBuilderAttributes::<OpTransactionSigned>::from_rpc_attrs(
+            B256::ZERO,
+            PayloadId::new([0; 8]),
+            attrs,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("non-canonical"), "{err}");
     }
 }

--- a/rust/op-reth/crates/primitives/src/transaction/signed.rs
+++ b/rust/op-reth/crates/primitives/src/transaction/signed.rs
@@ -335,7 +335,7 @@ impl Decodable2718 for OpTransactionSigned {
                 TxDeposit::signature(),
             )),
             op_alloy_consensus::OpTxType::PostExec => Ok(Self::new_unhashed(
-                OpTypedTransaction::PostExec(TxPostExec::decode_2718(buf)?),
+                OpTypedTransaction::PostExec(TxPostExec::rlp_decode(buf)?),
                 TxPostExec::signature(),
             )),
         }
@@ -581,7 +581,33 @@ mod tests {
         }
     }
 
+    /// `typed_decode` is handed the body after the `0x7D` type byte was consumed, so the post-exec
+    /// arm must decode the RLP body, not re-dispatch through `decode_2718`.
+    #[test]
+    fn test_roundtrip_post_exec_transaction_2718() {
+        let tx = OpTransactionSigned::new_unhashed(
+            OpTypedTransaction::PostExec(op_alloy_consensus::build_post_exec_tx(
+                7,
+                vec![op_alloy_consensus::SDMGasEntry { index: 1, gas_refund: 21_000 }],
+            )),
+            TxPostExec::signature(),
+        );
+        let encoded = tx.encoded_2718();
+        assert_eq!(encoded[0], op_alloy_consensus::POST_EXEC_TX_TYPE_ID);
+        let decoded =
+            OpTransactionSigned::decode_2718_exact(&encoded).expect("post-exec tx decodes");
+        assert_eq!(decoded, tx);
+    }
+
     proptest! {
+        #[test]
+        fn test_roundtrip_2718_encode_decode(reth_tx in arb::<OpTransactionSigned>()) {
+            let encoded = reth_tx.encoded_2718();
+            let decoded = OpTransactionSigned::decode_2718_exact(&encoded).unwrap();
+            assert_eq!(decoded, reth_tx);
+            assert_eq!(decoded.encoded_2718(), encoded);
+        }
+
         #[test]
         fn test_roundtrip_compact_encode_envelope(reth_tx in arb::<OpTransactionSigned>()) {
             let mut expected_buf = Vec::<u8>::new();


### PR DESCRIPTION
Deposit and PostExec are EIP-2718 typed transactions with no untyped wire form. Reject fallback decoding of their bare RLP bodies so a missing 0x7E or 0x7D type byte cannot bypass derivation's leading-byte transaction gates.

The generated envelope decoder at the pinned Alloy version also accepts bare EIP-2930, EIP-1559, and EIP-7702 bodies, as well as a 0x00-tagged legacy transaction.

Decode PostExec through its RLP-body helper after typed dispatch has consumed the type byte. Keep attribute transaction counting independent of decoding and compatible with no_std builds.