### PR TITLE
kona-sp1-proposer: reject terminal attempts before witness collection

### DIFF
--- a/rust/kona/sp1/README.md
+++ b/rust/kona/sp1/README.md
@@ -179,6 +179,44 @@ A restart loses all progress and re-detects games that still need proofs. A
 pre-flight check prevents duplicate `prove()` submissions. Fast finality also
 re-detects unproven, signer-created games after restart.
 
+### Terminal proof retry
+
+`Unexecutable` and local `ValidationFailed` requests are sticky. For unchanged
+attempt inputs, the proposer rejects the attempt before collecting witnesses
+or submitting another SPN request. Scheduler tasks may still run and check
+inputs. A change to the full attempt identity permits a new attempt.
+
+SIGUSR1 is a Unix signal: a message you send to a running program. Send it to
+the proposer to retry terminal proof requests without restarting it. This
+applies to all tracked games. The proposer keeps pending requests, finished
+proofs, and completed chunks. Normal scheduling decides when retries run.
+
+Check that the running build supports SIGUSR1 and has logged `kona-sp1-proposer started`.
+Older builds may exit when they receive this signal.
+
+Find the proposer's process ID (PID):
+
+```bash
+pgrep -fl kona-sp1-proposer
+```
+
+Replace `12345` below with that PID. Check that it is the right process before
+running `kill`:
+
+```bash
+ps -p 12345 -o pid=,command=
+kill -USR1 12345
+```
+
+Look for `Processed terminal proof retry` in the proposer logs:
+
+- `reset_games`: games cleared for another try.
+- `busy_games`: games with active proving tasks. These games were not reset.
+  Wait for them to finish, then send another signal to retry them.
+
+If a retry fails terminally, send another signal to try again. Several signals
+sent together may count as one request.
+
 ### Operator alarms
 
 `kona_sp1_proposer_game_proving_error` counts failed proving tasks. A sustained

--- a/rust/kona/sp1/crates/proposer/src/adapters.rs
+++ b/rust/kona/sp1/crates/proposer/src/adapters.rs
@@ -399,6 +399,10 @@ impl ProofEngine for ProductionProofEngine {
     fn clear(&self, game_address: Address) {
         self.proof_progress.clear(game_address);
     }
+
+    fn retry_terminal_requests(&self, game_address: Address) -> usize {
+        self.proof_progress.retry_terminal_requests(game_address)
+    }
 }
 
 /// Production transaction construction, serialized submission, and receipt decoding.

--- a/rust/kona/sp1/crates/proposer/src/bin/kona-sp1-proposer.rs
+++ b/rust/kona/sp1/crates/proposer/src/bin/kona-sp1-proposer.rs
@@ -111,7 +111,9 @@ async fn main() -> Result<()> {
         ProposerGauge::init_all();
     }
 
-    let proposer = Proposer::new(config, signer, factory, proof_provider).await?;
+    let proposer = Arc::new(Proposer::new(config, signer, factory, proof_provider).await?);
+    #[cfg(unix)]
+    proposer.install_proof_retry_signal()?;
 
     // Devstack readiness matches this message. Emit it before chain-dependent
     // initialization so a deriving supernode does not stall process readiness.
@@ -120,5 +122,5 @@ async fn main() -> Result<()> {
         None => tracing::info!("kona-sp1-proposer started"),
     }
 
-    Arc::new(proposer).run().await
+    proposer.run().await
 }

--- a/rust/kona/sp1/crates/proposer/src/ports.rs
+++ b/rust/kona/sp1/crates/proposer/src/ports.rs
@@ -235,6 +235,9 @@ pub(crate) trait ProofEngine: Send + Sync {
         responses: Vec<SuperRootAtTimestampResponse>,
     ) -> Result<Vec<u8>>;
     fn clear(&self, game_address: Address);
+    /// Resets only terminal requests, returning the number reset.
+    /// Scheduler policy requires the caller to skip games with tracked proving tasks.
+    fn retry_terminal_requests(&self, game_address: Address) -> usize;
 }
 
 /// Confirmed proposer transaction effects.

