### PR TITLE
docs: use Accordion instead of Expandable for collapsible sections

### DIFF
--- a/docs/public-docs/app-developers/guides/transactions/integrating-subblocks.mdx
+++ b/docs/public-docs/app-developers/guides/transactions/integrating-subblocks.mdx
@@ -25,7 +25,7 @@ You read subblock state with the same Ethereum JSON-RPC calls you already use.
 The difference is using the "pending" tag in some of them to explicitly query the pre-confirmed state instead of the last finalized block.
 
 *   **`eth_getBlockByNumber`**: Use the `pending` tag to retrieve the latest subblock snapshot.
-    <Expandable title="Sample response">
+    <Accordion title="Sample response">
 
       ```json
           {
@@ -38,11 +38,11 @@ The difference is using the "pending" tag in some of them to explicitly query th
             }
           }
       ```
-    </Expandable>
+    </Accordion>
 
 *   **`eth_call`**: Use the `pending` tag to execute calls against the most recent pre-confirmed state.
 
-    <Expandable title="Sample request">
+    <Accordion title="Sample request">
 
       ```json
       {
@@ -52,11 +52,11 @@ The difference is using the "pending" tag in some of them to explicitly query th
         "id": 1
       }
       ```
-    </Expandable>
+    </Accordion>
 
 *   `eth_getBalance` / `eth_getTransactionCount`: Use the `pending` tag to fetch balances or transaction counts respectively as they evolve within the block window.
 
-    <Expandable title="Sample response for `eth_getBalance`">
+    <Accordion title="Sample response for `eth_getBalance`">
 
       ```json
       {
@@ -65,9 +65,9 @@ The difference is using the "pending" tag in some of them to explicitly query th
         "result": "0x0234"
       }
       ```
-    </Expandable>
+    </Accordion>
 
-    <Expandable title="Sample response for `eth_getTransactionCount`">
+    <Accordion title="Sample response for `eth_getTransactionCount`">
 
       ```json
       {
@@ -76,7 +76,7 @@ The difference is using the "pending" tag in some of them to explicitly query th
         "result": "0x1b" // 27 transactions
       }
       ```
