### PR TITLE
op-conductor: support functional options in the constructor

### DIFF
--- a/op-conductor/app/app.go
+++ b/op-conductor/app/app.go
@@ -23,9 +23,27 @@ import (
 
 // Config describes how to build the application.
 type Config struct {
+	// Name and Usage default to op-conductor's own if left empty.
+	Name  string
+	Usage string
+
 	Version   string
 	GitCommit string
 	GitDate   string
+
+	// ExtraFlags are registered alongside op-conductor's own flags.
+	ExtraFlags []cli.Flag
+
+	// Options is called once the CLI context is available, so that embedders can
+	// build conductor options from their own flags. May be nil.
+	Options func(ctx *cli.Context, log log.Logger) ([]conductor.Option, error)
+}
+
+func (c Config) name() string {
+	if c.Name != "" {
+		return c.Name
+	}
+	return "op-conductor"
 }
 
 func (c Config) version() string {
@@ -38,10 +56,14 @@ func (c Config) version() string {
 // NewApp builds the CLI application without running it.
 func NewApp(cfg Config) *cli.App {
 	app := cli.NewApp()
-	app.Flags = cliapp.ProtectFlags(flags.Flags)
+	app.Flags = cliapp.ProtectFlags(append(append([]cli.Flag{}, flags.Flags...), cfg.ExtraFlags...))
 	app.Version = opservice.FormatVersion(cfg.version(), cfg.GitCommit, cfg.GitDate, "")
-	app.Name = "op-conductor"
-	app.Usage = "Optimism Sequencer Conductor Service"
+	app.Name = cfg.name()
+	if cfg.Usage != "" {
+		app.Usage = cfg.Usage
+	} else {
+		app.Usage = "Optimism Sequencer Conductor Service"
+	}
 	app.Description = "op-conductor help sequencer to run in highly available mode"
 	app.Action = cliapp.LifecycleCmd(Lifecycle(cfg))
 	app.Commands = []*cli.Command{}
@@ -62,7 +84,15 @@ func Lifecycle(cfg Config) cliapp.LifecycleAction {
 			return nil, fmt.Errorf("failed to read config: %w", err)
 		}
 
-		c, err := conductor.New(ctx.Context, conductorCfg, logger, cfg.version())
+		var opts []conductor.Option
+		if cfg.Options != nil {
+			opts, err = cfg.Options(ctx, logger)
+			if err != nil {
+				return nil, fmt.Errorf("failed to build conductor options: %w", err)
+			}
+		}
+
+		c, err := conductor.New(ctx.Context, conductorCfg, logger, cfg.version(), opts...)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create conductor: %w", err)
 		}

--- a/op-conductor/conductor/options.go
+++ b/op-conductor/conductor/options.go
@@ -1,0 +1,16 @@
+package conductor
+
+import (
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+// Option customizes an OpConductor at construction time.
+type Option func(*OpConductor)
+
+// WithRPCAPIs registers additional namespaces on the conductor's RPC server,
+// so embedders can expose their own endpoints on the same listener.
+func WithRPCAPIs(apis ...rpc.API) Option {
+	return func(oc *OpConductor) {
+		oc.extraAPIs = append(oc.extraAPIs, apis...)
+	}
+}

--- a/op-conductor/conductor/service.go
+++ b/op-conductor/conductor/service.go
@@ -42,8 +42,8 @@ var (
 )
 
 // New creates a new OpConductor instance.
-func New(ctx context.Context, cfg *Config, log log.Logger, version string) (*OpConductor, error) {
-	return NewOpConductor(ctx, cfg, log, metrics.NewMetrics(), version, nil, nil, nil)
+func New(ctx context.Context, cfg *Config, log log.Logger, version string, opts ...Option) (*OpConductor, error) {
+	return NewOpConductor(ctx, cfg, log, metrics.NewMetrics(), version, nil, nil, nil, opts...)
 }
 
 // NewOpConductor creates a new OpConductor instance.
@@ -56,6 +56,7 @@ func NewOpConductor(
 	ctrl client.SequencerControl,
 	cons consensus.Consensus,
 	hmon health.HealthMonitor,
+	opts ...Option,
 ) (*OpConductor, error) {
 	if err := cfg.Check(); err != nil {
 		return nil, fmt.Errorf("invalid config: %w", err)
@@ -77,6 +78,10 @@ func NewOpConductor(
 		retryBackoff: func() time.Duration { return time.Duration(rand.Intn(2000)) * time.Millisecond },
 	}
 	oc.loopActionFn = oc.loopAction
+
+	for _, opt := range opts {
+		opt(oc)
+	}
 
 	// explicitly set all atomic.Bool values
 	oc.leader.Store(false)         // upon start, it should not be the leader unless specified otherwise by raft bootstrap, in that case, it'll receive a leadership update from consensus.
@@ -315,6 +320,10 @@ func (oc *OpConductor) initRPCServer(ctx context.Context) error {
 		})
 	}
 
+	for _, api := range oc.extraAPIs {
+		server.AddAPI(api)
+	}
+
 	oc.rpcServer = server
 	return nil
 }
@@ -372,6 +381,8 @@ type OpConductor struct {
 	healthUpdateCh <-chan error
 	leaderUpdateCh <-chan bool
 	loopActionFn   func() // loopActionFn defines the logic to be executed inside control loop.
+
+	extraAPIs []rpc.API
 
 	wg             sync.WaitGroup
 	pauseCh        chan struct{}


### PR DESCRIPTION
Adds a variadic `Option` parameter to `New` and `NewOpConductor`, so behaviour can be customized without changing the constructor signature every time.

`WithRPCAPIs` is the first option. The RPC server is built inside `initRPCServer` and the field is unexported, so there was previously no way for an embedder to expose its own namespace on the conductor's listener.

`app.Config` gains `ExtraFlags` and `Options` so a binary built on the app package can register its own flags and turn them into conductor options.
- Say if a downstream client wants to get its own flags read and parsed into special Option with their specialized behaviour.

No behaviour change when no options are passed. (default: identical to op-conductor in runtime today)