--- a/rust/kona/sp1/crates/proposer/src/proposer.rs
+++ b/rust/kona/sp1/crates/proposer/src/proposer.rs
@@ -697,6 +697,7 @@ pub struct Proposer {
     pub prestates: Arc<PrestateCache>,
     tasks: Arc<tokio::sync::Mutex<TaskMap>>,
     next_task_id: Arc<AtomicU64>,
+    proof_retry_requested: Arc<AtomicBool>,
     state: Arc<RwLock<ProposerState>>,
     /// Proposer identity for foreign-game filtering and hardfork safety.
     pub identity: ProposerIdentity,
@@ -823,6 +824,7 @@ impl Proposer {
             prestates,
             tasks: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
             next_task_id: Arc::new(AtomicU64::new(1)),
+            proof_retry_requested: Arc::new(AtomicBool::new(false)),
             state: Arc::new(RwLock::new(ProposerState::default())),
             identity,
             last_successful_pinned_l1: Arc::new(RwLock::new(None)),
@@ -834,6 +836,48 @@ impl Proposer {
             max_challenge_duration: Arc::new(OnceCell::new()),
             undefendable: Arc::new(Mutex::new(HashSet::new())),
         })
+    }
+
+    /// Registers process-wide SIGUSR1 recovery. Call before advertising readiness.
+    #[cfg(unix)]
+    pub fn install_proof_retry_signal(self: &Arc<Self>) -> Result<()> {
+        let mut signal =
+            tokio::signal::unix::signal(tokio::signal::unix::SignalKind::user_defined1())
+                .context("register SIGUSR1 proof retry handler")?;
+        let proposer = Arc::clone(self);
+        tokio::spawn(async move {
+            while signal.recv().await.is_some() {
+                proposer.proof_retry_requested.store(true, Ordering::Relaxed);
+            }
+        });
+        Ok(())
+    }
+
+    async fn retry_terminal_proofs(&self) {
+        let active_games: HashSet<_> = self
+            .tasks
+            .lock()
+            .await
+            .values()
+            .filter_map(|(_, operation)| match operation.deduplication_key() {
+                TaskDeduplicationKey::Proving(address) => Some(address),
+                _ => None,
+            })
+            .collect();
+        let mut reset_games = Vec::new();
+        let mut busy_games = Vec::new();
+        for game in self.state.read().await.games.values() {
+            if active_games.contains(&game.address) {
+                busy_games.push(game.address);
+                continue;
+            }
+            let requests = self.proof_engine.retry_terminal_requests(game.address);
+            if requests > 0 {
+                reset_games.push(game.address);
+                tracing::info!(game_address = %game.address, requests, "Reset terminal proof requests");
+            }
+        }
+        tracing::info!(?reset_games, ?busy_games, "Processed terminal proof retry");
     }
 
     /// Runs the proposer indefinitely.