-    </Expandable>
+    </Accordion>
 
     Other methods, like `eth_getTransactionReceipt`, `eth_getTransactionByHash` or `eth_simulateV1`, return data from pre-confirmed transactions without requiring the `pending` tag.
     Consult the [Subblocks specification](https://specs.optimism.io/protocol/subblocks.html#json-rpc) for the supported methods and pending-state behavior.

--- a/docs/public-docs/app-developers/tutorials/bridging/bridge-crosschain-eth.mdx
+++ b/docs/public-docs/app-developers/tutorials/bridging/bridge-crosschain-eth.mdx
@@ -90,7 +90,7 @@ The tutorial uses these primary tools:
             DST_URL=http://localhost:9546
             ```
   
-        <Expandable title="Sanity check">
+        <Accordion title="Sanity check">
   
           Get the ETH balances for your address on both the source and destination chains.
   
@@ -99,7 +99,7 @@ The tutorial uses these primary tools:
           cast balance --ether `cast wallet address $PRIVATE_KEY` --rpc-url $DST_URL
           ```
   
-        </Expandable>
+        </Accordion>
   
   
       </Tab>
@@ -127,7 +127,7 @@ The tutorial uses these primary tools:
             DST_URL=https://interop-alpha-1.optimism.io          
             ```      
   
-        <Expandable title="Sanity check">
+        <Accordion title="Sanity check">
   
           Get the ETH balances for your address on both the source and destination chains.
   
@@ -135,7 +135,7 @@ The tutorial uses these primary tools:
           cast balance --ether `cast wallet address $PRIVATE_KEY` --rpc-url $SRC_URL
           cast balance --ether `cast wallet address $PRIVATE_KEY` --rpc-url $DST_URL
           ```
-        </Expandable>
+        </Accordion>
       </Tab>
     </Tabs>
   </Step>
@@ -276,7 +276,7 @@ The tutorial uses these primary tools:
     </Step>
   </Steps>
     
-        <Expandable title="Explanation of `transfer-eth.mts`">
+        <Accordion title="Explanation of `transfer-eth.mts`">
   
         ```typescript
             import { 
@@ -331,7 +331,7 @@ The tutorial uses these primary tools:
         ```
   
   This is how you use `@eth-optimism/viem` to create an executing message.
-  </Expandable>
+  </Accordion>
   </Step>
 
   <Step title="Run the example">

--- a/docs/public-docs/app-developers/tutorials/interoperability/manual-relay.mdx
+++ b/docs/public-docs/app-developers/tutorials/interoperability/manual-relay.mdx
@@ -11,7 +11,7 @@ diataxis: tutorial
 
 Learn to relay transactions directly by sending the correct transaction.
 
-<Expandable title="About this tutorial">
+<Accordion title="About this tutorial">
 
   **Prerequisite technical knowledge**
 
@@ -30,7 +30,7 @@ Learn to relay transactions directly by sending the correct transaction.
   * Git for version control  
   * Supersim environment configured and running  
   * Foundry tools installed (forge, cast, anvil)
-</Expandable>
+</Accordion>
 
 ### What you'll build
 
@@ -186,13 +186,13 @@ These steps are necessary to run the tutorial, regardless of whether you are usi
     console.log(`Greeting after the relay transaction: ${greeting3}`)
     ```
 
-    <Expandable title="Explanation">
+    <Accordion title="Explanation">
 
       ```javascript
       import { supersimL2A, supersimL2B } from '@eth-optimism/viem/chains' 
       import { walletActionsL2, publicActionsL2 } from '@eth-optimism/viem'
       ```
-    </Expandable>
+    </Accordion>
 
     Run JavaScript program:
 
@@ -261,7 +261,7 @@ Here is the detailed explanation:
     Whenever `L2ToL2CrossDomainMessenger` sends a message to a different blockchain, it emits a [`SendMessage`](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/L2/L2ToL2CrossDomainMessenger.sol#L83-L91) event.
     Extract only the latest `SendMessage` event from the logs.
 
-    <Expandable title="Example `log-entry`">
+    <Accordion title="Example `log-entry`">
 
       ```yaml
       - address: 0x4200000000000000000000000000000000000023
@@ -279,7 +279,7 @@ Here is the detailed explanation:
         transactionHash: 0x1d6f2e5e2c8f3eb055e95741380ca36492f784b9782848b66b66c65c5937ff3a
         transactionIndex: 0
       ```
-    </Expandable>
+    </Accordion>
 
 4.  Manipulate the log entry to obtain information
 

--- a/docs/public-docs/app-developers/tutorials/interoperability/message-passing.mdx
+++ b/docs/public-docs/app-developers/tutorials/interoperability/message-passing.mdx
@@ -12,7 +12,7 @@ diataxis: tutorial
 This tutorial demonstrates how to implement cross-chain communication within the OP Stack ecosystem. You'll build a complete
 message passing system that enables different chains to interact with each other using the `L2ToL2CrossDomainMessenger` contract.
 
-<Expandable title="About this tutorial">
+<Accordion title="About this tutorial">
 
   **Prerequisite technical knowledge**
 
@@ -42,7 +42,7 @@ message passing system that enables different chains to interact with each other
   * Supersim: For local blockchain simulation (optional)
   * TypeScript: For offchain code (for relaying messages manually)
   * Viem: For interactions with the chain from the offchain app
-</Expandable>
+</Accordion>
 
 ### What You'll Build
 
@@ -140,7 +140,7 @@ The implementation consists of three main components:
             </Tab>
         </Tabs>
 
-    <Expandable title="Sanity check">
+    <Accordion title="Sanity check">
 
       To verify that the chains are running, check the balance of `$USER_ADDRESS`.
 
@@ -148,7 +148,7 @@ The implementation consists of three main components:
       cast balance --ether $USER_ADDRESS --rpc-url $URL_CHAIN_A
       cast balance --ether $USER_ADDRESS --rpc-url $URL_CHAIN_B
       ```
-    </Expandable>
+    </Accordion>
   </Step>
 
   <Step title="Create the contracts">
@@ -192,7 +192,7 @@ The implementation consists of three main components:
         GREETER_B_ADDRESS=`forge create --rpc-url $URL_CHAIN_B --private-key $PRIVATE_KEY Greeter --broadcast | awk '/Deployed to:/ {print $3}'`
         ```
 
-        <Expandable title="Explanation">
+        <Accordion title="Explanation">
 
             The command that deploys the contract is:
 
@@ -220,9 +220,9 @@ The implementation consists of three main components:
             ```sh
             GREETER_B_ADDRESS=<the address>
             ```
-        </Expandable>
+        </Accordion>
 
-    <Expandable title="Sanity check">
+    <Accordion title="Sanity check">
 
       Run these commands to verify the contract works.
       The first and third commands retrieve the current greeting, while the second command updates it.
@@ -232,7 +232,7 @@ The implementation consists of three main components:
       cast send --private-key $PRIVATE_KEY --rpc-url $URL_CHAIN_B $GREETER_B_ADDRESS "setGreeting(string)" Hello$$
       cast call --rpc-url $URL_CHAIN_B $GREETER_B_ADDRESS "greet()" | cast --to-ascii
       ```
-    </Expandable>
+    </Accordion>
 
     4.  Install the Optimism Solidity libraries into the project.
 
@@ -276,7 +276,7 @@ The implementation consists of three main components:
             }
         ```
 
-        <Expandable title="Explanation">
+        <Accordion title="Explanation">
 
            ```solidity
                 function setGreeting(string calldata greeting) public {
@@ -293,7 +293,7 @@ The implementation consists of three main components:
            The encoded message is then passed to `messenger.sendMessage`, which forwards it to the destination contract (`greeterAddress`) on the specified chain (`greeterChainId`).
 
            This ensures that `setGreeting` is executed remotely with the provided `greeting` value (as long as there is an executing message to relay it).
-        </Expandable>
+        </Accordion>
 
     7.  Deploy `GreetingSender` to chain A.
 
@@ -379,7 +379,7 @@ In this section we change `Greeter.sol` to emit a separate event in it receives 
             }
         ```
 
-        <Expandable title="Explanation">
+        <Accordion title="Explanation">
 
             ```solidity
             interface IL2ToL2CrossDomainMessenger {
@@ -398,7 +398,7 @@ In this section we change `Greeter.sol` to emit a separate event in it receives 
             ```
 
             If we see that we got a message from `L2ToL2CrossDomainMessenger`, we call [`L2ToL2CrossDomainMessenger.crossDomainMessageContext`](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/src/L2/L2ToL2CrossDomainMessenger.sol#L118-L126).
-        </Expandable>
+        </Accordion>
 
     2.  Redeploy the contracts.
         Because the address of `Greeter` is immutable in `GreetingSender`, we need to redeploy both contracts.

--- a/docs/public-docs/chain-operators/guides/configuration/op-challenger-config-guide.mdx
+++ b/docs/public-docs/chain-operators/guides/configuration/op-challenger-config-guide.mdx
@@ -231,29 +231,29 @@ Check that you have properly installed the challenger component:
   </Step>
 
   <Step title="Understanding key configuration flags">
-  <Expandable title="--l1-eth-rpc">
+  <Accordion title="--l1-eth-rpc">
   
   *   This is the HTTP provider URL for a standard L1 node, can be a full node. `op-challenger` will be sending many requests, so chain operators need a node that is trusted and can easily handle many transactions.
   *   Note: Challenger has a lot of money, and it will spend it if it needs to interact with games. That might risk not defending games or challenging games correctly, so chain operators should really trust the nodes being pointed at Challenger.
-  </Expandable>
+  </Accordion>
   
-  <Expandable title="--l1-beacon">
+  <Accordion title="--l1-beacon">
   
   *   This is needed just to get blobs from.
   *   In some instances, chain operators might need a blob archiver or L1 consensus node configured not to prune blobs:
       *   If the chain is proposing regularly, a blob archiver isn't needed. There's only a small window in the blob retention period that games can be played.
       *   If the chain doesn't post a valid output root in 18 days, then a blob archiver running a challenge game is needed. If the actor gets pushed to the bottom of the game, it could lose if it's the only one protecting the chain.
-  </Expandable>
+  </Accordion>
   
-  <Expandable title="--l2-eth-rpc">
+  <Accordion title="--l2-eth-rpc">
   
   *   This needs to be an `op-reth` archive node, with `debug` enabled.
   *   Technically doesn't need to go to bedrock, but needs to have access to the start of any game that is still in progress.
   *   The withdrawal-proof data the challenger reads via `eth_getProof` is served by op-reth's historical-proofs store. Enable it with `--proofs-history --proofs-history.storage-version v2`, set a persistent `--proofs-history.storage-path`, and size `--proofs-history.window` to cover the dispute game window (≥ 28 days). On permissioned chains, `--rpc.eth-proof-window` bounds how far back `eth_getProof` will serve. See [Running op-reth with historical proofs](/node-operators/tutorials/reth-historical-proofs).
   *   **Seed the proofs storage once before starting the node with `--proofs-history`**, or op-reth refuses to start (the `proofs-history` ExEx panics with `Proofs storage not initialized`). With the node stopped, run `op-reth proofs init --chain <chain-or-genesis> --datadir <reth-datadir> --proofs-history.storage-path <proofs-db-path> --proofs-history.storage-version v2`. It snapshots the chain's current state to seed the sidecar; the ExEx then indexes forward as the node syncs. Initialize at (or near) genesis so the whole fault-proof window is covered — a node seeded at the current tip only serves proofs for blocks after that point.
-  </Expandable>
+  </Accordion>
   
-  <Expandable title="--rollup-rpc">
+  <Accordion title="--rollup-rpc">
   
   *   This needs to be an `op-node` archive node because challenger needs access to output roots from back when the games start. See below for important configuration details:
   
@@ -293,18 +293,18 @@ Check that you have properly installed the challenger component:
       <Info>
         Replace `<op-node-archive-node-url>` with the URL of your archive node and `<path-to-safe-head-db>` with the desired path for storing SafeDB data.
       </Info>
-  </Expandable>
+  </Accordion>
   
-  <Expandable title="--private-key">
+  <Accordion title="--private-key">
   
   *   Chain operators must specify a private key or use something else (like `op-signer`).
   *   This uses the same transaction manager arguments as `op-node` , batcher, and proposer, so chain operators can choose one of the following options:
       *   a mnemonic
       *   a private key
       *   `op-signer` endpoints
-  </Expandable>
+  </Accordion>
   
-  <Expandable title="--network">
+  <Accordion title="--network">
   
   *   This identifies the L2 network `op-challenger` is running for, e.g., `op-sepolia` or `op-mainnet`.
   *   When using the `--network` flag, the `--game-factory-address` will be automatically pulled from the [`superchain-registry`](https://github.com/ethereum-optimism/superchain-registry/blob/main/chainList.json).
@@ -331,15 +331,15 @@ Check that you have properly installed the challenger component:
   <Info>
     These options vary based on which `--network` is specified. Chain operators always need to specify a way to load prestates and must also specify the `--cannon-kona-server` whenever the docker image isn't being used.
   </Info>
-  </Expandable>
+  </Accordion>
   
-  <Expandable title="--datadir">
+  <Accordion title="--datadir">
   
   *   This is a directory that `op-challenger` can write to and store whatever data it needs.  It will manage this directory to add or remove data as needed under that directory.
   *   If running in docker, it should point to a docker volume or mount point, so the data isn't lost on every restart. The data can be recreated if needed but particularly if challenger has executed cannon as part of responding to a game it may mean a lot of extra processing.
-  </Expandable>
+  </Accordion>
   
-  <Expandable title="--cannon-kona-prestate / --cannon-kona-prestates-url">
+  <Accordion title="--cannon-kona-prestate / --cannon-kona-prestates-url">
   
   The prestate is effectively the version of `kona-client` that is deployed on chain (run inside the Cannon VM as the `cannon-kona` game type). And chain operators must use the right version. `op-challenger` will refuse to interact with games that have a different absolute prestate hash to avoid making invalid claims. If deploying your own contracts, chain operators must specify an absolute prestate hash taken from the `just reproducible-prestate-kona` command during contract deployment, which will also build the required prestate file.
   
@@ -356,7 +356,7 @@ Check that you have properly installed the challenger component:
     Challenger will refuse to interact with any games if it doesn't have the matching prestate.
     Check this [guide](/chain-operators/tutorials/absolute-prestate#generating-the-absolute-prestate) on how to generate a absolute prestate.
   </Info>
-  </Expandable>
+  </Accordion>
   </Step>
 </Steps>
 
@@ -454,29 +454,29 @@ The challenger should show logs indicating:
   <Step title="Understanding configuration flags">
   Each environment variable maps to a specific challenger configuration flag. Here's what each one does:
   
-  <Expandable title="--l1-eth-rpc">
+  <Accordion title="--l1-eth-rpc">
   
   *   This is the HTTP provider URL for a standard L1 node, can be a full node. `op-challenger` will be sending many requests, so chain operators need a node that is trusted and can easily handle many transactions.
   *   Note: Challenger has a lot of money, and it will spend it if it needs to interact with games. That might risk not defending games or challenging games correctly, so chain operators should really trust the nodes being pointed at Challenger.
-  </Expandable>
+  </Accordion>
   
-  <Expandable title="--l1-beacon">
+  <Accordion title="--l1-beacon">
   
   *   This is needed just to get blobs from.
   *   In some instances, chain operators might need a blob archiver or L1 consensus node configured not to prune blobs:
       *   If the chain is proposing regularly, a blob archiver isn't needed. There's only a small window in the blob retention period that games can be played.
       *   If the chain doesn't post a valid output root in 18 days, then a blob archiver running a challenge game is needed. If the actor gets pushed to the bottom of the game, it could lose if it's the only one protecting the chain.
-  </Expandable>
+  </Accordion>
   
-  <Expandable title="--l2-eth-rpc">
+  <Accordion title="--l2-eth-rpc">
   
   *   This needs to be an `op-reth` archive node, with `debug` enabled.
   *   Technically doesn't need to go to bedrock, but needs to have access to the start of any game that is still in progress.
   *   The withdrawal-proof data the challenger reads via `eth_getProof` is served by op-reth's historical-proofs store. Enable it with `--proofs-history --proofs-history.storage-version v2`, set a persistent `--proofs-history.storage-path`, and size `--proofs-history.window` to cover the dispute game window (≥ 28 days). On permissioned chains, `--rpc.eth-proof-window` bounds how far back `eth_getProof` will serve. See [Running op-reth with historical proofs](/node-operators/tutorials/reth-historical-proofs).
   *   **Seed the proofs storage once before starting the node with `--proofs-history`**, or op-reth refuses to start (the `proofs-history` ExEx panics with `Proofs storage not initialized`). With the node stopped, run `op-reth proofs init --chain <chain-or-genesis> --datadir <reth-datadir> --proofs-history.storage-path <proofs-db-path> --proofs-history.storage-version v2`. It snapshots the chain's current state to seed the sidecar; the ExEx then indexes forward as the node syncs. Initialize at (or near) genesis so the whole fault-proof window is covered — a node seeded at the current tip only serves proofs for blocks after that point.
-  </Expandable>
+  </Accordion>
   
-  <Expandable title="--rollup-rpc">
+  <Accordion title="--rollup-rpc">
   
   *   This needs to be an `op-node` archive node because challenger needs access to output roots from back when the games start. See below for important configuration details:
   
@@ -516,18 +516,18 @@ The challenger should show logs indicating:
       <Info>
         Replace `<op-node-archive-node-url>` with the URL of your archive node and `<path-to-safe-head-db>` with the desired path for storing SafeDB data.
       </Info>
-  </Expandable>
+  </Accordion>
   
-  <Expandable title="--private-key">
+  <Accordion title="--private-key">
   
   *   Chain operators must specify a private key or use something else (like `op-signer`).
   *   This uses the same transaction manager arguments as `op-node` , batcher, and proposer, so chain operators can choose one of the following options:
       *   a mnemonic
       *   a private key
       *   `op-signer` endpoints
-  </Expandable>
+  </Accordion>
   
-  <Expandable title="--network">
+  <Accordion title="--network">
   
   *   This identifies the L2 network `op-challenger` is running for, e.g., `op-sepolia` or `op-mainnet`.
   *   When using the `--network` flag, the `--game-factory-address` will be automatically pulled from the [`superchain-registry`](https://github.com/ethereum-optimism/superchain-registry/blob/main/chainList.json).
@@ -554,15 +554,15 @@ The challenger should show logs indicating:
   <Info>
     These options vary based on which `--network` is specified. Chain operators always need to specify a way to load prestates and must also specify the `--cannon-kona-server` whenever the docker image isn't being used.
   </Info>
-  </Expandable>
+  </Accordion>
   
-  <Expandable title="--datadir">
+  <Accordion title="--datadir">
   
   *   This is a directory that `op-challenger` can write to and store whatever data it needs.  It will manage this directory to add or remove data as needed under that directory.
   *   If running in docker, it should point to a docker volume or mount point, so the data isn't lost on every restart. The data can be recreated if needed but particularly if challenger has executed cannon as part of responding to a game it may mean a lot of extra processing.
-  </Expandable>
+  </Accordion>
   
-  <Expandable title="--cannon-kona-prestate / --cannon-kona-prestates-url">
+  <Accordion title="--cannon-kona-prestate / --cannon-kona-prestates-url">
   
   The prestate is effectively the version of `kona-client` that is deployed on chain (run inside the Cannon VM as the `cannon-kona` game type). And chain operators must use the right version. `op-challenger` will refuse to interact with games that have a different absolute prestate hash to avoid making invalid claims. If deploying your own contracts, chain operators must specify an absolute prestate hash taken from the `just reproducible-prestate-kona` command during contract deployment, which will also build the required prestate file.
   
@@ -579,7 +579,7 @@ The challenger should show logs indicating:
     Challenger will refuse to interact with any games if it doesn't have the matching prestate.
     Check this [guide](/chain-operators/tutorials/absolute-prestate#generating-the-absolute-prestate) on how to generate a absolute prestate.
   </Info>
-  </Expandable>
+  </Accordion>
   </Step>
 
   <Step title="Set up Docker Compose">

--- a/docs/public-docs/chain-operators/tutorials/create-l2-rollup/index.mdx
+++ b/docs/public-docs/chain-operators/tutorials/create-l2-rollup/index.mdx
@@ -59,19 +59,19 @@ Set up the following before you pick a setup path below. Both the automated and 
   Expand each dependency below for details
 </Info>
 
-<Expandable title="node">
+<Accordion title="node">
 
   We recommend using the latest LTS version of Node.js (currently v20).\
   [`nvm`](https://github.com/nvm-sh/nvm) is a useful tool that can help you manage multiple versions of Node.js on your machine.\
   You may experience unexpected errors on older versions of Node.js.
-</Expandable>
+</Accordion>
 
-<Expandable title="foundry">
+<Accordion title="foundry">
 
   We will use cast to generate wallet addresses in this guide.
-</Expandable>
+</Accordion>
 
-<Expandable title="direnv">
+<Accordion title="direnv">
 
   Parts of this tutorial use [`direnv`](https://direnv.net) as a way of loading environment variables from `.envrc` files into your shell.\
   This means you won't have to manually export environment variables every time you want to use them.\
@@ -84,9 +84,9 @@ Set up the following before you pick a setup path below. Both the automated and 
     Make sure that you have correctly hooked `direnv` into your shell by modifying your shell configuration file (like `~/.bashrc` or `~/.zshrc`).\
     If you haven't edited a config file then you probably haven't configured `direnv` properly (and things might not work later).
   </Info>
-</Expandable>
+</Accordion>
 
-<Expandable title="Docker">
+<Accordion title="Docker">
 
   Docker is used extensively in this tutorial for running various OP Stack components.\
   Make sure you have both Docker and Docker Compose installed and running on your system.\
@@ -100,7 +100,7 @@ Set up the following before you pick a setup path below. Both the automated and 
     docker run hello-world
     ```
   </Info>
-</Expandable>
+</Accordion>
 
 ### Get access to a sepolia node
 

--- a/docs/public-docs/chain-operators/tutorials/create-l2-rollup/op-challenger-setup.mdx
+++ b/docs/public-docs/chain-operators/tutorials/create-l2-rollup/op-challenger-setup.mdx
@@ -33,7 +33,7 @@ Complete these prerequisites before wiring up the challenger:
 <Steps>
 <Step title="Deploy OP Stack chain with fault proofs enabled">
 
-<Expandable title="Generate absolute prestate (Required)">
+<Accordion title="Generate absolute prestate (Required)">
 
 The challenger needs the absolute prestate to participate in dispute games. The prestate is the on-chain commitment to a specific build of `kona-client`, the maintained fault proof program. (`op-program`, which previously filled this role, has reached end-of-support; see [End of Support for op-geth and op-program](/notices/archive/op-geth-deprecation).) Here's how to generate it:
 
@@ -70,7 +70,7 @@ The challenger needs the absolute prestate to participate in dispute games. The 
   *   Keep the `0x<PRESTATE_HASH>.bin.gz` file accessible - you'll need it for the challenger setup
   *   For Superchain registry chains, you can find official `cannon64-kona` prestates in the [registry](https://github.com/ethereum-optimism/superchain-registry/blob/main/validation/standard/standard-prestates.toml)
 </Info>
-</Expandable>
+</Accordion>
 </Step>
 
 <Step title="Set up required infrastructure access">

--- a/docs/public-docs/chain-operators/tutorials/create-l2-rollup/op-deployer-setup.mdx
+++ b/docs/public-docs/chain-operators/tutorials/create-l2-rollup/op-deployer-setup.mdx
@@ -221,7 +221,7 @@ The intent file defines your chain's configuration.
   ```
 
 
-  <Expandable title="Understanding intent types">
+  <Accordion title="Understanding intent types">
 
     `op-deployer` supports three intent types:
 
@@ -230,7 +230,7 @@ The intent file defines your chain's configuration.
     *   `custom`: Full customization, requires manual configuration of all values
 
     For most users, `standard-overrides` provides the best balance of simplicity and flexibility.
-  </Expandable>
+  </Accordion>
 
       </Step>
 
@@ -275,7 +275,7 @@ The intent file defines your chain's configuration.
       challenger = "0xfd1d2e729ae8eee2e146c033bf4400fe75284301"
   ```
 
-  <Expandable title="Understanding the configuration values">
+  <Accordion title="Understanding the configuration values">
 
     **Global Settings:**
 
@@ -320,7 +320,7 @@ The intent file defines your chain's configuration.
     *   `batcher`: Submits L2 transaction batches to L1
     *   `proposer`: Submits L2 state roots to L1 for verification
     *   `challenger`: Monitors dispute games and defends valid states
-  </Expandable>
+  </Accordion>
 
       </Step>
     </Steps>

--- a/docs/public-docs/chain-operators/tutorials/create-l2-rollup/op-proposer-setup.mdx
+++ b/docs/public-docs/chain-operators/tutorials/create-l2-rollup/op-proposer-setup.mdx
@@ -187,7 +187,7 @@ For setting up the proposer, we recommend using Docker as it provides a consiste
       </Step>
     </Steps>
 
-    <Expandable title="Understanding proposer startup logs">
+    <Accordion title="Understanding proposer startup logs">
 
       When you first start your proposer, you'll see several types of log messages:
 
@@ -221,7 +221,7 @@ For setting up the proposer, we recommend using Docker as it provides a consiste
       If you see errors about "failed to dial" or connection issues:
 
       *   For source build: Verify your localhost ports and services
-    </Expandable>
+    </Accordion>
 
     Your proposer is now operational and will continuously submit state roots to L1!
   </Tab>
@@ -422,7 +422,7 @@ For setting up the proposer, we recommend using Docker as it provides a consiste
       </Step>
     </Steps>
 
-    <Expandable title="Understanding proposer startup logs">
+    <Accordion title="Understanding proposer startup logs">
 
       When you first start your proposer, you'll see several types of log messages:
 
@@ -456,7 +456,7 @@ For setting up the proposer, we recommend using Docker as it provides a consiste
       If you see errors about "failed to dial" or connection issues:
 
       *   For Docker: Check your network configuration and service names
-    </Expandable>
+    </Accordion>
 
     Your proposer is now operational!
   </Tab>

--- a/docs/public-docs/chain-operators/tutorials/create-l2-rollup/op-reth-setup.mdx
+++ b/docs/public-docs/chain-operators/tutorials/create-l2-rollup/op-reth-setup.mdx
@@ -365,7 +365,7 @@ For spinning up a sequencer, we recommend using Docker, as it provides a simpler
       </Step>
     </Steps>
 
-    <Expandable title=".env template">
+    <Accordion title=".env template">
 
       ```bash
       L1_RPC_URL=https://sepolia.infura.io/v3/YOUR_ACTUAL_INFURA_KEY
@@ -381,7 +381,7 @@ For spinning up a sequencer, we recommend using Docker, as it provides a simpler
       OP_RETH_AUTH_PORT=8551
       JWT_SECRET=./jwt.txt
       ```
-    </Expandable>
+    </Accordion>
 
     ## Sequencer specific configuration
 

--- a/docs/public-docs/chain-operators/tutorials/migrating-permissionless.mdx
+++ b/docs/public-docs/chain-operators/tutorials/migrating-permissionless.mdx
@@ -271,7 +271,7 @@ You have two main options for executing this step:
 
 If your privileged role (such as the Guardian) is controlled by a multisig or DAO governance system, use the provided JSON payload (`input.json`):
 
-<Expandable title="Create an `input.json` file with the transaction to update the `respectedGameType`: ">
+<Accordion title="Create an `input.json` file with the transaction to update the `respectedGameType`: ">
 
   ```json
   {
@@ -309,7 +309,7 @@ If your privileged role (such as the Guardian) is controlled by a multisig or DA
   }
 
   ```
-</Expandable>
+</Accordion>
 
 *   **Submit this JSON payload** through your interface (e.g., Safe transaction builder).
 *   **Simulate** this transaction using Tenderly before execution to ensure the expected state changes:

--- a/docs/public-docs/op-stack/features/subblocks.mdx
+++ b/docs/public-docs/op-stack/features/subblocks.mdx
@@ -110,40 +110,44 @@ For availability information, see [Enabling Subblocks](/chain-operators/guides/f
 
 ### Block building and availability
 
-<Expandable title="How often are subblocks produced?">
-  Every 200ms, but configurable to lower values.
-  OP Sepolia and OP Mainnet both move to 200 ms; see the [Subblocks notice](/notices/subblocks) for the rollout dates.
-</Expandable>
+<AccordionGroup>
+  <Accordion title="How often are subblocks produced?">
+    Every 200ms, but configurable to lower values.
+    OP Sepolia and OP Mainnet both move to 200 ms; see the [Subblocks notice](/notices/subblocks) for the rollout dates.
+  </Accordion>
 
-<Expandable title="Will a block always contain the maximum number of subblocks?">
-  No. Heavy execution in one interval reduces the time available for the ones after it, so the count varies between blocks.
-</Expandable>
+  <Accordion title="Will a block always contain the maximum number of subblocks?">
+    No. Heavy execution in one interval reduces the time available for the ones after it, so the count varies between blocks.
+  </Accordion>
 
-<Expandable title="Do large transactions get delayed?">
-  A large transaction can land in any subblock with enough gas capacity left, so in practice it lands later in the block.
-  See [Subblocks and gas usage](/app-developers/guides/transactions/subblocks-and-gas-usage) for a worked example.
-</Expandable>
+  <Accordion title="Do large transactions get delayed?">
+    A large transaction can land in any subblock with enough gas capacity left, so in practice it lands later in the block.
+    See [Subblocks and gas usage](/app-developers/guides/transactions/subblocks-and-gas-usage) for a worked example.
+  </Accordion>
+</AccordionGroup>
 
 ### Safety and continuity
 
-<Expandable title="What happens if the sequencer fails mid-block?">
-  The subblocks already published for the abandoned block do not seal.
-  In a multi-sequencer setup, `op-conductor` transfers leadership to a healthy sequencer, and the stream continues from the new leader through the same endpoint.
-  For details, see the [op-conductor documentation](/chain-operators/tools/op-conductor).
-</Expandable>
+<AccordionGroup>
+  <Accordion title="What happens if the sequencer fails mid-block?">
+    The subblocks already published for the abandoned block do not seal.
+    In a multi-sequencer setup, `op-conductor` transfers leadership to a healthy sequencer, and the stream continues from the new leader through the same endpoint.
+    For details, see the [op-conductor documentation](/chain-operators/tools/op-conductor).
+  </Accordion>
 
-<Expandable title="Do subblocks change the safety model of the chain?">
-  No. Every transaction in a subblock is executed by the same engine, under the same rules, as it would be in a block. Subblocks change when the sequencer tells you the outcome, not what the outcome is.
-</Expandable>
+  <Accordion title="Do subblocks change the safety model of the chain?">
+    No. Every transaction in a subblock is executed by the same engine, under the same rules, as it would be in a block. Subblocks change when the sequencer tells you the outcome, not what the outcome is.
+  </Accordion>
 
-<Expandable title="Can a pre-confirmation be revoked?">
-  Yes, under the same conditions that let the sequencer reorg an unsafe block. A pre-confirmation carries the sequencer's trust assumption, not the protocol's. See [Transaction finality](/op-stack/transactions/transaction-finality) for what each stage guarantees.
-</Expandable>
+  <Accordion title="Can a pre-confirmation be revoked?">
+    Yes, under the same conditions that let the sequencer reorg an unsafe block. A pre-confirmation carries the sequencer's trust assumption, not the protocol's. See [Transaction finality](/op-stack/transactions/transaction-finality) for what each stage guarantees.
+  </Accordion>
 
-<Expandable title="What does a pre-confirmation response contain?">
-  The transactions executed so far in the block, their receipts, and the cumulative `gas_used`, `receipts_root`, and `logs_bloom`.
-  It does not contain a usable `state_root` or `block_hash` — both are zeroed, as described in [what a subblock payload carries](#what-a-subblock-payload-carries).
-</Expandable>
+  <Accordion title="What does a pre-confirmation response contain?">
+    The transactions executed so far in the block, their receipts, and the cumulative `gas_used`, `receipts_root`, and `logs_bloom`.
+    It does not contain a usable `state_root` or `block_hash` — both are zeroed, as described in [what a subblock payload carries](#what-a-subblock-payload-carries).
+  </Accordion>
+</AccordionGroup>
 
 ## Next steps
 

--- a/docs/public-docs/op-stack/interop/explainer.mdx
+++ b/docs/public-docs/op-stack/interop/explainer.mdx
@@ -148,7 +148,7 @@ The crucial property of interop is the second bullet: a block is only treated as
 
 This dependency check is what protects users against a [double-spend across chains](/op-stack/interop/reorg). When a sequencer chooses to accept executing messages that reference unsafe initiating messages, it gets the lowest possible cross-chain latency, but it takes on the trust assumption that every sequencer in its [transitive dependency set](#what-is-the-transitive-dependency-set) will eventually post the data it gossiped. If any of them equivocates, the executing-message blocks are reorged out and replaced with deposit-only blocks. For a deeper discussion of the latency / security trade-off and how a chain operator can configure the minimum safety level it will accept for an inbound message, see [Cross-chain security measures](/op-stack/security/interop-security).
 
-<Expandable title="What is the transitive dependency set?">
+<Accordion title="What is the transitive dependency set?">
 
   The dependency set of a chain is the set of chains it directly accepts initiating messages from. The *transitive* dependency set also includes the dependencies of those chains, and so on.
 
@@ -165,7 +165,7 @@ This dependency check is what protects users against a [double-spend across chai
   In the picture above, chain A's direct dependency set is `{B}`, but its transitive dependency set is `{B, C, D, E}`. A block on chain D that depends on an unsafe initiating message from chain E remains unsafe until that chain E block is on L1 — and so does every chain B and chain A block that depends on the chain D block.
 
   Verifying transitively is what lets a chain accept low-latency messages without inheriting unbounded trust from chains it has never heard of: chain A only needs to accept the trust assumptions of chains in its own transitive dependency set.
-</Expandable>
+</Accordion>
 
 ## Interop clusters
 

--- a/docs/public-docs/op-stack/interop/reorg.mdx
+++ b/docs/public-docs/op-stack/interop/reorg.mdx
@@ -15,7 +15,7 @@ diataxis: explanation
 If not handled correctly, reorgs in a cross-chain context could result in a [double-spend problem](https://en.wikipedia.org/wiki/Double-spending).
 The most frequent solution to mitigate the double-spend problem is to wait for Ethereum finality; however, that solution results in high latency cross-chain communication and a poor user experience.
 
-<Expandable title="What is double-spending?">
+<Accordion title="What is double-spending?">
 
   ```mermaid
 
@@ -72,7 +72,7 @@ The most frequent solution to mitigate the double-spend problem is to wait for E
   The mechanism varies by asset.
   ETH is locked and unlocked in an on-chain liquidity contract; SuperchainERC20 tokens are burned and minted.
   The double-spend risk is the same either way.
-</Expandable>
+</Accordion>
 
 Most solutions to mitigate the double-spend problem rely on [L1 finality](https://ethereum.org/en/developers/docs/consensus-mechanisms/pos/#finality). However, that solution results in high latency and poor user experience.
 
@@ -176,13 +176,13 @@ A block in another chain can only depend on a specific block here if it referenc
 
 A block can also be canonically invalidated outright. If verifiers determine that an L2 block cannot be reproduced from L1 — for example because the batch claims an initiating message that does not exist on the source chain — the canonical chain replaces it with a *deposit-only block*: a block that contains only the deposit transactions forced through L1, with all sequencer transactions stripped out. For interop-specific failures like that example, [op-supernode](#how-the-dependency-check-is-enforced) is the verifier that makes the call.
 
-<Expandable title="What makes a block invalid?">
+<Accordion title="What makes a block invalid?">
 
   There are several potential reasons:
 
   *   The block posted to L1 includes incorrect information — for example, a batch claims an initiating message that the source chain never actually emitted, so any executing message that references it cannot be reproduced.
   *   The block was never posted at all. If the [sequencer window](https://specs.optimism.io/glossary.html#sequencing-window) elapses (3600 L1 blocks ≈ 12 hours on standard chains) without a batch covering an L1 epoch, verifiers fall back to a deposit-only block for that epoch.
-</Expandable>
+</Accordion>
 
 Functionally this is equivalent to equivocation, and the dependency rules above handle it the same way: only unsafe blocks (and any chain of blocks depending on them transitively) are reshaped, and any block that had already reached the safe label is untouched.
 

--- a/docs/public-docs/op-stack/security/interop-security.mdx
+++ b/docs/public-docs/op-stack/security/interop-security.mdx
@@ -21,7 +21,7 @@ Excluding L1 reorgs, this can happen in two ways:
 
     In this case, invalid blocks will be replaced with deposit only blocks by other verifiers.
 
-    <Expandable title="What are deposit only blocks?">
+    <Accordion title="What are deposit only blocks?">
 
       Normally the blocks that make it to the canonical blockchain are those posted to L1 by the sequencer.
       However, when those blocks are missing or invalid (for example because they rely on an initiating message that is missing), they're replaced by *deposit only blocks*, blocks whose content can be calculated from L1 without relying on the sequencer.
@@ -36,7 +36,7 @@ Excluding L1 reorgs, this can happen in two ways:
       A deposit only block only contains the deposit transactions and some internal transactions, not the sequencer transactions.
 
       For more information about this process, [see the technical specifications](https://specs.optimism.io/protocol/derivation.html?utm_source=op-docs&utm_medium=docs#deriving-the-transaction-list).
-    </Expandable>
+    </Accordion>
 
 ## The latency/security tradeoff
 


### PR DESCRIPTION
## Description

Mintlify's `<Expandable>` component is built for nested object fields in API reference pages and prepends "Show" / "Hide" to its title. The docs used it for FAQs, prerequisite blocks, flag references, and sample payloads, so on the live site toggles rendered as:

```
Show How often are subblocks produced?
Show What is double-spending?
Show --l1-eth-rpc
```

This PR switches every `<Expandable>` in `docs/public-docs` to `<Accordion>`, the component Mintlify recommends for general collapsible content and the one `governance/gov-faq.mdx` already uses. The header now shows the bare title with a chevron. The Subblocks FAQ additionally wraps each subsection in an `<AccordionGroup>` so the questions stack in one panel.

Content and links are unchanged. Every converted tag carried only a `title` attribute, and the diff is the tag rename plus indentation on the Subblocks page.

## Tests

Verified against the live site: the deployed `op-stack/features/subblocks` page emits `Show <question>` for all seven FAQ entries, while the deployed `governance/gov-faq` page (Accordion) renders titles with no prefix. Grep confirms no `Expandable` remains under `docs/public-docs`. The Mintlify preview on this PR should show the new headers.

## Additional context

Review agents: the diff touches only `.mdx` files, so none of the repo review agents (Go, Rust, CI config, deletion, StandardValidator, reth) match. No general code review was run; the change is a mechanical component swap with no prose edits.

Prev(from https://docs.optimism.io/op-stack/features/subblocks): 
<img width="842" height="328" alt="image" src="https://github.com/user-attachments/assets/d55c2f23-32fb-4dc1-8fc6-3b6585c939b5" />

After:
<img width="753" height="285" alt="image" src="https://github.com/user-attachments/assets/0dd5056b-bb98-4441-973a-bf60039390dd" />

