### PR TITLE
op-conductor: make leader transfer target selection pluggable

### DIFF
--- a/op-conductor/conductor/options.go
+++ b/op-conductor/conductor/options.go
@@ -7,6 +7,15 @@ import (
 // Option customizes an OpConductor at construction time.
 type Option func(*OpConductor)
 
+// WithTransferStrategy overrides how transfer targets are chosen when this
+// conductor gives up leadership. It takes precedence over the strategy implied
+// by the configuration flags.
+func WithTransferStrategy(s TransferStrategy) Option {
+	return func(oc *OpConductor) {
+		oc.transferStrategy = s
+	}
+}
+
 // WithRPCAPIs registers additional namespaces on the conductor's RPC server,
 // so embedders can expose their own endpoints on the same listener.
 func WithRPCAPIs(apis ...rpc.API) Option {

--- a/op-conductor/conductor/service.go
+++ b/op-conductor/conductor/service.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"math/rand"
 	"net/http"
-	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -81,6 +80,11 @@ func NewOpConductor(
 
 	for _, opt := range opts {
 		opt(oc)
+	}
+	// Fall back to the strategy implied by configuration if none was injected.
+	// Leaving it nil means deferring to the consensus layer's own selection.
+	if oc.transferStrategy == nil && cfg.RoundRobinLeaderTransfer {
+		oc.transferStrategy = RoundRobinTransferStrategy{}
 	}
 
 	// explicitly set all atomic.Bool values
@@ -382,7 +386,8 @@ type OpConductor struct {
 	leaderUpdateCh <-chan bool
 	loopActionFn   func() // loopActionFn defines the logic to be executed inside control loop.
 
-	extraAPIs []rpc.API
+	transferStrategy TransferStrategy
+	extraAPIs        []rpc.API
 
 	wg             sync.WaitGroup
 	pauseCh        chan struct{}
@@ -825,15 +830,8 @@ func (oc *OpConductor) action() {
 
 // transferLeader tries to transfer leadership to another server.
 func (oc *OpConductor) transferLeader() error {
-	// TransferLeader here will do round robin to try to transfer leadership to the next healthy node.
 	oc.log.Info("transferring leadership", "server", oc.cons.ServerID())
-	// Use round-robin if enabled, otherwise use default Raft leader transfer
-	var err error
-	if oc.cfg.RoundRobinLeaderTransfer {
-		err = oc.transferLeaderRoundRobin()
-	} else {
-		err = oc.cons.TransferLeader()
-	}
+	err := oc.executeTransfer()
 	oc.metrics.RecordLeaderTransfer(err == nil)
 	if err == nil {
 		oc.leader.Store(false)
@@ -851,97 +849,65 @@ func (oc *OpConductor) transferLeader() error {
 	}
 }
 
-// transferLeaderRoundRobin implements true round-robin leader transfer.
-// This ensures that each cluster member gets a chance to become leader,
-// by always transferring to the next node in sorted order.
-// For example, with nodes [seq1, seq2, seq3]:
-//   - seq1 transfers to seq2
-//   - seq2 transfers to seq3
-//   - seq3 transfers to seq1
+// executeTransfer asks the configured TransferStrategy for an ordered list of
+// candidates and attempts each in turn. Candidates can be rejected by raft for
+// reasons the strategy cannot see (unreachable, log too far behind), so a failed
+// attempt moves on to the next one rather than aborting.
 //
-// If a transfer fails (e.g., target node's log is behind), it will try the next node.
-func (oc *OpConductor) transferLeaderRoundRobin() error {
-	// Get cluster membership
-	membership, err := oc.cons.ClusterMembership()
+// If the strategy yields no candidates, or none of them accept, this falls back
+// to the consensus layer's own selection.
+func (oc *OpConductor) executeTransfer() error {
+	if oc.transferStrategy == nil {
+		return oc.cons.TransferLeader()
+	}
+
+	targets, err := oc.selectTransferTargets()
 	if err != nil {
-		return fmt.Errorf("failed to get cluster membership: %w", err)
+		oc.log.Warn("failed to select leadership transfer targets, falling back to default selection", "err", err)
+		return oc.cons.TransferLeader()
+	}
+	if len(targets) == 0 {
+		return oc.cons.TransferLeader()
 	}
 
-	myServerID := oc.cons.ServerID()
-
-	// Collect all voters (including self) for proper ordering
-	var allVoters []consensus.ServerInfo
-	for _, server := range membership.Servers {
-		if server.Suffrage == consensus.Voter {
-			allVoters = append(allVoters, server)
-		}
-	}
-
-	if len(allVoters) <= 1 {
-		oc.log.Warn("no other voters available for leader transfer, skipping")
-		return nil
-	}
-
-	// Sort all voters by ServerID to ensure consistent ordering across all nodes.
-	sort.Slice(allVoters, func(i, j int) bool {
-		return allVoters[i].ID < allVoters[j].ID
-	})
-
-	// Find my position in the sorted list
-	myIdx := -1
-	for i, server := range allVoters {
-		if server.ID == myServerID {
-			myIdx = i
-			break
-		}
-	}
-
-	if myIdx == -1 {
-		return errors.New("current server not found in voter list")
-	}
-
-	// Try to transfer to each voter in round-robin order, starting from the next one.
-	// This handles cases where a recently promoted voter may have stale logs.
-	numOtherVoters := len(allVoters) - 1
-	for attempt := 0; attempt < numOtherVoters; attempt++ {
-		targetIdx := (myIdx + 1 + attempt) % len(allVoters)
-		// Skip self
-		if targetIdx == myIdx {
-			continue
-		}
-		target := allVoters[targetIdx]
-
-		oc.log.Info("round-robin transferring leadership",
-			"from", myServerID,
+	self := oc.cons.ServerID()
+	for i, target := range targets {
+		oc.log.Info("transferring leadership to target",
+			"from", self,
 			"to", target.ID,
 			"targetAddr", target.Addr,
-			"attempt", attempt+1,
-			"totalVoters", len(allVoters),
+			"attempt", i+1,
+			"totalTargets", len(targets),
 		)
 
 		err := oc.cons.TransferLeaderTo(target.ID, target.Addr)
 		if err == nil {
-			return nil // Success
+			return nil
 		}
 
-		// ErrLeadershipTransferInProgress means a previous transfer is ongoing, just wait
+		// A transfer is already underway; let it finish rather than piling on.
 		if errors.Is(err, raft.ErrLeadershipTransferInProgress) {
 			oc.log.Debug("leadership transfer already in progress, waiting for completion")
 			return nil
 		}
 
-		// Log the failure and try next voter
-		oc.log.Warn("failed to transfer leadership to voter, trying next",
+		oc.log.Warn("failed to transfer leadership to target, trying next",
 			"target", target.ID,
 			"err", err,
-			"attempt", attempt+1,
+			"attempt", i+1,
 		)
 	}
 
-	// All round-robin attempts failed, fall back to Raft's default leader transfer
-	// which selects the candidate with the most up-to-date log.
-	oc.log.Warn("round-robin transfer failed for all voters, falling back to default leader transfer")
+	oc.log.Warn("all strategy targets failed, falling back to default leader transfer")
 	return oc.cons.TransferLeader()
+}
+
+func (oc *OpConductor) selectTransferTargets() ([]consensus.ServerInfo, error) {
+	membership, err := oc.cons.ClusterMembership()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get cluster membership: %w", err)
+	}
+	return oc.transferStrategy.SelectTargets(oc.shutdownCtx, oc.cons.ServerID(), membership)
 }
 
 func (oc *OpConductor) stopSequencer() error {

--- a/op-conductor/conductor/strategy.go
+++ b/op-conductor/conductor/strategy.go
@@ -1,0 +1,69 @@
+package conductor
+
+import (
+	"context"
+	"errors"
+	"sort"
+
+	"github.com/ethereum-optimism/optimism/op-conductor/consensus"
+)
+
+// TransferStrategy decides which cluster members a departing leader should hand
+// leadership to, and in what order.
+//
+// Implementations may perform I/O (e.g. querying peers) and must respect ctx.
+// Returning an empty target list defers to the consensus layer's own selection,
+// which picks the voter with the most up-to-date log. A conductor with no
+// strategy configured at all does the same, without fetching membership.
+type TransferStrategy interface {
+	SelectTargets(ctx context.Context, self string, membership *consensus.ClusterMembership) ([]consensus.ServerInfo, error)
+}
+
+// RoundRobinTransferStrategy walks the voters in sorted ServerID order, starting
+// from the member after the current one. This guarantees every member gets a
+// turn, so a cluster where the most up-to-date members are unhealthy still
+// converges on one that can sequence.
+//
+// It must be used by every member of the cluster: a mixed configuration can
+// bounce leadership between round-robin and log-based selection.
+type RoundRobinTransferStrategy struct{}
+
+var _ TransferStrategy = (*RoundRobinTransferStrategy)(nil)
+
+func (RoundRobinTransferStrategy) SelectTargets(_ context.Context, self string, membership *consensus.ClusterMembership) ([]consensus.ServerInfo, error) {
+	if membership == nil {
+		return nil, errors.New("nil cluster membership")
+	}
+
+	var voters []consensus.ServerInfo
+	for _, server := range membership.Servers {
+		if server.Suffrage == consensus.Voter {
+			voters = append(voters, server)
+		}
+	}
+	if len(voters) <= 1 {
+		return nil, nil
+	}
+
+	// Sort by ServerID so every member derives the same ring.
+	sort.Slice(voters, func(i, j int) bool {
+		return voters[i].ID < voters[j].ID
+	})
+
+	selfIdx := -1
+	for i, server := range voters {
+		if server.ID == self {
+			selfIdx = i
+			break
+		}
+	}
+	if selfIdx == -1 {
+		return nil, errors.New("current server not found in voter list")
+	}
+
+	targets := make([]consensus.ServerInfo, 0, len(voters)-1)
+	for i := 1; i < len(voters); i++ {
+		targets = append(targets, voters[(selfIdx+i)%len(voters)])
+	}
+	return targets, nil
+}

--- a/op-conductor/conductor/strategy_test.go
+++ b/op-conductor/conductor/strategy_test.go
@@ -1,0 +1,97 @@
+package conductor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-conductor/consensus"
+)
+
+func voters(ids ...string) *consensus.ClusterMembership {
+	m := &consensus.ClusterMembership{}
+	for _, id := range ids {
+		m.Servers = append(m.Servers, consensus.ServerInfo{
+			ID:       id,
+			Addr:     id + ":50050",
+			Suffrage: consensus.Voter,
+		})
+	}
+	return m
+}
+
+func targetIDs(t *testing.T, servers []consensus.ServerInfo) []string {
+	t.Helper()
+	out := make([]string, 0, len(servers))
+	for _, s := range servers {
+		out = append(out, s.ID)
+	}
+	return out
+}
+
+// Every member must derive the same ring, each starting from itself, so that
+// leadership walks the whole cluster instead of bouncing between two members.
+func TestRoundRobinTransferStrategy_RingOrder(t *testing.T) {
+	m := voters("seq1", "seq2", "seq3")
+	s := RoundRobinTransferStrategy{}
+
+	for _, tc := range []struct {
+		self string
+		want []string
+	}{
+		{self: "seq1", want: []string{"seq2", "seq3"}},
+		{self: "seq2", want: []string{"seq3", "seq1"}},
+		{self: "seq3", want: []string{"seq1", "seq2"}},
+	} {
+		t.Run(tc.self, func(t *testing.T) {
+			got, err := s.SelectTargets(context.Background(), tc.self, m)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, targetIDs(t, got))
+		})
+	}
+}
+
+// Ordering must come from the membership contents, not the order raft happens
+// to return them in.
+func TestRoundRobinTransferStrategy_OrderIsIndependentOfMembershipOrder(t *testing.T) {
+	s := RoundRobinTransferStrategy{}
+
+	forward, err := s.SelectTargets(context.Background(), "seq2", voters("seq1", "seq2", "seq3"))
+	require.NoError(t, err)
+	reversed, err := s.SelectTargets(context.Background(), "seq2", voters("seq3", "seq2", "seq1"))
+	require.NoError(t, err)
+
+	require.Equal(t, targetIDs(t, forward), targetIDs(t, reversed))
+}
+
+func TestRoundRobinTransferStrategy_SkipsNonVoters(t *testing.T) {
+	m := voters("seq1", "seq2")
+	m.Servers = append(m.Servers, consensus.ServerInfo{
+		ID:       "observer",
+		Addr:     "observer:50050",
+		Suffrage: consensus.Nonvoter,
+	})
+
+	got, err := RoundRobinTransferStrategy{}.SelectTargets(context.Background(), "seq1", m)
+	require.NoError(t, err)
+	require.Equal(t, []string{"seq2"}, targetIDs(t, got))
+}
+
+// With nobody else to hand off to, returning no targets lets the caller fall
+// back to the consensus layer rather than failing.
+func TestRoundRobinTransferStrategy_SingleVoterHasNoTargets(t *testing.T) {
+	got, err := RoundRobinTransferStrategy{}.SelectTargets(context.Background(), "seq1", voters("seq1"))
+	require.NoError(t, err)
+	require.Empty(t, got)
+}
+
+func TestRoundRobinTransferStrategy_ErrorsWhenSelfMissing(t *testing.T) {
+	_, err := RoundRobinTransferStrategy{}.SelectTargets(context.Background(), "seq9", voters("seq1", "seq2"))
+	require.ErrorContains(t, err, "not found in voter list")
+}
+
+func TestRoundRobinTransferStrategy_ErrorsOnNilMembership(t *testing.T) {
+	_, err := RoundRobinTransferStrategy{}.SelectTargets(context.Background(), "seq1", nil)
+	require.Error(t, err)
+}


### PR DESCRIPTION
Target selection is currently an `if/else` on `RoundRobinLeaderTransfer`, so adding a third behaviour means editing `transferLeader`. The flag itself is a sign that one fixed behaviour was never enough.

This PR introduces a `TransferStrategy` interface that returns an ordered list of candidates, and moves the existing round-robin logic into `RoundRobinTransferStrategy` unchanged.

Two things worth calling out:

- A strategy returns a list, not a single target, because raft can reject a candidate for reasons the strategy can't see — unreachable, or its log too far behind. Keeping the attempt loop, error handling, metrics and fallback in `executeTransfer` means strategies stay pure and easy to test.

- A conductor with no strategy configured goes straight to `cons.TransferLeader()` and makes no extra raft calls, so the default path is genuinely unchanged.

`--raft.round-robin-leader-transfer` still selects round-robin. Adds unit tests for it, which weren't practical while the logic was a method on `OpConductor`.