@@ -859,6 +903,9 @@ impl Proposer {
     pub(crate) async fn cycle(&self) -> Result<CycleResult> {
         let sync_disposition = self.sync_state().await?;
         let completions = self.reap_completed_tasks().await;
+        if self.proof_retry_requested.swap(false, Ordering::Relaxed) {
+            self.retry_terminal_proofs().await;
+        }
         let planned = self.determine_pending_operations().await;
         let snapshot = self.cycle_snapshot(sync_disposition).await;
         let scheduled = self.spawn_planned_operations(planned).await;
@@ -3788,11 +3835,12 @@ mod tests {
     }
 
     #[derive(Default)]
-    struct RecordingProofEngine {
+    pub(super) struct RecordingProofEngine {
         calls: StdMutex<Vec<(GameProofInputs, Vec<SuperRootAtTimestampResponse>)>>,
         proof: Vec<u8>,
         fail: bool,
         cleared: StdMutex<Vec<Address>>,
+        pub(super) retried: parking_lot::Mutex<Vec<Address>>,
         cached: StdMutex<Option<Vec<u8>>>,
         generations: std::sync::atomic::AtomicUsize,
     }
@@ -3822,6 +3870,11 @@ mod tests {
         fn clear(&self, game_address: Address) {
             *self.cached.lock().unwrap() = None;
             self.cleared.lock().unwrap().push(game_address);
+        }
+
+        fn retry_terminal_requests(&self, game_address: Address) -> usize {
+            self.retried.lock().push(game_address);
+            0
         }
     }
 
@@ -4384,6 +4437,44 @@ mod tests {
         let task_id = TaskId::allocate(&proposer.next_task_id);
         let handle = tokio::spawn(async { Ok(TaskSuccess::Completed) });
         proposer.tasks.lock().await.insert(task_id, (handle, operation));
+    }
+
+    #[tokio::test]
+    async fn terminal_retry_skips_active_games() {
+        let mut proposer = test_proposer().await;
+        let engine = Arc::new(RecordingProofEngine::default());
+        proposer.proof_engine = engine.clone();
+        let defense = game_with(1, u32::MAX, 100);
+        let fast_finality = game_with(2, u32::MAX, 100);
+        let settled = game_with(3, u32::MAX, 100);
+        for (game, purpose) in
+            [(&defense, ProvingPurpose::Defense), (&fast_finality, ProvingPurpose::FastFinality)]
+        {
+            insert_task(
+                &proposer,
+                OperationSummary::ProveGame {
+                    factory_index: game.index,
+                    address: game.address,
+                    purpose,
+                },
+            )
+            .await;
+        }
+        for game in [&defense, &fast_finality, &settled] {
+            proposer.state.write().await.games.insert(game.index, game.clone());
+        }
+
+        proposer.retry_terminal_proofs().await;
+        assert_eq!(*engine.retried.lock(), vec![settled.address]);
+
+        let tasks = proposer.tasks.lock().await.keys().copied().collect::<Vec<_>>();
+        proposer.finalize_tasks(&tasks, None).await.unwrap();
+        engine.retried.lock().clear();
+        proposer.retry_terminal_proofs().await;
+        assert_eq!(
+            engine.retried.lock().iter().copied().collect::<HashSet<_>>(),
+            HashSet::from([defense.address, fast_finality.address, settled.address]),
+        );
     }
 
     #[test]
@@ -5462,6 +5553,7 @@ mod tests {
             proof: proof.clone(),
             fail: false,
             cleared: StdMutex::new(Vec::new()),
+            retried: parking_lot::Mutex::default(),
             cached: StdMutex::new(None),
             generations: std::sync::atomic::AtomicUsize::new(0),
         });
@@ -5536,6 +5628,7 @@ mod tests {
                 proof: vec![0xaa],
                 fail,
                 cleared: StdMutex::new(Vec::new()),
+                retried: parking_lot::Mutex::default(),
                 cached: StdMutex::new(None),
                 generations: std::sync::atomic::AtomicUsize::new(0),
             });

--- a/rust/kona/sp1/crates/proposer/src/proposer/scenario/tests.rs
+++ b/rust/kona/sp1/crates/proposer/src/proposer/scenario/tests.rs
@@ -301,6 +301,10 @@ impl ProofEngine for NoopProofEngine {
     }
 
     fn clear(&self, _game_address: Address) {}
+
+    fn retry_terminal_requests(&self, _game_address: Address) -> usize {
+        0
+    }
 }
 
 struct NoopActionExecutor;
