### PR TITLE
op-chain-ops: Support interop kona prestates in check-prestate

### DIFF
--- a/op-chain-ops/cmd/check-prestate/README.md
+++ b/op-chain-ops/cmd/check-prestate/README.md
@@ -6,7 +6,7 @@ its type, and the underlying superchain-registry commit.
 It then also checks for each specified chain if the included chain configuration has changed
 compared to the latest changes in the superchain-registry.
 
-Only kona prestates (type `cannon64-kona`) are supported.
+Only kona prestates (types `cannon64-kona` and `cannon64-kona-interop`) are supported.
 
 ## Usage
 

--- a/op-chain-ops/cmd/check-prestate/main.go
+++ b/op-chain-ops/cmd/check-prestate/main.go
@@ -85,7 +85,9 @@ func main() {
 	}
 	log.Info("Found prestate", "version", prestateVersion, "type", prestateType)
 
-	if prestateType != "cannon64-kona" {
+	// Both kona variants are built from the same kona-client tag, so they share a
+	// superchain-registry pin and chain configs. Only the build features differ.
+	if prestateType != "cannon64-kona" && prestateType != "cannon64-kona-interop" {
 		log.Crit("Unsupported prestate type; only kona prestates are supported", "type", prestateType)
 	}
 	elCommitInfo, fppCommitInfo, commit, prestateConfigs := prestate.NewKonaPrestate().FindVersions(log, prestateVersion)

--- a/op-chain-ops/cmd/check-prestate/prestate/kona.go
+++ b/op-chain-ops/cmd/check-prestate/prestate/kona.go
@@ -87,7 +87,9 @@ func fetchSuperchainRegistryCommit(ref string) (string, error) {
 // gitlinkCommit returns the commit a submodule gitlink points to at ref, if path
 // is a gitlink (mode 160000 / type commit) in that tree.
 func gitlinkCommit(ref, path string) (string, bool) {
-	stdout, _, err := runGit("ls-tree", ref, "--", path)
+	// --full-tree keeps path resolution relative to the repo root, so the lookup works
+	// from any working directory, including the cmd directory the README says to use.
+	stdout, _, err := runGit("ls-tree", "--full-tree", ref, "--", path)
 	if err != nil {
 		return "", false
 	}

--- a/op-chain-ops/cmd/check-prestate/prestate/kona_test.go
+++ b/op-chain-ops/cmd/check-prestate/prestate/kona_test.go
@@ -1,0 +1,43 @@
+package prestate
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestGitlinkCommitFromSubdirectory guards the path resolution of gitlinkCommit.
+// The README tells users to run the tool from op-chain-ops/cmd/check-prestate, so a
+// cwd-relative lookup silently finds no gitlink and the tool reports the pin as missing.
+func TestGitlinkCommitFromSubdirectory(t *testing.T) {
+	const submodulePath = "superchain-registry"
+	const submoduleSHA = "08d6a44910d75e28a5ee1c7c047d3bdd0bbdbdd2"
+
+	repo := t.TempDir()
+	t.Chdir(repo)
+	for _, args := range [][]string{
+		{"init", "--quiet"},
+		{"config", "user.email", "test@example.com"},
+		{"config", "user.name", "test"},
+		{"update-index", "--add", "--cacheinfo", "160000," + submoduleSHA + "," + submodulePath},
+		{"commit", "--quiet", "--no-gpg-sign", "-m", "add gitlink"},
+	} {
+		if _, stderr, err := runGit(args...); err != nil {
+			t.Fatalf("git %v: %v (%s)", args, err, stderr)
+		}
+	}
+
+	subdir := filepath.Join(repo, "op-chain-ops", "cmd", "check-prestate")
+	if err := os.MkdirAll(subdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(subdir)
+
+	sha, ok := gitlinkCommit("HEAD", submodulePath)
+	if !ok {
+		t.Fatal("gitlinkCommit found no gitlink when run from a subdirectory")
+	}
+	if sha != submoduleSHA {
+		t.Fatalf("got %s, want %s", sha, submoduleSHA)
+	}
+}


### PR DESCRIPTION
`check-prestate` could not review a `cannon64-kona-interop` prestate, and could not resolve the superchain-registry pin for recent kona-client tags.

Two fixes:

- `gitlinkCommit` resolved the submodule path relative to the working directory. Run from the `op-chain-ops/cmd/check-prestate` directory the README documents, the lookup found nothing and the tool reported the pin as missing. The legacy `superchain-registry-commit.txt` lookup is root-relative, so this only surfaced once tags moved to the submodule gitlink. Fixed with `--full-tree`, covered by a regression test that fails on the current code.
- The prestate type check rejected `cannon64-kona-interop`. Both kona variants are built from the same kona-client tag, so they share a registry pin and chain configs; only the build features differ.

Found while reviewing the kona-client v1.7.0-rc.2 prestates.