### PR TITLE
contracts-bedrock: restore VerifyOPCM StandardValidator ref checks, fix the profile mismatch

### DIFF
--- a/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
@@ -602,9 +602,14 @@ contract DeployImplementations is Script {
         opcmImplementations.zkDisputeGameImpl = _implementations.zkDisputeGameImpl;
         opcmImplementations.sp1PlonkAdapterImpl = _implementations.sp1PlonkAdapterImpl;
 
+        // Unqualified names so DeployUtils.getCode resolves the default compiler profile's
+        // artifact. Both contracts are pulled into the validator profile's compilation graph by
+        // OPContractsManagerStandardValidator.sol, so a "File.sol:Contract" identifier can
+        // non-deterministically resolve to the 200-run build while VerifyOPCM compares against the
+        // default 999999-run artifact.
         IStandardValidatorUtils standardValidatorUtils = IStandardValidatorUtils(
             DeployUtils.createDeterministic({
-                _name: "StandardValidatorUtils.sol:StandardValidatorUtils",
+                _name: "StandardValidatorUtils",
                 _args: DeployUtils.encodeConstructor(abi.encodeCall(IStandardValidatorUtils.__constructor__, ())),
                 _salt: _salt
             })
@@ -612,7 +617,7 @@ contract DeployImplementations is Script {
 
         IOPContractsManagerMigrationValidator migrationValidatorImpl = IOPContractsManagerMigrationValidator(
             DeployUtils.createDeterministic({
-                _name: "OPContractsManagerMigrationValidator.sol:OPContractsManagerMigrationValidator",
+                _name: "OPContractsManagerMigrationValidator",
                 _args: DeployUtils.encodeConstructor(
                     abi.encodeCall(IOPContractsManagerMigrationValidator.__constructor__, ())
                 ),

--- a/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
@@ -602,11 +602,6 @@ contract DeployImplementations is Script {
         opcmImplementations.zkDisputeGameImpl = _implementations.zkDisputeGameImpl;
         opcmImplementations.sp1PlonkAdapterImpl = _implementations.sp1PlonkAdapterImpl;
 
-        // Unqualified names so DeployUtils.getCode resolves the default compiler profile's
-        // artifact. Both contracts are pulled into the validator profile's compilation graph by
-        // OPContractsManagerStandardValidator.sol, so a "File.sol:Contract" identifier can
-        // non-deterministically resolve to the 200-run build while VerifyOPCM compares against the
-        // default 999999-run artifact.
         IStandardValidatorUtils standardValidatorUtils = IStandardValidatorUtils(
             DeployUtils.createDeterministic({
                 _name: "StandardValidatorUtils",

--- a/packages/contracts-bedrock/scripts/deploy/VerifyOPCM.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/VerifyOPCM.s.sol
@@ -230,8 +230,9 @@ contract VerifyOPCM is Script {
         expectedGetters["opcmInteropMigrator"] = "SKIP"; // Address verified via bytecode comparison
         expectedGetters["opcmMigrator"] = "SKIP"; // Address verified via bytecode comparison
         expectedGetters["opcmStandardValidator"] = "SKIP"; // Address verified via bytecode comparison
-        validatorGetterChecks["standardValidatorUtils"] = "SKIP";
-        validatorGetterChecks["migrationValidator"] = "SKIP";
+        // BYTECODE checks are valid only while these contracts have no constructor args or immutables.
+        validatorGetterChecks["standardValidatorUtils"] = "BYTECODE:StandardValidatorUtils";
+        validatorGetterChecks["migrationValidator"] = "BYTECODE:OPContractsManagerMigrationValidator";
         expectedGetters["opcmUpgrader"] = "SKIP"; // Address verified via bytecode comparison
 
         // OPCM V2 Specific expected getters overrides
@@ -727,7 +728,7 @@ contract VerifyOPCM is Script {
 
         // For implementations, verify security-critical values.
         if (!_target.blueprint) {
-            success = _verifySecurityCriticalValues(_opcm, _target, artifact) && success;
+            success = _verifySecurityCriticalValues(_opcm, _target, artifact, _skipConstructorVerification) && success;
         }
 
         // If requested and this is not a blueprint, we also need to check the creation code.
@@ -1327,11 +1328,13 @@ contract VerifyOPCM is Script {
     /// @param _opcm The OPCM contract that contains the target contract reference.
     /// @param _target The contract reference being verified.
     /// @param _artifact The artifact info for the contract.
+    /// @param _skipConstructorVerification Whether to skip constructor verification.
     /// @return True if all security-critical values are correct.
     function _verifySecurityCriticalValues(
         IOPContractsManagerV2 _opcm,
         OpcmContractRef memory _target,
-        ArtifactInfo memory _artifact
+        ArtifactInfo memory _artifact,
+        bool _skipConstructorVerification
     )
         internal
         returns (bool)
@@ -1368,7 +1371,7 @@ contract VerifyOPCM is Script {
 
         // OPContractsManagerStandardValidator: Verify all constructor arg values
         if (LibString.eq(_target.name, "OPContractsManagerStandardValidator")) {
-            success = _verifyStandardValidatorArgs(_opcm, _target.addr) && success;
+            success = _verifyStandardValidatorArgs(_opcm, _target.addr, _skipConstructorVerification) && success;
         }
 
         return success;
@@ -1463,8 +1466,16 @@ contract VerifyOPCM is Script {
     /// @notice Verifies all StandardValidator getters are properly validated.
     /// @param _opcm The OPCM contract.
     /// @param _validator The StandardValidator contract address.
+    /// @param _skipConstructorVerification Whether to skip constructor verification.
     /// @return True if all getters are valid.
-    function _verifyStandardValidatorArgs(IOPContractsManagerV2 _opcm, address _validator) internal returns (bool) {
+    function _verifyStandardValidatorArgs(
+        IOPContractsManagerV2 _opcm,
+        address _validator,
+        bool _skipConstructorVerification
+    )
+        internal
+        returns (bool)
+    {
         bool success = true;
         console.log("  Verifying StandardValidator args...");
 
@@ -1521,6 +1532,10 @@ contract VerifyOPCM is Script {
                 success = _verifyEnvUint256(_validator, getter, envVar) && success;
             } else if (LibString.eq(check, "ZERO_ON_MAINNET")) {
                 success = _verifyZeroOnMainnet(_validator, getter) && success;
+            } else if (LibString.startsWith(check, "BYTECODE:")) {
+                string memory name = LibString.slice(check, bytes("BYTECODE:").length, bytes(check).length);
+                success = _verifyValidatorContractRef(_opcm, _validator, getter, name, _skipConstructorVerification)
+                    && success;
             }
         }
 
@@ -1528,6 +1543,47 @@ contract VerifyOPCM is Script {
             console.log("    [OK] All StandardValidator args verified");
         }
         return success;
+    }
+
+    /// @notice Verifies the contract a StandardValidator getter points at.
+    /// @dev These addresses hang off the StandardValidator rather than the OPCM, so the
+    ///      `opcm`-prefixed walk in `_getOpcmPropertyRefs` never reaches them. Without this they
+    ///      would go entirely unchecked.
+    /// @param _opcm The OPCM contract.
+    /// @param _validator The StandardValidator address.
+    /// @param _getter The zero-arg getter returning the contract address.
+    /// @param _contractName The artifact name the address is expected to match.
+    /// @param _skipConstructorVerification Whether to skip constructor verification.
+    /// @return True if the referenced contract matches its artifact.
+    function _verifyValidatorContractRef(
+        IOPContractsManagerV2 _opcm,
+        address _validator,
+        string memory _getter,
+        string memory _contractName,
+        bool _skipConstructorVerification
+    )
+        internal
+        returns (bool)
+    {
+        // nosemgrep: sol-style-use-abi-encodecall
+        (bool callSuccess, bytes memory returnedData) =
+            _validator.staticcall(abi.encodeWithSignature(string.concat(_getter, "()")));
+        if (!callSuccess || returnedData.length < 32) {
+            console.log(string.concat("    [FAIL] Failed to call ", _getter, "() on StandardValidator"));
+            return false;
+        }
+
+        address target = abi.decode(returnedData, (address));
+        if (target == address(0)) {
+            console.log(string.concat("    [FAIL] ", _getter, " is the zero address"));
+            return false;
+        }
+
+        return _verifyContractRef(
+            _opcm,
+            OpcmContractRef({ field: _getter, name: _contractName, addr: target, blueprint: false }),
+            _skipConstructorVerification
+        );
     }
 
     /// @notice Gets the field names from the Container implementations struct.

--- a/packages/contracts-bedrock/test/scripts/VerifyOPCM.t.sol
+++ b/packages/contracts-bedrock/test/scripts/VerifyOPCM.t.sol
@@ -98,8 +98,15 @@ contract VerifyOPCM_Harness is VerifyOPCM {
         return _verifyAnchorStateRegistryDelays(_asr);
     }
 
-    function verifyStandardValidatorArgs(IOPContractsManagerV2 _opcm, address _validator) public returns (bool) {
-        return _verifyStandardValidatorArgs(_opcm, _validator);
+    function verifyStandardValidatorArgs(
+        IOPContractsManagerV2 _opcm,
+        address _validator,
+        bool _skipConstructorVerification
+    )
+        public
+        returns (bool)
+    {
+        return _verifyStandardValidatorArgs(_opcm, _validator, _skipConstructorVerification);
     }
 
     function setValidatorGetterCheck(string memory _getter, string memory _check) public {
@@ -183,6 +190,35 @@ contract VerifyOPCM_Run_Test is VerifyOPCM_TestInit {
 
         // Run the script.
         harness.run(address(opcm), true);
+    }
+
+    function test_run_corruptedValidatorDependencies_reverts() public {
+        skipIfCoverage();
+
+        IOPContractsManagerStandardValidator validator =
+            IOPContractsManagerStandardValidator(opcm.opcmStandardValidator());
+        address[2] memory targets =
+            [address(validator.standardValidatorUtils()), address(validator.migrationValidator())];
+
+        harness.run(address(opcm), true);
+
+        for (uint256 i; i < targets.length; i++) {
+            bytes memory originalCode = targets[i].code;
+            bytes memory corruptedCode = abi.encodePacked(originalCode);
+            corruptedCode[0] = bytes1(uint8(corruptedCode[0]) ^ 0x01);
+
+            vm.etch(targets[i], corruptedCode);
+
+            vm.expectRevert(VerifyOPCM.VerifyOPCM_Failed.selector);
+            harness.run(address(opcm), true);
+
+            vm.etch(targets[i], hex"00");
+
+            vm.expectRevert(VerifyOPCM.VerifyOPCM_Failed.selector);
+            harness.run(address(opcm), true);
+
+            vm.etch(targets[i], originalCode);
+        }
     }
 
     /// @notice Tests that the runSingle script succeeds when run against production contracts.


### PR DESCRIPTION
Restores #22786 (reverted in #22806) and fixes the CI failure it caused.

### Commits

1. `776b4fc` — cherry-pick of #22786, unchanged.
2. `f021625` — the fix.

### Why it failed

`contracts-bedrock-tests-develop` failed on develop ([job 5547680](https://circleci.com/gh/ethereum-optimism/optimism/5547680)) with:

```
Encountered 2 failing tests in test/scripts/VerifyOPCM.t.sol:VerifyOPCM_Run_Test
[FAIL: VerifyOPCM_Failed()] test_run_corruptedValidatorDependencies_reverts()
[FAIL: VerifyOPCM_Failed()] test_run_succeeds()
```

The new `BYTECODE:` checks compare the deployed `standardValidatorUtils` / `migrationValidator` code against `forge-artifacts/<Name>.sol/<Name>.json` — the default compiler profile's artifact.

But `DeployImplementations` deployed both through the qualified `"File.sol:Contract"` identifier. `DeployUtils.getCode` explicitly passes those straight to `vm.getCode` rather than resolving the artifact path, and both contracts are pulled into the `validator` profile's compilation graph by `src/L1/OPContractsManagerStandardValidator.sol` (`optimizer_runs = 200`). So they're emitted twice — 200 runs and the default 999999 — and `vm.getCode` can resolve to either. Deploy the 200-run build, verify against the 999999-run artifact, mismatch.

This is the same failure mode and the same fix as #19323.

### Why PR CI was green on #22786

PR runs use `test_profile: liteci`; only develop runs `test_profile: ci`. Under `liteci` every compiler profile is `optimizer = false, optimizer_runs = 0`, so the two builds are byte-identical and the ambiguity is invisible.

**That also means CI on this PR will not exercise the fix.** No PR-triggered job runs `VerifyOPCM.t.sol` under the `ci` profile. It has to be checked locally, or on develop after merge.

### Testing the failing job locally

From `packages/contracts-bedrock`, reproduce the develop-only job by forcing the `ci` profile:

```bash
# Fails on 776b4fc (the cherry-pick alone), passes with f021625.
FOUNDRY_PROFILE=ci forge test --match-path 'test/scripts/VerifyOPCM.t.sol' -vv
```

The first build is slow — `optimizer_runs = 999999` across the whole tree. Dropping `FOUNDRY_PROFILE=ci` (or using `liteci`) reproduces the green PR run instead, which is the whole point: the bug only appears when the profiles disagree.

To confirm the two artifacts actually diverge:

```bash
FOUNDRY_PROFILE=ci forge build
jq -r '.deployedBytecode.object | length' forge-artifacts/StandardValidatorUtils.sol/StandardValidatorUtils*.json
```

Prompted by: maurelian