### PR TITLE
kona-sp1: add multi-cycle proposer policy scenarios

### DIFF
--- a/rust/kona/sp1/crates/proposer/src/proposer.rs
+++ b/rust/kona/sp1/crates/proposer/src/proposer.rs
@@ -1061,8 +1061,8 @@ impl Proposer {
     ///    not advanced, so the range is re-walked next cycle).
     /// 2. Remove invalid games and their subtrees.
     /// 3. Re-validate pending games (timestamps not yet safe from this node's view, unavailable
-    ///    super-root data, or an own-game claim mismatch); entries still pending past the anchor's
-    ///    deadline-lag cutoff are evicted.
+    ///    super-root data, or an untrusted root mismatch); entries still pending past the anchor's
+    ///    deadline-lag cutoff are evicted unless their prestate is locally available.
     /// 4. Synchronize the status of all cached games and apply actions: mark own games for
     ///    resolution (parent resolved in the defender's favor, game over), mark `DefenderWins`
     ///    games for bond claiming (finalized with credit, or a matured withdrawal), remove finished
@@ -1080,6 +1080,7 @@ impl Proposer {
                 self.proof_engine.clear(address);
             }
             self.pending_games.write().await.clear();
+            self.reset_creation_guard(None, "factory history became empty").await;
             ProposerGauge::SyncCursor.set(-1.0);
             return Ok(());
         };
@@ -1153,6 +1154,7 @@ impl Proposer {
                 self.proof_engine.clear(address);
             }
             self.pending_games.write().await.clear();
+            self.reset_creation_guard(None, "factory history was replaced").await;
         }
 
         let mut index = latest_index.clone();
@@ -1243,6 +1245,29 @@ impl Proposer {
         }
     }
 
