### PR TITLE
op-conductor: extract CLI wiring into app package

### DIFF
--- a/op-conductor/app/app.go
+++ b/op-conductor/app/app.go
@@ -1,0 +1,83 @@
+// Package app wires op-conductor into a runnable CLI application.
+//
+// It exists so that the standard binary and any embedding binary share the same
+// flag set, config parsing and lifecycle handling, instead of each duplicating
+// the wiring.
+package app
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/urfave/cli/v2"
+
+	"github.com/ethereum-optimism/optimism/op-conductor/conductor"
+	"github.com/ethereum-optimism/optimism/op-conductor/flags"
+	opservice "github.com/ethereum-optimism/optimism/op-service"
+	"github.com/ethereum-optimism/optimism/op-service/cliapp"
+	"github.com/ethereum-optimism/optimism/op-service/ctxinterrupt"
+	oplog "github.com/ethereum-optimism/optimism/op-service/log"
+)
+
+// Config describes how to build the application.
+type Config struct {
+	Version   string
+	GitCommit string
+	GitDate   string
+}
+
+func (c Config) version() string {
+	if c.Version != "" {
+		return c.Version
+	}
+	return "v0.0.0"
+}
+
+// NewApp builds the CLI application without running it.
+func NewApp(cfg Config) *cli.App {
+	app := cli.NewApp()
+	app.Flags = cliapp.ProtectFlags(flags.Flags)
+	app.Version = opservice.FormatVersion(cfg.version(), cfg.GitCommit, cfg.GitDate, "")
+	app.Name = "op-conductor"
+	app.Usage = "Optimism Sequencer Conductor Service"
+	app.Description = "op-conductor help sequencer to run in highly available mode"
+	app.Action = cliapp.LifecycleCmd(Lifecycle(cfg))
+	app.Commands = []*cli.Command{}
+	return app
+}
+
+// Lifecycle returns the lifecycle action that constructs an OpConductor from the
+// parsed CLI context.
+func Lifecycle(cfg Config) cliapp.LifecycleAction {
+	return func(ctx *cli.Context, closeApp context.CancelCauseFunc) (cliapp.Lifecycle, error) {
+		logCfg := oplog.ReadCLIConfig(ctx)
+		logger := oplog.NewLogger(oplog.AppOut(ctx), logCfg)
+		oplog.SetGlobalLogHandler(logger.Handler())
+		opservice.ValidateEnvVars(flags.EnvVarPrefix, flags.Flags, logger)
+
+		conductorCfg, err := conductor.NewConfig(ctx, logger)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read config: %w", err)
+		}
+
+		c, err := conductor.New(ctx.Context, conductorCfg, logger, cfg.version())
+		if err != nil {
+			return nil, fmt.Errorf("failed to create conductor: %w", err)
+		}
+		return c, nil
+	}
+}
+
+// Run builds and runs the application, blocking until it exits. It is the whole
+// body of a typical main().
+func Run(cfg Config) {
+	oplog.SetupDefaults()
+
+	app := NewApp(cfg)
+	ctx := ctxinterrupt.WithSignalWaiterMain(context.Background())
+	if err := app.RunContext(ctx, os.Args); err != nil {
+		log.Crit("Application failed", "message", err)
+	}
+}

--- a/op-conductor/cmd/main.go
+++ b/op-conductor/cmd/main.go
@@ -1,19 +1,7 @@
 package main
 
 import (
-	"context"
-	"fmt"
-	"os"
-
-	"github.com/ethereum/go-ethereum/log"
-	"github.com/urfave/cli/v2"
-
-	"github.com/ethereum-optimism/optimism/op-conductor/conductor"
-	"github.com/ethereum-optimism/optimism/op-conductor/flags"
-	opservice "github.com/ethereum-optimism/optimism/op-service"
-	"github.com/ethereum-optimism/optimism/op-service/cliapp"
-	"github.com/ethereum-optimism/optimism/op-service/ctxinterrupt"
-	oplog "github.com/ethereum-optimism/optimism/op-service/log"
+	"github.com/ethereum-optimism/optimism/op-conductor/app"
 )
 
 var (
@@ -23,39 +11,9 @@ var (
 )
 
 func main() {
-	oplog.SetupDefaults()
-
-	app := cli.NewApp()
-	app.Flags = cliapp.ProtectFlags(flags.Flags)
-	app.Version = opservice.FormatVersion(Version, GitCommit, GitDate, "")
-	app.Name = "op-conductor"
-	app.Usage = "Optimism Sequencer Conductor Service"
-	app.Description = "op-conductor help sequencer to run in highly available mode"
-	app.Action = cliapp.LifecycleCmd(OpConductorMain)
-	app.Commands = []*cli.Command{}
-
-	ctx := ctxinterrupt.WithSignalWaiterMain(context.Background())
-	err := app.RunContext(ctx, os.Args)
-	if err != nil {
-		log.Crit("Application failed", "message", err)
-	}
-}
-
-func OpConductorMain(ctx *cli.Context, closeApp context.CancelCauseFunc) (cliapp.Lifecycle, error) {
-	logCfg := oplog.ReadCLIConfig(ctx)
-	log := oplog.NewLogger(oplog.AppOut(ctx), logCfg)
-	oplog.SetGlobalLogHandler(log.Handler())
-	opservice.ValidateEnvVars(flags.EnvVarPrefix, flags.Flags, log)
-
-	cfg, err := conductor.NewConfig(ctx, log)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read config: %w", err)
-	}
-
-	c, err := conductor.New(ctx.Context, cfg, log, Version)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create conductor: %w", err)
-	}
-
-	return c, nil
+	app.Run(app.Config{
+		Version:   Version,
+		GitCommit: GitCommit,
+		GitDate:   GitDate,
+	})
 }


### PR DESCRIPTION
The setup in `op-conductor/cmd/main.go` lived in package main, so anything wanting to run op-conductor as a library had to copy it.

This moves the flag registration, config parsing and lifecycle wiring into a new `op-conductor/app` package. `op-conductor/cmd/main.go` becomes very slim now and just calls app.Run.

Pure code move. No behaviour change, no new flags, no new capability, the next PR in the stack is what makes this useful.