### PR TITLE
op-conductor: allow a leader to yield leadership voluntarily

### DIFF
--- a/op-conductor/conductor/options.go
+++ b/op-conductor/conductor/options.go
@@ -1,8 +1,14 @@
 package conductor
 
 import (
+	"time"
+
 	"github.com/ethereum/go-ethereum/rpc"
 )
+
+// defaultPolicyInterval is how often a leader re-consults its LeadershipPolicy
+// when no other event has triggered the control loop.
+const defaultPolicyInterval = 30 * time.Second
 
 // Option customizes an OpConductor at construction time.
 type Option func(*OpConductor)
@@ -13,6 +19,24 @@ type Option func(*OpConductor)
 func WithTransferStrategy(s TransferStrategy) Option {
 	return func(oc *OpConductor) {
 		oc.transferStrategy = s
+	}
+}
+
+// WithLeadershipPolicy installs a policy that lets a healthy leader voluntarily
+// give up leadership. The policy is consulted whenever the control loop runs
+// while this conductor is a healthy active leader, and additionally on the given
+// interval so that changes elsewhere in the cluster are eventually noticed.
+// A non-positive interval falls back to the default.
+//
+// Without this option no policy goroutine is started and the conductor behaves
+// exactly as it does today.
+func WithLeadershipPolicy(p LeadershipPolicy, interval time.Duration) Option {
+	return func(oc *OpConductor) {
+		oc.leadershipPolicy = p
+		if interval <= 0 {
+			interval = defaultPolicyInterval
+		}
+		oc.policyInterval = interval
 	}
 }
 

--- a/op-conductor/conductor/service.go
+++ b/op-conductor/conductor/service.go
@@ -387,6 +387,8 @@ type OpConductor struct {
 	loopActionFn   func() // loopActionFn defines the logic to be executed inside control loop.
 
 	transferStrategy TransferStrategy
+	leadershipPolicy LeadershipPolicy // optional, nil disables voluntary yielding.
+	policyInterval   time.Duration
 	extraAPIs        []rpc.API
 
 	wg             sync.WaitGroup
@@ -467,6 +469,11 @@ func (oc *OpConductor) Start(ctx context.Context) error {
 
 	oc.wg.Add(1)
 	go oc.loop()
+
+	if oc.leadershipPolicy != nil {
+		oc.wg.Add(1)
+		go oc.policyLoop()
+	}
 
 	oc.metrics.RecordInfo(oc.version)
 	oc.metrics.RecordUp()
@@ -807,7 +814,8 @@ func (oc *OpConductor) action() {
 		// start sequencer
 		err = oc.startSequencer()
 	case status.leader && status.healthy && status.active:
-		// normal leader, do nothing
+		// normal leader, but a policy may still prefer someone else to lead.
+		err = oc.maybeYieldLeadership()
 	}
 
 	oc.log.Debug("exiting action with status and error", "status", status, "err", err)
@@ -908,6 +916,50 @@ func (oc *OpConductor) selectTransferTargets() ([]consensus.ServerInfo, error) {
 		return nil, fmt.Errorf("failed to get cluster membership: %w", err)
 	}
 	return oc.transferStrategy.SelectTargets(oc.shutdownCtx, oc.cons.ServerID(), membership)
+}
+
+// maybeYieldLeadership consults the optional LeadershipPolicy and gives up
+// leadership if it asks us to. It is only reached while this conductor is a
+// healthy, actively sequencing leader.
+func (oc *OpConductor) maybeYieldLeadership() error {
+	if oc.leadershipPolicy == nil {
+		return nil
+	}
+
+	membership, err := oc.cons.ClusterMembership()
+	if err != nil {
+		return fmt.Errorf("failed to get cluster membership: %w", err)
+	}
+
+	yield, err := oc.leadershipPolicy.ShouldYieldLeadership(oc.shutdownCtx, oc.cons.ServerID(), membership)
+	if err != nil {
+		return fmt.Errorf("failed to evaluate leadership policy: %w", err)
+	}
+	if !yield {
+		return nil
+	}
+
+	oc.log.Info("leadership policy requested yielding leadership", "server", oc.cons.ServerID())
+	return oc.transferLeader()
+}
+
+// policyLoop periodically re-runs the control loop so that a leader notices
+// changes elsewhere in the cluster that no local event would surface. It only
+// enqueues work: every decision stays on the control loop.
+func (oc *OpConductor) policyLoop() {
+	defer oc.wg.Done()
+
+	ticker := time.NewTicker(oc.policyInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-oc.shutdownCtx.Done():
+			return
+		case <-ticker.C:
+			oc.queueAction()
+		}
+	}
 }
 
 func (oc *OpConductor) stopSequencer() error {

--- a/op-conductor/conductor/strategy.go
+++ b/op-conductor/conductor/strategy.go
@@ -19,6 +19,15 @@ type TransferStrategy interface {
 	SelectTargets(ctx context.Context, self string, membership *consensus.ClusterMembership) ([]consensus.ServerInfo, error)
 }
 
+// LeadershipPolicy allows a healthy, actively sequencing leader to voluntarily
+// give up leadership, for deployments where some members are preferred leaders.
+//
+// It is consulted from the control loop, so implementations should bound the
+// time they spend doing I/O.
+type LeadershipPolicy interface {
+	ShouldYieldLeadership(ctx context.Context, self string, membership *consensus.ClusterMembership) (bool, error)
+}
+
 // RoundRobinTransferStrategy walks the voters in sorted ServerID order, starting
 // from the member after the current one. This guarantees every member gets a
 // turn, so a cluster where the most up-to-date members are unhealthy still


### PR DESCRIPTION
A leader only ever gave up leadership when it became unhealthy, so there was no way for a deployment to say that some members are preferred leaders.

Adds a `LeadershipPolicy`, consulted in the one branch of `action()` that previously did nothing — the healthy, active leader case. If the policy asks to yield, the existing transfer path runs.

When a policy is configured, a ticker also runs so a leader notices changes elsewhere in the cluster that no local event would surface. The ticker only calls `queueAction()`; every decision still happens on the control loop, which already owns the "leader, health and active" state. With no policy configured the goroutine is never started (default).