### PR TITLE
contracts-bedrock: enable ETHLockbox on every chain

### DIFF
--- a/packages/contracts-bedrock/interfaces/L1/IOptimismPortal2.sol
+++ b/packages/contracts-bedrock/interfaces/L1/IOptimismPortal2.sol
@@ -33,6 +33,7 @@ interface IOptimismPortal2 is IProxyAdminOwnedBase {
     error OptimismPortal_MigratingToSameRegistry();
     error OptimismPortal_NoReentrancy();
     error OptimismPortal_NotUsingInterop();
+    error OptimismPortal_NotUsingLockbox();
     error OptimismPortal_ProofNotOldEnough();
     error OptimismPortal_Unproven();
     error OptimismPortal_InvalidInteropState();

--- a/packages/contracts-bedrock/scripts/deploy/ChainAssertions.sol
+++ b/packages/contracts-bedrock/scripts/deploy/ChainAssertions.sol
@@ -12,6 +12,7 @@ import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
 
 // Libraries
 import { Constants } from "src/libraries/Constants.sol";
+import { Features } from "src/libraries/Features.sol";
 import { Types } from "scripts/libraries/Types.sol";
 import { Blueprint } from "src/libraries/Blueprint.sol";
 import { GameType, Proposal } from "src/dispute/lib/Types.sol";
@@ -274,10 +275,8 @@ library ChainAssertions {
             require(address(portal.superchainConfig()) == address(_superchainConfig), "PORTAL-40");
             require(portal.guardian() == _superchainConfig.guardian(), "CHECK-OP2-40");
             require(portal.paused() == ISystemConfig(_contracts.SystemConfig).paused(), "CHECK-OP2-60");
-            require(
-                address(portal.ethLockbox()) == _contracts.ETHLockbox || address(portal.ethLockbox()) == address(0),
-                "CHECK-OP2-80"
-            );
+            require(address(portal.ethLockbox()) == _contracts.ETHLockbox, "CHECK-OP2-80");
+            require(ISystemConfig(_contracts.SystemConfig).isFeatureEnabled(Features.ETH_LOCKBOX), "CHECK-OP2-85");
             require(portal.proxyAdminOwner() == _opChainProxyAdminOwner, "CHECK-OP2-90");
         } else {
             require(address(portal.anchorStateRegistry()) == address(0), "CHECK-OP2-80");

--- a/packages/contracts-bedrock/snapshots/abi/OptimismPortal2.json
+++ b/packages/contracts-bedrock/snapshots/abi/OptimismPortal2.json
@@ -973,6 +973,11 @@
   },
   {
     "inputs": [],
+    "name": "OptimismPortal_NotUsingLockbox",
+    "type": "error"
+  },
+  {
+    "inputs": [],
     "name": "OptimismPortal_ProofNotOldEnough",
     "type": "error"
   },

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -20,24 +20,24 @@
     "sourceCodeHash": "0x0ef8461e8bc55314e61e60924465574db17bdf30bbbfe9739b52cac623bba2db"
   },
   "src/L1/OPContractsManagerStandardValidator.sol:OPContractsManagerStandardValidator": {
-    "initCodeHash": "0x13cc3e8d9c1907fa6108667848d07bf8a4cc79790392abc9e5dfce7a3768b4d0",
-    "sourceCodeHash": "0xac01c00c951bfab0bcb1fe917803a8b6393902d54bc131387f24f8cb7e59923d"
+    "initCodeHash": "0x40bd085e5d35b76d9502dfcaa98d88cbe764f563e2fbf52ca10b067f8544cf25",
+    "sourceCodeHash": "0xf5a113a4089d7569104e13ae9bda3aa376e02193fb45d4a8cbb526d6a98ccd7d"
   },
   "src/L1/OptimismPortal2.sol:OptimismPortal2": {
-    "initCodeHash": "0x5e069d964978d43a9a94439c023bc84d9ba86a56ba9f4db8defde90aba54ea8d",
-    "sourceCodeHash": "0xd3bad3c441881a04baadad7ea3e4911571c571a9af3ba30f591b1b116e586ace"
+    "initCodeHash": "0xe0a6ad1682c6d4ef08619434c472dace53f65f7ac4d97c46f179a5866cf10f7a",
+    "sourceCodeHash": "0x74dd1127e2428d9b4647570c9c7859eb3eac930613720f1ee9ebc7584c6095c5"
   },
   "src/L1/SuperchainConfig.sol:SuperchainConfig": {
     "initCodeHash": "0x68f3fa110e1509bd841932feab438df5b5995ee222fc69a4dd6fcd48428e06f5",
     "sourceCodeHash": "0x97e17703a4843694a3bc71be2adcd753a0755db34d1fafc674e2b9586435dc76"
   },
   "src/L1/SystemConfig.sol:SystemConfig": {
-    "initCodeHash": "0x22be3fa0865de31fdb3d41651b318203b68c64b23c14f4ced28e88f59c0d3d01",
-    "sourceCodeHash": "0xceeedf69dcb6c05b88fd1569c53606dec02195b4d393a6491876b6d2f0c2ff1f"
+    "initCodeHash": "0xda61d95ae9384de29c550148f9262f0a56ceabd6f1765405c624b5d49ee50c3e",
+    "sourceCodeHash": "0xbdc39417d125296d22d98a28534190aa52bebf6419fc2a48147ab6dada89fd00"
   },
   "src/L1/opcm/OPContractsManagerV2.sol:OPContractsManagerV2": {
-    "initCodeHash": "0x81553faee6dfead8f15319088db35dde88ddb8196a99c4df9f7eb7569b72b86f",
-    "sourceCodeHash": "0x55e34a11ced7e8b135e01d3a661276ab94173a6d92255c092c2ba44d25afc31d"
+    "initCodeHash": "0xb28cdedf494e4bd7b8f9f481c94b37f3e7ccd2bbc219540e387fcb4cdee79497",
+    "sourceCodeHash": "0xda0be798d1e8f6081641ddc08daa8087a6b86bb70f95debf4a88f1bea586cae0"
   },
   "src/L2/BaseFeeVault.sol:BaseFeeVault": {
     "initCodeHash": "0x18650c65fa6f23fefc6f0c5fff605f12be99fce0bfbcbc0644403138e4c8bb12",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -25,7 +25,7 @@
   },
   "src/L1/OptimismPortal2.sol:OptimismPortal2": {
     "initCodeHash": "0xe0a6ad1682c6d4ef08619434c472dace53f65f7ac4d97c46f179a5866cf10f7a",
-    "sourceCodeHash": "0x74dd1127e2428d9b4647570c9c7859eb3eac930613720f1ee9ebc7584c6095c5"
+    "sourceCodeHash": "0xe9c774a9b4f1a8eca4854c5ac6326083bfcafaa689b344855b8fbcc63bfed54e"
   },
   "src/L1/SuperchainConfig.sol:SuperchainConfig": {
     "initCodeHash": "0x68f3fa110e1509bd841932feab438df5b5995ee222fc69a4dd6fcd48428e06f5",
@@ -33,11 +33,11 @@
   },
   "src/L1/SystemConfig.sol:SystemConfig": {
     "initCodeHash": "0xda61d95ae9384de29c550148f9262f0a56ceabd6f1765405c624b5d49ee50c3e",
-    "sourceCodeHash": "0xbdc39417d125296d22d98a28534190aa52bebf6419fc2a48147ab6dada89fd00"
+    "sourceCodeHash": "0x10ffeb3dee3b31cf7c6ce24c990713f628c15003b4579ddcdfd1b30540969a7d"
   },
   "src/L1/opcm/OPContractsManagerV2.sol:OPContractsManagerV2": {
     "initCodeHash": "0xb28cdedf494e4bd7b8f9f481c94b37f3e7ccd2bbc219540e387fcb4cdee79497",
-    "sourceCodeHash": "0xda0be798d1e8f6081641ddc08daa8087a6b86bb70f95debf4a88f1bea586cae0"
+    "sourceCodeHash": "0xaaae615d72ce76d480f8b4e79d68a1c46fb9dca21a530fdac93ae09466395575"
   },
   "src/L2/BaseFeeVault.sol:BaseFeeVault": {
     "initCodeHash": "0x18650c65fa6f23fefc6f0c5fff605f12be99fce0bfbcbc0644403138e4c8bb12",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -36,8 +36,8 @@
     "sourceCodeHash": "0x10ffeb3dee3b31cf7c6ce24c990713f628c15003b4579ddcdfd1b30540969a7d"
   },
   "src/L1/opcm/OPContractsManagerV2.sol:OPContractsManagerV2": {
-    "initCodeHash": "0x876627afef8cc7d0fc4412db9418e692e584483c1b1b6f68b03e22344ad93eac",
-    "sourceCodeHash": "0x5c430f1053fab34f92307e2b64581f46d832e2923bd696e09295ed92ee4be268"
+    "initCodeHash": "0x6d50121f7d0b98f2848bdd6ebf826ea68460f115bc6f408a01149772c0230133",
+    "sourceCodeHash": "0x870f686a3d85adc29d3f974b519b6fd09d25f621b4db0a75e539586d0d9d600b"
   },
   "src/L2/BaseFeeVault.sol:BaseFeeVault": {
     "initCodeHash": "0x18650c65fa6f23fefc6f0c5fff605f12be99fce0bfbcbc0644403138e4c8bb12",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -36,8 +36,8 @@
     "sourceCodeHash": "0x10ffeb3dee3b31cf7c6ce24c990713f628c15003b4579ddcdfd1b30540969a7d"
   },
   "src/L1/opcm/OPContractsManagerV2.sol:OPContractsManagerV2": {
-    "initCodeHash": "0xb28cdedf494e4bd7b8f9f481c94b37f3e7ccd2bbc219540e387fcb4cdee79497",
-    "sourceCodeHash": "0xaaae615d72ce76d480f8b4e79d68a1c46fb9dca21a530fdac93ae09466395575"
+    "initCodeHash": "0x876627afef8cc7d0fc4412db9418e692e584483c1b1b6f68b03e22344ad93eac",
+    "sourceCodeHash": "0x5c430f1053fab34f92307e2b64581f46d832e2923bd696e09295ed92ee4be268"
   },
   "src/L2/BaseFeeVault.sol:BaseFeeVault": {
     "initCodeHash": "0x18650c65fa6f23fefc6f0c5fff605f12be99fce0bfbcbc0644403138e4c8bb12",

--- a/packages/contracts-bedrock/src/L1/OPContractsManagerStandardValidator.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManagerStandardValidator.sol
@@ -46,8 +46,8 @@ import { IBigStepper } from "interfaces/dispute/IBigStepper.sol";
 /// before and after an upgrade.
 contract OPContractsManagerStandardValidator is ISemver {
     /// @notice The semantic version of the OPContractsManagerStandardValidator contract.
-    /// @custom:semver 3.5.0
-    string public constant version = "3.5.0";
+    /// @custom:semver 3.6.0
+    string public constant version = "3.6.0";
 
     /// @notice The SuperchainConfig contract.
     ISuperchainConfig public superchainConfig;
@@ -440,8 +440,10 @@ contract OPContractsManagerStandardValidator is ISemver {
         IOptimismPortal2 _portal = IOptimismPortal2(payable(_sysCfg.optimismPortal()));
         IETHLockbox _lockbox = IETHLockbox(_portal.ethLockbox());
 
-        // If this chain isn't using the ETHLockbox, skip the validation.
-        if (!_sysCfg.isFeatureEnabled(Features.ETH_LOCKBOX)) {
+        // Validate the chain's ETHLockbox configuration.
+        _errors = internalRequire(_sysCfg.isFeatureEnabled(Features.ETH_LOCKBOX), "LOCKBOX-00", _errors);
+        _errors = internalRequire(address(_lockbox) != address(0), "LOCKBOX-05", _errors);
+        if (address(_lockbox) == address(0)) {
             return _errors;
         }
 

--- a/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
+++ b/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
@@ -493,8 +493,8 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
         finalizeWithdrawalTransactionExternalProof(_tx, msg.sender);
     }
 
-    /// @notice Migrates the total ETH balance of this contract to the ETHLockbox.
-    ///         Custom gas token chains use the lockbox only as a pause source and cannot migrate ETH.
+    /// @notice Migrates the total ETH balance of this contract to the ETHLockbox. Custom gas
+    ///         token chains keep custody in the portal and cannot migrate ETH.
     function migrateLiquidity() public {
         if (!_isUsingLockbox()) revert OptimismPortal_NotUsingLockbox();
         // Liquidity migration can only be triggered by the ProxyAdmin owner.

--- a/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
+++ b/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
@@ -230,6 +230,9 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
     /// is enabled
     error OptimismPortal_NotUsingInterop();
 
+    /// @notice Thrown when calling a function that requires an active ETHLockbox.
+    error OptimismPortal_NotUsingLockbox();
+
     /// @notice Thrown when a withdrawal has not been proven for long enough.
     error OptimismPortal_ProofNotOldEnough();
 
@@ -249,9 +252,9 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
     error OptimismPortal_DisputeGameNotInvalidated();
 
     /// @notice Semantic version.
-    /// @custom:semver 5.9.0
+    /// @custom:semver 5.10.0
     function version() public pure virtual returns (string memory) {
-        return "5.9.0";
+        return "5.10.0";
     }
 
     /// @param _proofMaturityDelaySeconds The proof maturity delay in seconds.
@@ -491,10 +494,13 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
     }
 
     /// @notice Migrates the total ETH balance of this contract to the ETHLockbox.
+    ///         Custom gas token chains use the lockbox only as a pause source and cannot migrate ETH.
     function migrateLiquidity() public {
-        if (!_isUsingInterop()) revert OptimismPortal_NotUsingInterop();
+        if (!_isUsingLockbox()) revert OptimismPortal_NotUsingLockbox();
         // Liquidity migration can only be triggered by the ProxyAdmin owner.
         _assertOnlyProxyAdminOwner();
+
+        if (_isUsingCustomGasToken()) revert OptimismPortal_NotAllowedOnCGTMode();
 
         // Migrate the liquidity.
         uint256 ethBalance = address(this).balance;
@@ -809,12 +815,9 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
         }
     }
 
-    /// @notice Asserts that the ETHLockbox is set/unset correctly depending on the feature flag.
+    /// @notice Asserts that the ETHLockbox is configured.
     function _assertValidLockboxState() internal view {
-        if (
-            systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX) && address(ethLockbox) == address(0)
-                || !systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX) && address(ethLockbox) != address(0)
-        ) {
+        if (!systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX) || address(ethLockbox) == address(0)) {
             revert OptimismPortal_InvalidLockboxState();
         }
     }

