### PR TITLE
release-notes: sharpen triage tags, drop semver framing, restructure sections

### DIFF
--- a/.claude/skills/release-notes/SKILL.md
+++ b/.claude/skills/release-notes/SKILL.md
@@ -27,6 +27,21 @@ gh release list --limit 20        # 'Draft' rows are the candidates
 creates a fresh draft when an RC is finalized, and that finalized draft is the one that gets
 published. If both exist, target the finalized one and say so.
 
+**If the newest tag is an RC with no finalized counterpart, ask before writing anything.**
+Tags may not be local yet, so fetch first:
+
+```bash
+git fetch --tags
+git tag -l '<component>/v*' --sort=-v:refname | head -5
+```
+
+Notes written against an RC carry `-rc.N` in the heading, compare link and image tag, and
+have to be retargeted later (step 8) — a retarget that refuses because the finalized tag
+sits on a different commit means regenerating from scratch. So ask the release manager
+whether they want to finalize with `just release` first. It is their call: this skill does
+not create or finalize tags, and `just release` is slow, so do not stall on it — write the
+RC notes if they say no.
+
 ## 2. Get the draft
 
 ```bash
@@ -36,9 +51,12 @@ gh release view <tag> --json body -q .body > /tmp/<component>-draft.md
 If there is no draft yet:
 
 ```bash
-GITHUB_TOKEN=$(gh auth token) just release-notes <component>              # latest stable -> latest RC
-GITHUB_TOKEN=$(gh auth token) just release-notes <component> latest develop
+GITHUB_TOKEN=$(gh auth token) mise exec -- just release-notes <component>              # latest stable -> latest RC
+GITHUB_TOKEN=$(gh auth token) mise exec -- just release-notes <component> latest develop
 ```
+
+git-cliff is a mise-pinned tool and is not on `PATH`, so without `mise exec --` the recipe
+fails with `git: 'cliff' is not a git command`, which names neither git-cliff nor mise.
 
 More than one `## What's Changed in ...` section means earlier RCs were never published.
 Merge them under the final tag and dedupe by PR number.
@@ -50,14 +68,17 @@ Merge them under the final tag and dedupe by PR number.
 ```
 
 Each PR is tagged `LINKED` (changed a package compiled into the binary, and which ones),
-`DEPS` (manifests only), `--` (nothing the binary compiles) or `?` (unresolvable). The tags
-come from `go list -deps` and `cargo tree`, so linkage is exact — but it proves the package
-is compiled in, not that the changed function is on the component's runtime path.
+`CONFIG` (moved the embedded superchain registry — `LINKED+CONFIG` when it did both),
+`DEPS` (manifests, no compiled package), `--` (nothing the binary compiles) or `?`
+(unresolvable, or the PR could not be fetched). The tags come from `go list -deps` and
+`cargo tree`, so linkage is exact — but it proves the package is compiled in, not that the
+changed function is on the component's runtime path.
 
 ## 4. Triage
 
-Drop `--` and non-security `DEPS` rows, then apply the judgment pass in
-`reference/triage.md` to every `LINKED` row.
+Drop `--` rows, then apply the judgment pass in `reference/triage.md` to every `LINKED` row.
+Never drop a `CONFIG` row without reading it, and check a `DEPS` row that lists paths — the
+lock diff may carry a security fix for a library this binary links.
 
 Read the intent of each surviving PR — you cannot write a self-contained entry from a title.
 Batch the lookups; if there are more than ~15, delegate the reading and ask for a one-line
@@ -68,43 +89,57 @@ short reason, so a reviewer can reinstate one in a single edit.
 
 ## 5. Curate the change list
 
-The substance of the job. Replace PR titles with grouped, self-contained entries:
+The substance of the job. Replace PR titles with grouped, self-contained entries.
 
-- group under `### Features` / `### Bug fixes` / `### Other`, or by domain; drop empty
-  headings, and use a flat list for a short release
+First lift out the two entries that get their own top-level section: anything an operator
+must act on before upgrading (`## Breaking changes`) and anything that moved a chain's
+embedded config (`## Chain Configuration`) — see step 6. Everything else:
+
+- under `## Other changes`, group into `### Features` / `### Bug fixes` /
+  `### Miscellaneous`, or by domain; drop empty headings, and use a flat list for a short
+  release
+- derivation changes, in op-node or kona, get their own `### Derivation` heading, first
 - fold PRs that are one logical change into one entry carrying all their numbers
 - **write impact, never implementation** — the symptom that appears or disappears, the
   flag/metric/config names, what the reader must do. Not goroutines, event loops, call
   paths, internal type names, or which PR was stacked on which. This is the correction made
   most often, and the PR descriptions you just read will pull you the wrong way
-- omit pure internal churn entirely
+- **a change with no user-visible impact does not appear at all** — not under
+  `### Miscellaneous`, not as a summarising line. Importability of the monorepo as a Go
+  module is not user impact: we do not maintain releases of it as a Go module, so a change
+  that only helps downstream importers is cut like any other internal churn
 - reference PRs as bare `(#NNNNN)`; no `by @author`
 - only mention a PR more than once if it included multiple logical changes which are worth describing separately
 
 ## 6. Write the Overview
 
-One callout at the top of `## Overview`: release type, what it contains, and one of
-`optional` / `optional but recommended` / `recommended` / `required`, scopable to a role.
-Always `> [!NOTE]`, except `required`, which uses `> [!CAUTION]`.
+One callout at the top of `## Overview`: which of `optional` / `recommended` / `strongly
+recommended` / `required` the release is, scopable to a role, and what it contains. Never a
+semver release type — our tags are not strict semver, so "this is a minor release" says
+nothing. `> [!NOTE]` for `optional`, `> [!IMPORTANT]` for either recommended level,
+`> [!CAUTION]` for `required`.
 
 Then check proportionality:
 
 - **Is the feature live?** Verify with the registry check in `reference/house-style.md`
   rather than assuming; ask the release manager for anything not expressed as a hardfork. A
-  dormant-path change that is a no-op for this component gets cut; one that will matter on
-  activation gets a line under a `### <Feature> (not yet in production)` heading. Either
-  way, do not describe an attack the live system cannot suffer.
+  change confined to an unreleased feature is cut entirely. It stays only if it also reaches
+  a live path, and is then described by that live effect — read what the change does, not
+  the feature name in its PR title. Either way, do not describe an attack the live system
+  cannot suffer.
 - **Would a reader shrug?** New metrics, a wrong version string and rare corner cases are
   bullets, not callouts.
 
 Add `## Breaking changes` only when an operator must *do* something before upgrading;
-Go-API-only changes do not qualify. The Overview block is the note's only callout.
+Go-API-only changes do not qualify. A release that moves a chain's embedded config — a new
+hardfork activation time, most often — gets a `## Chain Configuration` section of its own.
+The Overview block is the note's only callout.
 
 ## 7. Assemble
 
-Order: `## Overview` → optional `## Breaking changes` → `## What's Changed` with its
-subheadings → `**Full Changelog**` → image line → commented-out working notes. Write to
-`/tmp/<component>-notes.md`.
+Order: `## Overview` → optional `## Breaking changes` → optional `## Chain Configuration` →
+`## Other changes` with its subheadings → `**Full Changelog**` → image line → commented-out
+working notes. Write to `/tmp/<component>-notes.md`.
 
 ## 8. Retarget RC references when finalizing
 
