### PR TITLE
op-devstack: separate ZK challenger and initial bonds

### DIFF
--- a/op-acceptance-tests/tests/proofs/zk/zk_dispute_game_test.go
+++ b/op-acceptance-tests/tests/proofs/zk/zk_dispute_game_test.go
@@ -199,7 +199,8 @@ func TestProposerDefendsMultipleChallengedGamesConcurrently(gt *testing.T) {
 	)
 	factory := sys.DisputeGameFactory()
 	proposerAddr := zkProposerAddress(t, sys)
-	creator, challenger := fundedActors(sys)
+	creator := sys.FunderL1.NewFundedEOA(eth.OneEther)
+	challenger := sys.FunderL1.NewFundedEOA(eth.Ether(2))
 
 	// Create two foreign valid root games at distinct safe timestamps.
 	_, anchorSequence := sys.AnchorStateRegistry(sys.L2ChainA).AnchorRoot()

--- a/op-devstack/sysgo/add_game_type.go
+++ b/op-devstack/sysgo/add_game_type.go
@@ -117,7 +117,7 @@ func addGameTypesForRuntime(
 	for _, gt := range enabledGameTypes {
 		enabled[gt] = true
 	}
-	initBond := eth.GWei(80_000_000).ToBig() // 0.08 ETH
+	initBond := new(big.Int).Set(defaultInitBond)
 
 	cannonKonaPrestate := PrestateForGameType(t, gameTypes.CannonKonaGameType)
 	superCannonKonaPrestate := PrestateForGameType(t, gameTypes.SuperCannonKonaGameType)
@@ -225,7 +225,7 @@ func ZKDisputeGameConfigForRuntime() *embedded.ZKDisputeGameConfig {
 		AbsolutePrestate:     common.Hash{0x01}, // dummy for devstack, not validated at claim time
 		MaxChallengeDuration: 604800,            // 7 days
 		MaxProveDuration:     259200,            // 3 days
-		ChallengerBond:       eth.GWei(80_000_000).ToBig(),
+		ChallengerBond:       new(big.Int).Set(defaultZKChallengerBond),
 	}
 }
 

--- a/op-devstack/sysgo/superroot_via_upgrade.go
+++ b/op-devstack/sysgo/superroot_via_upgrade.go
@@ -19,8 +19,12 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/ioutil"
 )
 
-// defaultInitBond matches Deploy.s.sol DEFAULT_INIT_BOND (0.08 ether).
-var defaultInitBond = big.NewInt(8e16)
+var (
+	// defaultInitBond matches Deploy.s.sol DEFAULT_INIT_BOND (0.08 ether).
+	defaultInitBond = big.NewInt(8e16)
+	// defaultZKChallengerBond is independent from the bond required to create a ZK game.
+	defaultZKChallengerBond = big.NewInt(5e17)
+)
 
 // upgradeToSuperRoots calls OPCMv2.upgrade on each chain in the migration state
 // to enable all three super-root game types with the supplied starting anchor.
@@ -154,7 +158,7 @@ func buildZKUpgradeGameConfigs(
 				AbsolutePrestate:     programVKey,
 				MaxChallengeDuration: uint64(cfg.MaxChallengeDuration / time.Second),
 				MaxProveDuration:     uint64(cfg.MaxProveDuration / time.Second),
-				ChallengerBond:       new(big.Int).Set(defaultInitBond),
+				ChallengerBond:       new(big.Int).Set(defaultZKChallengerBond),
 			},
 		},
 	}


### PR DESCRIPTION
Use different bond values for the ZK game configuration so it's a bit more realistic.