--- a/packages/contracts-bedrock/src/L1/SystemConfig.sol
+++ b/packages/contracts-bedrock/src/L1/SystemConfig.sol
@@ -546,7 +546,9 @@ contract SystemConfig is ProxyAdminOwnedBase, OwnableUpgradeable, Reinitializabl
                 revert SystemConfig_InvalidFeatureState();
             }
 
-            // Do not change the pause key while the legacy key is paused.
+            // Enabling ETH_LOCKBOX switches paused() from the OptimismPortal identifier to the
+            // ETHLockbox identifier. Refuse while the OptimismPortal identifier is paused so the
+            // chain cannot become unpaused unexpectedly.
             if (superchainConfig.paused(optimismPortal())) {
                 revert SystemConfig_InvalidFeatureState();
             }

--- a/packages/contracts-bedrock/src/L1/SystemConfig.sol
+++ b/packages/contracts-bedrock/src/L1/SystemConfig.sol
@@ -175,9 +175,9 @@ contract SystemConfig is ProxyAdminOwnedBase, OwnableUpgradeable, Reinitializabl
     error SystemConfig_InvalidFeatureState();
 
     /// @notice Semantic version.
-    /// @custom:semver 4.0.0
+    /// @custom:semver 4.1.0
     function version() public pure virtual returns (string memory) {
-        return "4.0.0";
+        return "4.1.0";
     }
 
     /// @notice Constructs the SystemConfig contract.
@@ -541,26 +541,13 @@ contract SystemConfig is ProxyAdminOwnedBase, OwnableUpgradeable, Reinitializabl
 
         // Handle feature-specific safety logic here.
         if (_feature == Features.ETH_LOCKBOX) {
-            // It would probably better to check that the ETHLockbox contract is set inside the
-            // OptimismPortal2 contract before you're allowed to enable the feature here, but the
-            // portal checks that the feature is set before allowing you to set the lockbox, so
-            // these checks are good enough.
-
-            // Lockbox shouldn't be unset if the ethLockbox address is still configured in the
-            // OptimismPortal2 contract. Doing so would cause the system to start keeping ETH in
-            // the portal. This check means there's no way to stop using ETHLockbox at the moment
-            // after it's been configured (which is expected).
-            if (
-                isFeatureEnabled[_feature] && !_enabled
-                    && address(IOptimismPortal2(payable(optimismPortal())).ethLockbox()) != address(0)
-            ) {
+            // ETHLockbox cannot be disabled.
+            if (!_enabled) {
                 revert SystemConfig_InvalidFeatureState();
             }
 
-            // Lockbox can't be set or unset if the system is currently paused because it would
-            // change the pause identifier which would potentially cause the system to become
-            // unpaused unexpectedly.
-            if (paused()) {
+            // Do not change the pause key while the legacy key is paused.
+            if (superchainConfig.paused(optimismPortal())) {
                 revert SystemConfig_InvalidFeatureState();
             }
         }

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
@@ -158,9 +158,9 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
     ///         - Major bump: New required sequential upgrade
     ///         - Minor bump: Replacement OPCM for same upgrade
     ///         - Patch bump: Development changes (expected for normal dev work)
-    /// @custom:semver 8.0.3
+    /// @custom:semver 8.0.4
     function version() public pure returns (string memory) {
-        return "8.0.3";
+        return "8.0.4";
     }
 
     /// @param _standardValidator The standard validator for this OPCM release.
@@ -342,6 +342,11 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
         // even if the code is somehow forgotten it will not actually apply to the deployment. Make
         // sure to REMOVE the allowance once the upgrade is complete.
         if (SemverComp.lt(_version(), "9.0.0")) {
+            // Allow deploying an ETHLockbox for existing chains.
+            if (_isMatchingInstruction(_instruction, Constants.PERMITTED_PROXY_DEPLOYMENT_KEY, bytes("ETHLockbox"))) {
+                return true;
+            }
+
             // Super root games migration requires overriding anchor root.
             if (isDevFeatureEnabled(DevFeatures.SUPER_ROOT_GAMES_MIGRATION)) {
                 if (_isMatchingInstructionByKey(_instruction, "overrides.cfg.startingAnchorRoot")) return true;
@@ -443,28 +448,16 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
             )
         );
 
-        // ETHLockbox is a special case. It's only to be used or deployed if the ETH_LOCKBOX
-        // feature is enabled. If this is an initial deployment, we'll deploy a proxy for it
-        // largely because the legacy code expects this proxy to be deployed on initial deployment
-        // though this doesn't mean we actually have to set it up and initialize it. If this is an
-        // upgrade, we'll load/deploy the proxy only if the system feature is set.
-        // NOTE: It's important that we don't try to load the proxy here if we're upgrading a chain
-        // that doesn't have the feature enabled. Chains that don't have the feature enabled will
-        // return address(0) for optimismPortal.ethLockbox(). If we try to load the proxy here, we
-        // will revert because the contract returns the zero address (reverting is the safe thing
-        // to do, so we want to revert, but that would break the upgrade flow).
-        IETHLockbox ethLockbox;
-        if (isInitialDeployment || systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX)) {
-            ethLockbox = IETHLockbox(
-                _loadOrDeployProxy(
-                    address(optimismPortal),
-                    optimismPortal.ethLockbox.selector,
-                    proxyDeployArgs,
-                    "ETHLockbox",
-                    _extraInstructions
-                )
-            );
-        }
+        // Load or deploy the ETHLockbox.
+        IETHLockbox ethLockbox = IETHLockbox(
+            _loadOrDeployProxy(
+                address(optimismPortal),
+                optimismPortal.ethLockbox.selector,
+                proxyDeployArgs,
+                "ETHLockbox",
+                _extraInstructions
+            )
+        );
 
         // For every other contract, we load-or-build the proxy. Each contract has a theoretical
         // source where the address would be found. If the address isn't found there, we assume the
@@ -847,36 +840,41 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
             _cts.proxyAdmin, address(_cts.systemConfig), impls.systemConfigImpl, _makeSystemConfigInitArgs(_cfg, _cts)
         );
 
