### PR TITLE
op-reth: set TRACY_NO_INVARIANT_CHECK in cargo config

### DIFF
--- a/docs/ai/rust-dev.md
+++ b/docs/ai/rust-dev.md
@@ -72,6 +72,10 @@ just test-unit
 just test-docs
 ```
 
+`--all-features` pulls in tracy via `reth-tracing`. On hosts without an invariant TSC,
+`tracy-client-sys` otherwise `exit(1)`s before any test runs. `rust/.cargo/config.toml`
+sets `TRACY_NO_INVARIANT_CHECK=1` (non-forced; override with `=0` in the shell if needed).
+
 ### Running op-reth E2E Tests
 
 The op-reth E2E tests (`rust/op-reth/tests/proofs/`) run a full devnet with op-geth (sequencer) and op-reth (validator). They require two build prerequisites:

--- a/rust/.cargo/config.toml
+++ b/rust/.cargo/config.toml
@@ -1,6 +1,11 @@
 [alias]
 docs = "doc --workspace --all-features --no-deps"
 
+# tracy-client-sys exit(1)s on hosts without an invariant TSC when linked via --all-features.
+# Non-forced: an explicit TRACY_NO_INVARIANT_CHECK=0 in the shell still wins.
+[env]
+TRACY_NO_INVARIANT_CHECK = "1"
+
 [target.x86_64-pc-windows-msvc]
 rustflags = [
     # Increases the stack size to 10MB, which is


### PR DESCRIPTION
## Description

Fixes #22688.

`--all-features` (what `just test-unit` / `lint-clippy` use) links tracy via `reth-tracing`. On hosts without an invariant TSC, `tracy-client-sys` then `exit(1)`s before any test runs.

Adds a non-forced `[env]` entry in `rust/.cargo/config.toml` so cargo/nextest pick it up, and a short note under Running Tests in `docs/ai/rust-dev.md`. Shell `TRACY_NO_INVARIANT_CHECK=0` still wins if you want the guard.

## Testing

- Host has `constant_tsc`/`nonstop_tsc`, so the original exit(1) path did not reproduce here.
- Throwaway crate under a copy of this `.cargo/config.toml`: `cargo test` saw `TRACY_NO_INVARIANT_CHECK=1`; with `TRACY_NO_INVARIANT_CHECK=0` in the shell the override won.
- `tomllib` parse-check of `rust/.cargo/config.toml`.

Skipped rust-code-reviewer (config + docs only; no Rust source change).