@@ -502,6 +506,67 @@ async fn tick_does_not_wait_for_fetch_interval() {
             Some(&scheduled.operation)
         );
     }
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn sigusr1_requests_terminal_retry() {
+    const CHILD_ENV: &str = "KONA_SP1_SIGNAL_TEST_CHILD";
+    const CHILD_COMPLETED: &str = "__KONA_SP1_SIGUSR1_TERMINAL_RETRY_CHILD_COMPLETED__";
+    if std::env::var_os(CHILD_ENV).is_none() {
+        let (_, test_name) =
+            concat!(module_path!(), "::", stringify!(sigusr1_requests_terminal_retry))
+                .split_once("::")
+                .unwrap();
+        let mut command = tokio::process::Command::new(std::env::current_exe().unwrap());
+        command.args(["--exact", test_name, "--nocapture"]).env(CHILD_ENV, "1").kill_on_drop(true);
+        let output =
+            tokio::time::timeout(Duration::from_secs(10), command.output()).await.unwrap().unwrap();
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            output.status.success() && stdout.contains(CHILD_COMPLETED),
+            "signal subprocess failed or did not complete:\n{}\n{}",
+            stdout,
+            String::from_utf8_lossy(&output.stderr),
+        );
+        return;
+    }
+
+    let mut proposer = proposer_with(test_config(30), Arc::new(ScenarioL1View::new())).await;
+    let engine = Arc::new(crate::proposer::tests::RecordingProofEngine::default());
+    Arc::get_mut(&mut proposer).unwrap().proof_engine = engine.clone();
+    proposer.sync_state().await.unwrap();
+    // An unchallenged game exercises recovery without scheduling proof work.
+    let mut game = challenged_game(1, 5_000);
+    game.proposal_status = ProposalStatus::Unchallenged;
+    let address = game.address;
+    proposer.state.write().await.games.insert(game.index, game);
+    proposer.install_proof_retry_signal().unwrap();
+    let status = tokio::process::Command::new("kill")
+        .args(["-USR1", &std::process::id().to_string()])
+        .status()
+        .await
+        .unwrap();
+    assert!(status.success());
+    tokio::time::timeout(Duration::from_secs(1), async {
+        while !proposer.proof_retry_requested.load(Ordering::Relaxed) {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .unwrap();
+    let mut control = ScenarioControl::new(proposer.clone(), Duration::from_secs(1));
+    for _ in 0..2 {
+        let tick = control.tick().await.unwrap();
+        assert_eq!(
+            *engine.retried.lock(),
+            vec![address],
+            "one signal authorizes one recovery pass"
+        );
+        let tasks = tick.scheduled.iter().map(|scheduled| scheduled.task_id).collect::<Vec<_>>();
+        control.settle(&tasks).await.unwrap();
+    }
+    println!("{CHILD_COMPLETED}");
 }
 
 #[tokio::test(start_paused = true)]

--- a/rust/kona/sp1/crates/proposer/src/proving.rs
+++ b/rust/kona/sp1/crates/proposer/src/proving.rs
@@ -262,6 +262,41 @@ impl GameProgress {
         Self { identity, chunks, aggregation_request: Mutex::new(RequestState::Missing) }
     }
 
+    fn requests(
+        &self,
+    ) -> impl Iterator<Item = (Option<usize>, &'static str, &Mutex<RequestState>)> {
+        self.chunks
+            .iter()
+            .enumerate()
+            .flat_map(|(index, chunk)| {
+                [
+                    (Some(index), "range", &chunk.range_request),
+                    (Some(index), "consolidation", &chunk.consolidation_request),
+                ]
+            })
+            .chain(std::iter::once((None, "aggregation", &self.aggregation_request)))
+    }
+
+    fn check_terminal_requests(&self) -> Result<()> {
+        for (chunk_index, kind, request) in self.requests() {
+            match &*request.lock() {
+                RequestState::Terminal(outcome) => {
+                    if let Some(index) = chunk_index {
+                        bail!(
+                            "chunk {index} {kind} proof request reached terminal state: {outcome:?}"
+                        );
+                    }
+                    bail!("{kind} proof request reached terminal state: {outcome:?}");
+                }
+                RequestState::Missing |
+                RequestState::Submitting |
+                RequestState::Submitted(_) |
+                RequestState::Fulfilled(_) => {}
+            }
+        }
+        Ok(())
+    }
+
     fn request_summary(&self) -> RequestSummary {
         let mut summary = RequestSummary::default();
         let mut record = |state: &Mutex<RequestState>| match &*state.lock() {
@@ -270,11 +305,9 @@ impl GameProgress {
             RequestState::Fulfilled(_) => summary.fulfilled += 1,
             RequestState::Missing | RequestState::Terminal(_) => {}
         };
-        for chunk in &self.chunks {
-            record(&chunk.range_request);
-            record(&chunk.consolidation_request);
+        for (_, _, request) in self.requests() {
+            record(request);
         }
-        record(&self.aggregation_request);
         summary
     }
 }
@@ -322,6 +355,29 @@ impl InMemoryProofProgress {
 
     pub(crate) fn clear(&self, game_address: Address) {
         self.games.lock().remove(&game_address);
+    }
+
+    /// Resets only terminal request slots.
+    pub(crate) fn retry_terminal_requests(&self, game_address: Address) -> usize {
+        let games = self.games.lock();
+        let Some(progress) = games.get(&game_address) else {
+            return 0;
+        };
+        let mut reset = 0;
+        for (_, _, request) in progress.requests() {
+            let mut state = request.lock();
+            match &*state {
+                RequestState::Terminal(_) => {
+                    *state = RequestState::Missing;
+                    reset += 1;
+                }
+                RequestState::Missing |
+                RequestState::Submitting |
+                RequestState::Submitted(_) |
+                RequestState::Fulfilled(_) => {}
+            }
+        }
+        reset
     }
 }
 
@@ -423,6 +479,7 @@ async fn complete_request(
     Ok(proof)
 }
 
+/// Terminal requests are rejected by the preflight in `plan_game_attempt`.
 fn reuse_fulfilled_aggregation(
     state: &Mutex<RequestState>,
     game: &GameProofInputs,
@@ -430,9 +487,6 @@ fn reuse_fulfilled_aggregation(
 ) -> Result<Option<Vec<u8>>> {
     let proof = match &*state.lock() {
         RequestState::Fulfilled(proof) => Arc::clone(proof),
-        RequestState::Terminal(outcome) => {
-            bail!("aggregation proof request reached terminal state: {outcome:?}")
-        }
         _ => return Ok(None),
     };
     verify(&proof)?;
@@ -660,7 +714,6 @@ async fn prove_chunk_inner(
     let chunk_progress = &progress.chunks[index];
     let synthesized = &plan.synthesized;
     let span = synthesized.range_inputs.span;
-
     let range_host = build_interop_host(
         host_inputs,
         game.l1_head,
@@ -720,13 +773,13 @@ async fn prove_chunk_inner(
     Ok(ChunkResult { index, range_outputs, consolidation_outputs, proofs })
 }
 
+/// Selects cached progress and rejects terminal attempts before returning executable chunks.
 fn plan_game_attempt(
     provider: &ProofProvider,
     keys: Option<&ProofKeys>,
-    game: &GameProofInputs,
-    responses: &[SuperRootAtTimestampResponse],
-    split: RangeSplitCount,
-) -> Result<(Vec<ChunkPlan>, AttemptIdentity)> {
+    request: &ProveGameRequest<'_>,
+) -> Result<(Vec<ChunkPlan>, Arc<GameProgress>)> {
+    let ProveGameRequest { game_address, game, responses, split, proof_progress, .. } = *request;
     let chunks = split.split(game.starting_ts, game.claim_ts)?;
     let mut plans = Vec::with_capacity(chunks.len());
     let mut chunk_identities = Vec::with_capacity(chunks.len());
@@ -759,7 +812,9 @@ fn plan_game_attempt(
         provider: provider_identity(provider, keys)?,
         chunks: chunk_identities,
     };
-    Ok((plans, identity))
+    let progress = proof_progress.load_or_create(game_address, identity);
+    progress.check_terminal_requests()?;
+    Ok((plans, progress))
 }
 
 /// Inputs for one in-process game-proving attempt.
@@ -789,12 +844,11 @@ pub async fn prove_game_inner(
     host_inputs: &HostInputs,
     request: ProveGameRequest<'_>,
 ) -> Result<Vec<u8>> {
-    let ProveGameRequest { game_address, game, responses, split, max_concurrent, proof_progress } =
-        request;
     if !provider.is_mock() {
         ensure!(keys.is_some(), "network proving requires prestate proving keys");
     }
-    let (plans, identity) = plan_game_attempt(provider, keys, game, responses, split)?;
+    let (plans, progress) = plan_game_attempt(provider, keys, &request)?;
+    let ProveGameRequest { game, responses, max_concurrent, .. } = request;
     let chunk_count = plans.len();
     tracing::info!(
         starting_ts = game.starting_ts,
@@ -802,7 +856,6 @@ pub async fn prove_game_inner(
         chunks = chunk_count,
         "Proving game span"
     );
-    let progress = proof_progress.load_or_create(game_address, identity);
 
     if !provider.is_mock() &&
         let Some(proof) =
@@ -1172,7 +1225,7 @@ mod tests {
     }
 
     #[test]
-    fn synthesized_input_change_replaces_progress() {
+    fn terminal_attempt_retries_only_after_identity_change_or_reset() {
         let start = response_at(100, 0x01, 5);
         let middle = response_at(101, 0x02, 5);
         let end = response_at(102, 0x03, 5);
@@ -1180,27 +1233,150 @@ mod tests {
         let responses = vec![start.clone(), middle, end.clone()];
         let provider = ProofProvider::Mock(crate::prover::MockProofProvider);
         let cache = InMemoryProofProgress::default();
-        let game_address = Address::repeat_byte(0x45);
-
-        let (_, identity) =
-            plan_game_attempt(&provider, None, &game, &responses, RangeSplitCount::one()).unwrap();
-        let first = cache.load_or_create(game_address, identity);
-
-        let (_, identity) =
-            plan_game_attempt(&provider, None, &game, &responses, RangeSplitCount::one()).unwrap();
-        let unchanged = cache.load_or_create(game_address, identity);
-        assert!(Arc::ptr_eq(&first, &unchanged));
+        let request = ProveGameRequest {
+            game_address: Address::repeat_byte(0x45),
+            game: &game,
+            responses: &responses,
+            split: RangeSplitCount::one(),
+            max_concurrent: NonZeroUsize::MIN,
+            proof_progress: &cache,
+        };
+        let (_, progress) = plan_game_attempt(&provider, None, &request).unwrap();
+        *progress.chunks[0].range_request.lock() =
+            RequestState::Terminal(ProofTerminalState::Unexecutable);
+        assert!(plan_game_attempt(&provider, None, &request).is_err());
 
         let changed_responses = vec![start, response_at(101, 0x04, 5), end];
-        let (_, identity) =
-            plan_game_attempt(&provider, None, &game, &changed_responses, RangeSplitCount::one())
-                .unwrap();
-        let changed = cache.load_or_create(game_address, identity);
+        let request = ProveGameRequest { responses: &changed_responses, ..request };
+        let (_, progress) = plan_game_attempt(&provider, None, &request).unwrap();
+        *progress.chunks[0].range_request.lock() =
+            RequestState::Terminal(ProofTerminalState::ValidationFailed);
+        assert!(plan_game_attempt(&provider, None, &request).is_err());
 
-        assert!(!Arc::ptr_eq(&first, &changed));
-        assert_eq!(first.identity.game, changed.identity.game);
-        assert_eq!(first.identity.provider, changed.identity.provider);
-        assert_ne!(first.identity.chunks, changed.identity.chunks);
+        assert_eq!(cache.retry_terminal_requests(request.game_address), 1);
+        let (_, progress) = plan_game_attempt(&provider, None, &request).unwrap();
+        *progress.chunks[0].range_request.lock() =
+            RequestState::Terminal(ProofTerminalState::Unexecutable);
+        assert!(plan_game_attempt(&provider, None, &request).is_err());
+    }
+
+    #[test]
+    fn terminal_preflight_checks_later_children_and_aggregation() {
+        let responses =
+            vec![response_at(100, 1, 5), response_at(101, 2, 5), response_at(102, 3, 5)];
+        let game = game_for(&responses[0], &responses[2], 10);
+        let provider = ProofProvider::Mock(crate::prover::MockProofProvider);
+        for (slot, state) in [
+            (2, ProofTerminalState::Unexecutable),
+            (3, ProofTerminalState::ValidationFailed),
+            (4, ProofTerminalState::Unexecutable),
+        ] {
+            let cache = InMemoryProofProgress::default();
+            let request = ProveGameRequest {
+                game_address: Address::repeat_byte(0x45),
+                game: &game,
+                responses: &responses,
+                split: RangeSplitCount::new(2).unwrap(),
+                max_concurrent: NonZeroUsize::MIN,
+                proof_progress: &cache,
+            };
+            let (_, progress) = plan_game_attempt(&provider, None, &request).unwrap();
+            let (_, _, request_state) = progress.requests().nth(slot).unwrap();
+            *request_state.lock() = RequestState::Terminal(state);
+            let error = plan_game_attempt(&provider, None, &request)
+                .err()
+                .expect("terminal attempts must not return executable chunk plans");
+            assert!(!is_unprovable(&error), "{error}");
+        }
+    }
+
+    #[tokio::test]
+    async fn terminal_reset_preserves_reusable_work() {
+        let start = response_at(100, 1, 5);
+        let end = response_at(102, 3, 5);
+        let game = game_for(&start, &end, 10);
+        let address = Address::repeat_byte(0x45);
+        let cache = InMemoryProofProgress::default();
+        let identity = attempt_identity(game);
+        let progress = cache.load_or_create(address, identity.clone());
+        run_chunk_with_progress(&progress.chunks[0], async { Ok(chunk_result(0)) }).await.unwrap();
+        let mut proof = fulfilled_proof();
+        proof.public_values = SP1PublicValues::from(&[0x42]);
+        let proof = Arc::new(proof);
+        *progress.chunks[0].range_request.lock() = RequestState::Fulfilled(proof.clone());
+        *progress.chunks[0].consolidation_request.lock() = RequestState::Fulfilled(proof);
+        let pending_id = B256::repeat_byte(0x46);
+        *progress.chunks[1].range_request.lock() = RequestState::Submitted(pending_id);
+        *progress.chunks[1].consolidation_request.lock() =
+            RequestState::Terminal(ProofTerminalState::Unexecutable);
+        *progress.aggregation_request.lock() =
+            RequestState::Terminal(ProofTerminalState::ValidationFailed);
+
+        assert_eq!(cache.retry_terminal_requests(address), 2);
+        let progress = cache.load_or_create(address, identity);
+        run_chunk_with_progress(&progress.chunks[0], async { panic!("completed chunk was lost") })
+            .await
+            .unwrap();
+        let reused = complete_request(
+            &progress.chunks[0].range_request,
+            async || panic!("fulfilled request was resubmitted"),
+            async |_| panic!("fulfilled request was polled"),
+            |_| Ok(()),
+        )
+        .await
+        .unwrap();
+        assert_eq!(reused.public_values.as_slice(), &[0x42]);
+        complete_request(
+            &progress.chunks[1].range_request,
+            async || panic!("pending request was resubmitted"),
+            async |id| {
+                assert_eq!(id, pending_id);
+                Ok(fulfilled_proof())
+            },
+            |_| Ok(()),
+        )
+        .await
+        .unwrap();
+        let submissions = AtomicUsize::new(0);
+        for slot in [&progress.chunks[1].consolidation_request, &progress.aggregation_request] {
+            complete_request(
+                slot,
+                async || {
+                    submissions.fetch_add(1, Ordering::Relaxed);
+                    Ok(B256::repeat_byte(0x47))
+                },
+                async |_| Ok(fulfilled_proof()),
+                |_| Ok(()),
+            )
+            .await
+            .unwrap();
+        }
+        assert_eq!(submissions.load(Ordering::Relaxed), 2);
+    }
+
+    #[test]
+    fn terminal_reset_preserves_fulfilled_aggregation() {
+        let start = response_at(100, 1, 5);
+        let end = response_at(102, 3, 5);
+        let game = game_for(&start, &end, 10);
+        let address = Address::repeat_byte(0x48);
+        let cache = InMemoryProofProgress::default();
+        let identity = attempt_identity(game.clone());
+        let progress = cache.load_or_create(address, identity.clone());
+        let expected = expected_aggregation_public_values(&game);
+        let proof = SP1ProofWithPublicValues {
+            proof: SP1Proof::Plonk(Default::default()),
+            public_values: SP1PublicValues::from(&expected),
+            ..fulfilled_proof()
+        };
+        let bytes = proof.bytes();
+        *progress.aggregation_request.lock() = RequestState::Fulfilled(Arc::new(proof));
+        assert_eq!(cache.retry_terminal_requests(address), 0);
+        let progress = cache.load_or_create(address, identity);
+        assert_eq!(
+            reuse_fulfilled_aggregation(&progress.aggregation_request, &game, |_| Ok(())).unwrap(),
+            Some(bytes),
+        );
     }
 
     #[test]
@@ -1612,6 +1788,9 @@ mod tests {
         let release_admitted = Arc::new(tokio::sync::Notify::new());
         let admitted_completed = Arc::new(AtomicBool::new(false));
         let queued_started = Arc::new(AtomicBool::new(false));
+        let start = response_at(100, 1, 5);
+        let end = response_at(102, 3, 5);
+        let progress = Arc::new(GameProgress::new(attempt_identity(game_for(&start, &end, 10))));
 
         let tasks = (0..3).map(|index| {
             let admitted_started = Arc::clone(&admitted_started);
@@ -1619,18 +1798,33 @@ mod tests {
             let release_admitted = Arc::clone(&release_admitted);
             let admitted_completed = Arc::clone(&admitted_completed);
             let queued_started = Arc::clone(&queued_started);
+            let progress = Arc::clone(&progress);
             async move {
                 match index {
                     0 => {
                         admitted_started.notify_one();
                         release_admitted.notified().await;
+                        let result = complete_request(
+                            &progress.chunks[0].range_request,
+                            async || Ok(B256::repeat_byte(0x49)),
+                            async |proof_id| {
+                                Err(ProofWaitError::Terminal {
+                                    proof_id,
+                                    state: ProofTerminalState::Unexecutable,
+                                    fulfillment_status: 0,
+                                    execution_status: 0,
+                                })
+                            },
+                            |_| Ok(()),
+                        )
+                        .await;
                         admitted_completed.store(true, Ordering::SeqCst);
-                        Ok(index)
+                        result.map(|_| index)
                     }
                     1 => {
                         admitted_started.notified().await;
                         error_reported.notify_one();
-                        Err(anyhow::anyhow!("chunk B failed"))
+                        Err(std::io::Error::from(std::io::ErrorKind::TimedOut).into())
                     }
                     2 => {
                         queued_started.store(true, Ordering::SeqCst);
@@ -1652,7 +1846,8 @@ mod tests {
         let result = run_chunk_tasks_until_error(tasks, 2).await;
         controller.await.unwrap();
 
-        assert_eq!(result.unwrap_err().to_string(), "chunk B failed");
+        assert!(result.unwrap_err().downcast_ref::<std::io::Error>().is_some());
+        assert!(progress.check_terminal_requests().is_err());
         assert!(
             admitted_completed.load(Ordering::SeqCst),
             "admitted sibling was dropped before completion"


### PR DESCRIPTION
## Summary

The proposer already caches terminal SPN failures, but each retry collects witnesses again before checking that cached state. This wastes local compute without submitting a new SPN request.

Check terminal state after selecting progress for the current attempt identity, before starting any proof chunks. The check covers range, consolidation, and aggregation requests, and reports which slot is blocked. `Unexecutable` and `ValidationFailed` remain sticky until the identity changes or an operator requests a retry.

On Unix, operators can send `SIGUSR1` to retry terminal requests without restarting the proposer:

```bash
kill -USR1 <proposer-pid>
```

Recovery preserves pending request IDs, fulfilled proofs, and completed chunks. It skips games with active proving tasks and logs which games were reset or skipped. Busy games need another signal after their tasks settle.

Scheduler eligibility, concurrency limits, and lifecycle cleanup remain unchanged. Blocked games can still get scheduler attempts and input checks, but cannot reach witness collection.

Fixes #22764.

## Verification

- All 175 proposer tests pass, including sticky-state, identity-change, selective-reset, active-game exclusion, and real SIGUSR1 subprocess coverage.
- A temporary smoke probe confirmed zero chunk executions across repeated blocked attempts, then resumed chunk execution after reset or identity change. No live SPN proof was submitted.
- Regression tests fail when the terminal guard or scheduler-to-recovery call is removed. The signal test also rejects a child that exits successfully after matching zero tests.
- Clippy, rustdoc with warnings denied, and the workspace formatting check pass.

```bash
mise exec -- cargo nextest run --locked --package kona-sp1-proposer --all-features
mise exec -- cargo clippy --locked --package kona-sp1-proposer --all-targets --all-features --no-deps -- -D warnings
mise exec -- env RUSTDOCFLAGS='-D warnings' cargo doc --locked --package kona-sp1-proposer --all-features --no-deps
mise exec -- just fmt-check
```

Run these commands from `rust/`.