-        // Update the OptimismPortal. If a chain already uses ETHLockbox, preserve that lockbox
-        // during standard upgrades. New interop lockbox activation is performed by migrate().
-        bool isEthLockboxEnabled = _cts.systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX);
-        if (isEthLockboxEnabled && address(_cts.ethLockbox) == address(0)) {
+        // Enable ETHLockbox before updating the portal.
+        bool wasEthLockboxEnabled = _cts.systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX);
+        if (address(_cts.ethLockbox) == address(0)) {
             revert OPContractsManagerV2_InvalidEthLockbox();
         }
-        IETHLockbox portalLockbox = isEthLockboxEnabled ? _cts.ethLockbox : IETHLockbox(address(0));
+        if (!wasEthLockboxEnabled) {
+            _cts.systemConfig.setFeature(Features.ETH_LOCKBOX, true);
+        }
+
+        // Update the OptimismPortal.
         _upgrade(
             _cts.proxyAdmin,
             address(_cts.optimismPortal),
             impls.optimismPortalImpl,
-            abi.encodeCall(IOptimismPortal.initialize, (_cts.systemConfig, _cts.anchorStateRegistry, portalLockbox))
+            abi.encodeCall(IOptimismPortal.initialize, (_cts.systemConfig, _cts.anchorStateRegistry, _cts.ethLockbox))
         );
 
         // NOTE: Same general pattern, we call _upgrade for each contract rather than
         // iterating over some sort of array because it's easier to implement and understand.
 
-        // We upgrade/initialize the ETHLockbox if this is an initial deployment or if it's an
-        // upgrade and the ETH_LOCKBOX feature is enabled.
-        if (_isInitialDeployment || _cts.systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX)) {
-            IOptimismPortal[] memory portals = new IOptimismPortal[](1);
-            portals[0] = _cts.optimismPortal;
-            _upgrade(
-                _cts.proxyAdmin,
-                address(_cts.ethLockbox),
-                impls.ethLockboxImpl,
-                abi.encodeCall(
-                    IETHLockbox.initialize, (_systemConfigFor(_cts.systemConfig, address(_cts.ethLockbox)), portals)
-                )
-            );
+        // Update the ETHLockbox.
+        IOptimismPortal[] memory portals = new IOptimismPortal[](1);
+        portals[0] = _cts.optimismPortal;
+        _upgrade(
+            _cts.proxyAdmin,
+            address(_cts.ethLockbox),
+            impls.ethLockboxImpl,
+            abi.encodeCall(
+                IETHLockbox.initialize, (_systemConfigFor(_cts.systemConfig, address(_cts.ethLockbox)), portals)
+            )
+        );
+
+        // CGT chains use ETHLockbox only as a pause source.
+        if (!wasEthLockboxEnabled && !_cfg.useCustomGasToken) {
+            _cts.optimismPortal.migrateLiquidity();
         }
 
         // Update the L1CrossDomainMessenger.

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
@@ -872,7 +872,7 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
             )
         );
 
-        // CGT chains use ETHLockbox only as a pause source.
+        // Custom gas token chains keep custody in the portal and do not migrate ETH.
         if (!wasEthLockboxEnabled && !_cfg.useCustomGasToken) {
             _cts.optimismPortal.migrateLiquidity();
         }

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
@@ -341,12 +341,15 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
         // developers start working on the next release this will automatically become false so
         // even if the code is somehow forgotten it will not actually apply to the deployment. Make
         // sure to REMOVE the allowance once the upgrade is complete.
-        if (SemverComp.lt(_version(), "9.0.0")) {
-            // Allow deploying an ETHLockbox for existing chains.
+        // TODO(#22836): When OPCM bumps to v9, remove the anchor-root override here and from upgrade inputs.
+        if (SemverComp.parse(_version()).major == 9) {
+            // Allow deploying an ETHLockbox for existing chains only in the v9 release.
             if (_isMatchingInstruction(_instruction, Constants.PERMITTED_PROXY_DEPLOYMENT_KEY, bytes("ETHLockbox"))) {
                 return true;
             }
+        }
 
+        if (SemverComp.lt(_version(), "9.0.0")) {
             // Super root games migration requires overriding anchor root.
             if (isDevFeatureEnabled(DevFeatures.SUPER_ROOT_GAMES_MIGRATION)) {
                 if (_isMatchingInstructionByKey(_instruction, "overrides.cfg.startingAnchorRoot")) return true;

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
@@ -845,6 +845,10 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
 
         // Enable ETHLockbox before updating the portal.
         bool wasEthLockboxEnabled = _cts.systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX);
+        // The flag can be enabled without a configured lockbox. Check the old portal before
+        // reinitializing it, but skip the getter on initial deployments where it is not initialized.
+        bool wasUsingEthLockbox =
+            !_isInitialDeployment && wasEthLockboxEnabled && address(_cts.optimismPortal.ethLockbox()) != address(0);
         if (address(_cts.ethLockbox) == address(0)) {
             revert OPContractsManagerV2_InvalidEthLockbox();
         }
@@ -876,7 +880,7 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
         );
 
         // Custom gas token chains keep custody in the portal and do not migrate ETH.
-        if (!wasEthLockboxEnabled && !_cfg.useCustomGasToken) {
+        if (!wasUsingEthLockbox && !_cfg.useCustomGasToken) {
             _cts.optimismPortal.migrateLiquidity();
         }
 

--- a/packages/contracts-bedrock/src/libraries/Features.sol
+++ b/packages/contracts-bedrock/src/libraries/Features.sol
@@ -29,10 +29,7 @@ pragma solidity ^0.8.0;
 ///      System features have no Go mirror. For the parallel DEV feature checklist, see
 ///      packages/contracts-bedrock/src/libraries/DevFeatures.sol.
 library Features {
-    /// @notice The ETH_LOCKBOX feature determines if the system is configured to use the
-    ///         ETHLockbox contract in the OptimismPortal. When the ETH_LOCKBOX feature is active
-    ///         and the ETHLockbox contract has been configured, the OptimismPortal will use the
-    ///         ETHLockbox to store ETH instead of storing ETH directly in the portal itself.
+    /// @notice The ETH_LOCKBOX feature determines whether the system uses an ETHLockbox.
     bytes32 internal constant ETH_LOCKBOX = "ETH_LOCKBOX";
 
     /// @notice The CUSTOM_GAS_TOKEN feature determines if the system is configured to use a custom

--- a/packages/contracts-bedrock/test/L1/ETHLockbox.t.sol
+++ b/packages/contracts-bedrock/test/L1/ETHLockbox.t.sol
@@ -34,7 +34,7 @@ abstract contract ETHLockbox_TestInit is CommonTest {
         super.setUp();
 
         // If the ETHLockbox system feature is not enabled, skip these tests.
-        skipIfSysFeatureDisabled(Features.ETH_LOCKBOX);
+        assertTrue(systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX), "ETH_LOCKBOX must be enabled");
     }
 }
 

--- a/packages/contracts-bedrock/test/L1/OPContractsManagerStandardValidator.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManagerStandardValidator.t.sol
@@ -868,16 +868,28 @@ contract OPContractsManagerStandardValidator_OptimismPortal_Test is OPContractsM
 /// @title OPContractsManagerStandardValidator_ETHLockbox_Test
 /// @notice Tests validation of `ETHLockbox` configuration
 contract OPContractsManagerStandardValidator_ETHLockbox_Test is OPContractsManagerStandardValidator_TestInit {
+    /// @notice Tests that the ETHLockbox feature must be enabled.
+    function test_validate_ethLockboxFeatureDisabled_succeeds() public {
+        vm.mockCall(
+            address(systemConfig),
+            abi.encodeCall(ISystemConfig.isFeatureEnabled, (Features.ETH_LOCKBOX)),
+            abi.encode(false)
+        );
+        assertEq("LOCKBOX-00", _validate(true));
+    }
+
+    /// @notice Tests that the portal must reference an ETHLockbox.
+    function test_validate_ethLockboxMissing_succeeds() public {
+        vm.mockCall(address(optimismPortal2), abi.encodeCall(IOptimismPortal2.ethLockbox, ()), abi.encode(address(0)));
+        assertEq("LOCKBOX-05", _validate(true));
+    }
+
     /// @notice Tests that the validate function successfully returns the right error when the
     ///         ETHLockbox version is invalid.
     function test_validate_ethLockboxInvalidVersion_succeeds() public {
         vm.mockCall(address(ethLockbox), abi.encodeCall(ISemver.version, ()), abi.encode("0.0.0"));
 
-        if (isSysFeatureEnabled(Features.ETH_LOCKBOX)) {
-            assertEq("LOCKBOX-10", _validate(true));
-        } else {
-            assertEq("", _validate(true));
-        }
+        assertEq("LOCKBOX-10", _validate(true));
     }
 
     /// @notice Tests that the validate function successfully returns the right error when the
@@ -889,11 +901,7 @@ contract OPContractsManagerStandardValidator_ETHLockbox_Test is OPContractsManag
             abi.encode(address(0xbad))
         );
 
-        if (isSysFeatureEnabled(Features.ETH_LOCKBOX)) {
-            assertEq("LOCKBOX-20", _validate(true));
-        } else {
-            assertEq("", _validate(true));
-        }
+        assertEq("LOCKBOX-20", _validate(true));
     }
 
     /// @notice Tests that the validate function successfully returns the right error when the
@@ -903,11 +911,7 @@ contract OPContractsManagerStandardValidator_ETHLockbox_Test is OPContractsManag
             address(ethLockbox), abi.encodeCall(IProxyAdminOwnedBase.proxyAdmin, ()), abi.encode(address(0xbad))
         );
 
-        if (isSysFeatureEnabled(Features.ETH_LOCKBOX)) {
-            assertEq("LOCKBOX-30", _validate(true));
-        } else {
-            assertEq("", _validate(true));
-        }
+        assertEq("LOCKBOX-30", _validate(true));
     }
 
     /// @notice Tests that the validate function successfully returns the right error when the