@@ -135,8 +170,17 @@ Only after explicit approval:
 gh release edit <tag> --notes-file /tmp/<component>-notes.md
 ```
 
-This changes only the body, leaving draft/published state alone. Confirm with
-`gh release view <tag>` and report what changed.
+This changes only the body, leaving draft/published state alone. `edit` needs a release
+object to exist; when the tag has no draft, create one instead:
+
+```bash
+gh release create <tag> --draft --title '<tag>' --notes-file /tmp/<component>-notes.md
+```
+
+Add `--prerelease` for an RC. A draft's URL is an `untagged-<hash>` link until it is
+published — that is normal, and `gh release view <tag>` still resolves it.
+
+Confirm with `gh release view <tag>` and report what changed.
 
 ## Notes
 

--- a/.claude/skills/release-notes/SKILL.md
+++ b/.claude/skills/release-notes/SKILL.md
@@ -84,7 +84,13 @@ Batch the lookups; if there are more than ~15, delegate the reading and ask for 
 "what an operator would notice" per PR.
 
 Keep the raw bullets for cut PRs as HTML comments at the bottom of the draft, each with a
-short reason, so a reviewer can reinstate one in a single edit.
+short reason, so a reviewer can reinstate one in a single edit:
+
+```markdown
+<!--* op-core/fees: add Jovian DA-footprint calculation (#22163) — doesn't affect the batcher-->
+```
+
+Delete them before publishing, unless the release manager prefers to keep them.
 
 ## 5. Curate the change list
 
@@ -168,10 +174,5 @@ published — that is normal, and `gh release view <tag>` still resolves it.
 
 Confirm with `gh release view <tag>` and report what changed.
 
-## Notes
-
-- A change under `op-service/` or `op-core/` can change a component's behaviour. Never prune
-  on directory name alone; that is what step 3 is for.
-- Check a judgment call against history by examining recent releases for the same component.
-- Never overwrite a draft a human has curated. If the body carries hand-written prose or
-  commented-out bullets, propose specific edits instead of replacing it.
+Never overwrite a draft a human has curated. If the body carries hand-written prose or
+commented-out bullets, propose specific edits instead of replacing it.

--- a/.claude/skills/release-notes/SKILL.md
+++ b/.claude/skills/release-notes/SKILL.md
@@ -38,9 +38,8 @@ git tag -l '<component>/v*' --sort=-v:refname | head -5
 Notes written against an RC carry `-rc.N` in the heading, compare link and image tag, and
 have to be retargeted later (step 8) — a retarget that refuses because the finalized tag
 sits on a different commit means regenerating from scratch. So ask the release manager
-whether they want to finalize with `just release` first. It is their call: this skill does
-not create or finalize tags, and `just release` is slow, so do not stall on it — write the
-RC notes if they say no.
+whether they want to finalize with `just release` first. It is their call, and it is slow,
+so do not stall on it — write the RC notes if they say no.
 
 ## 2. Get the draft
 
@@ -89,51 +88,38 @@ short reason, so a reviewer can reinstate one in a single edit.
 
 ## 5. Curate the change list
 
-The substance of the job. Replace PR titles with grouped, self-contained entries.
+The substance of the job. Replace PR titles with grouped, self-contained entries, written to
+`reference/house-style.md` — read it now if you have not. It is the source of truth for the
+section layout, the grouping spine, impact-over-implementation, and what does not belong in
+a note at all. Do not work from memory of it.
 
-First lift out the two entries that get their own top-level section: anything an operator
-must act on before upgrading (`## Breaking changes`) and anything that moved a chain's
-embedded config (`## Chain Configuration`) — see step 6. Everything else:
+What this step decides:
 
-- under `## Other changes`, group into `### Features` / `### Bug fixes` /
-  `### Miscellaneous`, or by domain; drop empty headings, and use a flat list for a short
-  release
-- derivation changes, in op-node or kona, get their own `### Derivation` heading, first
-- fold PRs that are one logical change into one entry carrying all their numbers
-- **write impact, never implementation** — the symptom that appears or disappears, the
-  flag/metric/config names, what the reader must do. Not goroutines, event loops, call
-  paths, internal type names, or which PR was stacked on which. This is the correction made
-  most often, and the PR descriptions you just read will pull you the wrong way
-- **a change with no user-visible impact does not appear at all** — not under
-  `### Miscellaneous`, not as a summarising line. Importability of the monorepo as a Go
-  module is not user impact: we do not maintain releases of it as a Go module, so a change
-  that only helps downstream importers is cut like any other internal churn
-- reference PRs as bare `(#NNNNN)`; no `by @author`
-- only mention a PR more than once if it included multiple logical changes which are worth describing separately
+- which entries get a top-level section of their own — anything an operator must act on
+  before upgrading (`## Breaking changes`), anything that moved a chain's embedded config
+  (`## Chain Configuration`) — and which fall under `## Other changes`
+- which PRs are one logical change, folded into a single entry carrying all their numbers
+- which surviving PRs turn out to have no user-visible impact after all, and are cut here
+  rather than written up
+
+Reference PRs as bare `(#NNNNN)`; no `by @author`. Only mention a PR more than once if it
+included multiple logical changes worth describing separately.
 
 ## 6. Write the Overview
 
-One callout at the top of `## Overview`: which of `optional` / `recommended` / `strongly
-recommended` / `required` the release is, scopable to a role, and what it contains. Never a
-semver release type — our tags are not strict semver, so "this is a minor release" says
-nothing. `> [!NOTE]` for `optional`, `> [!IMPORTANT]` for either recommended level,
-`> [!CAUTION]` for `required`.
+One callout at the top of `## Overview`, classifying the release and saying what it contains.
+Take the classification vocabulary and the callout block type from
+`reference/house-style.md`, verbatim — the wording is fixed so that readers can compare
+releases, and it is not a place to paraphrase.
 
 Then check proportionality:
 
-- **Is the feature live?** Verify with the registry check in `reference/house-style.md`
-  rather than assuming; ask the release manager for anything not expressed as a hardfork. A
-  change confined to an unreleased feature is cut entirely. It stays only if it also reaches
-  a live path, and is then described by that live effect — read what the change does, not
-  the feature name in its PR title. Either way, do not describe an attack the live system
-  cannot suffer.
+- **Is the feature live?** Verify with the registry and DevFeature checks in
+  `reference/house-style.md` rather than assuming; ask the release manager for anything
+  expressed as neither. A change confined to an unreleased feature is cut entirely, and do
+  not describe an attack the live system cannot suffer.
 - **Would a reader shrug?** New metrics, a wrong version string and rare corner cases are
   bullets, not callouts.
-
-Add `## Breaking changes` only when an operator must *do* something before upgrading;
-Go-API-only changes do not qualify. A release that moves a chain's embedded config — a new
-hardfork activation time, most often — gets a `## Chain Configuration` section of its own.
-The Overview block is the note's only callout.
 
 ## 7. Assemble
 

--- a/.claude/skills/release-notes/SKILL.md
+++ b/.claude/skills/release-notes/SKILL.md
@@ -146,7 +146,8 @@ It **refuses**, leaving the file untouched, if the finalized tag is missing or s
 different commit than the RC. Surface that warning rather than editing by hand — a note
 generated for a different commit needs regenerating, not retagging.
 
-Then set the compare link's base to the previous **finalized** tag.
+It leaves the compare link's base alone and warns that it is still an RC — set it to the
+previous **finalized** tag, since a published note compares finalized tag to finalized tag.
 
 ## 9. Review before applying
 
@@ -166,11 +167,12 @@ This changes only the body, leaving draft/published state alone. `edit` needs a 
 object to exist; when the tag has no draft, create one instead:
 
 ```bash
-gh release create <tag> --draft --title '<tag>' --notes-file /tmp/<component>-notes.md
+gh release create <tag> --draft --title '<component> <version>' --notes-file /tmp/<component>-notes.md
 ```
 
-Add `--prerelease` for an RC. A draft's URL is an `untagged-<hash>` link until it is
-published — that is normal, and `gh release view <tag>` still resolves it.
+The title takes a space, not the tag's slash — `op-node v1.19.6`. Add `--prerelease` for an
+RC. A draft's URL is an `untagged-<hash>` link until it is published — that is normal, and
+`gh release view <tag>` still resolves it.
 
 Confirm with `gh release view <tag>` and report what changed.
 

--- a/.claude/skills/release-notes/reference/house-style.md
+++ b/.claude/skills/release-notes/reference/house-style.md
@@ -4,7 +4,8 @@ The target is a **curated change list**, as in
 [`op-challenger/v1.9.4`](https://github.com/ethereum-optimism/optimism/releases/tag/op-challenger%2Fv1.9.4)
 and
 [`op-contracts/v8.0.0-rc.2`](https://github.com/ethereum-optimism/optimism/releases/tag/op-contracts%2Fv8.0.0-rc.2).
-Read those two before drafting.
+Read those two before drafting for how entries are written — but take the section layout
+from the Shape below, not from them. Every published release predates it.
 
 A curated note is not the git-cliff list with prose bolted on top: the PR list is *replaced*
 by grouped, self-contained entries. Because each entry explains itself, the stack of
@@ -18,16 +19,22 @@ convention from one release.
 ```markdown
 ## Overview
 
-> [!NOTE]
-> This is a <patch|minor|major> release of <component> containing <what kind of changes>. It is an <recommendation> upgrade for all users.
-
-Note: <feature> is not yet live in production. Changes to those code paths in this release are preparation for future functionality and do not affect operators today.
+<!-- block type follows the recommendation: NOTE / IMPORTANT / CAUTION -->
+> [!IMPORTANT]
+> This is a <recommendation> release <for whom>. It contains <what kind of changes>.
 
 ## Breaking changes            <!-- only when there are any -->
 
 - **<Short name>** (#NNNNN). What changed, and what the operator must do before upgrading.
 
-## What's Changed
+## Chain Configuration         <!-- only when a chain's embedded config moved -->
+
+- **<Short name>** (#NNNNN). Which chains, which values, and what happens to a node that upgrades late.
+
+## Other changes
+
+### Derivation                 <!-- op-node or kona derivation changes, first -->
+- <Self-contained description> (#NNNNN)
 
 ### Features
 - <Self-contained description> (#NNNNN)
@@ -35,10 +42,10 @@ Note: <feature> is not yet live in production. Changes to those code paths in th
 ### Bug fixes
 - <Self-contained description> (#NNNNN, #NNNNN)
 
-### <Domain grouping, e.g. "Super dispute games (not yet in production)">
+### <Domain grouping, e.g. "Sequencer">
 - ...
 
-### Other
+### Miscellaneous
 - ...
 
 **Full Changelog**: https://github.com/ethereum-optimism/optimism/compare/<prev-finalized>...<this-finalized>
@@ -51,36 +58,31 @@ Note: <feature> is not yet live in production. Changes to those code paths in th
 ## The Overview sentence
 
 One standard sentence carries the upgrade recommendation, in a callout at the top of
-`## Overview`. Sentence one names the release type and what it contains; sentence two gives
-the recommendation.
+`## Overview`. Sentence one says what kind of release this is and for whom; sentence two
+says what it contains.
 
-Pick the release type from **what is in the diff**, not by comparing version numbers — our
-tags are not strict semver, so the numbers do not tell you this:
+**Never name a semver release type.** "This is a minor release" tells the reader nothing —
+our tags are not strict semver, so the version numbers do not carry that meaning. The
+recommendation is the classification.
 
-| Type | Use when |
-| --- | --- |
-| patch | No new features — fixes, dependency work, internal change |
-| minor | Small feature work alongside the fixes |
-| major | Something significant, or a large volume of change |
-
-Then exactly one of:
+Exactly one of:
 
 | Recommendation | Use when |
 | --- | --- |
-| `It is an optional upgrade for all users.` | Nothing operator-visible |
-| `It is an optional but recommended upgrade for all users.` | Fixes or features worth having, none urgent |
-| `It is a recommended upgrade for all users.` | A fix operators are likely to want |
-| `It is a required upgrade for <scope>.` | Not upgrading risks a halt, consensus divergence, or stalled safe-head progression. Name the scope, and say who is unaffected |
+| `This is an optional release ...` | Nothing operator-visible |
+| `This is a recommended release ...` | Fixes or features worth having, none urgent |
+| `This is a strongly recommended release ...` | A fix operators are likely to want |
+| `This is a required release for <scope> ...` | Not upgrading risks a halt, consensus divergence, or stalled safe-head progression. Name the scope, and say who is unaffected |
 
-Scope it to a role when only that role benefits — "It is an optional upgrade, but
-recommended for sequencers" — rather than recommending it to everyone on the strength of
-something most operators never see.
+Scope it to a role when only that role benefits — "a required release for World Chain
+operators running the built-in `--network` configs, and a strongly recommended one for
+everyone else" — rather than pitching it at everyone on the strength of something most
+operators never see.
 
-**The callout is always `> [!NOTE]`**, the one exception being `required`, which uses
-`> [!CAUTION]`. Holding the block type constant is the point: urgency comes from the
-sentence's fixed vocabulary, and the block only makes that sentence findable. Varying the
-block with severity is how a routine recommended upgrade ended up flagged as `[!WARNING]`,
-which overstates it and makes the recommendation harder to read.
+**The callout type follows the recommendation**: `> [!NOTE]` for `optional`,
+`> [!IMPORTANT]` for either recommended level, `> [!CAUTION]` for `required`. Nothing else —
+`[!WARNING]` is not in the vocabulary, and reaching for it is how a routine recommended
+upgrade once ended up overstated.
 
 ## Impact, not implementation
 
@@ -143,20 +145,27 @@ chain has explicitly set it.
 For anything expressed neither as a hardfork nor a DevFeature — dispute game types, say —
 there is no equivalent lookup, so ask the release manager rather than guessing.
 
-- If the change does nothing for *this component*, and only matters to another consumer of
-  the shared code, **cut it entirely**.
-- If it affects the component but only once the feature activates, give it one line under a
-  `### <Feature> (not yet in production)` heading and add the standard Note paragraph to the
-  Overview.
+**A change confined to an unreleased feature is cut entirely.** No `(not yet in production)`
+heading, no explanatory Note in the Overview — a reader upgrading today cannot act on it, and
+it competes for attention with the changes they can.
+
+The test is whether the change reaches a live path, not what motivated it. A fix written for
+an interop scenario that also alters pre-interop derivation stays in, described by its live
+effect; the same fix, if it only fires once the fork activates, does not. So read what the
+change does, not the feature name in its PR title.
 
 **Do not narrate an attack the code path cannot currently suffer.** State what the fix aligns
 or corrects; leave the exploit narrative out until the path is live.
 
 ## Curating the change list
 
-**Group by domain or change type.** `### Features` / `### Bug fixes` / `### Other` is the
-default spine; add domain headings where they carry more meaning. Drop any heading that would
-be empty, and use a flat list for a short release.
+**Group by domain or change type.** `### Features` / `### Bug fixes` / `### Miscellaneous`
+is the default spine under `## Other changes`; add domain headings where they carry more
+meaning. Drop any heading that would be empty, and use a flat list for a short release.
+
+**Derivation changes get `### Derivation`, listed first.** This holds for op-node and kona
+alike: derivation is the part of a release most likely to change what a node computes, so it
+is not left to fall into `### Bug fixes` among unrelated entries.
 
 **Group PRs that are one logical change** into one entry with all their numbers:
 `... are no longer required when only permissioned game types are configured (#21270, #21681)`.
@@ -166,9 +175,16 @@ the raw list is being replaced. Say what changed and why an operator cares:
 
 > - Tear down the whole VM process group when `--vm-timeout` is hit, preventing orphaned VM processes from lingering after a timeout (#21268)
 
-**Omit pure internal churn.** A reader gains nothing from being told that something they
-cannot observe was rearranged. The one exception is a release that would otherwise have an
-empty change list, where one summarising line is more honest than publishing nothing.
+**A change with no user-visible impact does not appear at all.** Not under
+`### Miscellaneous`, not as a summarising line — a reader gains nothing from being told that
+something they cannot observe was rearranged. The one exception is a release that would
+otherwise have an empty change list, where one summarising line is more honest than
+publishing nothing.
+
+Importability of the monorepo **as a Go module is not user impact**. We do not maintain
+releases of it as a Go module, so a change that only unblocks downstream importers — moving
+a symbol to a leaf package, shrinking a build closure — is cut like any other internal
+churn, however much work it was.
 
 **Only mention a PR more than once** if it included multiple logical changes worth
 describing separately.
@@ -181,8 +197,8 @@ in the release.
 
 ## Breaking changes
 
-When a change requires operator action before upgrading, it gets its own section above
-`## What's Changed`, with a bold short name and the required action stated plainly:
+When a change requires operator action before upgrading, it gets its own section directly
+below `## Overview`, with a bold short name and the required action stated plainly:
 
 ```markdown
 ## Breaking changes
@@ -190,8 +206,34 @@ When a change requires operator action before upgrading, it gets its own section
 - **`--cannon-kona-experimental-witness-endpoint` flag removed** (#20498). The `debug_executePayload`-based witness path is now the default for kona-cannon games. Operators passing this flag must remove it before upgrading — op-challenger will reject it as unknown.
 ```
 
-Go-API-only changes are **not** breaking changes for this purpose. They affect downstream
-importers, not operators; mention them under `### Other` if they are worth mentioning at all.
+**State the action, not why the old behaviour was wrong.** The entry exists so an operator
+knows what to do before upgrading; the history of the flag or field belongs in the PR.
+
+Go-API-only changes are **not** breaking changes for this purpose, and are not entries
+anywhere else either — see "A change with no user-visible impact" above.
+
+## Chain Configuration
+
+A release that moves a chain's embedded config gets its own `## Chain Configuration` section,
+after `## Breaking changes` when there is one and directly below `## Overview` when there is
+not — most often a new hardfork activation time arriving with a superchain-registry pin bump.
+It stands alone rather than nesting under breaking changes, because a registry bump
+frequently ships without one. Name the chains and the exact values, and say what happens to a
+node that upgrades late, since that is the whole reason the section exists:
+
+```markdown
+## Chain Configuration
+
+- **New World Chain Karst activation times** (#22624). The embedded superchain registry gains:
+
+  - `sepolia/worldchain` — `karst_time = 1788868800` (Tue 8 Sep 2026 12:00:00 UTC)
+  - `mainnet/worldchain` — `karst_time = 1789992000` (Mon 21 Sep 2026 12:00:00 UTC)
+
+  A World Chain node on an earlier release, running the built-in `--network` config rather than an explicit rollup config, will not activate Karst and will diverge from the chain. No other chain's activation times change in this release.
+```
+
+Saying which chains are *not* affected matters as much as which are: most readers of the
+note operate a different chain and should be able to stop reading at that sentence.
 
 ## Callouts
 

--- a/.claude/skills/release-notes/reference/house-style.md
+++ b/.claude/skills/release-notes/reference/house-style.md
@@ -4,11 +4,10 @@ This file is the source of truth. Changing the style means editing it, not infer
 convention from one release.
 
 The target is a **curated change list**, as in
-[`op-challenger/v1.9.4`](https://github.com/ethereum-optimism/optimism/releases/tag/op-challenger%2Fv1.9.4)
+[`op-node/v1.19.6`](https://github.com/ethereum-optimism/optimism/releases/tag/op-node%2Fv1.19.6)
 and
-[`op-contracts/v8.0.0-rc.2`](https://github.com/ethereum-optimism/optimism/releases/tag/op-contracts%2Fv8.0.0-rc.2)
-— read those two for how entries are written, but take the section layout from the Shape
-below. Every published release predates it.
+[`op-reth/v2.4.3`](https://github.com/ethereum-optimism/optimism/releases/tag/op-reth%2Fv2.4.3).
+Read those two before drafting.
 
 ## Shape
 
@@ -223,17 +222,19 @@ note operate a different chain and should be able to stop reading at that senten
 
 ## Tags, links and images
 
+The release **title** is `<component> <version>`, with a space — `op-node v1.19.6`, not the
+tag's slash form `op-node/v1.19.6`.
+
 For a finalized release the heading, the compare link's right side and the image tag all
 carry the plain version — never `-rc.N`.
 
-The compare link's **base** is the previous *finalized* tag, with three dots:
+A published note **must** compare finalized tag to finalized tag. git-cliff generates an RC
+base, and `scripts/retarget-tag.sh` does not touch it — set it to the previous finalized tag
+by hand, with three dots:
 
 ```markdown
-**Full Changelog**: https://github.com/ethereum-optimism/optimism/compare/op-node/v1.19.4...op-node/v1.19.5
+**Full Changelog**: https://github.com/ethereum-optimism/optimism/compare/op-node/v1.19.5...op-node/v1.19.6
 ```
-
-git-cliff generates an RC base and older notes still carry one; the current convention is
-finalized-to-finalized.
 
 If a release carries recurring boilerplate from the previous release, do not copy it forward
 blindly — such blocks are often self-limiting, or imply a second image line. Ask first.

--- a/.claude/skills/release-notes/reference/house-style.md
+++ b/.claude/skills/release-notes/reference/house-style.md
@@ -1,18 +1,14 @@
 # House style for OP Stack release notes
 
+This file is the source of truth. Changing the style means editing it, not inferring a new
+convention from one release.
+
 The target is a **curated change list**, as in
 [`op-challenger/v1.9.4`](https://github.com/ethereum-optimism/optimism/releases/tag/op-challenger%2Fv1.9.4)
 and
-[`op-contracts/v8.0.0-rc.2`](https://github.com/ethereum-optimism/optimism/releases/tag/op-contracts%2Fv8.0.0-rc.2).
-Read those two before drafting for how entries are written — but take the section layout
-from the Shape below, not from them. Every published release predates it.
-
-A curated note is not the git-cliff list with prose bolted on top: the PR list is *replaced*
-by grouped, self-contained entries. Because each entry explains itself, the stack of
-callouts older notes used to supply context is unnecessary.
-
-This file is the source of truth. Changing the style means editing it, not inferring a new
-convention from one release.
+[`op-contracts/v8.0.0-rc.2`](https://github.com/ethereum-optimism/optimism/releases/tag/op-contracts%2Fv8.0.0-rc.2)
+— read those two for how entries are written, but take the section layout from the Shape
+below. Every published release predates it.
 
 ## Shape
 
@@ -80,9 +76,9 @@ everyone else" — rather than pitching it at everyone on the strength of someth
 operators never see.
 
 **The callout type follows the recommendation**: `> [!NOTE]` for `optional`,
-`> [!IMPORTANT]` for either recommended level, `> [!CAUTION]` for `required`. Nothing else —
-`[!WARNING]` is not in the vocabulary, and reaching for it is how a routine recommended
-upgrade once ended up overstated.
+`> [!IMPORTANT]` for either recommended level, `> [!CAUTION]` for `required`. Those three and
+no others. This block is also the note's only callout — if you reach for a second, the
+content is an entry in the change list, or belongs in `## Breaking changes`.
 
 ## Impact, not implementation
 
@@ -136,36 +132,23 @@ grep -rl '<fork>_time' superchain-registry/superchain/configs/mainnet/
 grep -rl '<fork>_time' superchain-registry/superchain/configs/sepolia/
 ```
 
-For a `DevFeatures` bit, the default is the answer: anything behind a DevFeature that isn't
-forced to `true` should be considered disabled and not yet in production — we ship the
-defaults for feature toggles. `docs/ai/devfeatures.md` lists them; today only
-`SuperRootGamesMigration` is default-on, so everything else behind a bit is dormant unless a
-chain has explicitly set it.
+For a `DevFeatures` bit, the default is the answer: we ship the defaults for feature toggles,
+so anything behind a bit that is not forced to `true` is dormant unless a chain has
+explicitly set it. `docs/ai/devfeatures.md` lists which are default-on.
 
 For anything expressed neither as a hardfork nor a DevFeature — dispute game types, say —
 there is no equivalent lookup, so ask the release manager rather than guessing.
 
-**A change confined to an unreleased feature is cut entirely.** No `(not yet in production)`
-heading, no explanatory Note in the Overview — a reader upgrading today cannot act on it, and
-it competes for attention with the changes they can.
-
-The test is whether the change reaches a live path, not what motivated it. A fix written for
-an interop scenario that also alters pre-interop derivation stays in, described by its live
-effect; the same fix, if it only fires once the fork activates, does not. So read what the
-change does, not the feature name in its PR title.
+A change that turns out to be confined to an unreleased feature is cut — see "A change with
+no user-visible impact" below.
 
 **Do not narrate an attack the code path cannot currently suffer.** State what the fix aligns
 or corrects; leave the exploit narrative out until the path is live.
 
 ## Curating the change list
 
-**Group by domain or change type.** `### Features` / `### Bug fixes` / `### Miscellaneous`
-is the default spine under `## Other changes`; add domain headings where they carry more
-meaning. Drop any heading that would be empty, and use a flat list for a short release.
-
-**Derivation changes get `### Derivation`, listed first.** This holds for op-node and kona
-alike: derivation is the part of a release most likely to change what a node computes, so it
-is not left to fall into `### Bug fixes` among unrelated entries.
+**Add domain headings** beyond the Shape's spine where they carry more meaning. Drop any
+heading that would be empty, and use a flat list for a short release.
 
 **Group PRs that are one logical change** into one entry with all their numbers:
 `... are no longer required when only permissioned game types are configured (#21270, #21681)`.
@@ -175,16 +158,22 @@ the raw list is being replaced. Say what changed and why an operator cares:
 
 > - Tear down the whole VM process group when `--vm-timeout` is hit, preventing orphaned VM processes from lingering after a timeout (#21268)
 
-**A change with no user-visible impact does not appear at all.** Not under
-`### Miscellaneous`, not as a summarising line — a reader gains nothing from being told that
-something they cannot observe was rearranged. The one exception is a release that would
-otherwise have an empty change list, where one summarising line is more honest than
-publishing nothing.
+**A change with no user-visible impact does not appear at all** — not under
+`### Miscellaneous`, not as a summarising line. Three cases recur:
 
-Importability of the monorepo **as a Go module is not user impact**. We do not maintain
-releases of it as a Go module, so a change that only unblocks downstream importers — moving
-a symbol to a leaf package, shrinking a build closure — is cut like any other internal
-churn, however much work it was.
+- *Internal churn.* A reader gains nothing from being told that something they cannot
+  observe was rearranged.
+- *Go-module importability.* We do not maintain releases of the monorepo as a Go module, so
+  a change that only unblocks downstream importers — moving a symbol to a leaf package,
+  shrinking a build closure — is cut like any other churn, however much work it was.
+- *Anything confined to an unreleased feature.* No `(not yet in production)` heading, no
+  explanatory Note in the Overview. The test is whether the change reaches a live path, not
+  what motivated it: a fix written for an interop scenario that also alters pre-interop
+  derivation stays in, described by its live effect; the same fix, if it only fires once the
+  fork activates, does not.
+
+The one exception is a release that would otherwise have an empty change list, where one
+summarising line is more honest than publishing nothing.
 
 **Only mention a PR more than once** if it included multiple logical changes worth
 describing separately.
@@ -197,8 +186,8 @@ in the release.
 
 ## Breaking changes
 
-When a change requires operator action before upgrading, it gets its own section directly
-below `## Overview`, with a bold short name and the required action stated plainly:
+When a change requires operator action before upgrading, it gets its own section, with a bold
+short name and the required action stated plainly:
 
 ```markdown
 ## Breaking changes
@@ -214,12 +203,9 @@ anywhere else either — see "A change with no user-visible impact" above.
 
 ## Chain Configuration
 
-A release that moves a chain's embedded config gets its own `## Chain Configuration` section,
-after `## Breaking changes` when there is one and directly below `## Overview` when there is
-not — most often a new hardfork activation time arriving with a superchain-registry pin bump.
-It stands alone rather than nesting under breaking changes, because a registry bump
-frequently ships without one. Name the chains and the exact values, and say what happens to a
-node that upgrades late, since that is the whole reason the section exists:
+A release that moves a chain's embedded config gets its own section — most often a new
+hardfork activation time arriving with a superchain-registry pin bump. Name the chains and
+the exact values, and say what happens to a node that upgrades late:
 
 ```markdown
 ## Chain Configuration
@@ -235,16 +221,10 @@ node that upgrades late, since that is the whole reason the section exists:
 Saying which chains are *not* affected matters as much as which are: most readers of the
 note operate a different chain and should be able to stop reading at that sentence.
 
-## Callouts
-
-**Exactly one callout per note** — the Overview block. Nothing else. The curated list carries
-everything else, so if you find yourself reaching for a second, the content is an entry in
-the list or belongs in `## Breaking changes`.
-
 ## Tags, links and images
 
 For a finalized release the heading, the compare link's right side and the image tag all
-carry the plain version — never `-rc.N`. `scripts/retarget-tag.sh` does this.
+carry the plain version — never `-rc.N`.
 
 The compare link's **base** is the previous *finalized* tag, with three dots:
 
@@ -255,17 +235,5 @@ The compare link's **base** is the previous *finalized* tag, with three dots:
 git-cliff generates an RC base and older notes still carry one; the current convention is
 finalized-to-finalized.
 
-If a release carries recurring boilerplate from the previous release — the APKO migration
-block was one — do not copy it forward blindly. Its text was self-limiting, and it also
-implied a second image line. Ask before including it.
-
-## Working notes
-
-Keep the raw git-cliff bullets for cut PRs as HTML comments at the bottom of the draft while
-iterating, each with a short reason. A reviewer can then see what was considered and
-reinstate an entry in one edit. Delete them before publishing, or keep them if the release
-manager prefers.
-
-```markdown
-<!--* op-core/fees: add Jovian DA-footprint calculation (#22163) — doesn't affect the batcher-->
-```
+If a release carries recurring boilerplate from the previous release, do not copy it forward
+blindly — such blocks are often self-limiting, or imply a second image line. Ask first.

--- a/.claude/skills/release-notes/reference/triage.md
+++ b/.claude/skills/release-notes/reference/triage.md
@@ -25,16 +25,30 @@ change under `op-service/` or `op-core/` can absolutely change how the component
 `op-service/txmgr`, `op-service/bgpo` and `op-core/fees` all reach op-batcher.
 
 The right question: **does this PR change code compiled into this binary, and does that
-change alter behaviour an operator or downstream importer would notice?**
+change alter behaviour an operator would notice?** Downstream Go importers do not count —
+see the Drop list below.
 
 `scripts/pr-facts.sh` answers the first half exactly and tags every PR:
 
 | Tag | Meaning | Default |
 | --- | --- | --- |
 | `LINKED` | Changed a package in the binary's transitive dependency set; the listed packages are the ones that reach it | Candidate — apply the judgment pass |
-| `DEPS` | Changed only the dependency manifests | Drop, unless it is a security bump |
+| `CONFIG` | Moved the embedded superchain registry — submodule pin, generated archive checksum, or kona's snapshots. `LINKED+CONFIG` when compiled code moved too | Always read by hand |
+| `DEPS` | Changed the dependency manifests without touching a compiled package | Drop, unless it is a security bump |
 | `--` | Touched nothing the binary compiles | Drop |
 | `?` | Dependencies could not be resolved | Judge by hand |
+
+A `CONFIG` row carries no linkage evidence and never will: the embedded archive is generated
+at build time, so a registry pin bump is a submodule gitlink plus a checksum and no source
+file changes. It is also, routinely, the most consequential change in the release — read the
+PR body for which chains and which values moved. A new hardfork activation time is a
+`## Chain Configuration` entry and can make the release `required` for the chains it names.
+
+A `DEPS` row that lists paths rather than "(manifest only)" changed something else too, and
+the something else was not compiled in. Check the lock diff against the component's
+dependency set before dropping it: `rust: remove vulnerable libp2p paths` (#22714) looked
+like kona work, but moved `hickory-resolver` — which op-reth links for DNS discovery — off a
+High advisory.
 
 ## The judgment pass on LINKED rows
 
@@ -76,16 +90,18 @@ grep -rn "<ChangedSymbol>" <component>/ --include='*.go' | grep -v _test.go
 - a dev-feature toggle removal for a feature never on in production
 - comment, TODO, or docs cleanup
 - another component's work that merely brushed a shared package
-- a Go API change with no operator-facing effect — mention under `### Other` at most
+- a Go API change with no operator-facing effect, **including one that only unblocks
+  downstream importers** of the monorepo as a Go module — we do not maintain releases of it
+  as a Go module, so that is not a user-facing surface of any component
 
 **Keep a cross-component PR** when the component embeds the other one. op-supernode runs
 virtual op-nodes, so op-node's follow-source reorg metrics belong in the supernode notes even
 though the PR touches no `op-supernode/` path.
 
-**A change to a dormant feature** gets one line under a `### <Feature> (not yet in
-production)` heading if it affects this component once the feature activates, and is **cut
-entirely** if it is a no-op here and only matters to another consumer of the shared code.
-Check liveness against the registry — see `house-style.md`.
+**A change confined to an unreleased feature is cut entirely**, whether it is a no-op here or
+would matter to this component once the feature activates. Keep it only if it also reaches a
+path that is live today — and then describe the live effect, not the feature. Check liveness
+against the registry — see `house-style.md`.
 
 ## Fixes for bugs that never shipped
 
@@ -125,7 +141,7 @@ Two published releases, checked against their regenerated raw drafts:
 Regenerate any published release's raw draft to check a call:
 
 ```bash
-GITHUB_TOKEN=$(gh auth token) just release-notes op-node v1.19.3 v1.19.4
+GITHUB_TOKEN=$(gh auth token) mise exec -- just release-notes op-node v1.19.3 v1.19.4
 ```
 
 The v1.19.5 train is the closest reference for current practice. Surviving PR counts:

--- a/.claude/skills/release-notes/reference/triage.md
+++ b/.claude/skills/release-notes/reference/triage.md
@@ -91,8 +91,8 @@ grep -rn "<ChangedSymbol>" <component>/ --include='*.go' | grep -v _test.go
 - comment, TODO, or docs cleanup
 - another component's work that merely brushed a shared package
 - a Go API change with no operator-facing effect, **including one that only unblocks
-  downstream importers** of the monorepo as a Go module — we do not maintain releases of it
-  as a Go module, so that is not a user-facing surface of any component
+  downstream importers** of the monorepo as a Go module — see house-style.md for why that is
+  not a user-facing surface
 
 **Keep a cross-component PR** when the component embeds the other one. op-supernode runs
 virtual op-nodes, so op-node's follow-source reorg metrics belong in the supernode notes even

--- a/.claude/skills/release-notes/reference/triage.md
+++ b/.claude/skills/release-notes/reference/triage.md
@@ -38,17 +38,15 @@ see the Drop list below.
 | `--` | Touched nothing the binary compiles | Drop |
 | `?` | Dependencies could not be resolved | Judge by hand |
 
-A `CONFIG` row carries no linkage evidence and never will: the embedded archive is generated
-at build time, so a registry pin bump is a submodule gitlink plus a checksum and no source
-file changes. It is also, routinely, the most consequential change in the release — read the
-PR body for which chains and which values moved. A new hardfork activation time is a
-`## Chain Configuration` entry and can make the release `required` for the chains it names.
+A `CONFIG` row carries no linkage evidence and never will, yet is routinely the most
+consequential change in the release: read the PR body for which chains and which values
+moved. A new hardfork activation time is a `## Chain Configuration` entry and can make the
+release `required` for the chains it names.
 
-A `DEPS` row that lists paths rather than "(manifest only)" changed something else too, and
-the something else was not compiled in. Check the lock diff against the component's
-dependency set before dropping it: `rust: remove vulnerable libp2p paths` (#22714) looked
-like kona work, but moved `hickory-resolver` — which op-reth links for DNS discovery — off a
-High advisory.
+A `DEPS` row listing paths rather than "(manifest only)" changed something else too, which
+was not compiled in. Check the lock diff against the component's dependency set before
+dropping it — #22714 looked like kona work but moved `hickory-resolver`, which op-reth links
+for DNS discovery, off a High advisory.
 
 ## The judgment pass on LINKED rows
 
@@ -98,10 +96,8 @@ grep -rn "<ChangedSymbol>" <component>/ --include='*.go' | grep -v _test.go
 virtual op-nodes, so op-node's follow-source reorg metrics belong in the supernode notes even
 though the PR touches no `op-supernode/` path.
 
-**A change confined to an unreleased feature is cut entirely**, whether it is a no-op here or
-would matter to this component once the feature activates. Keep it only if it also reaches a
-path that is live today — and then describe the live effect, not the feature. Check liveness
-against the registry — see `house-style.md`.
+**A change confined to an unreleased feature is cut entirely.** Keep it only if it also
+reaches a path that is live today. `house-style.md` has the liveness checks.
 
 ## Fixes for bugs that never shipped
 

--- a/.claude/skills/release-notes/scripts/pr-facts.sh
+++ b/.claude/skills/release-notes/scripts/pr-facts.sh
@@ -16,10 +16,15 @@
 #
 #   LINKED  changed a package compiled into the binary; <paths> lists just those
 #           packages — that is the reason the PR may belong in the notes
-#   DEPS    changed only the dependency manifests (go.mod/go.sum, Cargo.toml/Cargo.lock)
+#   CONFIG  moved the embedded superchain registry (submodule pin, generated archive
+#           checksum, or kona's registry snapshots); read it by hand, a new activation time
+#           can make the release required. Appears as LINKED+CONFIG when the same PR also
+#           changed a compiled package
+#   DEPS    changed the dependency manifests (go.mod/go.sum, Cargo.toml/Cargo.lock) without
+#           touching a compiled package
 #   --      touched nothing the binary compiles; <paths> shows what it did touch
-#   ?       no component given, or dependencies could not be resolved; <paths> shows
-#           everything touched and the call is yours
+#   ?       no component given, dependencies could not be resolved, or the PR could not be
+#           fetched; <paths> shows everything touched and the call is yours
 #
 # Resolving the Rust dependency set takes ~2 minutes, so it is cached per component under
 # $TMPDIR and reused until rust/Cargo.lock changes.
@@ -129,7 +134,7 @@ for f in "$workdir"/pr-*; do
         }
         # The compilation unit a changed file belongs to: its package directory for Go,
         # its owning workspace crate (longest matching member directory) for Rust.
-        function unit(path,   d, best, n, seg) {
+        function unit(path,   d, best, rest) {
             if (mode == "go") {
                 # Test files are not compiled into the binary, so a PR that only adds
                 # coverage to a linked package does not change what ships.
@@ -140,11 +145,30 @@ for f in "$workdir"/pr-*; do
             best = ""
             for (d in pkgdir)
                 if (index(path, d "/") == 1 && length(d) > length(best)) best = d
-            return best == "" ? "" : pkgdir[best]
+            if (best == "") return ""
+            # Drop what the crate does not compile. A denylist rather than an allowlist of
+            # src/: crates here compile plenty from outside it -- kona embeds its registry
+            # snapshots from etc/, op-reth its dev genesis from res/, and the hardforks
+            # build script includes build_helpers.rs beside itself. Allowlisting src/ hid
+            # all three. What is left out cannot reach the binary.
+            rest = substr(path, length(best) + 2)
+            if (rest ~ /^(tests|benches|examples|scripts|testdata|proof-bench)\//) return ""
+            if (rest ~ /^(README|CHANGELOG)/) return ""
+            return pkgdir[best]
         }
         NR == 1 { num = $1; author = $2; count = $3; title = $4; next }
         {
             all[$0] = 1
+            # Every component embeds the registry, and for the Go and op-reth archives it
+            # is generated at build time -- a pin bump is a submodule gitlink plus a
+            # checksum, so no source file changes and nothing resolves as linked. Flagged
+            # explicitly because a new hardfork activation time is usually the most
+            # consequential change in the release. Matched by exact path rather than by
+            # substring, so an unrelated file whose name happens to contain
+            # "superchain-configs" cannot claim the tag.
+            if ($0 == "superchain-registry" || $0 ~ /^superchain-registry\// ||
+                $0 ~ /superchain-configs\.(zip|tar)/ ||
+                $0 ~ /^rust\/kona\/crates\/protocol\/registry\/etc\//) registry = 1
             if ($0 ~ /^(go\.(mod|sum)|rust\/Cargo\.(toml|lock))$/) { manifest = 1; next }
             other_files++
             if (mode == "none") next
@@ -159,8 +183,17 @@ for f in "$workdir"/pr-*; do
             }
             if (title ~ /^\(could not fetch/)   { tag = "?" }
             else if (mode == "none")            { tag = "?";      for (p in shorts) out = out " " p }
-            else if (length(hits))              { tag = "LINKED"; for (p in hits)   out = out " " p }
+            # CONFIG is additive, not an alternative to LINKED: a registry bump landing
+            # alongside compiled code is common, and the row must still say the chain
+            # configs moved.
+            else if (length(hits))              { tag = registry ? "LINKED+CONFIG" : "LINKED"
+                                                  for (p in hits)   out = out " " p }
+            else if (registry)                  { tag = "CONFIG"; out = " (embedded chain configs)" }
+            # DEPS, not "--", whenever a manifest moved. "--" claims the binary compiles
+            # nothing that changed, and a lockfile bump sitting next to one unrelated file
+            # (a deny.toml, or a source file from another package) is not that.
             else if (manifest && !other_files)  { tag = "DEPS";   out = " (manifest only)" }
+            else if (manifest)                  { tag = "DEPS";   for (p in shorts) out = out " " p }
             else                                { tag = "--";     for (p in shorts) out = out " " p }
             # gh returns at most 100 files, so a larger PR may hide its linked packages.
             if (count >= 100) count = count " (truncated, verify by hand)"

--- a/.claude/skills/release-notes/scripts/pr-facts.sh
+++ b/.claude/skills/release-notes/scripts/pr-facts.sh
@@ -146,11 +146,10 @@ for f in "$workdir"/pr-*; do
             for (d in pkgdir)
                 if (index(path, d "/") == 1 && length(d) > length(best)) best = d
             if (best == "") return ""
-            # Drop what the crate does not compile. A denylist rather than an allowlist of
-            # src/: crates here compile plenty from outside it -- kona embeds its registry
+            # Drop what the crate does not compile. A denylist, not an allowlist of src/:
+            # crates here compile plenty from outside it -- kona embeds its registry
             # snapshots from etc/, op-reth its dev genesis from res/, and the hardforks
-            # build script includes build_helpers.rs beside itself. Allowlisting src/ hid
-            # all three. What is left out cannot reach the binary.
+            # build script includes build_helpers.rs beside itself.
             rest = substr(path, length(best) + 2)
             if (rest ~ /^(tests|benches|examples|scripts|testdata|proof-bench)\//) return ""
             if (rest ~ /^(README|CHANGELOG)/) return ""
@@ -159,13 +158,11 @@ for f in "$workdir"/pr-*; do
         NR == 1 { num = $1; author = $2; count = $3; title = $4; next }
         {
             all[$0] = 1
-            # Every component embeds the registry, and for the Go and op-reth archives it
-            # is generated at build time -- a pin bump is a submodule gitlink plus a
-            # checksum, so no source file changes and nothing resolves as linked. Flagged
-            # explicitly because a new hardfork activation time is usually the most
-            # consequential change in the release. Matched by exact path rather than by
-            # substring, so an unrelated file whose name happens to contain
-            # "superchain-configs" cannot claim the tag.
+            # Every component embeds the registry, and the Go and op-reth archives are
+            # generated at build time -- a pin bump is a gitlink plus a checksum, so nothing
+            # resolves as linked, though a new activation time is usually the most
+            # consequential change in the release. Matched by exact path so an unrelated
+            # file whose name contains "superchain-configs" cannot claim the tag.
             if ($0 == "superchain-registry" || $0 ~ /^superchain-registry\// ||
                 $0 ~ /superchain-configs\.(zip|tar)/ ||
                 $0 ~ /^rust\/kona\/crates\/protocol\/registry\/etc\//) registry = 1

--- a/.claude/skills/release-notes/scripts/retarget-tag.sh
+++ b/.claude/skills/release-notes/scripts/retarget-tag.sh
@@ -3,8 +3,9 @@
 #
 # git-cliff generates a draft against the RC tag, so the heading, the right-hand side of
 # the compare link and the image tag all read `vX.Y.Z-rc.N`. A finalized release publishes
-# those as `vX.Y.Z`. The compare link's LEFT side stays an RC — it is the previous
-# release's base, and published notes leave it alone.
+# those as `vX.Y.Z`. The compare link's LEFT side is the previous release's base; this
+# script cannot know which release preceded this one, so it leaves that alone and warns if
+# it is still an RC. A published note compares finalized tag to finalized tag.
 #
 # Refuses to rewrite unless the finalized tag exists and points at the same commit as the
 # RC: retagging a note whose binary came from a different commit is worse than leaving the
@@ -87,3 +88,15 @@ awk -v comp="$component" -v rc="$rc" -v final="$final" '
 ' "$notes" > "$tmp"
 
 cat "$tmp" > "$notes"
+
+# Whatever RC survives is the compare link's base, which this script deliberately does not
+# rewrite. Publishing it that way compares a finalized release against an RC.
+leftover=$(grep -oE "$component/v[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+" "$notes" |
+           sort -u | paste -sd' ' - || true)
+if [ -n "$leftover" ]; then
+    cat >&2 <<EOF
+WARNING: $notes still references $leftover — the compare link's base.
+  Set it to the previous finalized release of $component before publishing; a published
+  note compares finalized tag to finalized tag.
+EOF
+fi


### PR DESCRIPTION
Writing the op-node/v1.19.6 and op-reth/v2.4.3 notes surfaced format rules the skill had wrong and two classes of PR its triage script was silently dropping. Both drafts were hand-edited to their final shape before publishing; this folds those decisions back into the skill so the next release does not re-derive them.

## Format

- A release is classified `optional` / `recommended` / `strongly recommended` / `required`, never as a semver type — our tags are not strict semver, so "this is a minor release" carries no information. The callout block follows that ladder (NOTE / IMPORTANT / CAUTION) instead of being fixed.
- New `## Chain Configuration` section for a release that moves a chain's embedded config. It stands on its own rather than nesting under breaking changes, because a registry pin bump frequently ships without one.
- `## What's Changed` becomes `## Other changes` — the sections above it are also changes, and the old heading was git-cliff's rather than ours. Its catch-all `### Other` becomes `### Miscellaneous`.
- Derivation changes get `### Derivation`, listed first.
- A change with no user-visible impact is cut outright rather than demoted to a catch-all. Two cases are called out because both landed in a draft: importability of the monorepo as a Go module (we do not maintain releases of it as a Go module), and anything confined to an unreleased feature — previously that got a `(not yet in production)` heading and an Overview note.

## pr-facts.sh

Three rows it got wrong on this release train, each verified against both drafts:

| PR | was | now |
| --- | --- | --- |
| #22624 superchain-registry pin bump | `--` | `CONFIG` (op-node) / `LINKED+CONFIG` (op-reth) |
| #22714, #22500 lockfile security bumps | `--` | `DEPS` |
| #22375 vestigial docker cleanup | `LINKED` | `--` |

The registry bump was the most consequential change in both releases — it carries the World Chain Karst activation times — and the script reported it as touching nothing the binary compiles, because the embedded archive is generated at build time. The `--` on #22714 hid a `hickory-resolver` advisory fix in a library op-reth links for DNS discovery; `DEPS` only fired when the manifests were the *only* changed files, so one unrelated file demoted the row.

## Review

Two review agents were run on the diff. Applied from their findings: `CONFIG` is additive (`LINKED+CONFIG`) rather than losing to `LINKED`, which would have missed #21441 and #21674; Rust linkage uses a denylist rather than an `src/`-only allowlist, which had dropped three genuinely compiled path classes (kona's `registry/etc/*.json`, op-reth's `res/genesis/dev.json`, `hardforks/build_helpers.rs`); the registry path match is anchored; and several cross-file contradictions the restructure left behind.

Also applied: `SKILL.md` no longer restates the recommendation ladder, the callout mapping, the no-user-visible-impact rule or the grouping spine. It already directs the writer to read `house-style.md` before writing, so the restatements bought nothing and could only drift; steps 5 and 6 now say what each step decides and defer the rules themselves.

Dismissed, for @sebastianst to confirm:

- `op-challenger/v1.9.4` and `op-contracts/v8.0.0-rc.2` stay linked as exemplars even though they predate the new layout, with a line saying to take entry style from them and section layout from the Shape. Every published release predates it, so there is no better exemplar yet.

Not run: the Go, Rust, contracts and CI-config reviewers — the diff touches none of those areas.

For review: the unreleased-feature rule (cut entirely, rather than a `(not yet in production)` heading) is the one change made without prior agreement, and the one most worth pushing back on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016SWr5hbk9Y5K37L3KcVNJN
