### PR TITLE
gitignore: ignore all rust target* dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ coverage.json
 **/lcov-all.info
 
 # Rust files
-**/target
+rust/**/target*
 
 yarn-error.log
 .yarn/*
@@ -59,9 +59,6 @@ crytic-export
 
 # ignore local asdf config
 .tool-versions
-
-# Rust files
-**/target
 
 # Locally-built superchain bundles, generated from the superchain-registry submodule.
 # The binary archives are gitignored; only their .sha256 (and generated text) are committed.


### PR DESCRIPTION
- remove duplicate entry
- ignore all `target*` dirs