@@ -915,11 +919,7 @@ contract OPContractsManagerStandardValidator_ETHLockbox_Test is OPContractsManag
     function test_validate_ethLockboxInvalidSystemConfig_succeeds() public {
         vm.mockCall(address(ethLockbox), abi.encodeCall(IETHLockbox.systemConfig, ()), abi.encode(address(0xbad)));
 
-        if (isSysFeatureEnabled(Features.ETH_LOCKBOX)) {
-            assertEq("LOCKBOX-40", _validate(true));
-        } else {
-            assertEq("", _validate(true));
-        }
+        assertEq("LOCKBOX-40", _validate(true));
     }
 
     /// @notice Tests that the validate function successfully returns the right error when the
@@ -929,11 +929,7 @@ contract OPContractsManagerStandardValidator_ETHLockbox_Test is OPContractsManag
             address(ethLockbox), abi.encodeCall(IETHLockbox.authorizedPortals, (optimismPortal2)), abi.encode(false)
         );
 
-        if (isSysFeatureEnabled(Features.ETH_LOCKBOX)) {
-            assertEq("LOCKBOX-50", _validate(true));
-        } else {
-            assertEq("", _validate(true));
-        }
+        assertEq("LOCKBOX-50", _validate(true));
     }
 }
 
@@ -1885,6 +1881,16 @@ abstract contract OPContractsManagerStandardValidator_SuperMode_TestInit is Supe
 contract OPContractsManagerStandardValidator_SuperModeCoreValidation_Test is
     OPContractsManagerStandardValidator_SuperMode_TestInit
 {
+    /// @notice Tests that the ETHLockbox feature must be enabled.
+    function test_validate_ethLockboxFeatureDisabled_succeeds() public {
+        vm.mockCall(
+            address(systemConfig),
+            abi.encodeCall(ISystemConfig.isFeatureEnabled, (Features.ETH_LOCKBOX)),
+            abi.encode(false)
+        );
+        assertEq("LOCKBOX-00", _validate(true));
+    }
+
     /// @notice Tests that the validate function succeeds in super mode with all games configured.
     function test_validate_succeeds() public view {
         string memory errors = _validate(false);

--- a/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
+++ b/packages/contracts-bedrock/test/L1/OptimismPortal2.t.sol
@@ -684,10 +684,15 @@ contract OptimismPortal2_DonateETH_Test is OptimismPortal2_TestInit {
 /// @title OptimismPortal2_MigrateLiquidity_Test
 /// @notice Test contract for OptimismPortal2 `migrateLiquidity` function.
 contract OptimismPortal2_MigrateLiquidity_Test is OptimismPortal2_TestInit {
-    function setUp() public virtual override {
-        super.setUp();
-        skipIfDevFeatureDisabled(DevFeatures.OPTIMISM_PORTAL_INTEROP);
-        forceEnableInterop();
+    /// @notice Tests that liquidity migration requires a configured lockbox.
+    function test_migrateLiquidity_noLockbox_reverts() external {
+        StorageSlot memory slot = ForgeArtifacts.getSlot("OptimismPortal2", "ethLockbox");
+        vm.store(address(optimismPortal2), bytes32(slot.slot), bytes32(0));
+        address proxyAdminOwner = optimismPortal2.proxyAdminOwner();
+
+        vm.expectRevert(IOptimismPortal.OptimismPortal_NotUsingLockbox.selector);
+        vm.prank(proxyAdminOwner);
+        optimismPortal2.migrateLiquidity();
     }
 
     /// @notice Tests the liquidity migration from the portal to the lockbox reverts if not called
@@ -701,6 +706,7 @@ contract OptimismPortal2_MigrateLiquidity_Test is OptimismPortal2_TestInit {
 
     /// @notice Tests that the liquidity migration from the portal to the lockbox succeeds.
     function test_migrateLiquidity_succeeds(uint256 _portalBalance) external {
+        skipIfSysFeatureEnabled(Features.CUSTOM_GAS_TOKEN);
         _portalBalance = uint256(bound(_portalBalance, 0, type(uint256).max - address(ethLockbox).balance));
         vm.deal(address(optimismPortal2), _portalBalance);
 
@@ -717,6 +723,23 @@ contract OptimismPortal2_MigrateLiquidity_Test is OptimismPortal2_TestInit {
 
         assertEq(address(optimismPortal2).balance, 0);
         assertEq(address(ethLockbox).balance, lockboxBalanceBefore + _portalBalance);
+    }
+
+    /// @notice Tests that the ProxyAdmin owner cannot migrate ETH on a custom gas token chain.
+    function test_migrateLiquidity_customGasToken_reverts() external {
+        skipIfSysFeatureDisabled(Features.CUSTOM_GAS_TOKEN);
+        assertTrue(systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX));
+        assertTrue(ethLockbox.authorizedPortals(optimismPortal2));
+        vm.deal(address(optimismPortal2), 1 ether);
+        uint256 lockboxBalanceBefore = address(ethLockbox).balance;
+        address proxyAdminOwner = optimismPortal2.proxyAdminOwner();
+
+        vm.expectRevert(IOptimismPortal.OptimismPortal_NotAllowedOnCGTMode.selector);
+        vm.prank(proxyAdminOwner);
+        optimismPortal2.migrateLiquidity();
+
+        assertEq(address(optimismPortal2).balance, 1 ether);
+        assertEq(address(ethLockbox).balance, lockboxBalanceBefore);
     }
 }
 
@@ -1624,11 +1647,8 @@ contract OptimismPortal2_FinalizeWithdrawalTransaction_Test is OptimismPortal2_T
     /// @notice Tests that `finalizeWithdrawalTransaction` reverts if the target reverts when
     ///         using the ETHLockbox.
     function test_finalizeWithdrawalTransaction_lockboxAndTargetFails_fails() external {
-        // Enable the ETHLockbox.
-        address dummyLockbox = address(0xdeadbeef);
-        forceEnableLockbox(dummyLockbox);
-        vm.deal(address(dummyLockbox), 0xFFFFFFFF);
-        vm.deal(address(optimismPortal2), _defaultTx.value);
+        vm.deal(address(ethLockbox), 0xFFFFFFFF);
+        vm.deal(address(optimismPortal2), 0);
 
         uint256 bobBalanceBefore = address(bob).balance;
         vm.etch(bob, hex"fe"); // Contract with just the invalid opcode.

--- a/packages/contracts-bedrock/test/L1/SystemConfig.t.sol
+++ b/packages/contracts-bedrock/test/L1/SystemConfig.t.sol
@@ -646,19 +646,27 @@ contract SystemConfig_Paused_Test is SystemConfig_TestInit {
         assertTrue(systemConfig.paused());
     }
 
-    /// @notice Tests that `paused()` ignores the legacy OptimismPortal pause identifier now that
-    ///         every chain uses the ETHLockbox.
+    /// @notice Tests that `paused()` returns true when OptimismPortal identifier is paused and
+    ///         the ETH_LOCKBOX feature is disabled.
     function test_paused_optimismPortalIdentifier_succeeds() external {
+        skipIfSysFeatureEnabled(Features.ETH_LOCKBOX);
+
+        // Initially not paused
         assertFalse(systemConfig.paused());
 
+        // Pause the system with OptimismPortal identifier
         vm.prank(superchainConfig.guardian());
         superchainConfig.pause(address(optimismPortal2));
 
-        assertFalse(systemConfig.paused());
+        // Verify paused state
+        assertTrue(systemConfig.paused());
     }
 
-    /// @notice Tests that `paused()` returns true when the ETHLockbox identifier is paused.
+    /// @notice Tests that `paused()` returns true when ETHLockbox identifier is paused and
+    ///         ETH_LOCKBOX feature is enabled.
     function test_paused_ethLockboxIdentifier_succeeds() external {
+        skipIfSysFeatureDisabled(Features.ETH_LOCKBOX);
+
         // Initially not paused
         assertFalse(systemConfig.paused());
 
@@ -674,10 +682,10 @@ contract SystemConfig_Paused_Test is SystemConfig_TestInit {
     function test_paused_bothPausesActive_succeeds() external {
         assertFalse(systemConfig.paused());
 
-        // Pause globally and by lockbox.
+        // Pause both globally and with identifier
         vm.startPrank(superchainConfig.guardian());
         superchainConfig.pause(address(0));
-        superchainConfig.pause(address(ethLockbox));
+        superchainConfig.pause(address(optimismPortal2));
         vm.stopPrank();
 
         // Verify paused state

--- a/packages/contracts-bedrock/test/L1/SystemConfig.t.sol
+++ b/packages/contracts-bedrock/test/L1/SystemConfig.t.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.15;
 
 // Testing
 import { CommonTest } from "test/setup/CommonTest.sol";
+import { stdStorage, StdStorage } from "forge-std/StdStorage.sol";
 
 // Scripts
 import { ForgeArtifacts, StorageSlot } from "scripts/libraries/ForgeArtifacts.sol";
@@ -645,27 +646,19 @@ contract SystemConfig_Paused_Test is SystemConfig_TestInit {
         assertTrue(systemConfig.paused());
     }
 
-    /// @notice Tests that `paused()` returns true when OptimismPortal identifier is paused and
-    ///         the ETH_LOCKBOX feature is disabled.
+    /// @notice Tests that `paused()` ignores the legacy OptimismPortal pause identifier now that
+    ///         every chain uses the ETHLockbox.
     function test_paused_optimismPortalIdentifier_succeeds() external {
-        skipIfSysFeatureEnabled(Features.ETH_LOCKBOX);
-
-        // Initially not paused
         assertFalse(systemConfig.paused());
 
-        // Pause the system with OptimismPortal identifier
         vm.prank(superchainConfig.guardian());
         superchainConfig.pause(address(optimismPortal2));
 
-        // Verify paused state
-        assertTrue(systemConfig.paused());
+        assertFalse(systemConfig.paused());
     }
 
-    /// @notice Tests that `paused()` returns true when ETHLockbox identifier is paused and
-    ///         ETH_LOCKBOX feature is enabled.
+    /// @notice Tests that `paused()` returns true when the ETHLockbox identifier is paused.
     function test_paused_ethLockboxIdentifier_succeeds() external {
-        skipIfSysFeatureDisabled(Features.ETH_LOCKBOX);
-
         // Initially not paused
         assertFalse(systemConfig.paused());
 
@@ -681,10 +674,10 @@ contract SystemConfig_Paused_Test is SystemConfig_TestInit {
     function test_paused_bothPausesActive_succeeds() external {
         assertFalse(systemConfig.paused());
 
-        // Pause both globally and with identifier
+        // Pause globally and by lockbox.
         vm.startPrank(superchainConfig.guardian());
         superchainConfig.pause(address(0));
-        superchainConfig.pause(address(optimismPortal2));
+        superchainConfig.pause(address(ethLockbox));
         vm.stopPrank();
 
         // Verify paused state
@@ -713,6 +706,8 @@ contract SystemConfig_Paused_Test is SystemConfig_TestInit {
 /// @title SystemConfig_SetFeature_Test
 /// @notice Test contract for SystemConfig `setFeature` function.
 contract SystemConfig_SetFeature_Test is SystemConfig_TestInit {
+    using stdStorage for StdStorage;
+
     event FeatureSet(bytes32 indexed feature, bool indexed enabled);
 
     /// @notice Tests that `setFeature` reverts if the caller is not ProxyAdmin or ProxyAdmin owner.
@@ -807,68 +802,42 @@ contract SystemConfig_SetFeature_Test is SystemConfig_TestInit {
         systemConfig.setFeature("EXAMPLE FEATURE", false);
     }
 
-    /// @notice Tests that disabling ETH_LOCKBOX reverts if the OptimismPortal has a non-zero
-    ///         ETHLockbox configured.
-    function test_setFeature_ethLockboxDisableWhileConfigured_reverts() external {
+    /// @notice Tests that ETH_LOCKBOX cannot be disabled.
+    function test_setFeature_ethLockboxDisable_reverts() external {
         address proxyAdmin = address(systemConfig.proxyAdmin());
-
-        // Ensure ETH_LOCKBOX is enabled first (no pause active in fresh setup).
-        if (!systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX)) {
-            vm.prank(proxyAdmin);
-            systemConfig.setFeature(Features.ETH_LOCKBOX, true);
-            assertTrue(systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX));
-        }
-
-        // Force the portal to have a configured ETHLockbox address.
-        StorageSlot memory slot = ForgeArtifacts.getSlot("OptimismPortal2", "ethLockbox");
-        vm.store(address(optimismPortal2), bytes32(slot.slot), bytes32(uint256(uint160(address(1)))));
-
-        // Disabling should revert due to safety check while lockbox is configured.
+        stdstore.target(address(systemConfig)).sig("isFeatureEnabled(bytes32)").with_key(Features.ETH_LOCKBOX)
+            .checked_write(true);
         vm.expectRevert(ISystemConfig.SystemConfig_InvalidFeatureState.selector);
         vm.prank(proxyAdmin);
         systemConfig.setFeature(Features.ETH_LOCKBOX, false);
     }
 
-    /// @notice Tests that enabling ETH_LOCKBOX while the system is paused (global) reverts.
-    function test_setFeature_ethLockboxEnableWhilePaused_reverts() external {
+    /// @notice Tests that a global pause does not block ETHLockbox activation.
+    function test_setFeature_ethLockboxEnableWhileGloballyPaused_succeeds() external {
         address proxyAdmin = address(systemConfig.proxyAdmin());
+        stdstore.target(address(systemConfig)).sig("isFeatureEnabled(bytes32)").with_key(Features.ETH_LOCKBOX)
+            .checked_write(false);
 
-        // Ensure ETH_LOCKBOX is enabled first (no pause active in fresh setup).
-        if (!systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX)) {
-            vm.prank(proxyAdmin);
-            systemConfig.setFeature(Features.ETH_LOCKBOX, true);
-            assertTrue(systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX));
-        }
-
-        // Pause globally.
         vm.prank(superchainConfig.guardian());
         superchainConfig.pause(address(0));
 
-        // Enabling while paused should revert.
+        vm.prank(proxyAdmin);
+        systemConfig.setFeature(Features.ETH_LOCKBOX, true);
+        assertTrue(systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX));
+        assertTrue(systemConfig.paused());
+    }
+
+    /// @notice Tests that a portal-scoped pause blocks ETHLockbox activation.
+    function test_setFeature_ethLockboxEnableWhilePortalPaused_reverts() external {
+        address proxyAdmin = address(systemConfig.proxyAdmin());
+        stdstore.target(address(systemConfig)).sig("isFeatureEnabled(bytes32)").with_key(Features.ETH_LOCKBOX)
+            .checked_write(false);
+        vm.prank(superchainConfig.guardian());
+        superchainConfig.pause(address(optimismPortal2));
+
         vm.expectRevert(ISystemConfig.SystemConfig_InvalidFeatureState.selector);
         vm.prank(proxyAdmin);
         systemConfig.setFeature(Features.ETH_LOCKBOX, true);
-    }
-
-    /// @notice Tests that disabling ETH_LOCKBOX while the system is paused (global) reverts.
-    function test_setFeature_ethLockboxDisableWhilePaused_reverts() external {
-        address proxyAdmin = address(systemConfig.proxyAdmin());
-
-        // Ensure ETH_LOCKBOX is enabled first.
-        if (!systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX)) {
-            vm.prank(proxyAdmin);
-            systemConfig.setFeature(Features.ETH_LOCKBOX, true);
-            assertTrue(systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX));
-        }
-
-        // Pause globally.
-        vm.prank(superchainConfig.guardian());
-        superchainConfig.pause(address(0));
-
-        // Disabling while paused should revert.
-        vm.expectRevert(ISystemConfig.SystemConfig_InvalidFeatureState.selector);
-        vm.prank(proxyAdmin);
-        systemConfig.setFeature(Features.ETH_LOCKBOX, false);
     }
 }
 

--- a/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.15;
 
 // Testing
 import { VmSafe } from "forge-std/Vm.sol";
+import { stdStorage, StdStorage } from "forge-std/StdStorage.sol";
 import { CommonTest } from "test/setup/CommonTest.sol";
 import { DisputeGames } from "test/setup/DisputeGames.sol";
 import { PastUpgrades } from "test/setup/PastUpgrades.sol";
@@ -259,6 +260,12 @@ contract OPContractsManagerV2_Upgrade_TestInit is OPContractsManagerV2_TestInit 
         address initialChallengerForV2 = DisputeGames.permissionedGameChallenger(disputeGameFactory);
         address initialProposerForV2 = DisputeGames.permissionedGameProposer(disputeGameFactory);
         v2UpgradeInput.systemConfig = systemConfig;
+        v2UpgradeInput.extraInstructions.push(
+            IOPContractsManagerUtils.ExtraInstruction({
+                key: Constants.PERMITTED_PROXY_DEPLOYMENT_KEY,
+                data: bytes("ETHLockbox")
+            })
+        );
         v2UpgradeInput.disputeGameConfigs.push(
             IOPContractsManagerUtils.DisputeGameConfig({
                 enabled: false,
@@ -534,8 +541,8 @@ contract OPContractsManagerV2_Upgrade_Test is OPContractsManagerV2_Upgrade_TestI
         runCurrentUpgradeV2(chainPAO);
     }
 
-    /// @notice Tests that upgrade does not perform one-off interop activation.
-    function test_upgrade_doesNotActivateInterop_succeeds() public {
+    /// @notice Tests upgrading a chain without ETHLockbox enabled.
+    function test_upgrade_activatesLockboxWithoutActivatingInterop_succeeds() public {
         bool interopEnabledBefore = systemConfig.isFeatureEnabled(Features.INTEROP);
         bool lockboxEnabledBefore = systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX);
         uint256 portalBalanceBefore = 1 ether;
@@ -547,11 +554,17 @@ contract OPContractsManagerV2_Upgrade_Test is OPContractsManagerV2_Upgrade_TestI
         runCurrentUpgradeV2(chainPAO);
 
         assertEq(systemConfig.isFeatureEnabled(Features.INTEROP), interopEnabledBefore, "INTEROP activation changed");
-        assertEq(
-            systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX), lockboxEnabledBefore, "ETH_LOCKBOX activation changed"
-        );
-        assertEq(address(optimismPortal2).balance, portalBalanceBefore, "portal liquidity migrated during upgrade");
-        assertEq(address(lockboxBefore).balance, lockboxBalanceBefore, "lockbox balance changed during upgrade");
+        assertTrue(systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX), "ETH_LOCKBOX was not activated");
+
+        IETHLockbox lockboxAfter = optimismPortal2.ethLockbox();
+        assertNotEq(address(lockboxAfter), address(0), "portal has no ETHLockbox");
+        if (lockboxEnabledBefore) {
+            assertEq(address(optimismPortal2).balance, portalBalanceBefore, "existing lockbox remigrated liquidity");
+            assertEq(address(lockboxAfter).balance, lockboxBalanceBefore, "existing lockbox balance changed");
+        } else {
+            assertEq(address(optimismPortal2).balance, 0, "legacy portal liquidity not migrated");
+            assertEq(address(lockboxAfter).balance, portalBalanceBefore, "new lockbox did not receive portal liquidity");
+        }
     }
 
     /// @notice Tests that the upgrade function reverts when not delegatecalled.
@@ -675,8 +688,6 @@ contract OPContractsManagerV2_Upgrade_Test is OPContractsManagerV2_Upgrade_TestI
     /// @notice Tests that the V2 upgrade function reverts if a permitted proxy deployment is
     ///         required but missing.
     function test_upgrade_missingPermittedProxyDeployment_reverts() public {
-        delete v2UpgradeInput.extraInstructions;
-
         // Simulate a missing DelayedWETH proxy so the upgrade path would need to deploy it.
         // nosemgrep: sol-style-use-abi-encodecall
         vm.mockCallRevert(address(systemConfig), abi.encodeWithSelector(ISystemConfig.delayedWETH.selector), "");
@@ -1778,6 +1789,8 @@ contract OPContractsManagerV2_UpgradeSuperchain_Test is OPContractsManagerV2_Upg
 /// @title OPContractsManagerV2_Deploy_Test
 /// @notice Tests OPContractsManagerV2.deploy
 contract OPContractsManagerV2_Deploy_Test is OPContractsManagerV2_TestInit {
+    using stdStorage for StdStorage;
+
     /// @notice Default deploy config.
     IOPContractsManagerV2.FullConfig deployConfig;
 
@@ -1941,6 +1954,72 @@ contract OPContractsManagerV2_Deploy_Test is OPContractsManagerV2_TestInit {
         });
     }
 
+    /// @notice Recreates the legacy disabled-lockbox storage state for upgrade tests.
+    function _setLegacyLockboxState(ISystemConfig _systemConfig, IOptimismPortal2 _portal) internal {
+        stdstore.target(address(_systemConfig)).sig("isFeatureEnabled(bytes32)").with_key(Features.ETH_LOCKBOX)
+            .checked_write(false);
+        stdstore.target(address(_systemConfig)).sig("isFeatureEnabled(bytes32)").with_key(Features.INTEROP)
+            .checked_write(false);
+        StorageSlot memory slot = ForgeArtifacts.getSlot("OptimismPortal2", "ethLockbox");
+        vm.store(address(_portal), bytes32(slot.slot), bytes32(0));
+        assertFalse(_systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX));
+        assertEq(address(_portal.ethLockbox()), address(0));
+    }
+
+    /// @notice Tests lockbox deployment permission and first activation without requiring a fork.
+    function test_upgrade_missingLockbox_succeeds() public {
+        IOPContractsManagerV2.ChainContracts memory cts = opcmV2.deploy(deployConfig);
+        _setLegacyLockboxState(cts.systemConfig, cts.optimismPortal);
+        vm.deal(address(cts.optimismPortal), 1 ether);
+
+        IOPContractsManagerV2.UpgradeInput memory input;
+        input.systemConfig = cts.systemConfig;
+        input.disputeGameConfigs = deployConfig.disputeGameConfigs;
+        address pao = cts.proxyAdmin.owner();
+
+        // Without the instruction, the upgrade must stop before changing any chain state.
+        prankDelegateCall(pao);
+        (bool success, bytes memory reason) =
+            address(opcmV2).delegatecall(abi.encodeCall(IOPContractsManagerV2.upgrade, (input)));
+        assertFalse(success);
+        // nosemgrep: sol-style-use-abi-encodecall
+        assertEq(
+            reason,
+            abi.encodeWithSelector(
+                IOPContractsManagerUtils.OPContractsManagerUtils_ProxyMustLoad.selector, "ETHLockbox"
+            )
+        );
+        assertEq(address(cts.optimismPortal.ethLockbox()), address(0));
+        assertFalse(cts.systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX));
+        assertEq(address(cts.optimismPortal).balance, 1 ether);
+
+        input.extraInstructions = new IOPContractsManagerUtils.ExtraInstruction[](1);
+        input.extraInstructions[0] = IOPContractsManagerUtils.ExtraInstruction({
+            key: Constants.PERMITTED_PROXY_DEPLOYMENT_KEY,
+            data: bytes("ETHLockbox")
+        });
+        prankDelegateCall(pao);
+        (success,) = address(opcmV2).delegatecall(abi.encodeCall(IOPContractsManagerV2.upgrade, (input)));
+        assertTrue(success, "upgrade failed");
+
+        IETHLockbox lockbox = cts.optimismPortal.ethLockbox();
+        assertNotEq(address(lockbox), address(0));
+        assertTrue(cts.systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX));
+        assertFalse(cts.systemConfig.isFeatureEnabled(Features.INTEROP));
+        assertTrue(lockbox.authorizedPortals(cts.optimismPortal));
+        assertEq(address(cts.optimismPortal).balance, 0);
+        assertEq(address(lockbox).balance, 1 ether);
+
+        // Repeating the upgrade reuses the lockbox and does not migrate portal liquidity again.
+        vm.deal(address(cts.optimismPortal), 2 ether);
+        prankDelegateCall(pao);
+        (success,) = address(opcmV2).delegatecall(abi.encodeCall(IOPContractsManagerV2.upgrade, (input)));
+        assertTrue(success, "repeat upgrade failed");
+        assertEq(address(cts.optimismPortal.ethLockbox()), address(lockbox));
+        assertEq(address(cts.optimismPortal).balance, 2 ether);
+        assertEq(address(lockbox).balance, 1 ether);
+    }
+
     /// @notice Tests that the deploy function succeeds and passes standard validation.
     function test_deploy_succeeds() public {
         // Run the deploy and standard validator checks.
@@ -1953,6 +2032,7 @@ contract OPContractsManagerV2_Deploy_Test is OPContractsManagerV2_TestInit {
         assertTrue(address(cts.systemConfig) != address(0), "systemConfig not deployed");
         assertTrue(address(cts.proxyAdmin) != address(0), "proxyAdmin not deployed");
         assertTrue(address(cts.optimismPortal) != address(0), "optimismPortal not deployed");
+        assertTrue(address(cts.ethLockbox) != address(0), "ethLockbox not deployed");
         assertTrue(address(cts.disputeGameFactory) != address(0), "disputeGameFactory not deployed");
         assertTrue(address(cts.anchorStateRegistry) != address(0), "anchorStateRegistry not deployed");
         assertTrue(address(cts.delayedWETH) != address(0), "delayedWETH not deployed");
@@ -1960,6 +2040,37 @@ contract OPContractsManagerV2_Deploy_Test is OPContractsManagerV2_TestInit {
         // Verify ownership is transferred to proxyAdminOwner.
         assertEq(cts.proxyAdmin.owner(), deployConfig.proxyAdminOwner, "proxyAdmin owner mismatch");
         assertEq(cts.disputeGameFactory.owner(), deployConfig.proxyAdminOwner, "disputeGameFactory owner mismatch");
+        assertTrue(cts.systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX), "ETH_LOCKBOX not enabled");
+        assertEq(address(cts.optimismPortal.ethLockbox()), address(cts.ethLockbox), "portal lockbox mismatch");
+    }
+
+    /// @notice Tests deploying a custom gas token chain.
+    function test_deploy_customGasTokenUsesLockboxPauseSource_succeeds() public {
+        deployConfig.useCustomGasToken = true;
+
+        bool superRoot = isDevFeatureEnabled(DevFeatures.SUPER_ROOT_GAMES_MIGRATION);
+        string memory expectedErrors = superRoot ? "SCKDG-SHAPE,SCKDG-10" : "CKDG-NOSHAPE,CKDG-10";
+        IOPContractsManagerV2.ChainContracts memory cts = runDeployV2(deployConfig, bytes(""), expectedErrors);
+
+        assertTrue(cts.systemConfig.isCustomGasToken(), "CGT not enabled");
+        assertTrue(cts.systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX), "ETH_LOCKBOX not enabled");
+        assertEq(address(cts.optimismPortal.ethLockbox()), address(cts.ethLockbox), "portal lockbox mismatch");
+
+        uint256 portalBalance = address(cts.optimismPortal).balance;
+        uint256 lockboxBalance = address(cts.ethLockbox).balance;
+        uint64 gasLimit = cts.optimismPortal.minimumGasLimit(0);
+        vm.deal(address(this), 1 ether);
+        vm.expectRevert(IOptimismPortal2.OptimismPortal_NotAllowedOnCGTMode.selector);
+        cts.optimismPortal.depositTransaction{ value: 1 ether }(address(this), 0, gasLimit, false, bytes(""));
+        assertEq(address(cts.optimismPortal).balance, portalBalance, "CGT portal ETH balance changed");
+        assertEq(address(cts.ethLockbox).balance, lockboxBalance, "CGT lockbox received ETH");
+
+        vm.prank(superchainConfig.guardian());
+        superchainConfig.pause(address(cts.ethLockbox));
+        assertTrue(cts.ethLockbox.paused(), "lockbox not paused");
+        assertTrue(cts.systemConfig.paused(), "SystemConfig not paused");
+        assertTrue(cts.optimismPortal.paused(), "portal not paused");
+        assertTrue(cts.anchorStateRegistry.paused(), "ASR not paused");
     }
 
     /// @notice Tests that deploy reverts when the superchainConfig needs upgrade.

--- a/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
@@ -1968,8 +1968,21 @@ contract OPContractsManagerV2_Deploy_Test is OPContractsManagerV2_TestInit {
 
     /// @notice Tests lockbox deployment permission and first activation without requiring a fork.
     function test_upgrade_missingLockbox_succeeds() public {
+        _testUpgradeMissingLockbox(false);
+    }
+
+    /// @notice Tests that a CGT chain without a lockbox can upgrade without migrating portal ETH.
+    function test_upgrade_missingLockboxCGT_succeeds() public {
+        _testUpgradeMissingLockbox(true);
+    }
+
+    /// @notice Tests first lockbox activation and repeat upgrades for ETH and CGT chains.
+    /// @param _useCustomGasToken Whether the chain uses a custom gas token.
+    function _testUpgradeMissingLockbox(bool _useCustomGasToken) internal {
+        deployConfig.useCustomGasToken = _useCustomGasToken;
         IOPContractsManagerV2.ChainContracts memory cts = opcmV2.deploy(deployConfig);
         _setLegacyLockboxState(cts.systemConfig, cts.optimismPortal);
+        assertEq(cts.systemConfig.isCustomGasToken(), _useCustomGasToken);
         vm.deal(address(cts.optimismPortal), 1 ether);
 
         IOPContractsManagerV2.UpgradeInput memory input;
@@ -2006,9 +2019,10 @@ contract OPContractsManagerV2_Deploy_Test is OPContractsManagerV2_TestInit {
         assertNotEq(address(lockbox), address(0));
         assertTrue(cts.systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX));
         assertFalse(cts.systemConfig.isFeatureEnabled(Features.INTEROP));
+        assertEq(cts.systemConfig.isCustomGasToken(), _useCustomGasToken);
         assertTrue(lockbox.authorizedPortals(cts.optimismPortal));
-        assertEq(address(cts.optimismPortal).balance, 0);
-        assertEq(address(lockbox).balance, 1 ether);
+        assertEq(address(cts.optimismPortal).balance, _useCustomGasToken ? 1 ether : 0);
+        assertEq(address(lockbox).balance, _useCustomGasToken ? 0 : 1 ether);
 
         // Repeating the upgrade reuses the lockbox and does not migrate portal liquidity again.
         vm.deal(address(cts.optimismPortal), 2 ether);
@@ -2016,8 +2030,9 @@ contract OPContractsManagerV2_Deploy_Test is OPContractsManagerV2_TestInit {
         (success,) = address(opcmV2).delegatecall(abi.encodeCall(IOPContractsManagerV2.upgrade, (input)));
         assertTrue(success, "repeat upgrade failed");
         assertEq(address(cts.optimismPortal.ethLockbox()), address(lockbox));
+        assertEq(cts.systemConfig.isCustomGasToken(), _useCustomGasToken);
         assertEq(address(cts.optimismPortal).balance, 2 ether);
-        assertEq(address(lockbox).balance, 1 ether);
+        assertEq(address(lockbox).balance, _useCustomGasToken ? 0 : 1 ether);
     }
 
     /// @notice Tests that the deploy function succeeds and passes standard validation.

--- a/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
@@ -2044,8 +2044,9 @@ contract OPContractsManagerV2_Deploy_Test is OPContractsManagerV2_TestInit {
         assertEq(address(cts.optimismPortal.ethLockbox()), address(cts.ethLockbox), "portal lockbox mismatch");
     }
 
-    /// @notice Tests deploying a custom gas token chain.
-    function test_deploy_customGasTokenUsesLockboxPauseSource_succeeds() public {
+    /// @notice Tests deploying a custom gas token chain. The ETHLockbox is enabled but the portal
+    ///         keeps custody of ETH.
+    function test_deploy_customGasToken_succeeds() public {
         deployConfig.useCustomGasToken = true;
 
         bool superRoot = isDevFeatureEnabled(DevFeatures.SUPER_ROOT_GAMES_MIGRATION);
@@ -2064,13 +2065,6 @@ contract OPContractsManagerV2_Deploy_Test is OPContractsManagerV2_TestInit {
         cts.optimismPortal.depositTransaction{ value: 1 ether }(address(this), 0, gasLimit, false, bytes(""));
         assertEq(address(cts.optimismPortal).balance, portalBalance, "CGT portal ETH balance changed");
         assertEq(address(cts.ethLockbox).balance, lockboxBalance, "CGT lockbox received ETH");
-
-        vm.prank(superchainConfig.guardian());
-        superchainConfig.pause(address(cts.ethLockbox));
-        assertTrue(cts.ethLockbox.paused(), "lockbox not paused");
-        assertTrue(cts.systemConfig.paused(), "SystemConfig not paused");
-        assertTrue(cts.optimismPortal.paused(), "portal not paused");
-        assertTrue(cts.anchorStateRegistry.paused(), "ASR not paused");
     }
 
     /// @notice Tests that deploy reverts when the superchainConfig needs upgrade.

--- a/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
@@ -16,6 +16,7 @@ import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
 import { Claim, Duration, Hash } from "src/dispute/lib/LibUDT.sol";
 import { GameType, GameTypes, Proposal } from "src/dispute/lib/Types.sol";
 import { LibGameArgs } from "src/dispute/lib/LibGameArgs.sol";
+import { SemverComp } from "src/libraries/SemverComp.sol";
 import { Constants } from "src/libraries/Constants.sol";
 import { DevFeatures } from "src/libraries/DevFeatures.sol";
 import { Features } from "src/libraries/Features.sol";
@@ -260,12 +261,14 @@ contract OPContractsManagerV2_Upgrade_TestInit is OPContractsManagerV2_TestInit 
         address initialChallengerForV2 = DisputeGames.permissionedGameChallenger(disputeGameFactory);
         address initialProposerForV2 = DisputeGames.permissionedGameProposer(disputeGameFactory);
         v2UpgradeInput.systemConfig = systemConfig;
-        v2UpgradeInput.extraInstructions.push(
-            IOPContractsManagerUtils.ExtraInstruction({
-                key: Constants.PERMITTED_PROXY_DEPLOYMENT_KEY,
-                data: bytes("ETHLockbox")
-            })
-        );
+        if (SemverComp.parse(opcmV2.version()).major == 9) {
+            v2UpgradeInput.extraInstructions.push(
+                IOPContractsManagerUtils.ExtraInstruction({
+                    key: Constants.PERMITTED_PROXY_DEPLOYMENT_KEY,
+                    data: bytes("ETHLockbox")
+                })
+            );
+        }
         v2UpgradeInput.disputeGameConfigs.push(
             IOPContractsManagerUtils.DisputeGameConfig({
                 enabled: false,
@@ -1968,12 +1971,64 @@ contract OPContractsManagerV2_Deploy_Test is OPContractsManagerV2_TestInit {
 
     /// @notice Tests lockbox deployment permission and first activation without requiring a fork.
     function test_upgrade_missingLockbox_succeeds() public {
+        vm.mockCall(address(opcmV2), abi.encodeCall(IOPContractsManagerV2.version, ()), abi.encode("9.0.0"));
         _testUpgradeMissingLockbox(false);
     }
 
     /// @notice Tests that a CGT chain without a lockbox can upgrade without migrating portal ETH.
     function test_upgrade_missingLockboxCGT_succeeds() public {
+        vm.mockCall(address(opcmV2), abi.encodeCall(IOPContractsManagerV2.version, ()), abi.encode("9.0.0"));
         _testUpgradeMissingLockbox(true);
+    }
+
+    /// @notice Tests first lockbox activation with a v9 development version.
+    function test_upgrade_missingLockboxV9Dev_succeeds() public {
+        vm.mockCall(address(opcmV2), abi.encodeCall(IOPContractsManagerV2.version, ()), abi.encode("9.0.0-dev"));
+        _testUpgradeMissingLockbox(false);
+    }
+
+    /// @notice Tests that v8 rejects the ETHLockbox deployment instruction.
+    function test_upgrade_lockboxInstructionV8_reverts() public {
+        _assertUpgradeInstructionRejected("8.0.4", Constants.PERMITTED_PROXY_DEPLOYMENT_KEY, bytes("ETHLockbox"));
+    }
+
+    /// @notice Tests that the ETHLockbox deployment allowance expires in v10.
+    function test_upgrade_lockboxInstructionV10_reverts() public {
+        _assertUpgradeInstructionRejected("10.0.0", Constants.PERMITTED_PROXY_DEPLOYMENT_KEY, bytes("ETHLockbox"));
+    }
+
+    /// @notice Tests that the anchor root override remains unavailable in v9.
+    function test_upgrade_anchorRootInstructionV9_reverts() public {
+        _assertUpgradeInstructionRejected(
+            "9.0.0", "overrides.cfg.startingAnchorRoot", abi.encode(deployConfig.startingAnchorRoot)
+        );
+    }
+
+    /// @notice Checks that an upgrade rejects an instruction at the specified OPCM version.
+    /// @param _version The OPCM version to simulate.
+    /// @param _key The instruction key.
+    /// @param _data The instruction data.
+    function _assertUpgradeInstructionRejected(
+        string memory _version,
+        string memory _key,
+        bytes memory _data
+    )
+        internal
+    {
+        vm.mockCall(address(opcmV2), abi.encodeCall(IOPContractsManagerV2.version, ()), abi.encode(_version));
+        IOPContractsManagerV2.UpgradeInput memory input;
+        input.systemConfig = systemConfig;
+        input.extraInstructions = new IOPContractsManagerUtils.ExtraInstruction[](1);
+        input.extraInstructions[0] = IOPContractsManagerUtils.ExtraInstruction({ key: _key, data: _data });
+        prankDelegateCall(proxyAdmin.owner());
+        (bool success, bytes memory reason) =
+            address(opcmV2).delegatecall(abi.encodeCall(IOPContractsManagerV2.upgrade, (input)));
+        assertFalse(success);
+        // nosemgrep: sol-style-use-abi-encodecall
+        assertEq(
+            reason,
+            abi.encodeWithSelector(IOPContractsManagerV2.OPContractsManagerV2_InvalidUpgradeInstruction.selector, _key)
+        );
     }
 
     /// @notice Tests first lockbox activation and repeat upgrades for ETH and CGT chains.

--- a/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
@@ -544,8 +544,9 @@ contract OPContractsManagerV2_Upgrade_Test is OPContractsManagerV2_Upgrade_TestI
         runCurrentUpgradeV2(chainPAO);
     }
 
-    /// @notice Tests upgrading a chain without ETHLockbox enabled.
-    function test_upgrade_activatesLockboxWithoutActivatingInterop_succeeds() public {
+    /// @notice Tests lockbox state and balances after upgrading the forked chain.
+    ///         CI currently runs this test for OP, Ink, and Unichain, which already have a lockbox enabled.
+    function test_upgrade_lockbox_succeeds() public {
         bool interopEnabledBefore = systemConfig.isFeatureEnabled(Features.INTEROP);
         bool lockboxEnabledBefore = systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX);
         uint256 portalBalanceBefore = 1 ether;

--- a/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
@@ -1973,19 +1973,31 @@ contract OPContractsManagerV2_Deploy_Test is OPContractsManagerV2_TestInit {
     /// @notice Tests lockbox deployment permission and first activation without requiring a fork.
     function test_upgrade_missingLockbox_succeeds() public {
         vm.mockCall(address(opcmV2), abi.encodeCall(IOPContractsManagerV2.version, ()), abi.encode("9.0.0"));
-        _testUpgradeMissingLockbox(false);
+        _testUpgradeMissingLockbox(false, false);
     }
 
     /// @notice Tests that a CGT chain without a lockbox can upgrade without migrating portal ETH.
     function test_upgrade_missingLockboxCGT_succeeds() public {
         vm.mockCall(address(opcmV2), abi.encodeCall(IOPContractsManagerV2.version, ()), abi.encode("9.0.0"));
-        _testUpgradeMissingLockbox(true);
+        _testUpgradeMissingLockbox(true, false);
     }
 
     /// @notice Tests first lockbox activation with a v9 development version.
     function test_upgrade_missingLockboxV9Dev_succeeds() public {
         vm.mockCall(address(opcmV2), abi.encodeCall(IOPContractsManagerV2.version, ()), abi.encode("9.0.0-dev"));
-        _testUpgradeMissingLockbox(false);
+        _testUpgradeMissingLockbox(false, false);
+    }
+
+    /// @notice Tests liquidity migration when the flag was enabled without configuring a lockbox.
+    function test_upgrade_missingLockboxFeatureEnabled_succeeds() public {
+        vm.mockCall(address(opcmV2), abi.encodeCall(IOPContractsManagerV2.version, ()), abi.encode("9.0.0"));
+        _testUpgradeMissingLockbox(false, true);
+    }
+
+    /// @notice Tests that an enabled flag without a lockbox does not migrate CGT portal ETH.
+    function test_upgrade_missingLockboxCGTFeatureEnabled_succeeds() public {
+        vm.mockCall(address(opcmV2), abi.encodeCall(IOPContractsManagerV2.version, ()), abi.encode("9.0.0"));
+        _testUpgradeMissingLockbox(true, true);
     }
 
     /// @notice Tests that v8 rejects the ETHLockbox deployment instruction.
@@ -2034,10 +2046,15 @@ contract OPContractsManagerV2_Deploy_Test is OPContractsManagerV2_TestInit {
 
     /// @notice Tests first lockbox activation and repeat upgrades for ETH and CGT chains.
     /// @param _useCustomGasToken Whether the chain uses a custom gas token.
-    function _testUpgradeMissingLockbox(bool _useCustomGasToken) internal {
+    /// @param _enableFeatureBeforeUpgrade Whether to enable the flag without configuring a lockbox.
+    function _testUpgradeMissingLockbox(bool _useCustomGasToken, bool _enableFeatureBeforeUpgrade) internal {
         deployConfig.useCustomGasToken = _useCustomGasToken;
         IOPContractsManagerV2.ChainContracts memory cts = opcmV2.deploy(deployConfig);
         _setLegacyLockboxState(cts.systemConfig, cts.optimismPortal);
+        if (_enableFeatureBeforeUpgrade) {
+            vm.prank(cts.proxyAdmin.owner());
+            cts.systemConfig.setFeature(Features.ETH_LOCKBOX, true);
+        }
         assertEq(cts.systemConfig.isCustomGasToken(), _useCustomGasToken);
         vm.deal(address(cts.optimismPortal), 1 ether);
 
@@ -2059,7 +2076,7 @@ contract OPContractsManagerV2_Deploy_Test is OPContractsManagerV2_TestInit {
             )
         );
         assertEq(address(cts.optimismPortal.ethLockbox()), address(0));
-        assertFalse(cts.systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX));
+        assertEq(cts.systemConfig.isFeatureEnabled(Features.ETH_LOCKBOX), _enableFeatureBeforeUpgrade);
         assertEq(address(cts.optimismPortal).balance, 1 ether);
 
         input.extraInstructions = new IOPContractsManagerUtils.ExtraInstruction[](1);

--- a/packages/contracts-bedrock/test/setup/ForkL1Live.s.sol
+++ b/packages/contracts-bedrock/test/setup/ForkL1Live.s.sol
@@ -20,6 +20,7 @@ import { GameType, GameTypes, Claim, Proposal, Hash } from "src/dispute/lib/Type
 import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
 import { LibString } from "@solady/utils/LibString.sol";
 import { LibGameArgs } from "src/dispute/lib/LibGameArgs.sol";
+import { Constants } from "src/libraries/Constants.sol";
 
 // Interfaces
 import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
@@ -346,8 +347,8 @@ contract ForkL1Live is Deployer, StdAssertions, FeatureFlags {
                 gameArgs: hex""
             });
 
-            // Migration needs 2 extra instructions: anchor root + game type overrides.
-            extraInstructions = new IOPContractsManagerUtils.ExtraInstruction[](2);
+            // Anchor root and game type overrides, plus the lockbox deployment permission below.
+            extraInstructions = new IOPContractsManagerUtils.ExtraInstruction[](3);
             extraInstructions[0] = IOPContractsManagerUtils.ExtraInstruction({
                 key: "overrides.cfg.startingAnchorRoot",
                 data: abi.encode(
@@ -415,9 +416,15 @@ contract ForkL1Live is Deployer, StdAssertions, FeatureFlags {
                 gameArgs: hex""
             });
 
-            // The standard upgrade path deploys no proxies, so it needs no extra instructions.
-            extraInstructions = new IOPContractsManagerUtils.ExtraInstruction[](0);
+            // The standard upgrade path only needs the lockbox deployment permission below.
+            extraInstructions = new IOPContractsManagerUtils.ExtraInstruction[](1);
         }
+
+        // Chains without a lockbox need permission to deploy one. Existing lockboxes are reused.
+        extraInstructions[extraInstructions.length - 1] = IOPContractsManagerUtils.ExtraInstruction({
+            key: Constants.PERMITTED_PROXY_DEPLOYMENT_KEY,
+            data: bytes("ETHLockbox")
+        });
 
         vm.prank(_delegateCaller, true);
         (bool upgradeSuccess,) = address(_opcm).delegatecall(

--- a/packages/contracts-bedrock/test/setup/ForkL1Live.s.sol
+++ b/packages/contracts-bedrock/test/setup/ForkL1Live.s.sol
@@ -20,6 +20,7 @@ import { GameType, GameTypes, Claim, Proposal, Hash } from "src/dispute/lib/Type
 import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
 import { LibString } from "@solady/utils/LibString.sol";
 import { LibGameArgs } from "src/dispute/lib/LibGameArgs.sol";
+import { SemverComp } from "src/libraries/SemverComp.sol";
 import { Constants } from "src/libraries/Constants.sol";
 
 // Interfaces
@@ -281,6 +282,8 @@ contract ForkL1Live is Deployer, StdAssertions, FeatureFlags {
         IOPContractsManagerUtils.DisputeGameConfig[] memory disputeGameConfigs;
         IOPContractsManagerUtils.ExtraInstruction[] memory extraInstructions;
 
+        bool permitLockboxDeployment = SemverComp.parse(_opcm.version()).major == 9;
+
         if (Config.devFeatureSuperRootGamesMigration()) {
             // Read the current respected game type from the ASR.
             IAnchorStateRegistry asr = IAnchorStateRegistry(artifacts.mustGetAddress("AnchorStateRegistryProxy"));
@@ -347,8 +350,8 @@ contract ForkL1Live is Deployer, StdAssertions, FeatureFlags {
                 gameArgs: hex""
             });
 
-            // Anchor root and game type overrides, plus the lockbox deployment permission below.
-            extraInstructions = new IOPContractsManagerUtils.ExtraInstruction[](3);
+            // Anchor root and game type overrides, plus lockbox deployment permission in v9.
+            extraInstructions = new IOPContractsManagerUtils.ExtraInstruction[](permitLockboxDeployment ? 3 : 2);
             extraInstructions[0] = IOPContractsManagerUtils.ExtraInstruction({
                 key: "overrides.cfg.startingAnchorRoot",
                 data: abi.encode(
@@ -416,15 +419,17 @@ contract ForkL1Live is Deployer, StdAssertions, FeatureFlags {
                 gameArgs: hex""
             });
 
-            // The standard upgrade path only needs the lockbox deployment permission below.
-            extraInstructions = new IOPContractsManagerUtils.ExtraInstruction[](1);
+            // The standard upgrade path only needs lockbox deployment permission in v9.
+            extraInstructions = new IOPContractsManagerUtils.ExtraInstruction[](permitLockboxDeployment ? 1 : 0);
         }
 
         // Chains without a lockbox need permission to deploy one. Existing lockboxes are reused.
-        extraInstructions[extraInstructions.length - 1] = IOPContractsManagerUtils.ExtraInstruction({
-            key: Constants.PERMITTED_PROXY_DEPLOYMENT_KEY,
-            data: bytes("ETHLockbox")
-        });
+        if (permitLockboxDeployment) {
+            extraInstructions[extraInstructions.length - 1] = IOPContractsManagerUtils.ExtraInstruction({
+                key: Constants.PERMITTED_PROXY_DEPLOYMENT_KEY,
+                data: bytes("ETHLockbox")
+            });
+        }
 
         vm.prank(_delegateCaller, true);
         (bool upgradeSuccess,) = address(_opcm).delegatecall(


### PR DESCRIPTION
**Description**

Enables an `ETHLockbox` on every OP chain, regardless of whether interop or a custom gas token is enabled.
Today only interop chains use a lockbox. Making the lockbox universal is the prerequisite for #22093, which will make it the pause identifier for the shared contracts. This PR does not change how any contract resolves pause state or the guardian.

Changes

- OPCMv2 `upgrade()` and `deploy()` load or deploy, initialize, authorize, and enable an `ETHLockbox` for every chain. Existing chains without a lockbox pass the `ETHLockbox` permitted proxy deployment instruction.
- The portal's ETH is migrated into the lockbox when the feature is first enabled. Repeat upgrades do not migrate again, and chains in an interop set keep their shared lockbox.
- `OptimismPortal2.migrateLiquidity()` requires a configured lockbox instead of interop and reverts on custom gas token chains.
- `ETH_LOCKBOX` can no longer be disabled. Enabling it is blocked only while a pause is active on the `OptimismPortal` identifier.
- `StandardValidator` (`LOCKBOX-00`, `LOCKBOX-05`) and `ChainAssertions` (`CHECK-OP2-80`, `CHECK-OP2-85`) require the feature and a nonzero lockbox.
- Updates contract snapshots and tests.
Custom gas token chains get an enabled lockbox but keep gas-token custody in the portal. Their portal balances are not migrated.

Safety considerations

- Legacy ETH liquidity is migrated only on first activation; repeated upgrades do not migrate again.
- `upgrade()` never creates a second lockbox for a chain that already has one.
- `SystemConfig.paused()` already selects the lockbox identifier when the feature is on, so enabling the feature moves a chain's scoped pause key from its portal to its lockbox at upgrade time. Deputy pause configuration and monitoring keyed on the portal address need updating. An active portal-scoped pause blocks the upgrade; a global pause is unaffected.

Closes https://github.com/ethereum-optimism/optimism/issues/22770