### PR TITLE
kona-node: honor conductor timeouts and reject unsupported safe lag

### DIFF
--- a/docs/public-docs/node-operators/kona-node/configuration.mdx
+++ b/docs/public-docs/node-operators/kona-node/configuration.mdx
@@ -112,11 +112,11 @@ Supported chain names include all those recognized by `alloy_chains` (e.g., `opt
 | Flag | Env | Description | Default |
 |------|-----|-------------|---------|
 | `--sequencer.stopped` | `KONA_NODE_SEQUENCER_STOPPED` | Start sequencer in stopped state | `false` |
-| `--sequencer.max-safe-lag <N>` | `KONA_NODE_SEQUENCER_MAX_SAFE_LAG` | Max L2 safe/unsafe lag | `0` |
+| `--sequencer.max-safe-lag <N>` | `KONA_NODE_SEQUENCER_MAX_SAFE_LAG` | Reserved for op-node compatibility. Kona currently requires `0` and exits at startup if a nonzero value is configured. | `0` |
 | `--sequencer.l1-confs <N>` | `KONA_NODE_SEQUENCER_L1_CONFS` | L1 block confirmations for sequencer | `4` |
 | `--sequencer.recover` | `KONA_NODE_SEQUENCER_RECOVER` | Strictly prepare next L1 origin and create empty L2 blocks | `false` |
 | `--conductor.rpc <URL>` | `KONA_NODE_CONDUCTOR_RPC` | RPC endpoint URL of an external conductor service. Supplying it enables the conductor integration in sequencer mode; it has no effect in validator mode. | - |
-| `--conductor.rpc.timeout <SECONDS>` | `KONA_NODE_CONDUCTOR_RPC_TIMEOUT` | Conductor service RPC timeout | `1` |
+| `--conductor.rpc.timeout <SECONDS>` | `KONA_NODE_CONDUCTOR_RPC_TIMEOUT` | Timeout applied to each conductor RPC request | `1` |
 
 ## Interop Arguments
 
@@ -159,4 +159,3 @@ in the help menu by running `kona-node node --help`. The only
 overrides currently supported are hardfork timestamps in seconds.
 
 [scr]: https://github.com/ethereum-optimism/superchain-registry/tree/main
-

--- a/docs/public-docs/node-operators/kona-node/design/sequencer.mdx
+++ b/docs/public-docs/node-operators/kona-node/design/sequencer.mdx
@@ -56,6 +56,8 @@ pub struct SequencerConfig {
     pub sequencer_recovery_mode: bool,
     /// The Url for the conductor RPC endpoint. If Some, enables the conductor service.
     pub conductor_rpc_url: Option<Url>,
+    /// The timeout applied to each conductor RPC request.
+    pub conductor_rpc_timeout: Duration,
     /// The confirmation delay for the sequencer.
     pub l1_conf_delay: u64,
 }
@@ -69,6 +71,7 @@ To configure a Kona node programmatically for sequencer mode, set `NodeMode::Seq
 
 ```rust
 use kona_node_service::{NodeMode, RollupNodeBuilder, SequencerConfig};
+use std::time::Duration;
 
 // Configure sequencer settings
 let sequencer_config = SequencerConfig {
@@ -77,6 +80,7 @@ let sequencer_config = SequencerConfig {
     conductor_rpc_url: Some(            // Optional conductor integration
         Url::parse("http://conductor:8080").unwrap()
     ),
+    conductor_rpc_timeout: Duration::from_secs(1),
     l1_conf_delay: 4,                   // L1 origin confirmation delay
 };
 
@@ -103,6 +107,7 @@ RollupNodeBuilder::new(
 | `sequencer_stopped` | Start sequencer in stopped state | `false` |
 | `sequencer_recovery_mode` | Enable recovery mode for catch-up | `false` |
 | `conductor_rpc_url` | Conductor service endpoint for leader election | `None` |
+| `conductor_rpc_timeout` | Timeout applied to each conductor RPC request | `1s` |
 | `l1_conf_delay` | Confirmation delay for L1 origin selection | `0` |
 
 ## Next Steps

--- a/docs/public-docs/node-operators/kona-node/run/sequencer.mdx
+++ b/docs/public-docs/node-operators/kona-node/run/sequencer.mdx
@@ -46,7 +46,7 @@ Sequencer mode requires all standard node arguments plus the `--mode=Sequencer` 
 | Flag | Environment Variable | Default | Description |
 |------|---------------------|---------|-------------|
 | `--sequencer.stopped` | `KONA_NODE_SEQUENCER_STOPPED` | `false` | Start sequencer in stopped state |
-| `--sequencer.max-safe-lag` | `KONA_NODE_SEQUENCER_MAX_SAFE_LAG` | `0` | Max L2 blocks between safe and unsafe heads |
+| `--sequencer.max-safe-lag` | `KONA_NODE_SEQUENCER_MAX_SAFE_LAG` | `0` | Reserved for op-node compatibility; Kona exits at startup if set above `0` |
 | `--sequencer.l1-confs` | `KONA_NODE_SEQUENCER_L1_CONFS` | `4` | L1 confirmations for origin selection |
 | `--sequencer.recover` | `KONA_NODE_SEQUENCER_RECOVER` | `false` | Force recovery mode operation |
 | `--conductor.rpc` | `KONA_NODE_CONDUCTOR_RPC` | - | Conductor service RPC endpoint |
@@ -84,12 +84,20 @@ kona-node node \
 kona-node node \
   --mode=Sequencer \
   --sequencer.recover=true \
-  --sequencer.max-safe-lag=100 \
   --l1-eth-rpc=http://localhost:8545 \
   --l1-beacon=http://localhost:5052 \
   --l2-engine-rpc=http://localhost:8551 \
   --chain=42161
 ```
+
+<Warning>
+Kona does not currently implement `--sequencer.max-safe-lag`. Only `0` (disabled) is supported;
+no safe-lag limit is enforced.
+
+When upgrading from a version that silently ignored this flag, any nonzero value supplied through
+the flag or `KONA_NODE_SEQUENCER_MAX_SAFE_LAG` now prevents startup. Remove the setting or change it
+to `0` to continue operating without a safe-lag limit.
+</Warning>
 
 ## Key Considerations
 

--- a/rust/kona/bin/node/src/commands/node.rs
+++ b/rust/kona/bin/node/src/commands/node.rs
@@ -278,6 +278,7 @@ impl NodeCommand {
 
     /// Run the Node subcommand.
     pub async fn run(self, args: &GlobalArgs) -> anyhow::Result<()> {
+        let sequencer_config = self.sequencer_flags.config()?;
         let cfg = self.get_l2_config(args)?;
 
         info!(
@@ -328,7 +329,7 @@ impl NodeCommand {
             p2p_config,
             rpc_config,
         )
-        .with_sequencer_config(self.sequencer_flags.config())
+        .with_sequencer_config(sequencer_config)
         .with_derivation_delegate_config(self.derivation_delegate_args.config())
         .with_dependency_set(dependency_set)
         .build()

--- a/rust/kona/bin/node/src/flags/sequencer.rs
+++ b/rust/kona/bin/node/src/flags/sequencer.rs
@@ -21,8 +21,8 @@ pub struct SequencerArgs {
     )]
     pub stopped: bool,
 
-    /// Maximum number of L2 blocks for restricting the distance between L2 safe and unsafe.
-    /// Disabled if 0.
+    /// Reserved for op-node compatibility and not currently supported by kona-node.
+    /// Values above 0 are rejected during startup.
     #[arg(
         long = "sequencer.max-safe-lag",
         default_value = "0",
@@ -67,12 +67,45 @@ impl Default for SequencerArgs {
 
 impl SequencerArgs {
     /// Creates a [`SequencerConfig`] from the [`SequencerArgs`].
-    pub fn config(&self) -> SequencerConfig {
-        SequencerConfig {
+    pub fn config(&self) -> anyhow::Result<SequencerConfig> {
+        anyhow::ensure!(
+            self.max_safe_lag == 0,
+            "--sequencer.max-safe-lag is not implemented in kona-node. Only 0 (disabled) is supported; no safe-lag limit will be enforced."
+        );
+
+        Ok(SequencerConfig {
             sequencer_stopped: self.stopped,
             sequencer_recovery_mode: self.recover,
             conductor_rpc_url: self.conductor_rpc.clone(),
+            conductor_rpc_timeout: self.conductor_rpc_timeout,
             l1_conf_delay: self.l1_confs,
-        }
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_rejects_unsupported_max_safe_lag() {
+        let args = SequencerArgs { max_safe_lag: 1, ..Default::default() };
+
+        let err = args.config().unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            "--sequencer.max-safe-lag is not implemented in kona-node. Only 0 (disabled) is supported; no safe-lag limit will be enforced."
+        );
+    }
+
+    #[test]
+    fn config_propagates_conductor_rpc_timeout() {
+        let timeout = Duration::from_secs(12);
+        let args = SequencerArgs { conductor_rpc_timeout: timeout, ..Default::default() };
+
+        let config = args.config().unwrap();
+
+        assert_eq!(config.conductor_rpc_timeout, timeout);
     }
 }

--- a/rust/kona/crates/node/service/Cargo.toml
+++ b/rust/kona/crates/node/service/Cargo.toml
@@ -76,6 +76,7 @@ rand.workspace = true
 anyhow.workspace = true
 backon.workspace = true
 mockall.workspace = true
+tokio = { workspace = true, features = ["test-util"] }
 alloy-primitives = { workspace = true, features = ["k256"] }
 alloy-rpc-types-engine = { workspace = true, features = ["arbitrary"] }
 alloy-consensus = { workspace = true, features = ["arbitrary"] }

--- a/rust/kona/crates/node/service/src/actors/sequencer/conductor.rs
+++ b/rust/kona/crates/node/service/src/actors/sequencer/conductor.rs
@@ -1,8 +1,9 @@
+use super::config::DEFAULT_CONDUCTOR_RPC_TIMEOUT;
 use alloy_rpc_client::ReqwestClient;
 use alloy_transport::{RpcError, TransportErrorKind};
 use async_trait::async_trait;
 use op_alloy_rpc_types_engine::OpExecutionPayloadEnvelope;
-use std::fmt::Debug;
+use std::{fmt::Debug, future::Future, time::Duration};
 use url::Url;
 
 /// Trait for interacting with the conductor service.
@@ -27,6 +28,8 @@ pub trait Conductor: Debug + Send + Sync {
 pub struct ConductorClient {
     /// The inner RPC provider
     rpc: ReqwestClient,
+    /// The timeout applied to each RPC request.
+    rpc_timeout: Duration,
 }
 
 #[async_trait]
@@ -36,37 +39,144 @@ impl Conductor for ConductorClient {
         &self,
         payload: &OpExecutionPayloadEnvelope,
     ) -> Result<(), ConductorError> {
-        self.rpc.request("conductor_commitUnsafePayload", [payload]).await.map_err(Into::into)
+        self.execute_with_timeout(self.rpc.request("conductor_commitUnsafePayload", [payload]))
+            .await
     }
 
     /// Override the leader of the conductor.
     async fn override_leader(&self) -> Result<(), ConductorError> {
-        self.rpc.request("conductor_overrideLeader", ()).await.map_err(Into::into)
+        self.execute_with_timeout(self.rpc.request("conductor_overrideLeader", ())).await
     }
 }
 
 impl ConductorClient {
     /// Creates a new conductor client using HTTP transport
     pub fn new_http(url: Url) -> Self {
+        Self::new_http_with_timeout(url, DEFAULT_CONDUCTOR_RPC_TIMEOUT)
+    }
+
+    /// Creates a new conductor client using HTTP transport with the given request timeout.
+    pub fn new_http_with_timeout(url: Url, rpc_timeout: Duration) -> Self {
         let rpc = ReqwestClient::new_http(url);
-        Self { rpc }
+        Self { rpc, rpc_timeout }
     }
 
     /// Check if the node is a leader of the conductor.
     pub async fn leader(&self) -> Result<bool, ConductorError> {
-        self.rpc.request("conductor_leader", ()).await.map_err(Into::into)
+        self.execute_with_timeout(self.rpc.request("conductor_leader", ())).await
     }
 
     /// Check if the conductor is active.
     pub async fn conductor_active(&self) -> Result<bool, ConductorError> {
-        self.rpc.request("conductor_active", ()).await.map_err(Into::into)
+        self.execute_with_timeout(self.rpc.request("conductor_active", ())).await
+    }
+
+    async fn execute_with_timeout<T>(
+        &self,
+        request: impl Future<Output = Result<T, RpcError<TransportErrorKind>>>,
+    ) -> Result<T, ConductorError> {
+        tokio::time::timeout(self.rpc_timeout, request)
+            .await
+            .map_err(|_| ConductorError::Timeout(self.rpc_timeout))?
+            .map_err(ConductorError::from)
     }
 }
 
 /// Error type for conductor operations
 #[derive(Debug, thiserror::Error)]
 pub enum ConductorError {
+    /// A conductor RPC request exceeded its configured timeout.
+    #[error("RPC request timed out after {0:?}")]
+    Timeout(Duration),
     /// An error occurred while making an RPC call to the conductor.
     #[error("RPC error: {0}")]
     Rpc(#[from] RpcError<TransportErrorKind>),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_consensus::Block;
+    use alloy_rpc_types_engine::ExecutionPayloadV1;
+    use futures::poll;
+    use jsonrpsee::{RpcModule, server::ServerBuilder, types::ErrorObjectOwned};
+    use op_alloy_consensus::OpTxEnvelope;
+    use rstest::rstest;
+    use std::{future::pending, task::Poll};
+    use tokio::time::{Instant, sleep_until};
+
+    async fn delayed_response<T>(response: T) -> Result<T, ErrorObjectOwned> {
+        tokio::time::sleep(Duration::from_secs(60)).await;
+        Ok(response)
+    }
+
+    #[tokio::test]
+    async fn conductor_requests_use_configured_timeout() {
+        let server = ServerBuilder::default().build("127.0.0.1:0").await.unwrap();
+        let addr = server.local_addr().unwrap();
+        let mut module = RpcModule::new(());
+        module
+            .register_async_method("conductor_commitUnsafePayload", |_, _, _| delayed_response(()))
+            .unwrap();
+        module
+            .register_async_method("conductor_overrideLeader", |_, _, _| delayed_response(()))
+            .unwrap();
+        module.register_async_method("conductor_leader", |_, _, _| delayed_response(true)).unwrap();
+        module.register_async_method("conductor_active", |_, _, _| delayed_response(true)).unwrap();
+        let _handle = server.start(module);
+
+        let timeout = Duration::from_millis(10);
+        let client = ConductorClient::new_http_with_timeout(
+            Url::parse(&format!("http://{addr}")).unwrap(),
+            timeout,
+        );
+        let payload =
+            OpExecutionPayloadEnvelope::V1(ExecutionPayloadV1::from_block_slow(&Block::<
+                OpTxEnvelope,
+            >::default(
+            )));
+
+        let (commit, override_leader, leader, active) = tokio::join!(
+            client.commit_unsafe_payload(&payload),
+            client.override_leader(),
+            client.leader(),
+            client.conductor_active(),
+        );
+
+        for result in [commit, override_leader] {
+            assert!(matches!(result, Err(ConductorError::Timeout(actual)) if actual == timeout));
+        }
+        for result in [leader, active] {
+            assert!(matches!(result, Err(ConductorError::Timeout(actual)) if actual == timeout));
+        }
+    }
+
+    #[rstest]
+    #[case::below_default(Duration::from_millis(10))]
+    #[case::above_default(Duration::from_secs(2))]
+    #[tokio::test(start_paused = true)]
+    async fn request_expires_at_configured_deadline(#[case] timeout: Duration) {
+        let client = ConductorClient::new_http_with_timeout(
+            Url::parse("http://127.0.0.1:8545").unwrap(),
+            timeout,
+        );
+        // A never-ready request can only complete through the client's timeout.
+        let request =
+            client.execute_with_timeout(pending::<Result<(), RpcError<TransportErrorKind>>>());
+        tokio::pin!(request);
+
+        let deadline = Instant::now() + timeout;
+        // Arm the timeout without awaiting it, which would auto-advance the paused clock.
+        assert!(poll!(&mut request).is_pending());
+
+        sleep_until(deadline - Duration::from_millis(1)).await;
+        assert!(poll!(&mut request).is_pending(), "request timed out before its deadline");
+
+        sleep_until(deadline).await;
+        // Poll once so an incorrectly longer timeout cannot advance time and pass the test.
+        assert!(matches!(
+            poll!(&mut request),
+            Poll::Ready(Err(ConductorError::Timeout(actual))) if actual == timeout
+        ));
+    }
 }

--- a/rust/kona/crates/node/service/src/actors/sequencer/config.rs
+++ b/rust/kona/crates/node/service/src/actors/sequencer/config.rs
@@ -2,12 +2,15 @@
 //!
 //! [`SequencerActor`]: super::SequencerActor
 
+use std::time::Duration;
 use url::Url;
+
+pub(crate) const DEFAULT_CONDUCTOR_RPC_TIMEOUT: Duration = Duration::from_secs(1);
 
 /// Configuration for the [`SequencerActor`].
 ///
 /// [`SequencerActor`]: super::SequencerActor
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SequencerConfig {
     /// Whether or not the sequencer is enabled at startup.
     pub sequencer_stopped: bool,
@@ -15,6 +18,20 @@ pub struct SequencerConfig {
     pub sequencer_recovery_mode: bool,
     /// The [`Url`] for the conductor RPC endpoint. If [`Some`], enables the conductor service.
     pub conductor_rpc_url: Option<Url>,
+    /// The timeout applied to each conductor RPC request.
+    pub conductor_rpc_timeout: Duration,
     /// The confirmation delay for the sequencer.
     pub l1_conf_delay: u64,
+}
+
+impl Default for SequencerConfig {
+    fn default() -> Self {
+        Self {
+            sequencer_stopped: false,
+            sequencer_recovery_mode: false,
+            conductor_rpc_url: None,
+            conductor_rpc_timeout: DEFAULT_CONDUCTOR_RPC_TIMEOUT,
+            l1_conf_delay: 0,
+        }
+    }
 }

--- a/rust/kona/crates/node/service/src/service/node.rs
+++ b/rust/kona/crates/node/service/src/service/node.rs
@@ -357,8 +357,9 @@ impl RollupNode {
         let delayed_origin_selector =
             L1OriginSelector::new(self.config.clone(), delayed_l1_provider);
 
-        let conductor =
-            self.sequencer_config.conductor_rpc_url.clone().map(ConductorClient::new_http);
+        let conductor = self.sequencer_config.conductor_rpc_url.clone().map(|url| {
+            ConductorClient::new_http_with_timeout(url, self.sequencer_config.conductor_rpc_timeout)
+        });
 
         let sequencer_engine_client =
             QueuedSequencerEngineClient { engine_actor_request_tx, unsafe_head_rx };


### PR DESCRIPTION
## Description

Partially addresses #22667 by handling two sequencer flags that kona-node previously accepted but silently ignored:

- Applies `--conductor.rpc.timeout` to every conductor RPC request.
- Rejects nonzero `--sequencer.max-safe-lag` values before startup, since safe-lag enforcement is not implemented.

Updates operator documentation to explain both behaviors.

**BREAKING CHANGE:** Nonzero `--sequencer.max-safe-lag` or `KONA_NODE_SEQUENCER_MAX_SAFE_LAG` values now prevent kona-node startup instead of being silently ignored. Remove the setting or set it to `0` to continue operating without safe-lag enforcement.

## Tests

- Checks that all four conductor RPC methods apply the configured timeout.
- Uses paused-clock tests with durations below and above the default to verify requests expire at the configured deadline, neither early nor late.
- Verifies timeout configuration propagation and rejection of unsupported nonzero safe-lag values.

## Additional context

This PR does not implement safe-lag enforcement. That functionality can be added in a follow-up PR; rejecting unsupported values now prevents operators from relying on protection that is not active.

Related to #22667