+    async fn reset_creation_guard(&self, expected: Option<Address>, reason: &'static str) {
+        let mut guarded_address = self.last_created_game_address.lock().await;
+        if *guarded_address == Address::ZERO ||
+            expected.is_some_and(|address| address != *guarded_address)
+        {
+            return;
+        }
+
+        let cleared_address = *guarded_address;
+        self.last_created_game_l2_sequence_number.store(0, Ordering::Relaxed);
+        *guarded_address = Address::ZERO;
+        tracing::info!(?cleared_address, reason, "Reset creation guard");
+    }
+
+    async fn invalid_game_result(&self, index: U256, game_address: Address) -> GameFetchResult {
+        self.reset_creation_guard(
+            Some(game_address),
+            "tracked game became terminal during discovery",
+        )
+        .await;
+        GameFetchResult::InvalidGame { index }
+    }
+
     /// Rechecks prior pending games; games first seen this cycle wait until the next sync.
     /// Loads each pending prestate before applying the eviction cutoff.
     async fn revalidate_pending_games(
@@ -1254,9 +1279,13 @@ impl Proposer {
         let previously_pending = {
             let pending = self.pending_games.read().await;
             pending
-                .keys()
-                .copied()
-                .filter(|index| !newly_pending.iter().any(|game| game.factory_index == *index))
+                .values()
+                .filter(|pending_game| {
+                    !newly_pending
+                        .iter()
+                        .any(|game| game.factory_index == pending_game.factory_index)
+                })
+                .cloned()
                 .collect::<Vec<_>>()
         };
         self.pending_games
@@ -1268,7 +1297,8 @@ impl Proposer {
             None => self.state.read().await.anchor_game.as_ref().map(|game| game.deadline),
         };
 
-        for index in previously_pending {
+        for pending_game in previously_pending {
+            let index = pending_game.factory_index;
             match self.fetch_game(index, pinned_block).await {
                 Ok(GameFetchResult::Pending {
                     index,
@@ -1304,6 +1334,11 @@ impl Proposer {
                             "Evicting pending game whose deadline fell behind the anchor beyond the lag cutoff"
                         );
                         self.pending_games.write().await.remove(&index);
+                        self.reset_creation_guard(
+                            Some(pending_game.address),
+                            "pending tracked game was evicted",
+                        )
+                        .await;
                     }
                 }
                 Ok(GameFetchResult::InvalidGame { index }) => {
@@ -1829,12 +1864,10 @@ impl Proposer {
     ///
     /// Terminal drops: unsupported game type, mismatched anchor state
     /// registry, disrespected game type at creation, an `l2SequenceNumber`
-    /// exceeding `u64`, or another proposer's
-    /// claim contradicting the canonical super root (our OWN game's claim
-    /// mismatch is held pending instead of terminally dropped, since bad
-    /// supernode data is the likelier cause). A timestamp not yet safe from
-    /// this node's view yields `Pending` instead: excluded from the DAG but
-    /// re-validated on later syncs.
+    /// exceeding `u64`, or a claim contradicting a trusted canonical super
+    /// root. A timestamp not yet safe from this node's view, or a mismatch
+    /// reported by an untrusted response, yields `Pending` instead: excluded
+    /// from the DAG but re-validated on later syncs.
     pub async fn fetch_game(&self, index: U256, pinned_block: BlockId) -> Result<GameFetchResult> {
         {
             let state = self.state.read().await;
@@ -1857,6 +1890,8 @@ impl Proposer {
                 expected_game_type = ZK_GAME_TYPE,
                 "Unsupported game type"
             );
+            self.reset_creation_guard(Some(game_address), "tracked game has unsupported game type")
+                .await;
             return Ok(GameFetchResult::UnsupportedType { game_address });
         }
 
@@ -1872,7 +1907,7 @@ impl Proposer {
                 parent_index,
                 "Invalid game: parent belongs to a rejected game subtree"
             );
-            return Ok(GameFetchResult::InvalidGame { index });
+            return Ok(self.invalid_game_result(index, game_address).await);
         }
 
         // Capture the game's own immutable args: bond claims bind its WETH
@@ -1896,7 +1931,7 @@ impl Proposer {
                 ?game_address,
                 "Invalid game: l2SequenceNumber exceeds u64"
             );
-            return Ok(GameFetchResult::InvalidGame { index });
+            return Ok(self.invalid_game_result(index, game_address).await);
         };
         let validity = self.l1_view.game_validity(game_address, pinned_block).await?;
         let claim = validity.root_claim;
@@ -1918,7 +1953,7 @@ impl Proposer {
                 ?game_address,
                 "Invalid game: resolved CHALLENGER_WINS (terminal)"
             );
-            return Ok(GameFetchResult::InvalidGame { index });
+            return Ok(self.invalid_game_result(index, game_address).await);
         }
 
         // Drop games whose type does not respect the expected type.
@@ -1929,7 +1964,7 @@ impl Proposer {
                 expected_game_type = ZK_GAME_TYPE,
                 "Invalid game: game type was not respected when created"
             );
-            return Ok(GameFetchResult::InvalidGame { index });
+            return Ok(self.invalid_game_result(index, game_address).await);
         }
 
         // Validate the claim against the canonical super root at the game's timestamp.
@@ -1980,7 +2015,7 @@ impl Proposer {
                         local_safe,
                         "Invalid game: timestamp beyond validation horizon"
                     );
-                    return Ok(GameFetchResult::InvalidGame { index });
+                    return Ok(self.invalid_game_result(index, game_address).await);
                 }
                 tracing::info!(
                     game_index = %index,
@@ -1998,14 +2033,13 @@ impl Proposer {
                 });
             }
             Some(super_root) if super_root.super_root != claim => {
-                if creator == self.proposer_address || !response_trusted(&super_root_at.response) {
+                if !response_trusted(&super_root_at.response) {
                     tracing::warn!(
                         game_index = %index,
                         ?game_address,
-                        own_game = creator == self.proposer_address,
                         ?claim,
                         canonical_super_root = ?super_root.super_root,
-                        "Root mismatch is not terminal for this observation; deferring validation"
+                        "Root mismatch from untrusted supernode response; deferring validation"
                     );
                     return Ok(GameFetchResult::Pending {
                         index,
@@ -2023,7 +2057,7 @@ impl Proposer {
                     canonical_super_root = ?super_root.super_root,
                     "Invalid game: root claim does not match canonical super root"
                 );
-                return Ok(GameFetchResult::InvalidGame { index });
+                return Ok(self.invalid_game_result(index, game_address).await);
             }
             Some(_) => {}
         }
@@ -2087,6 +2121,10 @@ impl Proposer {
                 // node's view. Bail and retry on a later tick.
                 bail!("no canonical super root at timestamp {sequence_number} yet");
             };
+            if !response_trusted(&super_root_at.response) {
+                ProposerGauge::SuperRootUnavailable.increment(1.0);
+                bail!("canonical super root at timestamp {sequence_number} is not trusted yet");
+            }
             let extra_data = zk_extra_data(parent_game_index, &super_root.proof_bytes);
             let existing_game =
                 self.l1_view.game_by_uuid(super_root.super_root, extra_data.clone()).await?;
@@ -2995,9 +3033,10 @@ impl Proposer {
         }
 
         let now = self
-            .query_time
-            .unix_timestamp()
-            .context("failed to read host time for game deadline")?;
+            .l1_view
+            .latest_l1_timestamp()
+            .await
+            .context("failed to fetch latest L1 block for game deadline")?;
         let max_duration = if is_defense {
             *self.max_prove_duration.get().context("max_prove_duration must be set via try_init")?
         } else {
@@ -3202,9 +3241,10 @@ impl Proposer {
         }
 
         let now = self
-            .query_time
-            .unix_timestamp()
-            .context("failed to read host time for game deadline")?;
+            .l1_view
+            .latest_l1_timestamp()
+            .await
+            .context("failed to fetch latest L1 block for game deadline")?;
         if now > claim.deadline {
             tracing::warn!(
                 ?game_address,
@@ -4421,8 +4461,15 @@ mod tests {
         proposer
     }
 
-    fn push_claim_error(asserter: &Asserter) {
+    fn push_claim_error_and_default_head(asserter: &Asserter) {
+        push_claim_error_and_head(asserter, 1_000);
+    }
+
+    fn push_claim_error_and_head(asserter: &Asserter, timestamp: u64) {
         asserter.push_failure_msg("claimData unavailable");
+        let mut block = Block::<alloy_rpc_types_eth::Transaction>::default();
+        block.header.timestamp = timestamp;
+        asserter.push_success(&block);
     }
 
     async fn insert_task(proposer: &Proposer, operation: OperationSummary) {
@@ -4640,6 +4687,8 @@ mod tests {
                     sequence_number: 0,
                 },
             );
+            proposer.last_created_game_l2_sequence_number.store(123, AtomicOrdering::Relaxed);
+            *proposer.last_created_game_address.lock().await = cached_address;
 
             proposer.sync_games(BlockId::number(1), 1_000).await.unwrap();
 
@@ -4650,7 +4699,13 @@ mod tests {
             assert_eq!(state.cursor, expected_cursor);
             assert!(state.games.is_empty());
             assert!(state.invalid_games.is_empty());
+            drop(state);
             assert!(proposer.pending_games.read().await.is_empty());
+            assert_eq!(
+                proposer.last_created_game_l2_sequence_number.load(AtomicOrdering::Relaxed),
+                0
+            );
+            assert_eq!(*proposer.last_created_game_address.lock().await, Address::ZERO);
             assert_eq!(*proof_engine.cleared.lock().unwrap(), vec![cached_address]);
         }
     }
@@ -5317,34 +5372,59 @@ mod tests {
 
         let canonical = B256::repeat_byte(0x11);
         let cases = [
-            (100, absent_super_root_at_timestamp(99), canonical, Expected::Pending),
+            (100, absent_super_root_at_timestamp(99), canonical, false, Expected::Pending),
             (
                 super::MAX_GAME_DEADLINE_LAG + 101,
                 absent_super_root_at_timestamp(100),
                 canonical,
+                false,
                 Expected::Invalid,
             ),
-            (100, super_root_at_timestamp(100, canonical, 12, 11), canonical, Expected::Valid),
+            (
+                100,
+                super_root_at_timestamp(100, canonical, 12, 11),
+                canonical,
+                false,
+                Expected::Valid,
+            ),
             (
                 100,
                 super_root_at_timestamp(100, canonical, 12, 11),
                 B256::repeat_byte(0x22),
+                false,
+                Expected::Invalid,
+            ),
+            (
+                100,
+                super_root_at_timestamp(100, canonical, 12, 11),
+                B256::repeat_byte(0x22),
+                true,
                 Expected::Invalid,
             ),
             (
                 100,
                 super_root_at_timestamp(100, canonical, 11, 11),
                 B256::repeat_byte(0x22),
+                false,
+                Expected::Pending,
+            ),
+            (
+                100,
+                super_root_at_timestamp(100, canonical, 11, 11),
+                B256::repeat_byte(0x22),
+                true,
                 Expected::Pending,
             ),
         ];
 
-        for (sequence_number, super_root_at, claim, expected) in cases {
+        for (sequence_number, super_root_at, claim, own_game, expected) in cases {
             let game_address = Address::repeat_byte(0x44);
+            let mut proposer = test_proposer().await;
             let view = Arc::new(RecordingL1View {
                 factory_game: FactoryGame { address: game_address, game_type: ZK_GAME_TYPE },
                 game_identity: GameIdentity {
                     sequence_number: U256::from(sequence_number),
+                    creator: if own_game { proposer.proposer_address } else { Address::ZERO },
                     ..Default::default()
                 },
                 game_validity: GameValidity {
@@ -5355,7 +5435,6 @@ mod tests {
                 },
                 ..Default::default()
             });
-            let mut proposer = test_proposer().await;
             proposer.l1_view = view;
             proposer.superroot_source = Arc::new(ScriptedSuperRootSource {
                 horizon: ProposalHorizon { safe_timestamp: 100, finalized_timestamp: 100 },
@@ -5967,7 +6046,7 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn should_skip_proving_uses_host_time_and_strict_expiry() {
+        async fn should_skip_proving_uses_l1_time_and_strict_expiry() {
             let asserter = Asserter::new();
             let provider = ProviderBuilder::default().connect_mocked_client(asserter.clone());
             let mut proposer = test_proposer_with_provider(provider).await;
@@ -5976,23 +6055,20 @@ mod tests {
             proposer.max_prove_duration.set(7200).unwrap();
             let game = Address::left_padding_from(&[0xdd]);
 
-            push_claim_error(&asserter);
-            proposer.query_time = Arc::new(TestQueryTime(1_000));
+            push_claim_error_and_head(&asserter, 1_000);
             assert!(
                 !proposer.should_skip_proving(game, 1_000, true).await.unwrap(),
                 "deadline equality is not expired"
             );
 
-            push_claim_error(&asserter);
-            proposer.query_time = Arc::new(TestQueryTime(1_001));
+            push_claim_error_and_head(&asserter, 1_001);
             assert!(
                 proposer.should_skip_proving(game, 1_000, true).await.unwrap(),
-                "host timestamp past the deadline must skip"
+                "L1 timestamp past the deadline must skip"
             );
             assert_eq!(*proof_engine.cleared.lock().unwrap(), vec![game]);
 
-            push_claim_error(&asserter);
-            proposer.query_time = Arc::new(TestQueryTime(1_000));
+            push_claim_error_and_head(&asserter, 1_000);
             assert!(
                 !proposer.should_skip_proving(game, 100_000, true).await.unwrap(),
                 "distant deadline must proceed"
@@ -6068,7 +6144,7 @@ mod tests {
             game.absolute_prestate = prestate;
             proposer.state.write().await.games.insert(game.index, game);
 
-            push_claim_error(&asserter);
+            push_claim_error_and_default_head(&asserter);
             let yes: Bytes = true.abi_encode().into();
             let no: Bytes = false.abi_encode().into();
             asserter.push_success(&yes);
@@ -6263,7 +6339,7 @@ mod tests {
 
             let no: Bytes = false.abi_encode().into();
             for _ in 0..3 {
-                push_claim_error(&asserter);
+                push_claim_error_and_default_head(&asserter);
                 asserter.push_success(&no);
                 asserter.push_success(&no);
             }
@@ -6304,7 +6380,7 @@ mod tests {
             game.creator = Address::left_padding_from(&[0xff]);
             proposer.state.write().await.games.insert(game.index, game);
 
-            push_claim_error(&asserter);
+            push_claim_error_and_default_head(&asserter);
             let (_, planned) = plan_creation(&proposer).await;
             assert!(planned.is_empty());
         }
@@ -6324,7 +6400,7 @@ mod tests {
             game.creator = proposer.proposer_address;
             proposer.state.write().await.games.insert(game.index, game);
 
-            push_claim_error(&asserter);
+            push_claim_error_and_default_head(&asserter);
             let yes: Bytes = true.abi_encode().into();
             let no: Bytes = false.abi_encode().into();
             asserter.push_success(&yes);
@@ -6378,7 +6454,7 @@ mod tests {
             )
             .await;
 
-            push_claim_error(&asserter);
+            push_claim_error_and_default_head(&asserter);
             let no: Bytes = false.abi_encode().into();
             asserter.push_success(&no);
             asserter.push_success(&no);
@@ -6412,9 +6488,9 @@ mod tests {
             // error on its missing cell, proving the selection wiring.
             proposer.max_challenge_duration.set(7200).unwrap();
             let game = Address::left_padding_from(&[0xab]);
-            push_claim_error(&asserter);
+            push_claim_error_and_default_head(&asserter);
             assert!(!proposer.should_skip_proving(game, 100_000, false).await.unwrap());
-            push_claim_error(&asserter);
+            push_claim_error_and_default_head(&asserter);
             assert!(proposer.should_skip_proving(game, 100_000, true).await.is_err());
         }
 

--- a/rust/kona/sp1/crates/proposer/src/proposer.rs
+++ b/rust/kona/sp1/crates/proposer/src/proposer.rs
@@ -1998,13 +1998,14 @@ impl Proposer {
                 });
             }
             Some(super_root) if super_root.super_root != claim => {
-                if !response_trusted(&super_root_at.response) {
+                if creator == self.proposer_address || !response_trusted(&super_root_at.response) {
                     tracing::warn!(
                         game_index = %index,
                         ?game_address,
+                        own_game = creator == self.proposer_address,
                         ?claim,
                         canonical_super_root = ?super_root.super_root,
-                        "Root mismatch from untrusted supernode response; deferring validation"
+                        "Root mismatch is not terminal for this observation; deferring validation"
                     );
                     return Ok(GameFetchResult::Pending {
                         index,
@@ -2994,10 +2995,9 @@ impl Proposer {
         }
 
         let now = self
-            .l1_view
-            .latest_l1_timestamp()
-            .await
-            .context("failed to fetch latest L1 block for game deadline")?;
+            .query_time
+            .unix_timestamp()
+            .context("failed to read host time for game deadline")?;
         let max_duration = if is_defense {
             *self.max_prove_duration.get().context("max_prove_duration must be set via try_init")?
         } else {
@@ -3202,10 +3202,9 @@ impl Proposer {
         }
 
         let now = self
-            .l1_view
-            .latest_l1_timestamp()
-            .await
-            .context("failed to fetch latest L1 block for game deadline")?;
+            .query_time
+            .unix_timestamp()
+            .context("failed to read host time for game deadline")?;
         if now > claim.deadline {
             tracing::warn!(
                 ?game_address,
@@ -4422,15 +4421,8 @@ mod tests {
         proposer
     }
 
-    fn push_claim_error_and_default_head(asserter: &Asserter) {
-        push_claim_error_and_head(asserter, 1_000);
-    }
-
-    fn push_claim_error_and_head(asserter: &Asserter, timestamp: u64) {
+    fn push_claim_error(asserter: &Asserter) {
         asserter.push_failure_msg("claimData unavailable");
-        let mut block = Block::<alloy_rpc_types_eth::Transaction>::default();
-        block.header.timestamp = timestamp;
-        asserter.push_success(&block);
     }
 
     async fn insert_task(proposer: &Proposer, operation: OperationSummary) {
@@ -5975,7 +5967,7 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn should_skip_proving_uses_l1_time_and_strict_expiry() {
+        async fn should_skip_proving_uses_host_time_and_strict_expiry() {
             let asserter = Asserter::new();
             let provider = ProviderBuilder::default().connect_mocked_client(asserter.clone());
             let mut proposer = test_proposer_with_provider(provider).await;
@@ -5984,20 +5976,23 @@ mod tests {
             proposer.max_prove_duration.set(7200).unwrap();
             let game = Address::left_padding_from(&[0xdd]);
 
-            push_claim_error_and_head(&asserter, 1_000);
+            push_claim_error(&asserter);
+            proposer.query_time = Arc::new(TestQueryTime(1_000));
             assert!(
                 !proposer.should_skip_proving(game, 1_000, true).await.unwrap(),
                 "deadline equality is not expired"
             );
 
-            push_claim_error_and_head(&asserter, 1_001);
+            push_claim_error(&asserter);
+            proposer.query_time = Arc::new(TestQueryTime(1_001));
             assert!(
                 proposer.should_skip_proving(game, 1_000, true).await.unwrap(),
-                "L1 timestamp past the deadline must skip"
+                "host timestamp past the deadline must skip"
             );
             assert_eq!(*proof_engine.cleared.lock().unwrap(), vec![game]);
 
-            push_claim_error_and_head(&asserter, 1_000);
+            push_claim_error(&asserter);
+            proposer.query_time = Arc::new(TestQueryTime(1_000));
             assert!(
                 !proposer.should_skip_proving(game, 100_000, true).await.unwrap(),
                 "distant deadline must proceed"
@@ -6073,7 +6068,7 @@ mod tests {
             game.absolute_prestate = prestate;
             proposer.state.write().await.games.insert(game.index, game);
 
-            push_claim_error_and_default_head(&asserter);
+            push_claim_error(&asserter);
             let yes: Bytes = true.abi_encode().into();
             let no: Bytes = false.abi_encode().into();
             asserter.push_success(&yes);
@@ -6268,7 +6263,7 @@ mod tests {
 
             let no: Bytes = false.abi_encode().into();
             for _ in 0..3 {
-                push_claim_error_and_default_head(&asserter);
+                push_claim_error(&asserter);
                 asserter.push_success(&no);
                 asserter.push_success(&no);
             }
@@ -6309,7 +6304,7 @@ mod tests {
             game.creator = Address::left_padding_from(&[0xff]);
             proposer.state.write().await.games.insert(game.index, game);
 
-            push_claim_error_and_default_head(&asserter);
+            push_claim_error(&asserter);
             let (_, planned) = plan_creation(&proposer).await;
             assert!(planned.is_empty());
         }
@@ -6329,7 +6324,7 @@ mod tests {
             game.creator = proposer.proposer_address;
             proposer.state.write().await.games.insert(game.index, game);
 
-            push_claim_error_and_default_head(&asserter);
+            push_claim_error(&asserter);
             let yes: Bytes = true.abi_encode().into();
             let no: Bytes = false.abi_encode().into();
             asserter.push_success(&yes);
@@ -6383,7 +6378,7 @@ mod tests {
             )
             .await;
 
-            push_claim_error_and_default_head(&asserter);
+            push_claim_error(&asserter);
             let no: Bytes = false.abi_encode().into();
             asserter.push_success(&no);
             asserter.push_success(&no);
@@ -6417,9 +6412,9 @@ mod tests {
             // error on its missing cell, proving the selection wiring.
             proposer.max_challenge_duration.set(7200).unwrap();
             let game = Address::left_padding_from(&[0xab]);
-            push_claim_error_and_default_head(&asserter);
+            push_claim_error(&asserter);
             assert!(!proposer.should_skip_proving(game, 100_000, false).await.unwrap());
-            push_claim_error_and_default_head(&asserter);
+            push_claim_error(&asserter);
             assert!(proposer.should_skip_proving(game, 100_000, true).await.is_err());
         }
 

--- a/rust/kona/sp1/crates/proposer/src/proposer.rs
+++ b/rust/kona/sp1/crates/proposer/src/proposer.rs
@@ -1075,12 +1075,20 @@ impl Proposer {
             .set(pinned_latest_index.map_or(-1.0, |i| i.to::<u64>() as f64));
 
         let Some(latest_index) = pinned_latest_index else {
-            let removed_addresses = self.state.write().await.reset_factory_cache();
+            let (removed_addresses, had_confirmed_factory_history) = {
+                let mut state = self.state.write().await;
+                // A first created game can exist at latest while a lagged confirmed pin still has
+                // no entries. Only a concrete cursor proves confirmed history later disappeared.
+                let had_confirmed_factory_history = state.cursor.index().is_some();
+                (state.reset_factory_cache(), had_confirmed_factory_history)
+            };
             for address in removed_addresses {
                 self.proof_engine.clear(address);
             }
             self.pending_games.write().await.clear();
-            self.reset_creation_guard(None, "factory history became empty").await;
+            if had_confirmed_factory_history {
+                self.reset_creation_guard(None, "confirmed factory history became empty").await;
+            }
             ProposerGauge::SyncCursor.set(-1.0);
             return Ok(());
         };

--- a/rust/kona/sp1/crates/proposer/src/proposer.rs
+++ b/rust/kona/sp1/crates/proposer/src/proposer.rs
@@ -2127,10 +2127,10 @@ impl Proposer {
                 // node's view. Bail and retry on a later tick.
                 bail!("no canonical super root at timestamp {sequence_number} yet");
             };
-            if !response_trusted(&super_root_at.response) {
-                ProposerGauge::SuperRootUnavailable.increment(1.0);
-                bail!("canonical super root at timestamp {sequence_number} is not trusted yet");
-            }
+            // A root available at the selected safety horizon is sufficient for creation.
+            // `response_trusted` requires L1 to advance beyond the root's required block and is
+            // reserved for making contradictory existing claims terminal; applying it at the
+            // moving proposal horizon can prevent creation indefinitely.
             let extra_data = zk_extra_data(parent_game_index, &super_root.proof_bytes);
             let existing_game =
                 self.l1_view.game_by_uuid(super_root.super_root, extra_data.clone()).await?;

--- a/rust/kona/sp1/crates/proposer/src/proposer.rs
+++ b/rust/kona/sp1/crates/proposer/src/proposer.rs
@@ -1490,13 +1490,11 @@ impl Proposer {
                             state.games.get(idx).is_some_and(|game| game.address == guarded_addr)
                         });
                         if guard_in_subtree {
-                            self.last_created_game_l2_sequence_number.store(0, Ordering::Relaxed);
-                            *self.last_created_game_address.lock().await = Address::ZERO;
-                            tracing::info!(
-                                ?guarded_addr,
-                                root_index = %index,
-                                "Reset creation guard: tracked game removed by ChallengerWins"
-                            );
+                            self.reset_creation_guard(
+                                Some(guarded_addr),
+                                "tracked game removed by ChallengerWins",
+                            )
+                            .await;
                         }
                     }
                     progress_addresses_to_clear.extend(state.invalidate_subtree(index));
@@ -2634,13 +2632,11 @@ impl Proposer {
                         .iter()
                         .any(|idx| state.games.get(idx).is_some_and(|g| g.address == guarded_addr));
                     if guard_in_subtree {
-                        self.last_created_game_l2_sequence_number.store(0, Ordering::Relaxed);
-                        *self.last_created_game_address.lock().await = Address::ZERO;
-                        tracing::info!(
-                            ?guarded_addr,
-                            root_index = parent_game_index,
-                            "Reset creation guard: tracked game removed with a retired/blacklisted ancestor"
-                        );
+                        self.reset_creation_guard(
+                            Some(guarded_addr),
+                            "tracked game removed with a retired/blacklisted ancestor",
+                        )
+                        .await;
                     }
                 }
                 let removed_addresses = state.invalidate_subtree(root_index);
@@ -3096,13 +3092,11 @@ impl Proposer {
                             state.games.get(index).is_some_and(|game| game.address == guarded_addr)
                         })
                     {
-                        self.last_created_game_l2_sequence_number.store(0, Ordering::Relaxed);
-                        *self.last_created_game_address.lock().await = Address::ZERO;
-                        tracing::info!(
-                            ?guarded_addr,
-                            root_index = %game_index,
-                            "Reset creation guard: tracked game removed with unprovable subtree"
-                        );
+                        self.reset_creation_guard(
+                            Some(guarded_addr),
+                            "tracked game removed with unprovable subtree",
+                        )
+                        .await;
                     }
                     state.invalidate_subtree(game_index)
                 } else {

--- a/rust/kona/sp1/crates/proposer/src/proposer.rs
+++ b/rust/kona/sp1/crates/proposer/src/proposer.rs
@@ -1247,6 +1247,11 @@ impl Proposer {
             );
             removed_addresses.extend(state.invalidate_subtree(index));
         }
+        self.reset_creation_guard_for_removed_games(
+            &removed_addresses,
+            "tracked game was removed with an invalid subtree",
+        )
+        .await;
         drop(state);
         for address in removed_addresses {
             self.proof_engine.clear(address);
@@ -1261,10 +1266,54 @@ impl Proposer {
             return;
         }
 
+        self.clear_creation_guard_locked(&mut guarded_address, reason);
+    }
+
+    async fn reset_creation_guard_for_removed_games(
+        &self,
+        removed_addresses: &[Address],
+        reason: &'static str,
+    ) {
+        let mut guarded_address = self.last_created_game_address.lock().await;
+        if *guarded_address == Address::ZERO || !removed_addresses.contains(&*guarded_address) {
+            return;
+        }
+
+        self.clear_creation_guard_locked(&mut guarded_address, reason);
+    }
+
+    fn clear_creation_guard_locked(&self, guarded_address: &mut Address, reason: &'static str) {
         let cleared_address = *guarded_address;
         self.last_created_game_l2_sequence_number.store(0, Ordering::Relaxed);
         *guarded_address = Address::ZERO;
         tracing::info!(?cleared_address, reason, "Reset creation guard");
+    }
+
+    async fn arm_creation_guard(
+        &self,
+        sequence_number: u64,
+        parent_game_index: u32,
+        game_address: Address,
+    ) {
+        // Serialize with subtree invalidation through the state lock. If the receipt returns after
+        // its parent was removed, arming this guard would leave a stale sequence number that can
+        // suppress fallback creation indefinitely at a frozen horizon.
+        let state = self.state.read().await;
+        if parent_game_index != u32::MAX &&
+            state.invalid_games.contains(&U256::from(parent_game_index))
+        {
+            tracing::info!(
+                sequence_number,
+                parent_game_index,
+                ?game_address,
+                "Not arming creation guard: parent was invalidated while receipt was pending"
+            );
+            return;
+        }
+
+        let mut guarded_address = self.last_created_game_address.lock().await;
+        self.last_created_game_l2_sequence_number.store(sequence_number, Ordering::Relaxed);
+        *guarded_address = game_address;
     }
 
     async fn invalid_game_result(&self, index: U256, game_address: Address) -> GameFetchResult {
@@ -1351,7 +1400,14 @@ impl Proposer {
                 }
                 Ok(GameFetchResult::InvalidGame { index }) => {
                     self.pending_games.write().await.remove(&index);
-                    let removed_addresses = self.state.write().await.invalidate_subtree(index);
+                    let mut state = self.state.write().await;
+                    let removed_addresses = state.invalidate_subtree(index);
+                    self.reset_creation_guard_for_removed_games(
+                        &removed_addresses,
+                        "tracked game was removed after pending revalidation",
+                    )
+                    .await;
+                    drop(state);
                     for address in removed_addresses {
                         self.proof_engine.clear(address);
                     }
@@ -1491,21 +1547,13 @@ impl Proposer {
                     tracing::debug!(game_index = %index, "Removed game from cache");
                 }
                 GameSyncAction::RemoveSubtree(index) => {
-                    let subtree = state.descendants_of(index);
-                    let guarded_addr = *self.last_created_game_address.lock().await;
-                    if guarded_addr != Address::ZERO {
-                        let guard_in_subtree = subtree.iter().any(|idx| {
-                            state.games.get(idx).is_some_and(|game| game.address == guarded_addr)
-                        });
-                        if guard_in_subtree {
-                            self.reset_creation_guard(
-                                Some(guarded_addr),
-                                "tracked game removed by ChallengerWins",
-                            )
-                            .await;
-                        }
-                    }
-                    progress_addresses_to_clear.extend(state.invalidate_subtree(index));
+                    let removed_addresses = state.invalidate_subtree(index);
+                    self.reset_creation_guard_for_removed_games(
+                        &removed_addresses,
+                        "tracked game removed by ChallengerWins",
+                    )
+                    .await;
+                    progress_addresses_to_clear.extend(removed_addresses);
                 }
             }
         }
@@ -2158,9 +2206,8 @@ impl Proposer {
 
                         // Record the sequence number and address so creation planning skips a
                         // duplicate while the pinned cache has not caught up to this game.
-                        self.last_created_game_l2_sequence_number
-                            .store(sequence_number, Ordering::Relaxed);
-                        *self.last_created_game_address.lock().await = game_address;
+                        self.arm_creation_guard(sequence_number, parent_game_index, game_address)
+                            .await;
                         ProposerGauge::GamesCreated.increment(1.0);
                         return Ok(());
                     }
@@ -2189,8 +2236,7 @@ impl Proposer {
                     game_address = ?existing_game,
                     "Adopting own existing game after create-tx uncertainty"
                 );
-                self.last_created_game_l2_sequence_number.store(sequence_number, Ordering::Relaxed);
-                *self.last_created_game_address.lock().await = existing_game;
+                self.arm_creation_guard(sequence_number, parent_game_index, existing_game).await;
                 return Ok(());
             }
             // Third-party collision: advance the timestamp - bounded by the
@@ -2288,9 +2334,12 @@ impl Proposer {
                 game_address = ?existing_game,
                 "Adopting in-flight game that landed after its confirmation timeout"
             );
-            self.last_created_game_l2_sequence_number
-                .store(record.sequence_number, Ordering::Relaxed);
-            *self.last_created_game_address.lock().await = existing_game;
+            self.arm_creation_guard(
+                record.sequence_number,
+                record.parent_game_index,
+                existing_game,
+            )
+            .await;
         } else {
             tracing::info!(
                 sequence_number = record.sequence_number,
@@ -2630,24 +2679,12 @@ impl Proposer {
                 );
                 let root_index = U256::from(parent_game_index);
                 let mut state = self.state.write().await;
-                // Mirror sync_games' RemoveSubtree handling: reset the
-                // duplicate-creation guard if the removed subtree contains
-                // the game it tracks (descendants_of includes the root).
-                let guarded_addr = *self.last_created_game_address.lock().await;
-                if guarded_addr != Address::ZERO {
-                    let guard_in_subtree = state
-                        .descendants_of(root_index)
-                        .iter()
-                        .any(|idx| state.games.get(idx).is_some_and(|g| g.address == guarded_addr));
-                    if guard_in_subtree {
-                        self.reset_creation_guard(
-                            Some(guarded_addr),
-                            "tracked game removed with a retired/blacklisted ancestor",
-                        )
-                        .await;
-                    }
-                }
                 let removed_addresses = state.invalidate_subtree(root_index);
+                self.reset_creation_guard_for_removed_games(
+                    &removed_addresses,
+                    "tracked game removed with a retired/blacklisted ancestor",
+                )
+                .await;
                 drop(state);
                 for address in removed_addresses {
                     self.proof_engine.clear(address);
@@ -3094,19 +3131,13 @@ impl Proposer {
                     .get(&game_index)
                     .is_some_and(|game| game.address == game_address)
                 {
-                    let guarded_addr = *self.last_created_game_address.lock().await;
-                    if guarded_addr != Address::ZERO &&
-                        state.descendants_of(game_index).iter().any(|index| {
-                            state.games.get(index).is_some_and(|game| game.address == guarded_addr)
-                        })
-                    {
-                        self.reset_creation_guard(
-                            Some(guarded_addr),
-                            "tracked game removed with unprovable subtree",
-                        )
-                        .await;
-                    }
-                    state.invalidate_subtree(game_index)
+                    let removed_addresses = state.invalidate_subtree(game_index);
+                    self.reset_creation_guard_for_removed_games(
+                        &removed_addresses,
+                        "tracked game removed with unprovable subtree",
+                    )
+                    .await;
+                    removed_addresses
                 } else {
                     vec![game_address]
                 };

--- a/rust/kona/sp1/crates/proposer/src/proposer/scenario/mod.rs
+++ b/rust/kona/sp1/crates/proposer/src/proposer/scenario/mod.rs
@@ -16,6 +16,7 @@ pub(super) enum ScenarioError {
     Initialization(String),
     Cycle(String),
     RunningTask { task_id: TaskId },
+    UnsettledTask { task_id: TaskId },
     UnknownTask { task_id: TaskId },
     AlreadyFinalized { task_id: TaskId },
     BarrierNotReached { task_id: TaskId, barrier: String },

--- a/rust/kona/sp1/crates/proposer/src/proposer/scenario/tests.rs
+++ b/rust/kona/sp1/crates/proposer/src/proposer/scenario/tests.rs
@@ -2662,8 +2662,8 @@ async fn untrusted_superroot_contradiction_retries_and_reaches_the_proof_engine(
 #[tokio::test]
 async fn own_creation_guard_survives_confirmation_lag_until_the_pin_catches_up() {
     let world = ScenarioWorld::new();
-    world.set_horizons(1, 1);
-    let create = ActionTarget::Create { sequence_number: 1, parent_game_index: u32::MAX };
+    world.set_horizons(2, 2);
+    let create = ActionTarget::Create { sequence_number: 2, parent_game_index: u32::MAX };
     world.script_action(create.clone(), 1, ActionOutcome::Timeout);
     let mut config = scenario_config();
     config.sync_l1_confirmations = 2;
@@ -2677,7 +2677,7 @@ async fn own_creation_guard_survives_confirmation_lag_until_the_pin_catches_up()
     assert_eq!(adopted.snapshot.sync_disposition, SyncDisposition::ConfirmedBlockUnavailable);
     assert!(adopted.scheduled.iter().any(|scheduled| matches!(
         scheduled.operation,
-        OperationSummary::ReconcileCreation { sequence_number: 1, .. }
+        OperationSummary::ReconcileCreation { sequence_number: 2, .. }
     )));
     scenario.settle_scheduled(&adopted).await.unwrap();
 
@@ -2690,11 +2690,30 @@ async fn own_creation_guard_survives_confirmation_lag_until_the_pin_catches_up()
     scenario.settle_scheduled(&guarded).await.unwrap();
     assert!(world.action_record(&create, 2).is_none());
 
+    world.set_horizons(1, 1);
     world.mine_block();
+    let lagged_empty = scenario.tick().await.unwrap();
+    assert_eq!(lagged_empty.snapshot.sync_disposition, SyncDisposition::Advanced);
+    assert_eq!(lagged_empty.snapshot.canonical_head_index, None);
+    assert!(!lagged_empty.scheduled.iter().any(|scheduled| matches!(
+        scheduled.operation,
+        OperationSummary::ProposeGame { .. } | OperationSummary::ReconcileCreation { .. }
+    )));
+    scenario.settle_scheduled(&lagged_empty).await.unwrap();
+    assert!(
+        world
+            .action_record(
+                &ActionTarget::Create { sequence_number: 1, parent_game_index: u32::MAX },
+                1,
+            )
+            .is_none()
+    );
+
+    world.set_horizons(2, 2);
     world.mine_block();
     let caught_up = scenario.tick().await.unwrap();
     assert_eq!(caught_up.snapshot.canonical_head_index, Some(U256::ZERO));
-    assert_eq!(caught_up.snapshot.canonical_head_sequence_number, Some(1));
+    assert_eq!(caught_up.snapshot.canonical_head_sequence_number, Some(2));
     scenario.settle_scheduled(&caught_up).await.unwrap();
 }
 

--- a/rust/kona/sp1/crates/proposer/src/proposer/scenario/tests.rs
+++ b/rust/kona/sp1/crates/proposer/src/proposer/scenario/tests.rs
@@ -37,8 +37,9 @@ use crate::{
 };
 
 use crate::proposer::{
-    CompactGameSummary, InFlightCreation, OperationSummary, Proposer, ProvingPurpose,
-    SyncDisposition, TaskClass, TaskCompletionOutcome, TaskFailureClass, TaskId, TaskSuccess,
+    CompactGameSummary, InFlightCreation, MAX_GAME_DEADLINE_LAG, OperationSummary, Proposer,
+    ProvingPurpose, SyncDisposition, TaskClass, TaskCompletionOutcome, TaskFailureClass, TaskId,
+    TaskSuccess,
 };
 
 const HEAD_NUMBER: u64 = 1;
@@ -50,8 +51,8 @@ struct ScenarioL1View {
     latest_head_notify: Notify,
     fail_latest_head: AtomicBool,
     fail_respected_game_type: AtomicBool,
-    fail_latest_l1_timestamp_on: AtomicU64,
-    latest_l1_timestamp_calls: AtomicU64,
+    fail_game_standing_on: AtomicU64,
+    game_standing_calls: AtomicU64,
     release_barrier: StdMutex<Option<NamedBarrier>>,
     task_finished: StdMutex<Option<oneshot::Receiver<()>>>,
 }
@@ -223,6 +224,10 @@ impl L1View for ScenarioL1View {
         _game: Address,
         _registry: Address,
     ) -> anyhow::Result<GameStanding> {
+        let call = self.game_standing_calls.fetch_add(1, Ordering::Relaxed) + 1;
+        if self.fail_game_standing_on.load(Ordering::Relaxed) == call {
+            anyhow::bail!("game standing unavailable")
+        }
         Ok(GameStanding { blacklisted: false, retired: false })
     }
 
@@ -239,10 +244,6 @@ impl L1View for ScenarioL1View {
     }
 
     async fn latest_l1_timestamp(&self) -> anyhow::Result<u64> {
-        let call = self.latest_l1_timestamp_calls.fetch_add(1, Ordering::Relaxed) + 1;
-        if self.fail_latest_l1_timestamp_on.load(Ordering::Relaxed) == call {
-            anyhow::bail!("latest timestamp unavailable")
-        }
         Ok(HEAD_TIMESTAMP)
     }
 }
@@ -697,7 +698,7 @@ async fn failed_defense_planning_does_not_stop_resolution_or_claims() {
         state.games.insert(U256::from(3), challenged_game(3, 7_000));
     }
     view.fail_respected_game_type.store(true, Ordering::Relaxed);
-    view.fail_latest_l1_timestamp_on.store(2, Ordering::Relaxed);
+    view.fail_game_standing_on.store(2, Ordering::Relaxed);
     let mut control = ScenarioControl::new(proposer, Duration::from_secs(1));
 
     let result = control.tick().await.unwrap();
@@ -2208,4 +2209,1316 @@ async fn publishing_a_rotated_prestate_enables_defense_on_the_next_tick() {
     )));
     scenario.settle_scheduled(&recovered).await.unwrap();
     assert_eq!(world.proof_record(&target, 1).unwrap().lifecycle, ProofLifecycle::Succeeded);
+}
+
+fn add_hourly_stall_history(
+    world: &ScenarioWorld,
+    challenged_head: bool,
+) -> (GameTarget, Vec<GameTarget>) {
+    let mut head = ScenarioGame::new(0, u32::MAX, 1, ScenarioWorld::default_prestate());
+    head.creator = ScenarioWorld::proposer_address();
+    if challenged_head {
+        head.proposal_status = ProposalStatus::Challenged;
+    }
+    let head_target = head.target();
+    world.add_game(head);
+
+    let mut foreign = Vec::new();
+    for hour in 1..=24 {
+        let game =
+            ScenarioGame::new(hour, hour as u32 - 1, 1 + hour * 3_600, B256::repeat_byte(0x44));
+        foreign.push(game.target());
+        world.add_game(game);
+    }
+    world.set_horizons(1, 1);
+    (head_target, foreign)
+}
+
+#[tokio::test]
+async fn frozen_horizon_keeps_twenty_four_hourly_foreign_games_pending() {
+    let world = ScenarioWorld::new();
+    let (head, foreign) = add_hourly_stall_history(&world, false);
+    let mut config = scenario_config();
+    config.proposal_interval_seconds = 3_600;
+    let mut scenario = ScenarioHarness::new(world.clone(), config).await.unwrap();
+
+    let stalled = scenario.tick().await.unwrap();
+
+    assert_eq!(stalled.snapshot.canonical_head_index, Some(head.factory_index));
+    assert_eq!(stalled.snapshot.canonical_head_sequence_number, Some(1));
+    assert_eq!(stalled.snapshot.pending_games.len(), 24);
+    assert_eq!(
+        stalled.snapshot.pending_games.iter().map(|game| game.factory_index).collect::<Vec<_>>(),
+        foreign.iter().map(|game| game.factory_index).collect::<Vec<_>>()
+    );
+    assert!(!stalled.scheduled.iter().any(|scheduled| matches!(
+        scheduled.operation,
+        OperationSummary::ProposeGame { .. } | OperationSummary::ReconcileCreation { .. }
+    )));
+    scenario.settle_scheduled(&stalled).await.unwrap();
+
+    assert!(world.superroot_journal().iter().any(|record| {
+        record.kind == SuperRootQueryKind::ProposalHorizon &&
+            record.requested_timestamp == world.observation().host_time &&
+            record.safe_timestamp == 1 &&
+            record.finalized_timestamp == 1 &&
+            record.outcome == SuperRootQueryOutcome::Horizon
+    }));
+    assert!(world.action_records().iter().all(|record| !matches!(
+        record.target,
+        ActionTarget::Create { sequence_number, .. } if sequence_number > 1
+    )));
+}
+
+#[tokio::test]
+async fn creation_stall_does_not_starve_defense_of_an_older_owned_game() {
+    let world = ScenarioWorld::new();
+    let (head, _) = add_hourly_stall_history(&world, true);
+    let mut config = scenario_config();
+    config.proposal_interval_seconds = 3_600;
+    let mut scenario = ScenarioHarness::new(world.clone(), config).await.unwrap();
+
+    let stalled = scenario.tick().await.unwrap();
+
+    assert_eq!(stalled.snapshot.pending_games.len(), 24);
+    assert!(
+        !stalled
+            .scheduled
+            .iter()
+            .any(|scheduled| matches!(scheduled.operation, OperationSummary::ProposeGame { .. }))
+    );
+    assert!(stalled.scheduled.iter().any(|scheduled| matches!(
+        scheduled.operation,
+        OperationSummary::ProveGame { address, purpose: ProvingPurpose::Defense, .. }
+            if address == head.address
+    )));
+    scenario.settle_scheduled(&stalled).await.unwrap();
+    assert_eq!(world.proof_record(&head, 1).unwrap().lifecycle, ProofLifecycle::Succeeded);
+}
+
+#[tokio::test]
+async fn superroot_recovery_adopts_the_foreign_tip_before_creating() {
+    let world = ScenarioWorld::new();
+    let (_, foreign) = add_hourly_stall_history(&world, false);
+    let mut config = scenario_config();
+    config.proposal_interval_seconds = 3_600;
+    let mut scenario = ScenarioHarness::new(world.clone(), config).await.unwrap();
+    let stalled = scenario.tick().await.unwrap();
+    scenario.settle_scheduled(&stalled).await.unwrap();
+
+    let tip = foreign.last().unwrap();
+    let tip_sequence = 1 + 24 * 3_600;
+    world.set_horizons(tip_sequence + 3_600, tip_sequence + 3_600);
+    world.mine_block();
+    let recovered = scenario.tick().await.unwrap();
+
+    assert!(recovered.snapshot.pending_games.is_empty());
+    assert_eq!(recovered.snapshot.canonical_head_index, Some(tip.factory_index));
+    assert_eq!(recovered.snapshot.canonical_head_sequence_number, Some(tip_sequence));
+    assert!(recovered.scheduled.iter().any(|scheduled| matches!(
+        scheduled.operation,
+        OperationSummary::ProposeGame { sequence_number, parent_game_index }
+            if sequence_number == tip_sequence + 3_600 &&
+                parent_game_index == tip.factory_index.to::<u32>()
+    )));
+    scenario.settle_scheduled(&recovered).await.unwrap();
+    let create = ActionTarget::Create {
+        sequence_number: tip_sequence + 3_600,
+        parent_game_index: tip.factory_index.to::<u32>(),
+    };
+    assert!(matches!(
+        world.action_record(&create, 1).unwrap().effect,
+        CommittedEffect::Created { .. }
+    ));
+}
+
+#[tokio::test]
+async fn rejected_foreign_topology_never_becomes_a_create_parent() {
+    let world = ScenarioWorld::new();
+    let mut invalid = ScenarioGame::new(0, u32::MAX, 1, ScenarioWorld::default_prestate());
+    invalid.root_claim = B256::repeat_byte(0xa1);
+    let invalid_target = invalid.target();
+    let child = ScenarioGame::new(1, 0, 2, ScenarioWorld::default_prestate());
+    let child_target = child.target();
+    let valid_root = ScenarioGame::new(2, u32::MAX, 3, ScenarioWorld::default_prestate());
+    let valid_tip = ScenarioGame::new(3, 2, 4, ScenarioWorld::default_prestate());
+    let valid_tip_target = valid_tip.target();
+    for game in [invalid, child, valid_root, valid_tip] {
+        world.add_game(game);
+    }
+    world.set_horizons(5, 5);
+    let mut scenario = ScenarioHarness::new(world.clone(), scenario_config()).await.unwrap();
+
+    let result = scenario.tick().await.unwrap();
+
+    assert_eq!(result.snapshot.canonical_head_index, Some(valid_tip_target.factory_index));
+    assert!(result.snapshot.pending_games.is_empty());
+    assert!(result.scheduled.iter().any(|scheduled| matches!(
+        scheduled.operation,
+        OperationSummary::ProposeGame { sequence_number: 5, parent_game_index: 3 }
+    )));
+    scenario.settle_scheduled(&result).await.unwrap();
+    assert!(world.action_records().iter().all(|record| !matches!(
+        record.target,
+        ActionTarget::Create { parent_game_index, .. }
+            if parent_game_index == invalid_target.factory_index.to::<u32>() ||
+                parent_game_index == child_target.factory_index.to::<u32>()
+    )));
+}
+
+#[tokio::test]
+async fn own_claim_mismatch_stays_pending_while_foreign_mismatch_is_terminal() {
+    let world = ScenarioWorld::new();
+    let mut own = ScenarioGame::new(0, u32::MAX, 1, ScenarioWorld::default_prestate());
+    own.creator = ScenarioWorld::proposer_address();
+    own.root_claim = B256::repeat_byte(0xb1);
+    let own_target = own.target();
+    let mut foreign = ScenarioGame::new(1, u32::MAX, 1, ScenarioWorld::default_prestate());
+    foreign.root_claim = B256::repeat_byte(0xb2);
+    let foreign_target = foreign.target();
+    world.add_game(own);
+    world.add_game(foreign);
+    world.set_horizons(1, 1);
+    let mut config = scenario_config();
+    config.proposal_interval_seconds = 100;
+    let mut scenario = ScenarioHarness::new(world.clone(), config).await.unwrap();
+
+    let first = scenario.tick().await.unwrap();
+    assert_eq!(
+        first.snapshot.pending_games.iter().map(|game| game.factory_index).collect::<Vec<_>>(),
+        vec![own_target.factory_index]
+    );
+    assert!(
+        !first.snapshot.pending_games.iter().any(|game| game.address == foreign_target.address)
+    );
+    scenario.settle_scheduled(&first).await.unwrap();
+
+    world.mine_block();
+    let retried = scenario.tick().await.unwrap();
+    assert_eq!(retried.snapshot.pending_games.len(), 1);
+    assert_eq!(retried.snapshot.pending_games[0].address, own_target.address);
+    scenario.settle_scheduled(&retried).await.unwrap();
+    assert!(
+        world
+            .superroot_journal()
+            .iter()
+            .filter(|record| {
+                record.kind == SuperRootQueryKind::AtTimestamp && record.requested_timestamp == 1
+            })
+            .count() >=
+            3
+    );
+}
+
+#[tokio::test]
+async fn beyond_horizon_game_is_terminal_without_wedging_discovery() {
+    let world = ScenarioWorld::new();
+    let far = ScenarioGame::new(
+        0,
+        u32::MAX,
+        1 + MAX_GAME_DEADLINE_LAG + 1,
+        ScenarioWorld::default_prestate(),
+    );
+    let far_target = far.target();
+    let valid = ScenarioGame::new(1, u32::MAX, 1, ScenarioWorld::default_prestate());
+    let valid_target = valid.target();
+    world.add_game(far);
+    world.add_game(valid);
+    world.set_horizons(1, 1);
+    let mut config = scenario_config();
+    config.proposal_interval_seconds = 100;
+    let mut scenario = ScenarioHarness::new(world.clone(), config).await.unwrap();
+
+    let first = scenario.tick().await.unwrap();
+    assert_eq!(first.snapshot.canonical_head_index, Some(valid_target.factory_index));
+    assert!(first.snapshot.pending_games.is_empty());
+    scenario.settle_scheduled(&first).await.unwrap();
+
+    let later = ScenarioGame::new(2, 1, 2, ScenarioWorld::default_prestate());
+    let later_target = later.target();
+    world.add_game(later);
+    world.set_horizons(2, 2);
+    let resumed = scenario.tick().await.unwrap();
+    assert_eq!(resumed.snapshot.canonical_head_index, Some(later_target.factory_index));
+    assert!(!resumed.snapshot.pending_games.iter().any(|game| game.address == far_target.address));
+    scenario.settle_scheduled(&resumed).await.unwrap();
+}
+
+#[tokio::test]
+async fn superroot_journal_preserves_query_boundaries_and_trust_metadata() {
+    let world = ScenarioWorld::new();
+    world.set_horizons(10, 9);
+    let trusted = B256::repeat_byte(0xc1);
+    let untrusted = B256::repeat_byte(0xc2);
+    world.script_superroot(
+        2,
+        1,
+        SuperRootOutcome::Root { root: trusted, current_l1: 10, required_l1: 9 },
+    );
+    world.script_superroot(
+        3,
+        1,
+        SuperRootOutcome::Root { root: untrusted, current_l1: 9, required_l1: 9 },
+    );
+    world.script_superroot(4, 1, SuperRootOutcome::Unavailable);
+    world.script_superroot(5, 1, SuperRootOutcome::TransportFailure);
+    world.script_superroot(6, 1, SuperRootOutcome::Malformed);
+    let source = world.superroot_source();
+
+    assert_eq!(
+        source.proposal_horizon(77).await.unwrap(),
+        ProposalHorizon { safe_timestamp: 10, finalized_timestamp: 9 }
+    );
+    assert_eq!(source.super_root_at_timestamp(2).await.unwrap().root.unwrap().super_root, trusted);
+    assert_eq!(
+        source.super_root_at_timestamp(3).await.unwrap().root.unwrap().super_root,
+        untrusted
+    );
+    assert!(source.super_root_at_timestamp(4).await.unwrap().root.is_none());
+    assert!(source.super_root_at_timestamp(5).await.unwrap_err().to_string().contains("transport"));
+    assert!(source.super_root_at_timestamp(6).await.unwrap_err().to_string().contains("malformed"));
+
+    let journal = world.superroot_journal();
+    assert!(journal.contains(&SuperRootQueryRecord {
+        kind: SuperRootQueryKind::ProposalHorizon,
+        requested_timestamp: 77,
+        attempt: 1,
+        safe_timestamp: 10,
+        finalized_timestamp: 9,
+        current_l1: None,
+        required_l1: None,
+        outcome: SuperRootQueryOutcome::Horizon,
+    }));
+    for (timestamp, current_l1, required_l1, outcome) in [
+        (2, Some(10), Some(9), SuperRootQueryOutcome::Trusted(trusted)),
+        (3, Some(9), Some(9), SuperRootQueryOutcome::Untrusted(untrusted)),
+        (4, Some(2), None, SuperRootQueryOutcome::Unavailable),
+        (5, None, None, SuperRootQueryOutcome::TransportFailure),
+        (6, None, None, SuperRootQueryOutcome::Malformed),
+    ] {
+        assert!(journal.contains(&SuperRootQueryRecord {
+            kind: SuperRootQueryKind::AtTimestamp,
+            requested_timestamp: timestamp,
+            attempt: 1,
+            safe_timestamp: 10,
+            finalized_timestamp: 9,
+            current_l1,
+            required_l1,
+            outcome,
+        }));
+    }
+}
+
+async fn discover_then_challenge(world: &ScenarioWorld) -> (ScenarioHarness, GameTarget) {
+    let mut game = ScenarioGame::new(0, u32::MAX, 1, ScenarioWorld::default_prestate());
+    game.creator = ScenarioWorld::proposer_address();
+    let target = game.target();
+    world.add_game(game);
+    world.set_horizons(1, 1);
+    let mut config = scenario_config();
+    config.proposal_interval_seconds = 100;
+    let mut scenario = ScenarioHarness::new(world.clone(), config).await.unwrap();
+    let discovered = scenario.tick().await.unwrap();
+    scenario.settle_scheduled(&discovered).await.unwrap();
+    world.update_game(&target, |game| {
+        game.proposal_status = ProposalStatus::Challenged;
+        game.deadline = 5_000;
+    });
+    (scenario, target)
+}
+
+#[tokio::test]
+async fn trusted_superroot_contradiction_is_suppressed_without_proof_execution() {
+    let world = ScenarioWorld::new();
+    let (mut scenario, target) = discover_then_challenge(&world).await;
+    let mismatch = B256::repeat_byte(0xd1);
+    world.script_next_superroot(
+        1,
+        SuperRootOutcome::Root { root: mismatch, current_l1: 10, required_l1: 9 },
+    );
+
+    let contradicted = scenario.tick().await.unwrap();
+    let prove_id = contradicted.task_id_for(|operation| {
+        matches!(
+            operation,
+            OperationSummary::ProveGame { address, .. } if *address == target.address
+        )
+    });
+    let completions = scenario.settle_scheduled(&contradicted).await.unwrap();
+    assert!(completions.iter().any(|completion| {
+        completion.task_id == prove_id &&
+            completion.outcome == TaskCompletionOutcome::TerminallyUnprovable
+    }));
+    assert!(world.proof_record(&target, 1).is_none());
+    assert!(world.superroot_journal().iter().any(|record| {
+        record.kind == SuperRootQueryKind::AtTimestamp &&
+            record.requested_timestamp == 1 &&
+            record.current_l1 == Some(10) &&
+            record.required_l1 == Some(9) &&
+            record.outcome == SuperRootQueryOutcome::Trusted(mismatch)
+    }));
+
+    world.mine_block();
+    let suppressed = scenario.tick().await.unwrap();
+    assert!(!suppressed.scheduled.iter().any(|scheduled| matches!(
+        scheduled.operation,
+        OperationSummary::ProveGame { address, .. } if address == target.address
+    )));
+    scenario.settle_scheduled(&suppressed).await.unwrap();
+    assert!(world.proof_record(&target, 1).is_none());
+}
+
+#[tokio::test]
+async fn untrusted_superroot_contradiction_retries_and_reaches_the_proof_engine() {
+    let world = ScenarioWorld::new();
+    let (mut scenario, target) = discover_then_challenge(&world).await;
+    let mismatch = B256::repeat_byte(0xd2);
+    world.script_next_superroot(
+        1,
+        SuperRootOutcome::Root { root: mismatch, current_l1: 9, required_l1: 9 },
+    );
+
+    let contradicted = scenario.tick().await.unwrap();
+    let completions = scenario.settle_scheduled(&contradicted).await.unwrap();
+    assert!(completions.iter().any(|completion| {
+        matches!(
+            completion.outcome,
+            TaskCompletionOutcome::Failed(TaskFailureClass::ReturnedError(_))
+        ) && completion.target ==
+            crate::proposer::OperationTarget::Game {
+                factory_index: target.factory_index,
+                address: target.address,
+            }
+    }));
+    assert!(world.proof_record(&target, 1).is_none());
+    assert!(world.superroot_journal().iter().any(|record| {
+        record.requested_timestamp == 1 &&
+            record.current_l1 == Some(9) &&
+            record.required_l1 == Some(9) &&
+            record.outcome == SuperRootQueryOutcome::Untrusted(mismatch)
+    }));
+
+    let retry = scenario.tick().await.unwrap();
+    assert!(retry.scheduled.iter().any(|scheduled| matches!(
+        scheduled.operation,
+        OperationSummary::ProveGame { address, .. } if address == target.address
+    )));
+    scenario.settle_scheduled(&retry).await.unwrap();
+    assert_eq!(world.proof_record(&target, 1).unwrap().lifecycle, ProofLifecycle::Succeeded);
+}
+
+#[tokio::test]
+async fn own_creation_guard_survives_confirmation_lag_until_the_pin_catches_up() {
+    let world = ScenarioWorld::new();
+    world.set_horizons(1, 1);
+    let create = ActionTarget::Create { sequence_number: 1, parent_game_index: u32::MAX };
+    world.script_action(create.clone(), 1, ActionOutcome::Timeout);
+    let mut config = scenario_config();
+    config.sync_l1_confirmations = 2;
+    let mut scenario = ScenarioHarness::new(world.clone(), config).await.unwrap();
+
+    let submitted = scenario.tick().await.unwrap();
+    scenario.settle_scheduled(&submitted).await.unwrap();
+    scenario.include_transaction(&create, 1, InclusionDepth::LatestOnly).unwrap();
+
+    let adopted = scenario.tick().await.unwrap();
+    assert_eq!(adopted.snapshot.sync_disposition, SyncDisposition::ConfirmedBlockUnavailable);
+    assert!(adopted.scheduled.iter().any(|scheduled| matches!(
+        scheduled.operation,
+        OperationSummary::ReconcileCreation { sequence_number: 1, .. }
+    )));
+    scenario.settle_scheduled(&adopted).await.unwrap();
+
+    let guarded = scenario.tick().await.unwrap();
+    assert!(guarded.snapshot.in_flight_creation.is_none());
+    assert!(!guarded.scheduled.iter().any(|scheduled| matches!(
+        scheduled.operation,
+        OperationSummary::ProposeGame { .. } | OperationSummary::ReconcileCreation { .. }
+    )));
+    scenario.settle_scheduled(&guarded).await.unwrap();
+    assert!(world.action_record(&create, 2).is_none());
+
+    world.mine_block();
+    world.mine_block();
+    let caught_up = scenario.tick().await.unwrap();
+    assert_eq!(caught_up.snapshot.canonical_head_index, Some(U256::ZERO));
+    assert_eq!(caught_up.snapshot.canonical_head_sequence_number, Some(1));
+    scenario.settle_scheduled(&caught_up).await.unwrap();
+}
+
+#[tokio::test]
+async fn own_creation_guard_survives_an_unchanged_head_without_confirmations() {
+    let world = ScenarioWorld::new();
+    world.add_game(ScenarioGame::new(0, u32::MAX, 1, ScenarioWorld::default_prestate()));
+    world.set_horizons(2, 2);
+    let create = ActionTarget::Create { sequence_number: 2, parent_game_index: 0 };
+    let mut scenario = ScenarioHarness::new(world.clone(), scenario_config()).await.unwrap();
+
+    let created = scenario.tick().await.unwrap();
+    scenario.settle_scheduled(&created).await.unwrap();
+    assert!(matches!(
+        world.action_record(&create, 1).unwrap().effect,
+        CommittedEffect::Created { .. }
+    ));
+
+    let created_game = world.observation().games.last().unwrap().target();
+    world.update_game(&created_game, |game| game.root_claim = B256::repeat_byte(0xe3));
+    let learned = scenario.tick().await.unwrap();
+    assert_eq!(learned.snapshot.canonical_head_index, Some(U256::ZERO));
+    assert!(learned.snapshot.pending_games.iter().any(|game| game.address == created_game.address));
+    assert!(!learned.scheduled.iter().any(|scheduled| matches!(
+        scheduled.operation,
+        OperationSummary::ProposeGame { .. } | OperationSummary::ReconcileCreation { .. }
+    )));
+    scenario.settle_scheduled(&learned).await.unwrap();
+
+    let unchanged = scenario.tick().await.unwrap();
+    assert_eq!(unchanged.snapshot.sync_disposition, SyncDisposition::UnchangedConfirmedHead);
+    assert!(!unchanged.scheduled.iter().any(|scheduled| matches!(
+        scheduled.operation,
+        OperationSummary::ProposeGame { .. } | OperationSummary::ReconcileCreation { .. }
+    )));
+    scenario.settle_scheduled(&unchanged).await.unwrap();
+    assert!(world.action_record(&create, 2).is_none());
+}
+
+#[tokio::test]
+async fn challenger_wins_removal_resets_the_address_matched_creation_guard() {
+    let world = ScenarioWorld::new();
+    world.set_horizons(1, 1);
+    let first_create = ActionTarget::Create { sequence_number: 1, parent_game_index: u32::MAX };
+    let mut scenario = ScenarioHarness::new(world.clone(), scenario_config()).await.unwrap();
+    let created = scenario.tick().await.unwrap();
+    scenario.settle_scheduled(&created).await.unwrap();
+    let guarded_game = world.observation().games[0].target();
+    assert!(matches!(
+        world.action_record(&first_create, 1).unwrap().effect,
+        CommittedEffect::Created { address, .. } if address == guarded_game.address
+    ));
+
+    let learned = scenario.tick().await.unwrap();
+    assert_eq!(learned.snapshot.canonical_head_index, Some(guarded_game.factory_index));
+    scenario.settle_scheduled(&learned).await.unwrap();
+
+    world.update_game(&guarded_game, |game| game.status = GameStatus::ChallengerWins);
+    world.set_horizons(2, 2);
+    let removed = scenario.tick().await.unwrap();
+    assert_eq!(removed.snapshot.canonical_head_index, None);
+    assert!(removed.scheduled.iter().any(|scheduled| matches!(
+        scheduled.operation,
+        OperationSummary::ProposeGame { sequence_number: 2, parent_game_index: u32::MAX }
+    )));
+    scenario.settle_scheduled(&removed).await.unwrap();
+    assert!(
+        world
+            .action_record(
+                &ActionTarget::Create { sequence_number: 2, parent_game_index: u32::MAX },
+                1,
+            )
+            .is_some()
+    );
+}
+
+#[tokio::test]
+async fn stale_foreign_pending_game_is_evicted_but_owned_post_defense_game_is_retained() {
+    let world = ScenarioWorld::new();
+    let anchor_deadline = 2_000_000;
+    let stale_deadline = anchor_deadline - MAX_GAME_DEADLINE_LAG - 1;
+    let mut foreign = ScenarioGame::new(0, 2, 11, B256::repeat_byte(0xe1));
+    foreign.deadline = stale_deadline;
+    let foreign_target = foreign.target();
+    let mut owned = ScenarioGame::new(1, 2, 12, ScenarioWorld::default_prestate());
+    owned.creator = ScenarioWorld::proposer_address();
+    owned.proposal_status = ProposalStatus::ChallengedAndValidProofProvided;
+    owned.deadline = stale_deadline;
+    let owned_target = owned.target();
+    let mut anchor = ScenarioGame::new(2, u32::MAX, 10, ScenarioWorld::default_prestate());
+    anchor.deadline = anchor_deadline;
+    let anchor_target = anchor.target();
+    for game in [foreign, owned, anchor] {
+        world.add_game(game);
+    }
+    world.set_anchor_game(&anchor_target);
+    world.set_horizons(10, 10);
+    let mut config = scenario_config();
+    config.proposal_interval_seconds = 100;
+    let mut scenario = ScenarioHarness::new(world.clone(), config).await.unwrap();
+
+    let discovered = scenario.tick().await.unwrap();
+    assert_eq!(discovered.snapshot.pending_games.len(), 2);
+    scenario.settle_scheduled(&discovered).await.unwrap();
+
+    world.mine_block();
+    let evicted = scenario.tick().await.unwrap();
+    assert_eq!(evicted.snapshot.pending_games.len(), 1);
+    assert_eq!(evicted.snapshot.pending_games[0].address, owned_target.address);
+    assert!(
+        !evicted.snapshot.pending_games.iter().any(|game| game.address == foreign_target.address)
+    );
+    scenario.settle_scheduled(&evicted).await.unwrap();
+}
+
+#[tokio::test]
+async fn incremental_discovery_stops_before_old_history_and_resumes_for_new_entries() {
+    let world = ScenarioWorld::new();
+    let mut oldest = ScenarioGame::new(0, u32::MAX, 1, ScenarioWorld::default_prestate());
+    oldest.deadline = 1;
+    let oldest_target = oldest.target();
+    let mut skipped = ScenarioGame::new(1, u32::MAX, 2, ScenarioWorld::default_prestate());
+    skipped.deadline = 2;
+    let skipped_target = skipped.target();
+    let mut boundary =
+        ScenarioGame::new(2, u32::MAX, 3, ScenarioWorld::default_prestate()).challenged();
+    boundary.deadline = 2_000_000 - MAX_GAME_DEADLINE_LAG - 1;
+    let boundary_target = boundary.target();
+    let mut anchor = ScenarioGame::new(3, u32::MAX, 4, ScenarioWorld::default_prestate());
+    anchor.deadline = 2_000_000;
+    let anchor_target = anchor.target();
+    for game in [oldest, skipped, boundary, anchor] {
+        world.add_game(game);
+    }
+    world.set_anchor_game(&anchor_target);
+    world.set_horizons(4, 4);
+    let mut config = scenario_config();
+    config.proposal_interval_seconds = 100;
+    let mut scenario = ScenarioHarness::new(world.clone(), config).await.unwrap();
+
+    let bounded = scenario.tick().await.unwrap();
+    assert_eq!(bounded.snapshot.canonical_head_index, Some(anchor_target.factory_index));
+    assert!(
+        world
+            .l1_read_record(
+                L1ReadBoundary::FactoryGame,
+                &L1ReadTarget::Game(boundary_target.clone()),
+                1,
+            )
+            .is_some()
+    );
+    assert!(
+        world
+            .l1_read_record(L1ReadBoundary::FactoryGame, &L1ReadTarget::Game(skipped_target), 1,)
+            .is_none()
+    );
+    assert!(
+        world
+            .l1_read_record(L1ReadBoundary::FactoryGame, &L1ReadTarget::Game(oldest_target), 1,)
+            .is_none()
+    );
+    assert!(bounded.scheduled.iter().any(|scheduled| matches!(
+        scheduled.operation,
+        OperationSummary::ProveGame { address, .. } if address == boundary_target.address
+    )));
+    scenario.settle_scheduled(&bounded).await.unwrap();
+
+    world.update_game(&anchor_target, |game| game.deadline += 100);
+    let next = ScenarioGame::new(4, 3, 5, ScenarioWorld::default_prestate());
+    let next_target = next.target();
+    world.add_game(next);
+    world.set_horizons(5, 5);
+    let resumed = scenario.tick().await.unwrap();
+    assert_eq!(resumed.snapshot.canonical_head_index, Some(next_target.factory_index));
+    assert!(
+        world
+            .l1_read_record(L1ReadBoundary::FactoryGame, &L1ReadTarget::Game(next_target), 1,)
+            .is_some()
+    );
+    scenario.settle_scheduled(&resumed).await.unwrap();
+}
+
+#[tokio::test]
+async fn empty_and_truncated_factories_reset_cached_history() {
+    let empty_world = ScenarioWorld::new();
+    let valid = ScenarioGame::new(0, u32::MAX, 1, ScenarioWorld::default_prestate());
+    let pending = ScenarioGame::new(1, 0, 2, ScenarioWorld::default_prestate());
+    empty_world.add_game(valid);
+    empty_world.add_game(pending);
+    empty_world.set_horizons(1, 1);
+    let mut config = scenario_config();
+    config.proposal_interval_seconds = 100;
+    let mut empty_scenario =
+        ScenarioHarness::new(empty_world.clone(), config.clone()).await.unwrap();
+    let seeded = empty_scenario.tick().await.unwrap();
+    assert_eq!(seeded.snapshot.pending_games.len(), 1);
+    empty_scenario.settle_scheduled(&seeded).await.unwrap();
+
+    empty_world.clear_factory();
+    let cleared = empty_scenario.tick().await.unwrap();
+    assert_eq!(cleared.snapshot.canonical_head_index, None);
+    assert!(cleared.snapshot.pending_games.is_empty());
+    empty_scenario.settle_scheduled(&cleared).await.unwrap();
+
+    let truncated_world = ScenarioWorld::new();
+    for index in 0..=2 {
+        truncated_world.add_game(ScenarioGame::new(
+            index,
+            u32::MAX,
+            index + 1,
+            ScenarioWorld::default_prestate(),
+        ));
+    }
+    truncated_world.set_horizons(10, 10);
+    let mut truncated = ScenarioHarness::new(truncated_world.clone(), config).await.unwrap();
+    let initial = truncated.tick().await.unwrap();
+    truncated.settle_scheduled(&initial).await.unwrap();
+
+    truncated_world.replace_factory(vec![ScenarioGame::new(
+        0,
+        u32::MAX,
+        10,
+        ScenarioWorld::default_prestate(),
+    )]);
+    let reset = truncated.tick().await.unwrap();
+    assert_eq!(reset.snapshot.canonical_head_index, Some(U256::ZERO));
+    assert_eq!(reset.snapshot.canonical_head_sequence_number, Some(10));
+    assert!(reset.snapshot.pending_games.is_empty());
+    truncated.settle_scheduled(&reset).await.unwrap();
+}
+
+#[tokio::test]
+async fn respected_game_type_pause_recovers_on_the_next_tick() {
+    let world = ScenarioWorld::new();
+    world.set_horizons(1, 1);
+    world.set_respected_game_type(ZK_GAME_TYPE + 1);
+    let mut scenario = ScenarioHarness::new(world.clone(), scenario_config()).await.unwrap();
+
+    let paused = scenario.tick().await.unwrap();
+    assert!(
+        !paused
+            .scheduled
+            .iter()
+            .any(|scheduled| matches!(scheduled.operation, OperationSummary::ProposeGame { .. }))
+    );
+    scenario.settle_scheduled(&paused).await.unwrap();
+
+    world.set_respected_game_type(ZK_GAME_TYPE);
+    let resumed = scenario.tick().await.unwrap();
+    assert!(resumed.scheduled.iter().any(|scheduled| matches!(
+        scheduled.operation,
+        OperationSummary::ProposeGame { sequence_number: 1, parent_game_index: u32::MAX }
+    )));
+    scenario.settle_scheduled(&resumed).await.unwrap();
+}
+
+#[tokio::test]
+async fn missing_registered_prestate_pauses_creation_and_self_heals() {
+    let world = ScenarioWorld::new();
+    let missing = B256::repeat_byte(0xe2);
+    world.rotate_registered_prestate(missing, DEFAULT_MAX_DURATION);
+    world.set_horizons(1, 1);
+    let mut scenario = ScenarioHarness::new(world.clone(), scenario_config()).await.unwrap();
+
+    let paused = scenario.tick().await.unwrap();
+    assert!(
+        !paused
+            .scheduled
+            .iter()
+            .any(|scheduled| matches!(scheduled.operation, OperationSummary::ProposeGame { .. }))
+    );
+    scenario.settle_scheduled(&paused).await.unwrap();
+
+    world.publish_prestate(missing);
+    let resumed = scenario.tick().await.unwrap();
+    assert!(resumed.scheduled.iter().any(|scheduled| matches!(
+        scheduled.operation,
+        OperationSummary::ProposeGame { sequence_number: 1, .. }
+    )));
+    scenario.settle_scheduled(&resumed).await.unwrap();
+}
+
+#[tokio::test]
+async fn resolution_filters_candidates_and_isolates_preflight_and_transaction_failures() {
+    let world = ScenarioWorld::new();
+    let mut parent =
+        ScenarioGame::new(0, u32::MAX, 1, ScenarioWorld::default_prestate()).claimable(0);
+    parent.deadline = 1_500;
+    let parent_target = parent.target();
+    let eligible =
+        ScenarioGame::new(1, 0, 2, ScenarioWorld::default_prestate()).provable_for_resolution();
+    let eligible_target = eligible.target();
+    let unowned = ScenarioGame::new(2, 0, 3, B256::repeat_byte(0xf1)).provable_for_resolution();
+    let unowned_target = unowned.target();
+    let mut elapsed = ScenarioGame::new(3, u32::MAX, 4, ScenarioWorld::default_prestate());
+    elapsed.deadline = 1_500;
+    let elapsed_target = elapsed.target();
+    let mut future = ScenarioGame::new(4, u32::MAX, 5, ScenarioWorld::default_prestate());
+    future.deadline = 2_000;
+    let future_target = future.target();
+    let already_resolved = ScenarioGame::new(5, u32::MAX, 6, ScenarioWorld::default_prestate())
+        .provable_for_resolution();
+    let already_resolved_target = already_resolved.target();
+    let status_failure = ScenarioGame::new(6, u32::MAX, 7, ScenarioWorld::default_prestate())
+        .provable_for_resolution();
+    let status_failure_target = status_failure.target();
+    let invalid_status = ScenarioGame::new(7, u32::MAX, 8, ScenarioWorld::default_prestate())
+        .provable_for_resolution();
+    let invalid_status_target = invalid_status.target();
+    let tx_failure = ScenarioGame::new(8, u32::MAX, 9, ScenarioWorld::default_prestate())
+        .provable_for_resolution();
+    let tx_failure_target = tx_failure.target();
+    let success = ScenarioGame::new(9, u32::MAX, 10, ScenarioWorld::default_prestate())
+        .provable_for_resolution();
+    let success_target = success.target();
+    for game in [
+        parent,
+        eligible,
+        unowned,
+        elapsed,
+        future,
+        already_resolved,
+        status_failure,
+        invalid_status,
+        tx_failure,
+        success,
+    ] {
+        world.add_game(game);
+    }
+    world.set_latest_l1_time(2_000);
+    world.update_game(&already_resolved_target, |game| {
+        game.status = GameStatus::DefenderWins;
+        game.proposal_status = ProposalStatus::Resolved;
+        game.finalized = true;
+    });
+    world.set_horizons(10, 10);
+    world.script_l1_fault(
+        L1ReadBoundary::GameStatus,
+        L1ReadTarget::Game(status_failure_target.clone()),
+        1,
+    );
+    world.script_game_status(invalid_status_target.clone(), 1, u8::MAX);
+    world.script_action(
+        ActionTarget::Resolve(tx_failure_target.clone()),
+        1,
+        ActionOutcome::PreSubmitFailure,
+    );
+    let mut config = scenario_config();
+    config.proposal_interval_seconds = 100;
+    config.sync_l1_confirmations = 1;
+    let mut scenario = ScenarioHarness::new(world.clone(), config).await.unwrap();
+
+    let result = scenario.tick().await.unwrap();
+    scenario.settle_scheduled(&result).await.unwrap();
+
+    for target in
+        [&eligible_target, &elapsed_target, &status_failure_target, &invalid_status_target]
+    {
+        assert!(matches!(
+            world.action_record(&ActionTarget::Resolve(target.clone()), 1).unwrap().effect,
+            CommittedEffect::Resolved { game } if game == target.address
+        ));
+    }
+    assert_eq!(
+        world
+            .action_record(&ActionTarget::Resolve(tx_failure_target.clone()), 1)
+            .unwrap()
+            .lifecycle,
+        ActionLifecycle::PreSubmitFailed
+    );
+    assert!(matches!(
+        world.action_record(&ActionTarget::Resolve(success_target.clone()), 1).unwrap().effect,
+        CommittedEffect::Resolved { game } if game == success_target.address
+    ));
+    for target in [unowned_target, future_target, already_resolved_target, parent_target] {
+        assert!(world.action_record(&ActionTarget::Resolve(target), 1).is_none());
+    }
+    assert_eq!(
+        world
+            .l1_read_record(
+                L1ReadBoundary::GameStatus,
+                &L1ReadTarget::Game(status_failure_target),
+                1,
+            )
+            .unwrap()
+            .outcome,
+        L1ReadOutcome::Failure
+    );
+    assert_eq!(
+        world
+            .l1_read_record(
+                L1ReadBoundary::GameStatus,
+                &L1ReadTarget::Game(invalid_status_target),
+                1,
+            )
+            .unwrap()
+            .outcome,
+        L1ReadOutcome::Status(u8::MAX)
+    );
+}
+
+#[tokio::test]
+async fn claim_flow_uses_owned_game_state_and_tolerates_degraded_preflights() {
+    let world = ScenarioWorld::new();
+    let games = (0..=5)
+        .map(|index| {
+            let prestate = if index == 5 {
+                B256::repeat_byte(0xf2)
+            } else {
+                ScenarioWorld::default_prestate()
+            };
+            let mut game = ScenarioGame::new(index, u32::MAX, index + 1, prestate)
+                .claimable(if index == 4 { 0 } else { 10 + index });
+            game.weth = Address::left_padding_from(&[0x60, index as u8 + 1]);
+            game.anchor_state_registry = Address::left_padding_from(&[0x70, index as u8 + 1]);
+            game
+        })
+        .collect::<Vec<_>>();
+    let unlock = games[0].target();
+    let degraded_credit = games[1].target();
+    let degraded_withdrawal = games[2].target();
+    let failed = games[3].target();
+    let drained = games[4].target();
+    let unowned = games[5].target();
+    for game in games {
+        world.add_game(game);
+    }
+    world.set_horizons(6, 6);
+    world.script_l1_fault(
+        L1ReadBoundary::ClaimCredit,
+        L1ReadTarget::Game(degraded_credit.clone()),
+        1,
+    );
+    world.script_l1_fault(
+        L1ReadBoundary::ClaimWithdrawal,
+        L1ReadTarget::Game(degraded_withdrawal.clone()),
+        1,
+    );
+    world.script_action(
+        ActionTarget::ClaimCredit(failed.clone()),
+        1,
+        ActionOutcome::PreSubmitFailure,
+    );
+    world.mine_block();
+    let mut config = scenario_config();
+    config.proposal_interval_seconds = 100;
+    config.sync_l1_confirmations = 1;
+    let mut scenario = ScenarioHarness::new(world.clone(), config).await.unwrap();
+
+    let first = scenario.tick().await.unwrap();
+    scenario.settle_scheduled(&first).await.unwrap();
+
+    for target in [&unlock, &degraded_credit, &degraded_withdrawal] {
+        assert!(matches!(
+            world.action_record(&ActionTarget::ClaimCredit(target.clone()), 1)
+                .unwrap()
+                .effect,
+            CommittedEffect::ClaimUnlocked { game, .. } if game == target.address
+        ));
+    }
+    assert_eq!(
+        world.action_record(&ActionTarget::ClaimCredit(failed.clone()), 1).unwrap().lifecycle,
+        ActionLifecycle::PreSubmitFailed
+    );
+    assert!(world.action_record(&ActionTarget::ClaimCredit(drained), 1).is_none());
+    assert!(world.action_record(&ActionTarget::ClaimCredit(unowned), 1).is_none());
+    assert_eq!(
+        world
+            .l1_read_record(L1ReadBoundary::ClaimCredit, &L1ReadTarget::Game(degraded_credit), 1,)
+            .unwrap()
+            .outcome,
+        L1ReadOutcome::Failure
+    );
+    assert_eq!(
+        world
+            .l1_read_record(
+                L1ReadBoundary::ClaimWithdrawal,
+                &L1ReadTarget::Game(degraded_withdrawal),
+                1,
+            )
+            .unwrap()
+            .outcome,
+        L1ReadOutcome::Failure
+    );
+
+    let unlock_time = world.observation().latest_l1.timestamp;
+    world.set_latest_l1_time(unlock_time + 20);
+    let pinned_immature = scenario.tick().await.unwrap();
+    assert_eq!(
+        pinned_immature.snapshot.last_successful_pinned_l1.unwrap().timestamp,
+        unlock_time,
+        "candidate selection must use the pinned L1 timestamp"
+    );
+    assert_eq!(world.observation().latest_l1.timestamp, unlock_time + 20);
+    scenario.settle_scheduled(&pinned_immature).await.unwrap();
+    assert!(world.action_record(&ActionTarget::ClaimCredit(unlock.clone()), 2).is_none());
+
+    world.mine_block();
+    let payout = scenario.tick().await.unwrap();
+    assert_eq!(payout.snapshot.last_successful_pinned_l1.unwrap().timestamp, unlock_time + 20);
+    scenario.settle_scheduled(&payout).await.unwrap();
+    assert!(matches!(
+        world.action_record(&ActionTarget::ClaimCredit(unlock.clone()), 2).unwrap().effect,
+        CommittedEffect::ClaimPaid { game, amount }
+            if game == unlock.address && amount == U256::from(10)
+    ));
+    assert_eq!(
+        world
+            .l1_read_record(L1ReadBoundary::LatestL1Timestamp, &L1ReadTarget::Global, 1)
+            .unwrap()
+            .outcome,
+        L1ReadOutcome::Success,
+        "payout maturity must recheck latest L1 time"
+    );
+}
+
+#[tokio::test]
+async fn policy_uses_pinned_latest_host_and_safety_times_independently() {
+    let resolution_world = ScenarioWorld::new();
+    let mut elapsed = ScenarioGame::new(0, u32::MAX, 1, ScenarioWorld::default_prestate());
+    elapsed.deadline = 1_500;
+    let elapsed_target = elapsed.target();
+    resolution_world.add_game(elapsed);
+    resolution_world.set_latest_l1_time(2_000);
+    resolution_world.set_horizons(1, 1);
+    let mut resolution_config = scenario_config();
+    resolution_config.proposal_interval_seconds = 100;
+    resolution_config.sync_l1_confirmations = 1;
+    let mut resolution =
+        ScenarioHarness::new(resolution_world.clone(), resolution_config).await.unwrap();
+
+    let pinned_old = resolution.tick().await.unwrap();
+    resolution.settle_scheduled(&pinned_old).await.unwrap();
+    assert!(
+        resolution_world.action_record(&ActionTarget::Resolve(elapsed_target.clone()), 1).is_none()
+    );
+    resolution_world.mine_block();
+    let pinned_new = resolution.tick().await.unwrap();
+    resolution.settle_scheduled(&pinned_new).await.unwrap();
+    assert!(resolution_world.action_record(&ActionTarget::Resolve(elapsed_target), 1).is_some());
+
+    let proof_world = ScenarioWorld::new();
+    let mut challenged =
+        ScenarioGame::new(0, u32::MAX, 1, ScenarioWorld::default_prestate()).challenged();
+    challenged.deadline = 1_500;
+    let challenged_target = challenged.target();
+    proof_world.add_game(challenged);
+    proof_world.set_latest_l1_time(2_000);
+    proof_world.set_host_time(1_000);
+    proof_world.set_horizons(1, 1);
+    proof_world.block_proof(challenged_target.clone(), 1, ProofOutcome::Success, "host deadline");
+    let mut proof_config = scenario_config();
+    proof_config.proposal_interval_seconds = 100;
+    let mut proof = ScenarioHarness::new(proof_world.clone(), proof_config).await.unwrap();
+    let before_host_deadline = proof.tick().await.unwrap();
+    assert!(before_host_deadline.scheduled.iter().any(|scheduled| matches!(
+        scheduled.operation,
+        OperationSummary::ProveGame { address, .. } if address == challenged_target.address
+    )));
+    let proof_id = before_host_deadline.task_id_for(|operation| {
+        matches!(operation, OperationSummary::ProveGame { address, .. } if *address == challenged_target.address)
+    });
+    proof.wait_for_proof_barrier(proof_id, &challenged_target, 1).await.unwrap();
+    proof.settle(&before_host_deadline.task_ids_except(proof_id)).await.unwrap();
+    proof_world.set_host_time(1_501);
+    proof.release_proof_barrier(&challenged_target, 1).unwrap();
+    proof.settle(&[proof_id]).await.unwrap();
+    assert_eq!(
+        proof_world.proof_record(&challenged_target, 1).unwrap().lifecycle,
+        ProofLifecycle::Succeeded
+    );
+    assert!(
+        proof_world.action_record(&ActionTarget::Prove(challenged_target.clone()), 1).is_none()
+    );
+    let after_host_deadline = proof.tick().await.unwrap();
+    assert!(!after_host_deadline.scheduled.iter().any(|scheduled| matches!(
+        scheduled.operation,
+        OperationSummary::ProveGame { address, .. } if address == challenged_target.address
+    )));
+    proof.settle_scheduled(&after_host_deadline).await.unwrap();
+
+    let horizon_world = ScenarioWorld::new();
+    let head = ScenarioGame::new(0, u32::MAX, 1, ScenarioWorld::default_prestate());
+    horizon_world.add_game(head);
+    horizon_world.set_host_time(9_000);
+    horizon_world.set_horizons(2, 1);
+    let mut horizon = ScenarioHarness::new(horizon_world.clone(), scenario_config()).await.unwrap();
+    let finalized_bound = horizon.tick().await.unwrap();
+    assert!(
+        !finalized_bound
+            .scheduled
+            .iter()
+            .any(|scheduled| matches!(scheduled.operation, OperationSummary::ProposeGame { .. }))
+    );
+    horizon.settle_scheduled(&finalized_bound).await.unwrap();
+    horizon_world.set_finalized_time(2);
+    let advanced_bound = horizon.tick().await.unwrap();
+    assert!(advanced_bound.scheduled.iter().any(|scheduled| matches!(
+        scheduled.operation,
+        OperationSummary::ProposeGame { sequence_number: 2, .. }
+    )));
+    horizon.settle_scheduled(&advanced_bound).await.unwrap();
+    assert!(horizon_world.superroot_journal().iter().any(|record| {
+        record.kind == SuperRootQueryKind::ProposalHorizon &&
+            record.requested_timestamp == 9_000 &&
+            record.safe_timestamp == 2 &&
+            record.finalized_timestamp == 1
+    }));
+}
+
+#[tokio::test]
+async fn restart_reconstructs_world_state_but_resets_all_proposer_local_memory() {
+    let world = ScenarioWorld::new();
+    let mut game =
+        ScenarioGame::new(0, u32::MAX, 1, ScenarioWorld::default_prestate()).challenged();
+    game.creator = ScenarioWorld::proposer_address();
+    let game_target = game.target();
+    world.add_game(game);
+    world.set_horizons(2, 2);
+    let create_target = ActionTarget::Create { sequence_number: 2, parent_game_index: 0 };
+    world.script_action(create_target.clone(), 1, ActionOutcome::Timeout);
+    world.script_superroot(
+        1,
+        2,
+        SuperRootOutcome::Root { root: B256::repeat_byte(0xf3), current_l1: 10, required_l1: 9 },
+    );
+    let mut scenario = ScenarioHarness::new(world.clone(), scenario_config()).await.unwrap();
+
+    let before_restart = scenario.tick().await.unwrap();
+    let old_max_task = before_restart.task_ids().into_iter().max().unwrap();
+    let completions = scenario.settle_scheduled(&before_restart).await.unwrap();
+    assert!(
+        completions
+            .iter()
+            .any(|completion| completion.outcome == TaskCompletionOutcome::TerminallyUnprovable)
+    );
+    assert!(before_restart.scheduled.iter().any(|scheduled| matches!(
+        scheduled.operation,
+        OperationSummary::ProposeGame { sequence_number: 2, parent_game_index: 0 }
+    )));
+    assert_eq!(world.observation().games.len(), 1);
+    scenario.drop_transaction(&create_target, 1).unwrap();
+
+    scenario.restart().await.unwrap();
+    let reconstructed = scenario.tick().await.unwrap();
+    assert_eq!(reconstructed.snapshot.canonical_head_index, Some(game_target.factory_index));
+    assert_eq!(reconstructed.snapshot.canonical_head_sequence_number, Some(1));
+    assert!(reconstructed.snapshot.active_tasks.is_empty());
+    assert_eq!(reconstructed.scheduled.iter().map(|task| task.task_id.get()).min(), Some(1));
+    assert!(old_max_task.get() > 1);
+    assert!(reconstructed.scheduled.iter().any(|scheduled| matches!(
+        scheduled.operation,
+        OperationSummary::ProposeGame { sequence_number: 2, parent_game_index: 0 }
+    )));
+    assert!(reconstructed.scheduled.iter().any(|scheduled| matches!(
+        scheduled.operation,
+        OperationSummary::ProveGame { address, .. } if address == game_target.address
+    )));
+    scenario.settle_scheduled(&reconstructed).await.unwrap();
+    assert_eq!(world.proof_record(&game_target, 1).unwrap().lifecycle, ProofLifecycle::Succeeded);
+    assert_eq!(world.observation().games.len(), 2);
+}
+
+#[tokio::test]
+async fn factory_discovery_fault_retries_the_same_uncommitted_range() {
+    let world = ScenarioWorld::new();
+    let first = ScenarioGame::new(0, u32::MAX, 1, ScenarioWorld::default_prestate());
+    let first_target = first.target();
+    let second = ScenarioGame::new(1, 0, 2, ScenarioWorld::default_prestate());
+    let second_target = second.target();
+    world.add_game(first);
+    world.add_game(second);
+    world.set_horizons(2, 2);
+    world.script_l1_fault(
+        L1ReadBoundary::FactoryGame,
+        L1ReadTarget::Game(second_target.clone()),
+        1,
+    );
+    let mut config = scenario_config();
+    config.proposal_interval_seconds = 100;
+    let mut scenario = ScenarioHarness::new(world.clone(), config).await.unwrap();
+
+    let error = scenario.tick().await.unwrap_err();
+    assert!(matches!(error, ScenarioError::Cycle(message) if message.contains("FactoryGame")));
+    assert_eq!(
+        world
+            .l1_read_record(
+                L1ReadBoundary::FactoryGame,
+                &L1ReadTarget::Game(second_target.clone()),
+                1,
+            )
+            .unwrap()
+            .outcome,
+        L1ReadOutcome::Failure
+    );
+    assert!(
+        world
+            .l1_read_record(
+                L1ReadBoundary::FactoryGame,
+                &L1ReadTarget::Game(first_target.clone()),
+                1,
+            )
+            .is_none()
+    );
+
+    let retried = scenario.tick().await.unwrap();
+    assert_eq!(retried.snapshot.canonical_head_index, Some(second_target.factory_index));
+    assert_eq!(
+        world
+            .l1_read_record(L1ReadBoundary::FactoryGame, &L1ReadTarget::Game(second_target), 2,)
+            .unwrap()
+            .outcome,
+        L1ReadOutcome::Success
+    );
+    assert!(
+        world
+            .l1_read_record(L1ReadBoundary::FactoryGame, &L1ReadTarget::Game(first_target), 1,)
+            .is_some()
+    );
+    scenario.settle_scheduled(&retried).await.unwrap();
+}
+
+#[tokio::test]
+async fn pending_game_read_fault_keeps_unrelated_resolution_actionable() {
+    let world = ScenarioWorld::new();
+    let actionable = ScenarioGame::new(0, u32::MAX, 1, ScenarioWorld::default_prestate())
+        .provable_for_resolution();
+    let actionable_target = actionable.target();
+    let pending = ScenarioGame::new(1, 0, 2, B256::repeat_byte(0xf4));
+    let pending_target = pending.target();
+    world.add_game(actionable);
+    world.add_game(pending);
+    world.set_horizons(1, 1);
+    world.script_action(
+        ActionTarget::Resolve(actionable_target.clone()),
+        1,
+        ActionOutcome::PreSubmitFailure,
+    );
+    let mut config = scenario_config();
+    config.proposal_interval_seconds = 100;
+    let mut scenario = ScenarioHarness::new(world.clone(), config).await.unwrap();
+    let discovered = scenario.tick().await.unwrap();
+    scenario.settle_scheduled(&discovered).await.unwrap();
+    assert_eq!(discovered.snapshot.pending_games.len(), 1);
+
+    world.script_l1_fault(L1ReadBoundary::GameClaim, L1ReadTarget::Game(pending_target.clone()), 2);
+    world.mine_block();
+    let isolated = scenario.tick().await.unwrap();
+    assert_eq!(isolated.snapshot.pending_games.len(), 1);
+    scenario.settle_scheduled(&isolated).await.unwrap();
+    assert_eq!(
+        world
+            .l1_read_record(L1ReadBoundary::GameClaim, &L1ReadTarget::Game(pending_target), 2,)
+            .unwrap()
+            .outcome,
+        L1ReadOutcome::Failure
+    );
+    assert!(matches!(
+        world
+            .action_record(&ActionTarget::Resolve(actionable_target.clone()), 2)
+            .unwrap()
+            .effect,
+        CommittedEffect::Resolved { game } if game == actionable_target.address
+    ));
+}
+
+#[tokio::test]
+async fn cached_game_refresh_fault_is_isolated_from_other_targets() {
+    let world = ScenarioWorld::new();
+    let failed_refresh = ScenarioGame::new(0, u32::MAX, 1, ScenarioWorld::default_prestate())
+        .provable_for_resolution();
+    let failed_target = failed_refresh.target();
+    let actionable = ScenarioGame::new(1, u32::MAX, 2, ScenarioWorld::default_prestate())
+        .provable_for_resolution();
+    let actionable_target = actionable.target();
+    world.add_game(failed_refresh);
+    world.add_game(actionable);
+    world.set_horizons(2, 2);
+    world.script_action(
+        ActionTarget::Resolve(failed_target.clone()),
+        1,
+        ActionOutcome::PreSubmitFailure,
+    );
+    world.script_action(
+        ActionTarget::Resolve(actionable_target.clone()),
+        1,
+        ActionOutcome::PreSubmitFailure,
+    );
+    let mut config = scenario_config();
+    config.proposal_interval_seconds = 100;
+    let mut scenario = ScenarioHarness::new(world.clone(), config).await.unwrap();
+    let initial = scenario.tick().await.unwrap();
+    scenario.settle_scheduled(&initial).await.unwrap();
+
+    world.script_l1_fault(
+        L1ReadBoundary::GameLifecycle,
+        L1ReadTarget::Game(failed_target.clone()),
+        2,
+    );
+    world.mine_block();
+    let isolated = scenario.tick().await.unwrap();
+    scenario.settle_scheduled(&isolated).await.unwrap();
+    assert_eq!(
+        world
+            .l1_read_record(L1ReadBoundary::GameLifecycle, &L1ReadTarget::Game(failed_target), 2,)
+            .unwrap()
+            .outcome,
+        L1ReadOutcome::Failure
+    );
+    assert!(matches!(
+        world
+            .action_record(&ActionTarget::Resolve(actionable_target.clone()), 2)
+            .unwrap()
+            .effect,
+        CommittedEffect::Resolved { game } if game == actionable_target.address
+    ));
+}
+
+#[tokio::test]
+async fn lifecycle_refresh_does_not_touch_unused_status_branches() {
+    let world = ScenarioWorld::new();
+    let progress_parent = ScenarioGame::new(0, u32::MAX, 1, ScenarioWorld::default_prestate());
+    let progress_parent_target = progress_parent.target();
+    let in_progress = ScenarioGame::new(1, 0, 2, ScenarioWorld::default_prestate());
+    let in_progress_target = in_progress.target();
+    let defender_parent = ScenarioGame::new(2, u32::MAX, 3, ScenarioWorld::default_prestate());
+    let defender_parent_target = defender_parent.target();
+    let defender_wins = ScenarioGame::new(3, 2, 4, ScenarioWorld::default_prestate()).claimable(0);
+    let defender_target = defender_wins.target();
+    for game in [progress_parent, in_progress, defender_parent, defender_wins] {
+        world.add_game(game);
+    }
+    world.set_horizons(4, 4);
+    world.script_l1_fault(
+        L1ReadBoundary::BondState,
+        L1ReadTarget::Game(in_progress_target.clone()),
+        1,
+    );
+    world.script_l1_fault(
+        L1ReadBoundary::ParentGameStatus,
+        L1ReadTarget::Game(defender_parent_target.clone()),
+        1,
+    );
+    let mut config = scenario_config();
+    config.proposal_interval_seconds = 100;
+    let mut scenario = ScenarioHarness::new(world.clone(), config).await.unwrap();
+
+    let result = scenario.tick().await.unwrap();
+    scenario.settle_scheduled(&result).await.unwrap();
+
+    assert!(
+        world
+            .l1_read_record(L1ReadBoundary::BondState, &L1ReadTarget::Game(in_progress_target), 1,)
+            .is_none()
+    );
+    assert!(
+        world
+            .l1_read_record(
+                L1ReadBoundary::ParentGameStatus,
+                &L1ReadTarget::Game(defender_parent_target),
+                1,
+            )
+            .is_none()
+    );
+    assert!(
+        world
+            .l1_read_record(
+                L1ReadBoundary::ParentGameStatus,
+                &L1ReadTarget::Game(progress_parent_target),
+                1,
+            )
+            .is_some()
+    );
+    assert!(
+        world
+            .l1_read_record(L1ReadBoundary::BondState, &L1ReadTarget::Game(defender_target), 1,)
+            .is_some()
+    );
 }

--- a/rust/kona/sp1/crates/proposer/src/proposer/scenario/tests.rs
+++ b/rust/kona/sp1/crates/proposer/src/proposer/scenario/tests.rs
@@ -1801,7 +1801,7 @@ async fn failed_create_before_submission_allows_a_later_create_without_consuming
 }
 
 #[tokio::test]
-async fn untrusted_creation_root_pauses_bonding_until_the_response_is_trusted() {
+async fn creation_uses_an_available_root_at_the_current_l1_frontier() {
     let world = ScenarioWorld::new();
     world.set_horizons(1, 1);
     world.script_superroot(
@@ -1812,22 +1812,12 @@ async fn untrusted_creation_root_pauses_bonding_until_the_response_is_trusted() 
     let target = ActionTarget::Create { sequence_number: 1, parent_game_index: u32::MAX };
     let mut scenario = ScenarioHarness::new(world.clone(), scenario_config()).await.unwrap();
 
-    let paused = scenario.tick().await.unwrap();
-    let completions = scenario.settle_scheduled(&paused).await.unwrap();
-    assert!(completions.iter().any(|completion| matches!(
-        &completion.outcome,
-        TaskCompletionOutcome::Failed(TaskFailureClass::ReturnedError(message))
-            if message.contains("is not trusted yet")
-    )));
-    assert!(world.action_record(&target, 1).is_none());
-    assert!(world.observation().games.is_empty());
-
-    let retried = scenario.tick().await.unwrap();
-    assert!(retried.scheduled.iter().any(|scheduled| matches!(
+    let result = scenario.tick().await.unwrap();
+    assert!(result.scheduled.iter().any(|scheduled| matches!(
         scheduled.operation,
         OperationSummary::ProposeGame { sequence_number: 1, parent_game_index: u32::MAX }
     )));
-    scenario.settle_scheduled(&retried).await.unwrap();
+    scenario.settle_scheduled(&result).await.unwrap();
     assert_eq!(world.action_record(&target, 1).unwrap().lifecycle, ActionLifecycle::Confirmed);
     assert_eq!(
         world
@@ -1838,10 +1828,7 @@ async fn untrusted_creation_root_pauses_bonding_until_the_response_is_trusted() 
             })
             .map(|record| record.outcome.clone())
             .collect::<Vec<_>>(),
-        vec![
-            SuperRootQueryOutcome::Untrusted(canonical_super_root(1)),
-            SuperRootQueryOutcome::Trusted(canonical_super_root(1)),
-        ]
+        vec![SuperRootQueryOutcome::Untrusted(canonical_super_root(1))]
     );
 }
 

--- a/rust/kona/sp1/crates/proposer/src/proposer/scenario/tests.rs
+++ b/rust/kona/sp1/crates/proposer/src/proposer/scenario/tests.rs
@@ -271,7 +271,7 @@ impl SuperRootSource for FixedSuperRootSource {
         let root = B256::left_padding_from(&timestamp.to_be_bytes());
         Ok(SuperRootAtTimestamp {
             response: SuperRootAtTimestampResponse {
-                current_l1: SuperBlockId::default(),
+                current_l1: SuperBlockId { number: 1, ..Default::default() },
                 current_safe_timestamp: timestamp,
                 current_local_safe_timestamp: timestamp,
                 current_finalized_timestamp: timestamp,
@@ -1800,6 +1800,51 @@ async fn failed_create_before_submission_allows_a_later_create_without_consuming
 }
 
 #[tokio::test]
+async fn untrusted_creation_root_pauses_bonding_until_the_response_is_trusted() {
+    let world = ScenarioWorld::new();
+    world.set_horizons(1, 1);
+    world.script_superroot(
+        1,
+        1,
+        SuperRootOutcome::Root { root: canonical_super_root(1), current_l1: 1, required_l1: 1 },
+    );
+    let target = ActionTarget::Create { sequence_number: 1, parent_game_index: u32::MAX };
+    let mut scenario = ScenarioHarness::new(world.clone(), scenario_config()).await.unwrap();
+
+    let paused = scenario.tick().await.unwrap();
+    let completions = scenario.settle_scheduled(&paused).await.unwrap();
+    assert!(completions.iter().any(|completion| matches!(
+        &completion.outcome,
+        TaskCompletionOutcome::Failed(TaskFailureClass::ReturnedError(message))
+            if message.contains("is not trusted yet")
+    )));
+    assert!(world.action_record(&target, 1).is_none());
+    assert!(world.observation().games.is_empty());
+
+    let retried = scenario.tick().await.unwrap();
+    assert!(retried.scheduled.iter().any(|scheduled| matches!(
+        scheduled.operation,
+        OperationSummary::ProposeGame { sequence_number: 1, parent_game_index: u32::MAX }
+    )));
+    scenario.settle_scheduled(&retried).await.unwrap();
+    assert_eq!(world.action_record(&target, 1).unwrap().lifecycle, ActionLifecycle::Confirmed);
+    assert_eq!(
+        world
+            .superroot_journal()
+            .iter()
+            .filter(|record| {
+                record.kind == SuperRootQueryKind::AtTimestamp && record.requested_timestamp == 1
+            })
+            .map(|record| record.outcome.clone())
+            .collect::<Vec<_>>(),
+        vec![
+            SuperRootQueryOutcome::Untrusted(canonical_super_root(1)),
+            SuperRootQueryOutcome::Trusted(canonical_super_root(1)),
+        ]
+    );
+}
+
+#[tokio::test]
 async fn reverted_create_consumes_a_nonce_without_creating_a_game() {
     let world = ScenarioWorld::new();
     world.set_horizons(1, 1);
@@ -2367,7 +2412,7 @@ async fn rejected_foreign_topology_never_becomes_a_create_parent() {
 }
 
 #[tokio::test]
-async fn own_claim_mismatch_stays_pending_while_foreign_mismatch_is_terminal() {
+async fn claim_mismatch_outcome_depends_on_trust_not_creator() {
     let world = ScenarioWorld::new();
     let mut own = ScenarioGame::new(0, u32::MAX, 1, ScenarioWorld::default_prestate());
     own.creator = ScenarioWorld::proposer_address();
@@ -2379,6 +2424,12 @@ async fn own_claim_mismatch_stays_pending_while_foreign_mismatch_is_terminal() {
     world.add_game(own);
     world.add_game(foreign);
     world.set_horizons(1, 1);
+    let canonical = canonical_super_root(1);
+    world.script_superroot(
+        1,
+        2,
+        SuperRootOutcome::Root { root: canonical, current_l1: 1, required_l1: 1 },
+    );
     let mut config = scenario_config();
     config.proposal_interval_seconds = 100;
     let mut scenario = ScenarioHarness::new(world.clone(), config).await.unwrap();
@@ -2395,18 +2446,18 @@ async fn own_claim_mismatch_stays_pending_while_foreign_mismatch_is_terminal() {
 
     world.mine_block();
     let retried = scenario.tick().await.unwrap();
-    assert_eq!(retried.snapshot.pending_games.len(), 1);
-    assert_eq!(retried.snapshot.pending_games[0].address, own_target.address);
+    assert!(retried.snapshot.pending_games.is_empty());
+    assert_eq!(retried.snapshot.canonical_head_index, None);
     scenario.settle_scheduled(&retried).await.unwrap();
-    assert!(
+    assert_eq!(
         world
             .superroot_journal()
             .iter()
             .filter(|record| {
                 record.kind == SuperRootQueryKind::AtTimestamp && record.requested_timestamp == 1
             })
-            .count() >=
-            3
+            .count(),
+        3
     );
 }
 
@@ -2647,7 +2698,7 @@ async fn own_creation_guard_survives_confirmation_lag_until_the_pin_catches_up()
 }
 
 #[tokio::test]
-async fn own_creation_guard_survives_an_unchanged_head_without_confirmations() {
+async fn pending_trusted_mismatch_releases_the_address_matched_creation_guard() {
     let world = ScenarioWorld::new();
     world.add_game(ScenarioGame::new(0, u32::MAX, 1, ScenarioWorld::default_prestate()));
     world.set_horizons(2, 2);
@@ -2663,6 +2714,10 @@ async fn own_creation_guard_survives_an_unchanged_head_without_confirmations() {
 
     let created_game = world.observation().games.last().unwrap().target();
     world.update_game(&created_game, |game| game.root_claim = B256::repeat_byte(0xe3));
+    world.script_next_superroot(
+        2,
+        SuperRootOutcome::Root { root: canonical_super_root(2), current_l1: 2, required_l1: 2 },
+    );
     let learned = scenario.tick().await.unwrap();
     assert_eq!(learned.snapshot.canonical_head_index, Some(U256::ZERO));
     assert!(learned.snapshot.pending_games.iter().any(|game| game.address == created_game.address));
@@ -2680,6 +2735,16 @@ async fn own_creation_guard_survives_an_unchanged_head_without_confirmations() {
     )));
     scenario.settle_scheduled(&unchanged).await.unwrap();
     assert!(world.action_record(&create, 2).is_none());
+
+    world.mine_block();
+    let terminal = scenario.tick().await.unwrap();
+    assert!(terminal.snapshot.pending_games.is_empty());
+    assert!(terminal.scheduled.iter().any(|scheduled| matches!(
+        scheduled.operation,
+        OperationSummary::ProposeGame { sequence_number: 2, parent_game_index: 0 }
+    )));
+    scenario.settle_scheduled(&terminal).await.unwrap();
+    assert_eq!(world.action_record(&create, 2).unwrap().lifecycle, ActionLifecycle::Confirmed);
 }
 
 #[tokio::test]
@@ -3160,92 +3225,94 @@ async fn claim_flow_uses_owned_game_state_and_tolerates_degraded_preflights() {
 }
 
 #[tokio::test]
-async fn policy_uses_pinned_latest_host_and_safety_times_independently() {
-    let resolution_world = ScenarioWorld::new();
+async fn resolution_eligibility_uses_the_pinned_l1_timestamp() {
+    let world = ScenarioWorld::new();
     let mut elapsed = ScenarioGame::new(0, u32::MAX, 1, ScenarioWorld::default_prestate());
     elapsed.deadline = 1_500;
     let elapsed_target = elapsed.target();
-    resolution_world.add_game(elapsed);
-    resolution_world.set_latest_l1_time(2_000);
-    resolution_world.set_horizons(1, 1);
-    let mut resolution_config = scenario_config();
-    resolution_config.proposal_interval_seconds = 100;
-    resolution_config.sync_l1_confirmations = 1;
-    let mut resolution =
-        ScenarioHarness::new(resolution_world.clone(), resolution_config).await.unwrap();
+    world.add_game(elapsed);
+    world.set_latest_l1_time(2_000);
+    world.set_horizons(1, 1);
+    let mut config = scenario_config();
+    config.proposal_interval_seconds = 100;
+    config.sync_l1_confirmations = 1;
+    let mut scenario = ScenarioHarness::new(world.clone(), config).await.unwrap();
 
-    let pinned_old = resolution.tick().await.unwrap();
-    resolution.settle_scheduled(&pinned_old).await.unwrap();
-    assert!(
-        resolution_world.action_record(&ActionTarget::Resolve(elapsed_target.clone()), 1).is_none()
-    );
-    resolution_world.mine_block();
-    let pinned_new = resolution.tick().await.unwrap();
-    resolution.settle_scheduled(&pinned_new).await.unwrap();
-    assert!(resolution_world.action_record(&ActionTarget::Resolve(elapsed_target), 1).is_some());
+    let pinned_old = scenario.tick().await.unwrap();
+    scenario.settle_scheduled(&pinned_old).await.unwrap();
+    assert!(world.action_record(&ActionTarget::Resolve(elapsed_target.clone()), 1).is_none());
+    world.mine_block();
+    let pinned_new = scenario.tick().await.unwrap();
+    scenario.settle_scheduled(&pinned_new).await.unwrap();
+    assert!(world.action_record(&ActionTarget::Resolve(elapsed_target), 1).is_some());
+}
 
-    let proof_world = ScenarioWorld::new();
+#[tokio::test]
+async fn proof_deadlines_use_latest_l1_time_independently_of_host_time() {
+    let world = ScenarioWorld::new();
     let mut challenged =
         ScenarioGame::new(0, u32::MAX, 1, ScenarioWorld::default_prestate()).challenged();
     challenged.deadline = 1_500;
     let challenged_target = challenged.target();
-    proof_world.add_game(challenged);
-    proof_world.set_latest_l1_time(2_000);
-    proof_world.set_host_time(1_000);
-    proof_world.set_horizons(1, 1);
-    proof_world.block_proof(challenged_target.clone(), 1, ProofOutcome::Success, "host deadline");
-    let mut proof_config = scenario_config();
-    proof_config.proposal_interval_seconds = 100;
-    let mut proof = ScenarioHarness::new(proof_world.clone(), proof_config).await.unwrap();
-    let before_host_deadline = proof.tick().await.unwrap();
-    assert!(before_host_deadline.scheduled.iter().any(|scheduled| matches!(
+    world.add_game(challenged);
+    world.set_host_time(2_000);
+    world.set_horizons(1, 1);
+    world.block_proof(challenged_target.clone(), 1, ProofOutcome::Success, "chain deadline");
+    let mut config = scenario_config();
+    config.proposal_interval_seconds = 100;
+    let mut scenario = ScenarioHarness::new(world.clone(), config).await.unwrap();
+
+    let before_chain_deadline = scenario.tick().await.unwrap();
+    assert!(before_chain_deadline.scheduled.iter().any(|scheduled| matches!(
         scheduled.operation,
         OperationSummary::ProveGame { address, .. } if address == challenged_target.address
     )));
-    let proof_id = before_host_deadline.task_id_for(|operation| {
+    let proof_id = before_chain_deadline.task_id_for(|operation| {
         matches!(operation, OperationSummary::ProveGame { address, .. } if *address == challenged_target.address)
     });
-    proof.wait_for_proof_barrier(proof_id, &challenged_target, 1).await.unwrap();
-    proof.settle(&before_host_deadline.task_ids_except(proof_id)).await.unwrap();
-    proof_world.set_host_time(1_501);
-    proof.release_proof_barrier(&challenged_target, 1).unwrap();
-    proof.settle(&[proof_id]).await.unwrap();
+    scenario.wait_for_proof_barrier(proof_id, &challenged_target, 1).await.unwrap();
+    scenario.settle(&before_chain_deadline.task_ids_except(proof_id)).await.unwrap();
+    world.set_latest_l1_time(1_501);
+    scenario.release_proof_barrier(&challenged_target, 1).unwrap();
+    scenario.settle(&[proof_id]).await.unwrap();
     assert_eq!(
-        proof_world.proof_record(&challenged_target, 1).unwrap().lifecycle,
+        world.proof_record(&challenged_target, 1).unwrap().lifecycle,
         ProofLifecycle::Succeeded
     );
-    assert!(
-        proof_world.action_record(&ActionTarget::Prove(challenged_target.clone()), 1).is_none()
-    );
-    let after_host_deadline = proof.tick().await.unwrap();
-    assert!(!after_host_deadline.scheduled.iter().any(|scheduled| matches!(
+    assert!(world.action_record(&ActionTarget::Prove(challenged_target.clone()), 1).is_none());
+
+    let after_chain_deadline = scenario.tick().await.unwrap();
+    assert!(!after_chain_deadline.scheduled.iter().any(|scheduled| matches!(
         scheduled.operation,
         OperationSummary::ProveGame { address, .. } if address == challenged_target.address
     )));
-    proof.settle_scheduled(&after_host_deadline).await.unwrap();
+    scenario.settle_scheduled(&after_chain_deadline).await.unwrap();
+}
 
-    let horizon_world = ScenarioWorld::new();
+#[tokio::test]
+async fn proposal_safety_horizon_uses_host_time_without_conflating_safe_and_finalized() {
+    let world = ScenarioWorld::new();
     let head = ScenarioGame::new(0, u32::MAX, 1, ScenarioWorld::default_prestate());
-    horizon_world.add_game(head);
-    horizon_world.set_host_time(9_000);
-    horizon_world.set_horizons(2, 1);
-    let mut horizon = ScenarioHarness::new(horizon_world.clone(), scenario_config()).await.unwrap();
-    let finalized_bound = horizon.tick().await.unwrap();
+    world.add_game(head);
+    world.set_host_time(9_000);
+    world.set_horizons(2, 1);
+    let mut scenario = ScenarioHarness::new(world.clone(), scenario_config()).await.unwrap();
+    let finalized_bound = scenario.tick().await.unwrap();
     assert!(
         !finalized_bound
             .scheduled
             .iter()
             .any(|scheduled| matches!(scheduled.operation, OperationSummary::ProposeGame { .. }))
     );
-    horizon.settle_scheduled(&finalized_bound).await.unwrap();
-    horizon_world.set_finalized_time(2);
-    let advanced_bound = horizon.tick().await.unwrap();
+    scenario.settle_scheduled(&finalized_bound).await.unwrap();
+    world.set_finalized_time(2);
+    let advanced_bound = scenario.tick().await.unwrap();
     assert!(advanced_bound.scheduled.iter().any(|scheduled| matches!(
         scheduled.operation,
         OperationSummary::ProposeGame { sequence_number: 2, .. }
     )));
-    horizon.settle_scheduled(&advanced_bound).await.unwrap();
-    assert!(horizon_world.superroot_journal().iter().any(|record| {
+    scenario.settle_scheduled(&advanced_bound).await.unwrap();
+    assert!(world.superroot_journal().iter().any(|record| {
         record.kind == SuperRootQueryKind::ProposalHorizon &&
             record.requested_timestamp == 9_000 &&
             record.safe_timestamp == 2 &&
@@ -3273,6 +3340,11 @@ async fn restart_reconstructs_world_state_but_resets_all_proposer_local_memory()
 
     let before_restart = scenario.tick().await.unwrap();
     let old_max_task = before_restart.task_ids().into_iter().max().unwrap();
+    let first_unsettled = before_restart.task_ids().into_iter().min().unwrap();
+    assert_eq!(
+        scenario.restart().await.unwrap_err(),
+        ScenarioError::UnsettledTask { task_id: first_unsettled }
+    );
     let completions = scenario.settle_scheduled(&before_restart).await.unwrap();
     assert!(
         completions

--- a/rust/kona/sp1/crates/proposer/src/proposer/scenario/tests.rs
+++ b/rust/kona/sp1/crates/proposer/src/proposer/scenario/tests.rs
@@ -1336,6 +1336,7 @@ async fn created_game_resolution_credits_and_claims_initial_bond() {
     let receipt = actions.create_game(root_claim, extra_data, init_bond).await.unwrap();
     let game = world.observation().games.into_iter().next().unwrap();
     let target = game.target();
+    let registry = game.anchor_state_registry;
     assert_eq!(game.bond.credit, U256::ZERO);
     assert_eq!(
         world
@@ -1360,7 +1361,7 @@ async fn created_game_resolution_credits_and_claims_initial_bond() {
     assert!(
         !world
             .l1_view()
-            .game_lifecycle(receipt.game_address, Address::ZERO, BlockId::latest())
+            .game_lifecycle(receipt.game_address, registry, BlockId::latest())
             .await
             .unwrap()
             .is_finalized
@@ -1373,7 +1374,7 @@ async fn created_game_resolution_credits_and_claims_initial_bond() {
     assert!(
         world
             .l1_view()
-            .game_lifecycle(receipt.game_address, Address::ZERO, BlockId::latest())
+            .game_lifecycle(receipt.game_address, registry, BlockId::latest())
             .await
             .unwrap()
             .is_finalized

--- a/rust/kona/sp1/crates/proposer/src/proposer/scenario/tests.rs
+++ b/rust/kona/sp1/crates/proposer/src/proposer/scenario/tests.rs
@@ -2371,7 +2371,9 @@ async fn rejected_foreign_topology_never_becomes_a_create_parent() {
     let mut invalid = ScenarioGame::new(0, u32::MAX, 1, ScenarioWorld::default_prestate());
     invalid.root_claim = B256::repeat_byte(0xa1);
     let invalid_target = invalid.target();
-    let child = ScenarioGame::new(1, 0, 2, ScenarioWorld::default_prestate());
+    // Keep the invalid descendant ahead of the healthy branch so it would become canonical if
+    // pruning failed to remove the whole rejected subtree.
+    let child = ScenarioGame::new(1, 0, 5, ScenarioWorld::default_prestate());
     let child_target = child.target();
     let valid_root = ScenarioGame::new(2, u32::MAX, 3, ScenarioWorld::default_prestate());
     let valid_tip = ScenarioGame::new(3, 2, 4, ScenarioWorld::default_prestate());
@@ -2379,7 +2381,7 @@ async fn rejected_foreign_topology_never_becomes_a_create_parent() {
     for game in [invalid, child, valid_root, valid_tip] {
         world.add_game(game);
     }
-    world.set_horizons(5, 5);
+    world.set_horizons(6, 6);
     let mut scenario = ScenarioHarness::new(world.clone(), scenario_config()).await.unwrap();
 
     let result = scenario.tick().await.unwrap();
@@ -2388,7 +2390,7 @@ async fn rejected_foreign_topology_never_becomes_a_create_parent() {
     assert!(result.snapshot.pending_games.is_empty());
     assert!(result.scheduled.iter().any(|scheduled| matches!(
         scheduled.operation,
-        OperationSummary::ProposeGame { sequence_number: 5, parent_game_index: 3 }
+        OperationSummary::ProposeGame { sequence_number: 6, parent_game_index: 3 }
     )));
     scenario.settle_scheduled(&result).await.unwrap();
     assert!(world.action_records().iter().all(|record| !matches!(
@@ -2758,12 +2760,16 @@ async fn pending_trusted_mismatch_releases_the_address_matched_creation_guard() 
 #[tokio::test]
 async fn challenger_wins_removal_resets_the_address_matched_creation_guard() {
     let world = ScenarioWorld::new();
-    world.set_horizons(1, 1);
-    let first_create = ActionTarget::Create { sequence_number: 1, parent_game_index: u32::MAX };
+    let root = ScenarioGame::new(0, u32::MAX, 1, ScenarioWorld::default_prestate());
+    let root_target = root.target();
+    world.add_game(root);
+    world.set_horizons(2, 2);
+    let first_create = ActionTarget::Create { sequence_number: 2, parent_game_index: 0 };
     let mut scenario = ScenarioHarness::new(world.clone(), scenario_config()).await.unwrap();
+
     let created = scenario.tick().await.unwrap();
     scenario.settle_scheduled(&created).await.unwrap();
-    let guarded_game = world.observation().games[0].target();
+    let guarded_game = world.observation().games.last().unwrap().target();
     assert!(matches!(
         world.action_record(&first_create, 1).unwrap().effect,
         CommittedEffect::Created { address, .. } if address == guarded_game.address
@@ -2773,21 +2779,66 @@ async fn challenger_wins_removal_resets_the_address_matched_creation_guard() {
     assert_eq!(learned.snapshot.canonical_head_index, Some(guarded_game.factory_index));
     scenario.settle_scheduled(&learned).await.unwrap();
 
+    // Park a descendant after it is confirmed on L1 but before its receipt task can replace the
+    // guard. The losing parent is then removed while that receipt remains live.
+    world.set_horizons(3, 3);
+    let descendant_create = ActionTarget::Create {
+        sequence_number: 3,
+        parent_game_index: guarded_game.factory_index.to::<u32>(),
+    };
+    world.block_action(
+        descendant_create.clone(),
+        1,
+        ActionBarrierPoint::AfterInclusion,
+        ActionOutcome::Success,
+        "descendant receipt after inclusion",
+    );
+    let descendant = scenario.tick().await.unwrap();
+    let descendant_id = descendant.task_id_for(|operation| {
+        matches!(
+            operation,
+            OperationSummary::ProposeGame { sequence_number: 3, parent_game_index }
+                if *parent_game_index == guarded_game.factory_index.to::<u32>()
+        )
+    });
+    scenario
+        .wait_for_action_barrier(
+            descendant_id,
+            &descendant_create,
+            1,
+            ActionBarrierPoint::AfterInclusion,
+        )
+        .await
+        .unwrap();
+
     world.update_game(&guarded_game, |game| game.status = GameStatus::ChallengerWins);
-    world.set_horizons(2, 2);
     let removed = scenario.tick().await.unwrap();
-    assert_eq!(removed.snapshot.canonical_head_index, None);
-    assert!(removed.scheduled.iter().any(|scheduled| matches!(
-        scheduled.operation,
-        OperationSummary::ProposeGame { sequence_number: 2, parent_game_index: u32::MAX }
-    )));
+    assert_eq!(removed.snapshot.canonical_head_index, Some(root_target.factory_index));
+    assert!(
+        !removed
+            .scheduled
+            .iter()
+            .any(|scheduled| matches!(scheduled.operation, OperationSummary::ProposeGame { .. }))
+    );
+
+    scenario
+        .release_action_barrier(&descendant_create, 1, ActionBarrierPoint::AfterInclusion)
+        .unwrap();
+    scenario.settle(&[descendant_id]).await.unwrap();
     scenario.settle_scheduled(&removed).await.unwrap();
+
+    // The fallback has the removed descendant's timestamp but a different parent/UUID. It is
+    // possible only if subtree removal cleared the old guard and the delayed receipt did not arm a
+    // stale replacement guard.
+    let fallback = scenario.tick().await.unwrap();
+    assert!(fallback.scheduled.iter().any(|scheduled| matches!(
+        scheduled.operation,
+        OperationSummary::ProposeGame { sequence_number: 3, parent_game_index: 0 }
+    )));
+    scenario.settle_scheduled(&fallback).await.unwrap();
     assert!(
         world
-            .action_record(
-                &ActionTarget::Create { sequence_number: 2, parent_game_index: u32::MAX },
-                1,
-            )
+            .action_record(&ActionTarget::Create { sequence_number: 3, parent_game_index: 0 }, 1,)
             .is_some()
     );
 }

--- a/rust/kona/sp1/crates/proposer/src/proposer/scenario/tests.rs
+++ b/rust/kona/sp1/crates/proposer/src/proposer/scenario/tests.rs
@@ -2425,6 +2425,7 @@ async fn claim_mismatch_outcome_depends_on_trust_not_creator() {
     world.add_game(foreign);
     world.set_horizons(1, 1);
     let canonical = canonical_super_root(1);
+    // Reverse discovery visits foreign index 1 first, so attempt 2 belongs to own index 0.
     world.script_superroot(
         1,
         2,

--- a/rust/kona/sp1/crates/proposer/src/proposer/scenario/world.rs
+++ b/rust/kona/sp1/crates/proposer/src/proposer/scenario/world.rs
@@ -58,6 +58,92 @@ pub(super) struct GameTarget {
     pub(super) address: Address,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub(super) enum L1ReadBoundary {
+    LatestGameIndex,
+    FactoryGame,
+    GameClaim,
+    GameIdentity,
+    GameValidity,
+    GameLifecycle,
+    ParentGameStatus,
+    BondState,
+    GameStatus,
+    ClaimCredit,
+    ClaimWithdrawal,
+    WethDelay,
+    ParentStanding,
+    GameStanding,
+    ProofStatus,
+    ProofInputs,
+    AnchorStateRegistry,
+    LatestL1Timestamp,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub(super) enum L1ReadTarget {
+    Factory,
+    Global,
+    Game(GameTarget),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum L1ReadScript {
+    Failure,
+    Status(u8),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum L1ReadOutcome {
+    Success,
+    Failure,
+    Status(u8),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) struct L1ReadRecord {
+    pub(super) boundary: L1ReadBoundary,
+    pub(super) target: L1ReadTarget,
+    pub(super) attempt: u64,
+    pub(super) outcome: L1ReadOutcome,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) enum SuperRootOutcome {
+    Root { root: B256, current_l1: u64, required_l1: u64 },
+    Unavailable,
+    TransportFailure,
+    Malformed,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum SuperRootQueryKind {
+    ProposalHorizon,
+    AtTimestamp,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) enum SuperRootQueryOutcome {
+    Horizon,
+    Trusted(B256),
+    Untrusted(B256),
+    Unavailable,
+    TransportFailure,
+    Malformed,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) struct SuperRootQueryRecord {
+    pub(super) kind: SuperRootQueryKind,
+    pub(super) requested_timestamp: u64,
+    pub(super) attempt: u64,
+    pub(super) safe_timestamp: u64,
+    pub(super) finalized_timestamp: u64,
+    pub(super) current_l1: Option<u64>,
+    pub(super) required_l1: Option<u64>,
+    pub(super) outcome: SuperRootQueryOutcome,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub(super) enum ActionTarget {
     Create { sequence_number: u64, parent_game_index: u32 },
@@ -516,6 +602,10 @@ struct WorldData {
     finalized_time: u64,
     sync_confirmations: Option<u64>,
     pending_nonce: u64,
+    l1_read_scripts: Scripts<(L1ReadBoundary, L1ReadTarget), L1ReadScript>,
+    l1_read_records: Vec<L1ReadRecord>,
+    superroot_scripts: Scripts<u64, SuperRootOutcome>,
+    superroot_records: Vec<SuperRootQueryRecord>,
     action_scripts: Scripts<ActionTarget, ActionScript>,
     proof_scripts: Scripts<GameTarget, ProofScript>,
     barriers: HashMap<BarrierKey, NamedBarrier>,
@@ -573,6 +663,10 @@ impl ScenarioWorld {
                 finalized_time: INITIAL_SUPER_ROOT_HORIZON,
                 sync_confirmations: None,
                 pending_nonce: 0,
+                l1_read_scripts: Scripts::default(),
+                l1_read_records: Vec::new(),
+                superroot_scripts: Scripts::default(),
+                superroot_records: Vec::new(),
                 action_scripts: Scripts::default(),
                 proof_scripts: Scripts::default(),
                 barriers: HashMap::new(),
@@ -608,6 +702,54 @@ impl ScenarioWorld {
             game.bind_proof_inputs(state);
             state.games.insert(game.factory_index, game);
         })
+    }
+
+    pub(super) fn update_game(
+        &self,
+        target: &GameTarget,
+        update: impl FnOnce(&mut ScenarioGame),
+    ) -> L1BlockRef {
+        self.append_block(|state| {
+            let game = state.games.get_mut(&target.factory_index).expect("scenario game missing");
+            assert_eq!(game.address, target.address, "scenario game target address changed");
+            update(game);
+        })
+    }
+
+    pub(super) fn set_anchor_game(&self, target: &GameTarget) -> L1BlockRef {
+        self.append_block(|state| {
+            let game =
+                state.games.get(&target.factory_index).expect("scenario anchor game missing");
+            assert_eq!(game.address, target.address, "scenario anchor target address changed");
+            state.registered_anchor_game = game.address;
+            state.anchor_root = AnchorRoot {
+                root: game.root_claim,
+                sequence_number: U256::from(game.sequence_number),
+            };
+        })
+    }
+
+    pub(super) fn clear_factory(&self) -> L1BlockRef {
+        self.append_block(|state| {
+            state.games.clear();
+            state.registered_anchor_game = Address::ZERO;
+        })
+    }
+
+    pub(super) fn replace_factory(&self, mut games: Vec<ScenarioGame>) -> L1BlockRef {
+        self.append_block(|state| {
+            state.games.clear();
+            state.registered_anchor_game = Address::ZERO;
+            games.sort_unstable_by_key(|game| game.factory_index);
+            for mut game in games {
+                game.bind_proof_inputs(state);
+                state.games.insert(game.factory_index, game);
+            }
+        })
+    }
+
+    pub(super) fn set_respected_game_type(&self, game_type: u32) -> L1BlockRef {
+        self.append_block(|state| state.respected_game_type = game_type)
     }
 
     pub(super) fn rotate_registered_prestate(
@@ -662,6 +804,54 @@ impl ScenarioWorld {
             data.sync_confirmations = Some(confirmations);
         }
         Ok(())
+    }
+
+    pub(super) fn script_l1_fault(
+        &self,
+        boundary: L1ReadBoundary,
+        target: L1ReadTarget,
+        attempt: u64,
+    ) {
+        self.lock().l1_read_scripts.script_exact(
+            (boundary, target),
+            attempt,
+            L1ReadScript::Failure,
+        );
+    }
+
+    pub(super) fn script_game_status(&self, target: GameTarget, attempt: u64, status: u8) {
+        self.lock().l1_read_scripts.script_exact(
+            (L1ReadBoundary::GameStatus, L1ReadTarget::Game(target)),
+            attempt,
+            L1ReadScript::Status(status),
+        );
+    }
+
+    pub(super) fn l1_read_record(
+        &self,
+        boundary: L1ReadBoundary,
+        target: &L1ReadTarget,
+        attempt: u64,
+    ) -> Option<L1ReadRecord> {
+        self.lock()
+            .l1_read_records
+            .iter()
+            .find(|record| {
+                record.boundary == boundary && record.target == *target && record.attempt == attempt
+            })
+            .cloned()
+    }
+
+    pub(super) fn script_superroot(&self, timestamp: u64, attempt: u64, outcome: SuperRootOutcome) {
+        self.lock().superroot_scripts.script_exact(timestamp, attempt, outcome);
+    }
+
+    pub(super) fn script_next_superroot(&self, timestamp: u64, outcome: SuperRootOutcome) {
+        self.lock().superroot_scripts.script_next(timestamp, outcome);
+    }
+
+    pub(super) fn superroot_journal(&self) -> Vec<SuperRootQueryRecord> {
+        self.lock().superroot_records.clone()
     }
 
     pub(super) fn script_action(&self, target: ActionTarget, attempt: u64, outcome: ActionOutcome) {
@@ -744,6 +934,14 @@ impl ScenarioWorld {
         attempt: u64,
     ) -> Option<ActionRecord> {
         self.lock().action_records.get(&AttemptKey::new(target.clone(), attempt)).cloned()
+    }
+
+    pub(super) fn action_records(&self) -> Vec<ActionRecord> {
+        let mut records = self.lock().action_records.values().cloned().collect::<Vec<_>>();
+        records.sort_unstable_by(|left, right| {
+            left.target.cmp(&right.target).then_with(|| left.attempt.cmp(&right.attempt))
+        });
+        records
     }
 
     pub(super) fn proof_record(&self, target: &GameTarget, attempt: u64) -> Option<ProofRecord> {
@@ -924,6 +1122,33 @@ impl WorldData {
 
     fn game_target(&self, address: Address) -> Result<GameTarget> {
         Ok(self.latest_state().game(address)?.target())
+    }
+
+    fn record_l1_read(
+        &mut self,
+        boundary: L1ReadBoundary,
+        target: L1ReadTarget,
+    ) -> Result<Option<u8>> {
+        let key = (boundary, target.clone());
+        let (attempt, script) = self.l1_read_scripts.next(&key);
+        let outcome = match script {
+            None => L1ReadOutcome::Success,
+            Some(L1ReadScript::Failure) => L1ReadOutcome::Failure,
+            Some(L1ReadScript::Status(status)) => L1ReadOutcome::Status(status),
+        };
+        self.l1_read_records.push(L1ReadRecord {
+            boundary,
+            target: target.clone(),
+            attempt,
+            outcome,
+        });
+        match script {
+            None => Ok(None),
+            Some(L1ReadScript::Failure) => {
+                bail!("scripted {boundary:?} failure for {target:?} attempt {attempt}")
+            }
+            Some(L1ReadScript::Status(status)) => Ok(Some(status)),
+        }
     }
 
     fn proof_target(&self, address: Address, game: &GameProofInputs) -> Result<GameTarget> {
@@ -1185,6 +1410,31 @@ impl FakeL1View {
     fn latest_state(&self) -> Arc<L1State> {
         self.0.lock().latest_state()
     }
+
+    fn state_for_game(
+        &self,
+        boundary: L1ReadBoundary,
+        game: Address,
+        block: BlockId,
+    ) -> Result<(Arc<L1State>, Option<u8>)> {
+        let mut data = self.0.lock();
+        let state = data.state_at(block)?;
+        let target = state.game(game)?.target();
+        let scripted = data.record_l1_read(boundary, L1ReadTarget::Game(target))?;
+        Ok((state, scripted))
+    }
+
+    fn latest_state_for_game(
+        &self,
+        boundary: L1ReadBoundary,
+        game: Address,
+    ) -> Result<(Arc<L1State>, Option<u8>)> {
+        let mut data = self.0.lock();
+        let state = data.latest_state();
+        let target = state.game(game)?.target();
+        let scripted = data.record_l1_read(boundary, L1ReadTarget::Game(target))?;
+        Ok((state, scripted))
+    }
 }
 
 #[async_trait]
@@ -1206,7 +1456,10 @@ impl L1View for FakeL1View {
     }
 
     async fn latest_game_index(&self, block: BlockId) -> Result<Option<U256>> {
-        Ok(self.state(block)?.games.keys().next_back().copied())
+        let mut data = self.0.lock();
+        let state = data.state_at(block)?;
+        data.record_l1_read(L1ReadBoundary::LatestGameIndex, L1ReadTarget::Factory)?;
+        Ok(state.games.keys().next_back().copied())
     }
 
     async fn registered_anchor_game(&self, block: BlockId) -> Result<Address> {
@@ -1214,13 +1467,16 @@ impl L1View for FakeL1View {
     }
 
     async fn factory_game(&self, index: U256, block: BlockId) -> Result<FactoryGame> {
-        let state = self.state(block)?;
+        let mut data = self.0.lock();
+        let state = data.state_at(block)?;
         let game = state.games.get(&index).context("factory game missing")?;
+        let target = game.target();
+        data.record_l1_read(L1ReadBoundary::FactoryGame, L1ReadTarget::Game(target))?;
         Ok(FactoryGame { address: game.address, game_type: game.game_type })
     }
 
     async fn game_claim(&self, game: Address, block: BlockId) -> Result<GameClaim> {
-        let state = self.state(block)?;
+        let (state, _) = self.state_for_game(L1ReadBoundary::GameClaim, game, block)?;
         let game = state.game(game)?;
         Ok(GameClaim {
             status: game.proposal_status as u8,
@@ -1230,7 +1486,7 @@ impl L1View for FakeL1View {
     }
 
     async fn game_identity(&self, game: Address, block: BlockId) -> Result<GameIdentity> {
-        let state = self.state(block)?;
+        let (state, _) = self.state_for_game(L1ReadBoundary::GameIdentity, game, block)?;
         let game = state.game(game)?;
         Ok(GameIdentity {
             anchor_state_registry: game.anchor_state_registry,
@@ -1241,7 +1497,7 @@ impl L1View for FakeL1View {
     }
 
     async fn game_validity(&self, game: Address, block: BlockId) -> Result<GameValidity> {
-        let state = self.state(block)?;
+        let (state, _) = self.state_for_game(L1ReadBoundary::GameValidity, game, block)?;
         let game = state.game(game)?;
         Ok(GameValidity {
             root_claim: game.root_claim,
@@ -1257,8 +1513,13 @@ impl L1View for FakeL1View {
         _registry: Address,
         block: BlockId,
     ) -> Result<GameLifecycle> {
-        let state = self.state(block)?;
+        let (state, _) = self.state_for_game(L1ReadBoundary::GameLifecycle, game, block)?;
         let game = state.game(game)?;
+        ensure!(
+            game.anchor_state_registry == _registry,
+            "game lifecycle used registry {_registry}, expected {}",
+            game.anchor_state_registry
+        );
         Ok(GameLifecycle {
             proposal_status: game.proposal_status,
             deadline: game.deadline,
@@ -1269,8 +1530,12 @@ impl L1View for FakeL1View {
     }
 
     async fn parent_game_status(&self, parent_index: u32, block: BlockId) -> Result<u8> {
-        let state = self.state(block)?;
-        Ok(state.games.get(&U256::from(parent_index)).context("parent game missing")?.status as u8)
+        let mut data = self.0.lock();
+        let state = data.state_at(block)?;
+        let game = state.games.get(&U256::from(parent_index)).context("parent game missing")?;
+        let target = game.target();
+        data.record_l1_read(L1ReadBoundary::ParentGameStatus, L1ReadTarget::Game(target))?;
+        Ok(game.status as u8)
     }
 
     async fn bond_state(
@@ -1280,8 +1545,14 @@ impl L1View for FakeL1View {
         _proposer: Address,
         block: BlockId,
     ) -> Result<BondState> {
-        let state = self.state(block)?;
-        Ok(state.game(game)?.bond)
+        let (state, _) = self.state_for_game(L1ReadBoundary::BondState, game, block)?;
+        let game = state.game(game)?;
+        ensure!(game.weth == _weth, "bond state used WETH {_weth}, expected {}", game.weth);
+        ensure!(
+            _proposer == ScenarioWorld::proposer_address(),
+            "bond state used unexpected proposer {_proposer}"
+        );
+        Ok(game.bond)
     }
 
     async fn init_bond(&self) -> Result<U256> {
@@ -1289,8 +1560,8 @@ impl L1View for FakeL1View {
     }
 
     async fn game_status(&self, game: Address) -> Result<u8> {
-        let state = self.latest_state();
-        Ok(state.game(game)?.status as u8)
+        let (state, scripted) = self.latest_state_for_game(L1ReadBoundary::GameStatus, game)?;
+        Ok(scripted.unwrap_or(state.game(game)?.status as u8))
     }
 
     async fn claim_preflight(
@@ -1299,22 +1570,48 @@ impl L1View for FakeL1View {
         _weth: Address,
         _proposer: Address,
     ) -> ClaimPreflight {
-        let state = self.latest_state();
-        let credit = state.game(game).map(|game| game.bond.credit);
-        let withdrawal = state.game(game).map(|game| WithdrawalState {
-            amount: game.bond.withdrawal_amount,
-            timestamp: game.bond.withdrawal_timestamp,
-        });
+        let mut data = self.0.lock();
+        let state = data.latest_state();
+        let target = match state.game(game) {
+            Ok(game) => game.target(),
+            Err(error) => {
+                let message = error.to_string();
+                return ClaimPreflight {
+                    credit: Err(anyhow::anyhow!(message.clone())),
+                    withdrawal: Err(anyhow::anyhow!(message)),
+                };
+            }
+        };
+        let game_state = state.game(game).expect("game was just resolved");
+        let arguments_valid =
+            game_state.weth == _weth && _proposer == ScenarioWorld::proposer_address();
+        let credit = if arguments_valid {
+            data.record_l1_read(L1ReadBoundary::ClaimCredit, L1ReadTarget::Game(target.clone()))
+                .map(|_| game_state.bond.credit)
+        } else {
+            Err(anyhow::anyhow!("claim preflight used the wrong game WETH or proposer"))
+        };
+        let withdrawal = if arguments_valid {
+            data.record_l1_read(L1ReadBoundary::ClaimWithdrawal, L1ReadTarget::Game(target)).map(
+                |_| WithdrawalState {
+                    amount: game_state.bond.withdrawal_amount,
+                    timestamp: game_state.bond.withdrawal_timestamp,
+                },
+            )
+        } else {
+            Err(anyhow::anyhow!("claim preflight used the wrong game WETH or proposer"))
+        };
         ClaimPreflight { credit, withdrawal }
     }
 
     async fn weth_delay(&self, weth: Address) -> Result<U256> {
-        let state = self.latest_state();
-        Ok(state
-            .games
-            .values()
-            .find(|game| game.weth == weth)
-            .map_or_else(|| U256::from(10), |game| game.bond.delay))
+        let mut data = self.0.lock();
+        let state = data.latest_state();
+        let game = state.games.values().find(|game| game.weth == weth);
+        let target =
+            game.map(|game| L1ReadTarget::Game(game.target())).unwrap_or(L1ReadTarget::Global);
+        data.record_l1_read(L1ReadBoundary::WethDelay, target)?;
+        Ok(game.map_or_else(|| U256::from(10), |game| game.bond.delay))
     }
 
     async fn game_by_uuid(&self, root_claim: B256, extra_data: Vec<u8>) -> Result<Address> {
@@ -1341,32 +1638,47 @@ impl L1View for FakeL1View {
     }
 
     async fn parent_standing(&self, game: Address, _registry: Address) -> Result<GameStanding> {
-        let state = self.latest_state();
-        Ok(state.game(game)?.standing)
+        let (state, _) = self.latest_state_for_game(L1ReadBoundary::ParentStanding, game)?;
+        let game = state.game(game)?;
+        let registered = state.registered_args.anchor_state_registry;
+        ensure!(
+            _registry == registered,
+            "parent standing used registry {_registry}, expected {registered}"
+        );
+        Ok(game.standing)
     }
 
     async fn game_standing(&self, game: Address, _registry: Address) -> Result<GameStanding> {
-        let state = self.latest_state();
-        Ok(state.game(game)?.standing)
+        let (state, _) = self.latest_state_for_game(L1ReadBoundary::GameStanding, game)?;
+        let game = state.game(game)?;
+        ensure!(
+            _registry == game.anchor_state_registry,
+            "game standing used registry {_registry}, expected {}",
+            game.anchor_state_registry
+        );
+        Ok(game.standing)
     }
 
     async fn proof_status(&self, game: Address) -> Result<u8> {
-        let state = self.latest_state();
+        let (state, _) = self.latest_state_for_game(L1ReadBoundary::ProofStatus, game)?;
         Ok(state.game(game)?.proposal_status as u8)
     }
 
     async fn proof_inputs(&self, game: Address) -> Result<ProofInputs> {
-        let state = self.latest_state();
+        let (state, _) = self.latest_state_for_game(L1ReadBoundary::ProofInputs, game)?;
         Ok(state.game(game)?.proof_inputs)
     }
 
     async fn anchor_state_registry(&self, game: Address) -> Result<Address> {
-        let state = self.latest_state();
+        let (state, _) = self.latest_state_for_game(L1ReadBoundary::AnchorStateRegistry, game)?;
         Ok(state.game(game)?.anchor_state_registry)
     }
 
     async fn latest_l1_timestamp(&self) -> Result<u64> {
-        Ok(self.latest_state().block.timestamp)
+        let mut data = self.0.lock();
+        let state = data.latest_state();
+        data.record_l1_read(L1ReadBoundary::LatestL1Timestamp, L1ReadTarget::Global)?;
+        Ok(state.block.timestamp)
     }
 }
 
@@ -1384,29 +1696,101 @@ struct FakeSuperRootSource(ScenarioWorld);
 
 #[async_trait]
 impl SuperRootSource for FakeSuperRootSource {
-    async fn proposal_horizon(&self, _timestamp: u64) -> Result<ProposalHorizon> {
-        let data = self.0.lock();
-        Ok(ProposalHorizon {
-            safe_timestamp: data.safe_time,
-            finalized_timestamp: data.finalized_time,
-        })
+    async fn proposal_horizon(&self, timestamp: u64) -> Result<ProposalHorizon> {
+        let mut data = self.0.lock();
+        let safe = data.safe_time;
+        let finalized = data.finalized_time;
+        let attempt = data
+            .superroot_records
+            .iter()
+            .filter(|record| {
+                record.kind == SuperRootQueryKind::ProposalHorizon &&
+                    record.requested_timestamp == timestamp
+            })
+            .count() as u64 +
+            1;
+        data.superroot_records.push(SuperRootQueryRecord {
+            kind: SuperRootQueryKind::ProposalHorizon,
+            requested_timestamp: timestamp,
+            attempt,
+            safe_timestamp: safe,
+            finalized_timestamp: finalized,
+            current_l1: None,
+            required_l1: None,
+            outcome: SuperRootQueryOutcome::Horizon,
+        });
+        Ok(ProposalHorizon { safe_timestamp: safe, finalized_timestamp: finalized })
     }
 
     async fn super_root_at_timestamp(&self, timestamp: u64) -> Result<SuperRootAtTimestamp> {
-        let data = self.0.lock();
+        let mut data = self.0.lock();
         let safe = data.safe_time;
         let finalized = data.finalized_time;
-        if timestamp > safe {
-            let response = superroot_response(timestamp, safe, finalized, None);
-            return Ok(SuperRootAtTimestamp { response, root: None });
-        }
+        let (attempt, scripted) = data.superroot_scripts.next(&timestamp);
+        let outcome = scripted.unwrap_or_else(|| {
+            if timestamp > safe {
+                SuperRootOutcome::Unavailable
+            } else {
+                SuperRootOutcome::Root {
+                    root: canonical_super_root(timestamp),
+                    current_l1: 2,
+                    required_l1: 1,
+                }
+            }
+        });
+        let (current_l1, required_l1, journal_outcome) = match outcome {
+            SuperRootOutcome::Root { root, current_l1, required_l1 } => (
+                Some(current_l1),
+                Some(required_l1),
+                if current_l1 > required_l1 {
+                    SuperRootQueryOutcome::Trusted(root)
+                } else {
+                    SuperRootQueryOutcome::Untrusted(root)
+                },
+            ),
+            SuperRootOutcome::Unavailable => (Some(2), None, SuperRootQueryOutcome::Unavailable),
+            SuperRootOutcome::TransportFailure => {
+                (None, None, SuperRootQueryOutcome::TransportFailure)
+            }
+            SuperRootOutcome::Malformed => (None, None, SuperRootQueryOutcome::Malformed),
+        };
+        data.superroot_records.push(SuperRootQueryRecord {
+            kind: SuperRootQueryKind::AtTimestamp,
+            requested_timestamp: timestamp,
+            attempt,
+            safe_timestamp: safe,
+            finalized_timestamp: finalized,
+            current_l1,
+            required_l1,
+            outcome: journal_outcome,
+        });
+        drop(data);
 
-        let root = canonical_super_root(timestamp);
-        let response = superroot_response(timestamp, safe, finalized, Some((1, root)));
-        Ok(SuperRootAtTimestamp {
-            response,
-            root: Some(SuperRootAt { proof_bytes: vec![0x01], super_root: root }),
-        })
+        match outcome {
+            SuperRootOutcome::Root { root, current_l1, required_l1 } => {
+                let response = superroot_response(
+                    timestamp,
+                    safe,
+                    finalized,
+                    current_l1,
+                    Some((required_l1, root)),
+                );
+                Ok(SuperRootAtTimestamp {
+                    response,
+                    root: Some(SuperRootAt { proof_bytes: vec![0x01], super_root: root }),
+                })
+            }
+            SuperRootOutcome::Unavailable => Ok(SuperRootAtTimestamp {
+                response: superroot_response(timestamp, safe, finalized, 2, None),
+                root: None,
+            }),
+            SuperRootOutcome::TransportFailure => {
+                bail!("scripted superroot transport failure at timestamp {timestamp}")
+            }
+            SuperRootOutcome::Malformed => {
+                bail!("scripted malformed superroot response at timestamp {timestamp}")
+            }
+        }
     }
 }
 
@@ -1414,10 +1798,11 @@ fn superroot_response(
     timestamp: u64,
     safe: u64,
     finalized: u64,
+    current_l1: u64,
     data: Option<(u64, B256)>,
 ) -> SuperRootAtTimestampResponse {
     SuperRootAtTimestampResponse {
-        current_l1: SuperBlockId { number: 2, ..Default::default() },
+        current_l1: SuperBlockId { number: current_l1, ..Default::default() },
         current_safe_timestamp: safe,
         current_local_safe_timestamp: safe,
         current_finalized_timestamp: finalized,
@@ -1673,6 +2058,7 @@ pub(super) struct ScenarioHarness {
     world: ScenarioWorld,
     proposer: Arc<Proposer>,
     control: ScenarioControl,
+    config: ProposerConfig,
 }
 
 impl ScenarioHarness {
@@ -1688,7 +2074,19 @@ impl ScenarioHarness {
             .await
             .map_err(|error| ScenarioError::Initialization(error.to_string()))?;
         let control = ScenarioControl::new(proposer.clone(), SCENARIO_WATCHDOG);
-        Ok(Self { world, proposer, control })
+        Ok(Self { world, proposer, control, config })
+    }
+
+    pub(super) async fn restart(&mut self) -> Result<(), ScenarioError> {
+        let tasks = self.proposer.tasks.lock().await;
+        if let Some(task_id) = tasks.keys().min().copied() {
+            return Err(ScenarioError::RunningTask { task_id });
+        }
+        drop(tasks);
+
+        let replacement = Self::new(self.world.clone(), self.config.clone()).await?;
+        *self = replacement;
+        Ok(())
     }
 
     pub(super) async fn tick(&mut self) -> Result<CycleResult, ScenarioError> {

--- a/rust/kona/sp1/crates/proposer/src/proposer/scenario/world.rs
+++ b/rust/kona/sp1/crates/proposer/src/proposer/scenario/world.rs
@@ -171,12 +171,14 @@ pub(super) enum ProofOutcome {
 pub(super) enum ActionBarrierPoint {
     BeforeSigner,
     AfterSubmission,
+    AfterInclusion,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 enum BarrierPoint {
     BeforeSigner,
     AfterSubmission,
+    AfterInclusion,
     Proof,
 }
 
@@ -185,6 +187,7 @@ impl From<ActionBarrierPoint> for BarrierPoint {
         match point {
             ActionBarrierPoint::BeforeSigner => Self::BeforeSigner,
             ActionBarrierPoint::AfterSubmission => Self::AfterSubmission,
+            ActionBarrierPoint::AfterInclusion => Self::AfterInclusion,
         }
     }
 }
@@ -246,11 +249,12 @@ struct ActionScript {
     outcome: ActionOutcome,
     before_signer: Option<NamedBarrier>,
     after_submission: Option<NamedBarrier>,
+    after_inclusion: Option<NamedBarrier>,
 }
 
 impl ActionScript {
     const fn immediate(outcome: ActionOutcome) -> Self {
-        Self { outcome, before_signer: None, after_submission: None }
+        Self { outcome, before_signer: None, after_submission: None, after_inclusion: None }
     }
 }
 
@@ -877,17 +881,29 @@ impl ScenarioWorld {
                 outcome != ActionOutcome::PreSubmitFailure,
             "a pre-submit failure cannot reach an after-submission barrier"
         );
+        assert!(
+            point != ActionBarrierPoint::AfterInclusion || outcome == ActionOutcome::Success,
+            "only a successful action can reach an after-inclusion barrier"
+        );
         let barrier = NamedBarrier::new(name);
         let script = match point {
             ActionBarrierPoint::BeforeSigner => ActionScript {
                 outcome,
                 before_signer: Some(barrier.clone()),
                 after_submission: None,
+                after_inclusion: None,
             },
             ActionBarrierPoint::AfterSubmission => ActionScript {
                 outcome,
                 before_signer: None,
                 after_submission: Some(barrier.clone()),
+                after_inclusion: None,
+            },
+            ActionBarrierPoint::AfterInclusion => ActionScript {
+                outcome,
+                before_signer: None,
+                after_submission: None,
+                after_inclusion: Some(barrier.clone()),
             },
         };
         let mut data = self.lock();
@@ -1404,6 +1420,11 @@ fn publish_prestate_at(directory: &Path, prestate: B256) {
 #[derive(Clone)]
 struct FakeL1View(ScenarioWorld);
 
+struct GameReadResult {
+    state: Arc<L1State>,
+    scripted_status: Option<u8>,
+}
+
 impl FakeL1View {
     fn state(&self, block: BlockId) -> Result<Arc<L1State>> {
         self.0.lock().state_at(block)
@@ -1418,24 +1439,20 @@ impl FakeL1View {
         boundary: L1ReadBoundary,
         game: Address,
         block: BlockId,
-    ) -> Result<(Arc<L1State>, Option<u8>)> {
+    ) -> Result<GameReadResult> {
         let mut data = self.0.lock();
         let state = data.state_at(block)?;
         let target = state.game(game)?.target();
-        let scripted = data.record_l1_read(boundary, L1ReadTarget::Game(target))?;
-        Ok((state, scripted))
+        let scripted_status = data.record_l1_read(boundary, L1ReadTarget::Game(target))?;
+        Ok(GameReadResult { state, scripted_status })
     }
 
     fn latest_state_for_game(
         &self,
         boundary: L1ReadBoundary,
         game: Address,
-    ) -> Result<(Arc<L1State>, Option<u8>)> {
-        let mut data = self.0.lock();
-        let state = data.latest_state();
-        let target = state.game(game)?.target();
-        let scripted = data.record_l1_read(boundary, L1ReadTarget::Game(target))?;
-        Ok((state, scripted))
+    ) -> Result<GameReadResult> {
+        self.state_for_game(boundary, game, BlockId::latest())
     }
 }
 
@@ -1478,7 +1495,8 @@ impl L1View for FakeL1View {
     }
 
     async fn game_claim(&self, game: Address, block: BlockId) -> Result<GameClaim> {
-        let (state, _) = self.state_for_game(L1ReadBoundary::GameClaim, game, block)?;
+        let GameReadResult { state, .. } =
+            self.state_for_game(L1ReadBoundary::GameClaim, game, block)?;
         let game = state.game(game)?;
         Ok(GameClaim {
             status: game.proposal_status as u8,
@@ -1488,7 +1506,8 @@ impl L1View for FakeL1View {
     }
 
     async fn game_identity(&self, game: Address, block: BlockId) -> Result<GameIdentity> {
-        let (state, _) = self.state_for_game(L1ReadBoundary::GameIdentity, game, block)?;
+        let GameReadResult { state, .. } =
+            self.state_for_game(L1ReadBoundary::GameIdentity, game, block)?;
         let game = state.game(game)?;
         Ok(GameIdentity {
             anchor_state_registry: game.anchor_state_registry,
@@ -1499,7 +1518,8 @@ impl L1View for FakeL1View {
     }
 
     async fn game_validity(&self, game: Address, block: BlockId) -> Result<GameValidity> {
-        let (state, _) = self.state_for_game(L1ReadBoundary::GameValidity, game, block)?;
+        let GameReadResult { state, .. } =
+            self.state_for_game(L1ReadBoundary::GameValidity, game, block)?;
         let game = state.game(game)?;
         Ok(GameValidity {
             root_claim: game.root_claim,
@@ -1515,7 +1535,8 @@ impl L1View for FakeL1View {
         registry: Address,
         block: BlockId,
     ) -> Result<GameLifecycle> {
-        let (state, _) = self.state_for_game(L1ReadBoundary::GameLifecycle, game, block)?;
+        let GameReadResult { state, .. } =
+            self.state_for_game(L1ReadBoundary::GameLifecycle, game, block)?;
         let game = state.game(game)?;
         ensure!(
             game.anchor_state_registry == registry,
@@ -1547,7 +1568,8 @@ impl L1View for FakeL1View {
         proposer: Address,
         block: BlockId,
     ) -> Result<BondState> {
-        let (state, _) = self.state_for_game(L1ReadBoundary::BondState, game, block)?;
+        let GameReadResult { state, .. } =
+            self.state_for_game(L1ReadBoundary::BondState, game, block)?;
         let game = state.game(game)?;
         ensure!(game.weth == weth, "bond state used WETH {weth}, expected {}", game.weth);
         ensure!(
@@ -1562,8 +1584,9 @@ impl L1View for FakeL1View {
     }
 
     async fn game_status(&self, game: Address) -> Result<u8> {
-        let (state, scripted) = self.latest_state_for_game(L1ReadBoundary::GameStatus, game)?;
-        Ok(scripted.unwrap_or(state.game(game)?.status as u8))
+        let GameReadResult { state, scripted_status } =
+            self.latest_state_for_game(L1ReadBoundary::GameStatus, game)?;
+        Ok(scripted_status.unwrap_or(state.game(game)?.status as u8))
     }
 
     async fn claim_preflight(
@@ -1640,7 +1663,8 @@ impl L1View for FakeL1View {
     }
 
     async fn parent_standing(&self, game: Address, registry: Address) -> Result<GameStanding> {
-        let (state, _) = self.latest_state_for_game(L1ReadBoundary::ParentStanding, game)?;
+        let GameReadResult { state, .. } =
+            self.latest_state_for_game(L1ReadBoundary::ParentStanding, game)?;
         let game = state.game(game)?;
         let registered = state.registered_args.anchor_state_registry;
         ensure!(
@@ -1651,7 +1675,8 @@ impl L1View for FakeL1View {
     }
 
     async fn game_standing(&self, game: Address, registry: Address) -> Result<GameStanding> {
-        let (state, _) = self.latest_state_for_game(L1ReadBoundary::GameStanding, game)?;
+        let GameReadResult { state, .. } =
+            self.latest_state_for_game(L1ReadBoundary::GameStanding, game)?;
         let game = state.game(game)?;
         ensure!(
             registry == game.anchor_state_registry,
@@ -1662,17 +1687,20 @@ impl L1View for FakeL1View {
     }
 
     async fn proof_status(&self, game: Address) -> Result<u8> {
-        let (state, _) = self.latest_state_for_game(L1ReadBoundary::ProofStatus, game)?;
+        let GameReadResult { state, .. } =
+            self.latest_state_for_game(L1ReadBoundary::ProofStatus, game)?;
         Ok(state.game(game)?.proposal_status as u8)
     }
 
     async fn proof_inputs(&self, game: Address) -> Result<ProofInputs> {
-        let (state, _) = self.latest_state_for_game(L1ReadBoundary::ProofInputs, game)?;
+        let GameReadResult { state, .. } =
+            self.latest_state_for_game(L1ReadBoundary::ProofInputs, game)?;
         Ok(state.game(game)?.proof_inputs)
     }
 
     async fn anchor_state_registry(&self, game: Address) -> Result<Address> {
-        let (state, _) = self.latest_state_for_game(L1ReadBoundary::AnchorStateRegistry, game)?;
+        let GameReadResult { state, .. } =
+            self.latest_state_for_game(L1ReadBoundary::AnchorStateRegistry, game)?;
         Ok(state.game(game)?.anchor_state_registry)
     }
 
@@ -1956,6 +1984,9 @@ impl FakeActionExecutor {
                     CommittedEffect::Created { address, .. } => Some(address),
                     _ => None,
                 };
+                if let Some(barrier) = script.after_inclusion {
+                    barrier.park_unassigned().await;
+                }
                 Ok(ActionResult { transaction_hash, created_address })
             }
             ActionOutcome::Revert => {

--- a/rust/kona/sp1/crates/proposer/src/proposer/scenario/world.rs
+++ b/rust/kona/sp1/crates/proposer/src/proposer/scenario/world.rs
@@ -605,6 +605,7 @@ struct WorldData {
     l1_read_scripts: Scripts<(L1ReadBoundary, L1ReadTarget), L1ReadScript>,
     l1_read_records: Vec<L1ReadRecord>,
     superroot_scripts: Scripts<u64, SuperRootOutcome>,
+    proposal_horizon_attempts: HashMap<u64, u64>,
     superroot_records: Vec<SuperRootQueryRecord>,
     action_scripts: Scripts<ActionTarget, ActionScript>,
     proof_scripts: Scripts<GameTarget, ProofScript>,
@@ -666,6 +667,7 @@ impl ScenarioWorld {
                 l1_read_scripts: Scripts::default(),
                 l1_read_records: Vec::new(),
                 superroot_scripts: Scripts::default(),
+                proposal_horizon_attempts: HashMap::new(),
                 superroot_records: Vec::new(),
                 action_scripts: Scripts::default(),
                 proof_scripts: Scripts::default(),
@@ -1510,14 +1512,14 @@ impl L1View for FakeL1View {
     async fn game_lifecycle(
         &self,
         game: Address,
-        _registry: Address,
+        registry: Address,
         block: BlockId,
     ) -> Result<GameLifecycle> {
         let (state, _) = self.state_for_game(L1ReadBoundary::GameLifecycle, game, block)?;
         let game = state.game(game)?;
         ensure!(
-            game.anchor_state_registry == _registry,
-            "game lifecycle used registry {_registry}, expected {}",
+            game.anchor_state_registry == registry,
+            "game lifecycle used registry {registry}, expected {}",
             game.anchor_state_registry
         );
         Ok(GameLifecycle {
@@ -1541,16 +1543,16 @@ impl L1View for FakeL1View {
     async fn bond_state(
         &self,
         game: Address,
-        _weth: Address,
-        _proposer: Address,
+        weth: Address,
+        proposer: Address,
         block: BlockId,
     ) -> Result<BondState> {
         let (state, _) = self.state_for_game(L1ReadBoundary::BondState, game, block)?;
         let game = state.game(game)?;
-        ensure!(game.weth == _weth, "bond state used WETH {_weth}, expected {}", game.weth);
+        ensure!(game.weth == weth, "bond state used WETH {weth}, expected {}", game.weth);
         ensure!(
-            _proposer == ScenarioWorld::proposer_address(),
-            "bond state used unexpected proposer {_proposer}"
+            proposer == ScenarioWorld::proposer_address(),
+            "bond state used unexpected proposer {proposer}"
         );
         Ok(game.bond)
     }
@@ -1567,8 +1569,8 @@ impl L1View for FakeL1View {
     async fn claim_preflight(
         &self,
         game: Address,
-        _weth: Address,
-        _proposer: Address,
+        weth: Address,
+        proposer: Address,
     ) -> ClaimPreflight {
         let mut data = self.0.lock();
         let state = data.latest_state();
@@ -1584,7 +1586,7 @@ impl L1View for FakeL1View {
         };
         let game_state = state.game(game).expect("game was just resolved");
         let arguments_valid =
-            game_state.weth == _weth && _proposer == ScenarioWorld::proposer_address();
+            game_state.weth == weth && proposer == ScenarioWorld::proposer_address();
         let credit = if arguments_valid {
             data.record_l1_read(L1ReadBoundary::ClaimCredit, L1ReadTarget::Game(target.clone()))
                 .map(|_| game_state.bond.credit)
@@ -1637,23 +1639,23 @@ impl L1View for FakeL1View {
         Ok(self.state(block)?.respected_game_type)
     }
 
-    async fn parent_standing(&self, game: Address, _registry: Address) -> Result<GameStanding> {
+    async fn parent_standing(&self, game: Address, registry: Address) -> Result<GameStanding> {
         let (state, _) = self.latest_state_for_game(L1ReadBoundary::ParentStanding, game)?;
         let game = state.game(game)?;
         let registered = state.registered_args.anchor_state_registry;
         ensure!(
-            _registry == registered,
-            "parent standing used registry {_registry}, expected {registered}"
+            registry == registered,
+            "parent standing used registry {registry}, expected {registered}"
         );
         Ok(game.standing)
     }
 
-    async fn game_standing(&self, game: Address, _registry: Address) -> Result<GameStanding> {
+    async fn game_standing(&self, game: Address, registry: Address) -> Result<GameStanding> {
         let (state, _) = self.latest_state_for_game(L1ReadBoundary::GameStanding, game)?;
         let game = state.game(game)?;
         ensure!(
-            _registry == game.anchor_state_registry,
-            "game standing used registry {_registry}, expected {}",
+            registry == game.anchor_state_registry,
+            "game standing used registry {registry}, expected {}",
             game.anchor_state_registry
         );
         Ok(game.standing)
@@ -1700,15 +1702,9 @@ impl SuperRootSource for FakeSuperRootSource {
         let mut data = self.0.lock();
         let safe = data.safe_time;
         let finalized = data.finalized_time;
-        let attempt = data
-            .superroot_records
-            .iter()
-            .filter(|record| {
-                record.kind == SuperRootQueryKind::ProposalHorizon &&
-                    record.requested_timestamp == timestamp
-            })
-            .count() as u64 +
-            1;
+        let attempt = data.proposal_horizon_attempts.entry(timestamp).or_default();
+        *attempt += 1;
+        let attempt = *attempt;
         data.superroot_records.push(SuperRootQueryRecord {
             kind: SuperRootQueryKind::ProposalHorizon,
             requested_timestamp: timestamp,
@@ -2080,7 +2076,7 @@ impl ScenarioHarness {
     pub(super) async fn restart(&mut self) -> Result<(), ScenarioError> {
         let tasks = self.proposer.tasks.lock().await;
         if let Some(task_id) = tasks.keys().min().copied() {
-            return Err(ScenarioError::RunningTask { task_id });
+            return Err(ScenarioError::UnsettledTask { task_id });
         }
         drop(tasks);
 


### PR DESCRIPTION
## Summary

Adds comprehensive multi-cycle proposer policy coverage using the deterministic `ScenarioWorld` and `ScenarioHarness`.

The scenarios cover:

- Frozen proposal horizons and long foreign-game histories
- Concurrent defense while creation is stalled
- Trusted and untrusted superroot contradictions
- Timed-out creation, late inclusion, and duplicate-creation guards
- Invalid topology, ownership, resolution, claim, and payout policy
- Independent pinned L1, latest L1, host, safe, and finalized clocks
- Factory, pending-game, and cached-game read-failure isolation
- Fresh proposer reconstruction over existing confirmed history

The scenario world now supports:

- L1 read faults keyed by boundary, target, and attempt
- Superroot query journaling with trust and L1 metadata
- Fresh proposer restarts over persistent world state
- Small history mutation controls required by the policy scenarios

The scenarios also pin the intended creation and contradiction boundaries:

- A root available at the selected proposal safety horizon is sufficient for creation; the stricter L1 metadata trust predicate is used only to classify contradictory existing claims.
- Trusted claim mismatches are terminal regardless of creator; untrusted observations remain retryable.
- The duplicate-creation guard is cleared when its tracked game becomes terminal or when factory history resets.

Treating a trusted contradiction as terminal may immediately release the creation guard and allow a
replacement at the same timestamp, putting a second bond at risk if the trusted response itself is
wrong. This is intentional: trusted supernode responses are the proposer's canonicality boundary;
retaining the guard would otherwise block recovery indefinitely at a frozen horizon.


## Proposer policy corrections

The scenarios exposed two policy defects:

- Claim mismatches are now classified by superroot trust rather than game creator. A trusted contradiction is terminal for both owned and foreign games, while an untrusted contradiction remains pending and retryable
- The duplicate-creation guard is cleared when its tracked game becomes terminal or is removed, and when previously confirmed factor history resets. An empty factory caused only by confirmation lag preserves the guard, preventing a second bond against the same anchor.

## Meta
Fixes https://github.com/ethereum-optimism/optimism/issues/22171