### PR TITLE
contracts-bedrock: verify StandardValidator sub-contract references in VerifyOPCM

### DIFF
--- a/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
@@ -604,7 +604,7 @@ contract DeployImplementations is Script {
 
         IStandardValidatorUtils standardValidatorUtils = IStandardValidatorUtils(
             DeployUtils.createDeterministic({
-                _name: "StandardValidatorUtils.sol:StandardValidatorUtils",
+                _name: "StandardValidatorUtils",
                 _args: DeployUtils.encodeConstructor(abi.encodeCall(IStandardValidatorUtils.__constructor__, ())),
                 _salt: _salt
             })

--- a/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
@@ -604,7 +604,7 @@ contract DeployImplementations is Script {
 
         IStandardValidatorUtils standardValidatorUtils = IStandardValidatorUtils(
             DeployUtils.createDeterministic({
-                _name: "StandardValidatorUtils",
+                _name: "StandardValidatorUtils.sol:StandardValidatorUtils",
                 _args: DeployUtils.encodeConstructor(abi.encodeCall(IStandardValidatorUtils.__constructor__, ())),
                 _salt: _salt
             })

--- a/packages/contracts-bedrock/scripts/deploy/VerifyOPCM.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/VerifyOPCM.s.sol
@@ -230,8 +230,8 @@ contract VerifyOPCM is Script {
         expectedGetters["opcmInteropMigrator"] = "SKIP"; // Address verified via bytecode comparison
         expectedGetters["opcmMigrator"] = "SKIP"; // Address verified via bytecode comparison
         expectedGetters["opcmStandardValidator"] = "SKIP"; // Address verified via bytecode comparison
-        validatorGetterChecks["standardValidatorUtils"] = "SKIP";
-        validatorGetterChecks["migrationValidator"] = "SKIP";
+        validatorGetterChecks["standardValidatorUtils"] = "BYTECODE:StandardValidatorUtils";
+        validatorGetterChecks["migrationValidator"] = "BYTECODE:OPContractsManagerMigrationValidator";
         expectedGetters["opcmUpgrader"] = "SKIP"; // Address verified via bytecode comparison
 
         // OPCM V2 Specific expected getters overrides
@@ -727,7 +727,7 @@ contract VerifyOPCM is Script {
 
         // For implementations, verify security-critical values.
         if (!_target.blueprint) {
-            success = _verifySecurityCriticalValues(_opcm, _target, artifact) && success;
+            success = _verifySecurityCriticalValues(_opcm, _target, artifact, _skipConstructorVerification) && success;
         }
 
         // If requested and this is not a blueprint, we also need to check the creation code.
@@ -1327,11 +1327,13 @@ contract VerifyOPCM is Script {
     /// @param _opcm The OPCM contract that contains the target contract reference.
     /// @param _target The contract reference being verified.
     /// @param _artifact The artifact info for the contract.
+    /// @param _skipConstructorVerification Whether to skip constructor verification.
     /// @return True if all security-critical values are correct.
     function _verifySecurityCriticalValues(
         IOPContractsManagerV2 _opcm,
         OpcmContractRef memory _target,
-        ArtifactInfo memory _artifact
+        ArtifactInfo memory _artifact,
+        bool _skipConstructorVerification
     )
         internal
         returns (bool)
@@ -1368,7 +1370,7 @@ contract VerifyOPCM is Script {
 
         // OPContractsManagerStandardValidator: Verify all constructor arg values
         if (LibString.eq(_target.name, "OPContractsManagerStandardValidator")) {
-            success = _verifyStandardValidatorArgs(_opcm, _target.addr) && success;
+            success = _verifyStandardValidatorArgs(_opcm, _target.addr, _skipConstructorVerification) && success;
         }
 
         return success;
@@ -1463,8 +1465,16 @@ contract VerifyOPCM is Script {
     /// @notice Verifies all StandardValidator getters are properly validated.
     /// @param _opcm The OPCM contract.
     /// @param _validator The StandardValidator contract address.
+    /// @param _skipConstructorVerification Whether to skip constructor verification.
     /// @return True if all getters are valid.
-    function _verifyStandardValidatorArgs(IOPContractsManagerV2 _opcm, address _validator) internal returns (bool) {
+    function _verifyStandardValidatorArgs(
+        IOPContractsManagerV2 _opcm,
+        address _validator,
+        bool _skipConstructorVerification
+    )
+        internal
+        returns (bool)
+    {
         bool success = true;
         console.log("  Verifying StandardValidator args...");
 
@@ -1521,6 +1531,10 @@ contract VerifyOPCM is Script {
                 success = _verifyEnvUint256(_validator, getter, envVar) && success;
             } else if (LibString.eq(check, "ZERO_ON_MAINNET")) {
                 success = _verifyZeroOnMainnet(_validator, getter) && success;
+            } else if (LibString.startsWith(check, "BYTECODE:")) {
+                string memory name = LibString.slice(check, bytes("BYTECODE:").length, bytes(check).length);
+                success = _verifyValidatorContractRef(_opcm, _validator, getter, name, _skipConstructorVerification)
+                    && success;
             }
         }
 
@@ -1528,6 +1542,47 @@ contract VerifyOPCM is Script {
             console.log("    [OK] All StandardValidator args verified");
         }
         return success;
+    }
+
+    /// @notice Verifies the contract a StandardValidator getter points at.
+    /// @dev These addresses hang off the StandardValidator rather than the OPCM, so the
+    ///      `opcm`-prefixed walk in `_getOpcmPropertyRefs` never reaches them. Without this they
+    ///      would go entirely unchecked.
+    /// @param _opcm The OPCM contract.
+    /// @param _validator The StandardValidator address.
+    /// @param _getter The zero-arg getter returning the contract address.
+    /// @param _contractName The artifact name the address is expected to match.
+    /// @param _skipConstructorVerification Whether to skip constructor verification.
+    /// @return True if the referenced contract matches its artifact.
+    function _verifyValidatorContractRef(
+        IOPContractsManagerV2 _opcm,
+        address _validator,
+        string memory _getter,
+        string memory _contractName,
+        bool _skipConstructorVerification
+    )
+        internal
+        returns (bool)
+    {
+        // nosemgrep: sol-style-use-abi-encodecall
+        (bool callSuccess, bytes memory returnedData) =
+            _validator.staticcall(abi.encodeWithSignature(string.concat(_getter, "()")));
+        if (!callSuccess || returnedData.length < 32) {
+            console.log(string.concat("    [FAIL] Failed to call ", _getter, "() on StandardValidator"));
+            return false;
+        }
+
+        address target = abi.decode(returnedData, (address));
+        if (target == address(0)) {
+            console.log(string.concat("    [FAIL] ", _getter, " is the zero address"));
+            return false;
+        }
+
+        return _verifyContractRef(
+            _opcm,
+            OpcmContractRef({ field: _getter, name: _contractName, addr: target, blueprint: false }),
+            _skipConstructorVerification
+        );
     }
 
     /// @notice Gets the field names from the Container implementations struct.

--- a/packages/contracts-bedrock/scripts/deploy/VerifyOPCM.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/VerifyOPCM.s.sol
@@ -230,6 +230,7 @@ contract VerifyOPCM is Script {
         expectedGetters["opcmInteropMigrator"] = "SKIP"; // Address verified via bytecode comparison
         expectedGetters["opcmMigrator"] = "SKIP"; // Address verified via bytecode comparison
         expectedGetters["opcmStandardValidator"] = "SKIP"; // Address verified via bytecode comparison
+        // BYTECODE checks are valid only while these contracts have no constructor args or immutables.
         validatorGetterChecks["standardValidatorUtils"] = "BYTECODE:StandardValidatorUtils";
         validatorGetterChecks["migrationValidator"] = "BYTECODE:OPContractsManagerMigrationValidator";
         expectedGetters["opcmUpgrader"] = "SKIP"; // Address verified via bytecode comparison

--- a/packages/contracts-bedrock/test/scripts/VerifyOPCM.t.sol
+++ b/packages/contracts-bedrock/test/scripts/VerifyOPCM.t.sol
@@ -98,8 +98,15 @@ contract VerifyOPCM_Harness is VerifyOPCM {
         return _verifyAnchorStateRegistryDelays(_asr);
     }
 
-    function verifyStandardValidatorArgs(IOPContractsManagerV2 _opcm, address _validator) public returns (bool) {
-        return _verifyStandardValidatorArgs(_opcm, _validator);
+    function verifyStandardValidatorArgs(
+        IOPContractsManagerV2 _opcm,
+        address _validator,
+        bool _skipConstructorVerification
+    )
+        public
+        returns (bool)
+    {
+        return _verifyStandardValidatorArgs(_opcm, _validator, _skipConstructorVerification);
     }
 
     function setValidatorGetterCheck(string memory _getter, string memory _check) public {

--- a/packages/contracts-bedrock/test/scripts/VerifyOPCM.t.sol
+++ b/packages/contracts-bedrock/test/scripts/VerifyOPCM.t.sol
@@ -192,6 +192,27 @@ contract VerifyOPCM_Run_Test is VerifyOPCM_TestInit {
         harness.run(address(opcm), true);
     }
 
+    function test_run_corruptedValidatorDependencies_reverts() public {
+        skipIfCoverage();
+
+        IOPContractsManagerStandardValidator validator =
+            IOPContractsManagerStandardValidator(opcm.opcmStandardValidator());
+        address[2] memory targets =
+            [address(validator.standardValidatorUtils()), address(validator.migrationValidator())];
+
+        harness.run(address(opcm), true);
+
+        for (uint256 i; i < targets.length; i++) {
+            bytes memory originalCode = targets[i].code;
+            vm.etch(targets[i], hex"00");
+
+            vm.expectRevert(VerifyOPCM.VerifyOPCM_Failed.selector);
+            harness.run(address(opcm), true);
+
+            vm.etch(targets[i], originalCode);
+        }
+    }
+
     /// @notice Tests that the runSingle script succeeds when run against production contracts.
     function test_runSingle_succeeds() public {
         VerifyOPCM.OpcmContractRef[][2] memory refsByType;

--- a/packages/contracts-bedrock/test/scripts/VerifyOPCM.t.sol
+++ b/packages/contracts-bedrock/test/scripts/VerifyOPCM.t.sol
@@ -204,6 +204,14 @@ contract VerifyOPCM_Run_Test is VerifyOPCM_TestInit {
 
         for (uint256 i; i < targets.length; i++) {
             bytes memory originalCode = targets[i].code;
+            bytes memory corruptedCode = abi.encodePacked(originalCode);
+            corruptedCode[0] = bytes1(uint8(corruptedCode[0]) ^ 0x01);
+
+            vm.etch(targets[i], corruptedCode);
+
+            vm.expectRevert(VerifyOPCM.VerifyOPCM_Failed.selector);
+            harness.run(address(opcm), true);
+
             vm.etch(targets[i], hex"00");
 
             vm.expectRevert(VerifyOPCM.VerifyOPCM_Failed.selector);


### PR DESCRIPTION
`VerifyOPCM` marked two `OPContractsManagerStandardValidator` getters as `SKIP`:

```solidity
validatorGetterChecks["standardValidatorUtils"] = "SKIP";
validatorGetterChecks["migrationValidator"] = "SKIP";
```

Every other `SKIP` in that block is commented with `// Address verified via bytecode comparison` comment and is genuinely covered elsewhere, because `_getOpcmPropertyRefs` walks the `opcm`-prefixed getters on the OPCM itself and bytecode-compares each one. 

These addresses are stored in the `OPContractsManagerStandardValidator` rather than the OPCM, so that walk never reaches them. 

This adds a `BYTECODE:<ContractName>` check type that resolves the address from the getter  and uses `_verifyContractRef` to check it. 