### PR TITLE
interop: Exclude acyclic prerequisites from cycle replacement

### DIFF
--- a/op-acceptance-tests/tests/interop/proofs/serial/interop_fault_proofs_test.go
+++ b/op-acceptance-tests/tests/interop/proofs/serial/interop_fault_proofs_test.go
@@ -86,7 +86,6 @@ func TestInteropFaultProofs_IntraBlock(gt *testing.T) {
 }
 
 func TestInteropFaultProofs_CycleReplacementPreservesAcyclicPrerequisite(gt *testing.T) {
-	gt.Skip("requires exact cycle participant detection; see ethereum-optimism/optimism#22825")
 	t := devtest.SerialT(gt)
 	sys := presets.NewThreeChainInterop(t, presets.WithoutHonestProposer())
 	sfp.RunCycleReplacementPreservesAcyclicPrerequisiteTest(t, sys, proofRunners()...)

--- a/op-supernode/supernode/activity/interop/cycle.go
+++ b/op-supernode/supernode/activity/interop/cycle.go
@@ -42,89 +42,95 @@ func (g *dependencyGraph) addEdge(from, to *dependencyNode) {
 
 // checkCycle finds strongly connected components and marks only cycle nodes unresolved.
 // It returns ErrCycle when the graph contains a directed cycle.
+//
+// The search uses Kosaraju's algorithm. It records a depth-first finish order over
+// dependsOn edges, then collects strongly connected components over dependedOnBy edges
+// in decreasing finish order. Every node lands in exactly one component, so every node
+// gets a fresh resolved value.
 func checkCycle(g *dependencyGraph) error {
-	graphNodes := make(map[*dependencyNode]struct{}, len(*g))
-	for _, node := range *g {
-		node.resolved = false
-		graphNodes[node] = struct{}{}
-	}
+	finishOrder := dependencyFinishOrder(g)
 
-	type dfsFrame struct {
-		node     *dependencyNode
-		nextEdge int
-	}
-
-	// The first pass records finish order in the dependency graph.
-	visited := make(map[*dependencyNode]bool, len(*g))
-	finishOrder := make([]*dependencyNode, 0, len(*g))
-	for _, start := range *g {
-		if visited[start] {
-			continue
-		}
-		visited[start] = true
-		stack := []dfsFrame{{node: start}}
-		for len(stack) > 0 {
-			frame := &stack[len(stack)-1]
-			if frame.nextEdge < len(frame.node.dependsOn) {
-				next := frame.node.dependsOn[frame.nextEdge]
-				frame.nextEdge++
-				if _, ok := graphNodes[next]; !ok || visited[next] {
-					continue
-				}
-				visited[next] = true
-				stack = append(stack, dfsFrame{node: next})
-				continue
-			}
-			finishOrder = append(finishOrder, frame.node)
-			stack = stack[:len(stack)-1]
-		}
-	}
-
-	// The second pass collects components in the reversed graph.
-	visited = make(map[*dependencyNode]bool, len(*g))
+	assigned := make(map[*dependencyNode]bool, len(*g))
 	hasCycle := false
 	for i := len(finishOrder) - 1; i >= 0; i-- {
 		start := finishOrder[i]
-		if visited[start] {
+		if assigned[start] {
 			continue
 		}
 
-		visited[start] = true
-		stack := []*dependencyNode{start}
-		component := make([]*dependencyNode, 0, 1)
-		for len(stack) > 0 {
-			node := stack[len(stack)-1]
-			stack = stack[:len(stack)-1]
-			component = append(component, node)
-			for _, next := range node.dependedOnBy {
-				if _, ok := graphNodes[next]; !ok || visited[next] {
+		// The component doubles as the queue: every appended node is still unvisited.
+		assigned[start] = true
+		component := []*dependencyNode{start}
+		for next := 0; next < len(component); next++ {
+			for _, dependent := range component[next].dependedOnBy {
+				if assigned[dependent] {
 					continue
 				}
-				visited[next] = true
-				stack = append(stack, next)
+				assigned[dependent] = true
+				component = append(component, dependent)
 			}
 		}
 
-		// A multi-node component always contains a directed cycle.
-		componentHasCycle := len(component) > 1
-		if len(component) == 1 {
-			for _, dependency := range component[0].dependsOn {
-				if dependency == component[0] {
-					componentHasCycle = true
-					break
-				}
-			}
-		}
+		inCycle := componentHasCycle(component)
 		for _, node := range component {
-			node.resolved = !componentHasCycle
+			node.resolved = !inCycle
 		}
-		hasCycle = hasCycle || componentHasCycle
+		hasCycle = hasCycle || inCycle
 	}
 
 	if hasCycle {
 		return ErrCycle
 	}
 	return nil
+}
+
+// componentHasCycle reports whether a strongly connected component holds a directed cycle.
+// A component of more than one node always does. A single node does only through a self-edge.
+// The component always holds at least its start node.
+func componentHasCycle(component []*dependencyNode) bool {
+	if len(component) > 1 {
+		return true
+	}
+	return slices.Contains(component[0].dependsOn, component[0])
+}
+
+// dependencyFinishOrder returns the graph nodes in depth-first finish order over dependsOn
+// edges. The traversal is iterative so that adversarial dependency depth cannot exhaust the
+// call stack.
+func dependencyFinishOrder(g *dependencyGraph) []*dependencyNode {
+	type dfsFrame struct {
+		node     *dependencyNode
+		nextEdge int
+	}
+
+	visited := make(map[*dependencyNode]bool, len(*g))
+	finishOrder := make([]*dependencyNode, 0, len(*g))
+	for _, start := range *g {
+		if visited[start] {
+			continue
+		}
+
+		visited[start] = true
+		stack := []dfsFrame{{node: start}}
+		for len(stack) > 0 {
+			top := len(stack) - 1
+			node := stack[top].node
+			if stack[top].nextEdge == len(node.dependsOn) {
+				finishOrder = append(finishOrder, node)
+				stack = stack[:top]
+				continue
+			}
+
+			next := node.dependsOn[stack[top].nextEdge]
+			stack[top].nextEdge++
+			if visited[next] {
+				continue
+			}
+			visited[next] = true
+			stack = append(stack, dfsFrame{node: next})
+		}
+	}
+	return finishOrder
 }
 
 // executingMessageBefore finds the latest EM in the slice with logIndex <= targetLogIdx.
@@ -196,7 +202,7 @@ func buildCycleGraph(ts uint64, chainEMs map[eth.ChainID]map[uint32]*messages.Ex
 // verifyCycleMessages is the cycle verification function for same-timestamp interop.
 // It verifies that same-timestamp executing messages form valid dependency relationships
 // with strongly connected component detection.
-
+//
 // Returns a Result with InvalidHeads populated for chains participating in cycles.
 func (i *Interop) verifyCycleMessages(ts uint64, blocksAtTimestamp map[eth.ChainID]eth.BlockID, view *frontierVerificationView) (Result, error) {
 	result := Result{

--- a/op-supernode/supernode/activity/interop/cycle.go
+++ b/op-supernode/supernode/activity/interop/cycle.go
@@ -40,62 +40,91 @@ func (g *dependencyGraph) addEdge(from, to *dependencyNode) {
 	to.dependedOnBy = append(to.dependedOnBy, from)
 }
 
-// checkCycle runs Kahn's topological sort algorithm to detect cycles.
-// Returns nil if the graph is acyclic (valid), ErrCycle if a cycle is detected.
-//
-// Algorithm:
-// 1. Find nodes with no dependedOnBy (nothing depends on them) → add to removeSet, mark resolved
-// 2. Remove items in removeSet from dependedOnBy of all nodes
-// 3. Repeat until either:
-//   - All nodes resolved → acyclic (valid)
-//   - No progress (removeSet empty but unresolved nodes remain) → cycle detected
+// checkCycle finds strongly connected components and marks only cycle nodes unresolved.
+// It returns ErrCycle when the graph contains a directed cycle.
 func checkCycle(g *dependencyGraph) error {
-	if len(*g) == 0 {
-		return nil
+	graphNodes := make(map[*dependencyNode]struct{}, len(*g))
+	for _, node := range *g {
+		node.resolved = false
+		graphNodes[node] = struct{}{}
 	}
 
-	for {
-		// Part 1: Find nodes with no dependedOnBy and mark them resolved
-		var removeSet []*dependencyNode
-		for _, node := range *g {
-			if !node.resolved && len(node.dependedOnBy) == 0 {
-				node.resolved = true
-				removeSet = append(removeSet, node)
+	type dfsFrame struct {
+		node     *dependencyNode
+		nextEdge int
+	}
+
+	// The first pass records finish order in the dependency graph.
+	visited := make(map[*dependencyNode]bool, len(*g))
+	finishOrder := make([]*dependencyNode, 0, len(*g))
+	for _, start := range *g {
+		if visited[start] {
+			continue
+		}
+		visited[start] = true
+		stack := []dfsFrame{{node: start}}
+		for len(stack) > 0 {
+			frame := &stack[len(stack)-1]
+			if frame.nextEdge < len(frame.node.dependsOn) {
+				next := frame.node.dependsOn[frame.nextEdge]
+				frame.nextEdge++
+				if _, ok := graphNodes[next]; !ok || visited[next] {
+					continue
+				}
+				visited[next] = true
+				stack = append(stack, dfsFrame{node: next})
+				continue
+			}
+			finishOrder = append(finishOrder, frame.node)
+			stack = stack[:len(stack)-1]
+		}
+	}
+
+	// The second pass collects components in the reversed graph.
+	visited = make(map[*dependencyNode]bool, len(*g))
+	hasCycle := false
+	for i := len(finishOrder) - 1; i >= 0; i-- {
+		start := finishOrder[i]
+		if visited[start] {
+			continue
+		}
+
+		visited[start] = true
+		stack := []*dependencyNode{start}
+		component := make([]*dependencyNode, 0, 1)
+		for len(stack) > 0 {
+			node := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			component = append(component, node)
+			for _, next := range node.dependedOnBy {
+				if _, ok := graphNodes[next]; !ok || visited[next] {
+					continue
+				}
+				visited[next] = true
+				stack = append(stack, next)
 			}
 		}
 
-		// If no nodes can be removed, check termination
-		if len(removeSet) == 0 {
-			// Check if all nodes are resolved
-			for _, node := range *g {
-				if !node.resolved {
-					// Unresolved nodes remain but no progress → cycle detected
-					return ErrCycle
+		// A multi-node component always contains a directed cycle.
+		componentHasCycle := len(component) > 1
+		if len(component) == 1 {
+			for _, dependency := range component[0].dependsOn {
+				if dependency == component[0] {
+					componentHasCycle = true
+					break
 				}
 			}
-			// All nodes resolved → acyclic
-			return nil
 		}
-
-		// Part 2: Remove items in removeSet from dependedOnBy of all nodes
-		for _, removed := range removeSet {
-			// Remove this node from dependedOnBy of nodes it depends on
-			for _, dependency := range removed.dependsOn {
-				dependency.dependedOnBy = removeFromSlice(dependency.dependedOnBy, removed)
-			}
+		for _, node := range component {
+			node.resolved = !componentHasCycle
 		}
+		hasCycle = hasCycle || componentHasCycle
 	}
-}
 
-// removeFromSlice removes a node from a slice of nodes.
-func removeFromSlice(slice []*dependencyNode, toRemove *dependencyNode) []*dependencyNode {
-	result := make([]*dependencyNode, 0, len(slice))
-	for _, n := range slice {
-		if n != toRemove {
-			result = append(result, n)
-		}
+	if hasCycle {
+		return ErrCycle
 	}
-	return result
+	return nil
 }
 
 // executingMessageBefore finds the latest EM in the slice with logIndex <= targetLogIdx.
@@ -166,8 +195,8 @@ func buildCycleGraph(ts uint64, chainEMs map[eth.ChainID]map[uint32]*messages.Ex
 
 // verifyCycleMessages is the cycle verification function for same-timestamp interop.
 // It verifies that same-timestamp executing messages form valid dependency relationships
-// using Kahn's topological sort algorithm.
-//
+// with strongly connected component detection.
+
 // Returns a Result with InvalidHeads populated for chains participating in cycles.
 func (i *Interop) verifyCycleMessages(ts uint64, blocksAtTimestamp map[eth.ChainID]eth.BlockID, view *frontierVerificationView) (Result, error) {
 	result := Result{
@@ -209,11 +238,10 @@ func (i *Interop) verifyCycleMessages(ts uint64, blocksAtTimestamp map[eth.Chain
 		chainEMs[chainID] = execMsgs
 	}
 
-	// Build dependency graph and check for cycles
+	// Build the dependency graph and check for cycles.
 	graph := buildCycleGraph(ts, chainEMs)
 	if err := checkCycle(graph); err != nil {
-		// Cycle detected - mark only chains with unresolved nodes as invalid
-		// (bystander chains that have same-ts EMs but aren't part of the cycle are spared)
+		// Mark only chains with cycle nodes as invalid.
 		cycleChains := collectCycleParticipants(graph)
 		if len(cycleChains) > 0 {
 			result.InvalidHeads = make(map[eth.ChainID]InvalidHead)
@@ -230,8 +258,8 @@ func (i *Interop) verifyCycleMessages(ts uint64, blocksAtTimestamp map[eth.Chain
 	return result, nil
 }
 
-// collectCycleParticipants returns the set of chains that have unresolved nodes
-// after running checkCycle. These are the chains actually participating in a cycle.
+// collectCycleParticipants returns chains with directed-cycle nodes.
+// checkCycle marks only those nodes unresolved.
 func collectCycleParticipants(graph *dependencyGraph) map[eth.ChainID]bool {
 	cycleChains := make(map[eth.ChainID]bool)
 	for _, node := range *graph {

--- a/op-supernode/supernode/activity/interop/cycle_test.go
+++ b/op-supernode/supernode/activity/interop/cycle_test.go
@@ -196,34 +196,52 @@ func TestExecutingMessageBefore(t *testing.T) {
 func TestCheckCycle(t *testing.T) {
 	t.Parallel()
 
+	chainA := eth.ChainIDFromUInt64(10)
+	chainB := eth.ChainIDFromUInt64(8453)
+	chainC := eth.ChainIDFromUInt64(420)
+	chainD := eth.ChainIDFromUInt64(999)
+
 	tests := []struct {
-		name        string
-		buildGraph  func() *dependencyGraph
-		expectCycle bool
+		name         string
+		buildGraph   func() *dependencyGraph
+		expectChains []eth.ChainID
 	}{
 		{
 			name: "empty graph has no cycle",
 			buildGraph: func() *dependencyGraph {
 				return &dependencyGraph{}
 			},
-			expectCycle: false,
 		},
 		{
 			name: "single node no deps resolves",
 			buildGraph: func() *dependencyGraph {
 				g := &dependencyGraph{}
-				g.addNode(&dependencyNode{chainID: eth.ChainIDFromUInt64(10), logIndex: 0})
+				g.addNode(&dependencyNode{chainID: chainA, logIndex: 0})
 				return g
 			},
-			expectCycle: false,
+		},
+		{
+			name: "self-loop detected",
+			buildGraph: func() *dependencyGraph {
+				// An EM that names a log at or after its own index in its own block
+				// resolves to itself, which is a cycle of one node.
+				g := &dependencyGraph{}
+				a := &dependencyNode{chainID: chainA, logIndex: 0, execMsg: &messages.ExecutingMessage{
+					ChainID: chainA, LogIdx: 0,
+				}}
+				g.addNode(a)
+				g.addEdge(a, a)
+				return g
+			},
+			expectChains: []eth.ChainID{chainA},
 		},
 		{
 			name: "linear chain A->B->C resolves (acyclic)",
 			buildGraph: func() *dependencyGraph {
 				g := &dependencyGraph{}
-				a := &dependencyNode{chainID: eth.ChainIDFromUInt64(10), logIndex: 0}
-				b := &dependencyNode{chainID: eth.ChainIDFromUInt64(10), logIndex: 1}
-				c := &dependencyNode{chainID: eth.ChainIDFromUInt64(10), logIndex: 2}
+				a := &dependencyNode{chainID: chainA, logIndex: 0}
+				b := &dependencyNode{chainID: chainA, logIndex: 1}
+				c := &dependencyNode{chainID: chainA, logIndex: 2}
 				g.addNode(a)
 				g.addNode(b)
 				g.addNode(c)
@@ -232,14 +250,13 @@ func TestCheckCycle(t *testing.T) {
 				g.addEdge(b, a)
 				return g
 			},
-			expectCycle: false,
 		},
 		{
 			name: "simple cycle A<->B detected",
 			buildGraph: func() *dependencyGraph {
 				g := &dependencyGraph{}
-				a := &dependencyNode{chainID: eth.ChainIDFromUInt64(10), logIndex: 0}
-				b := &dependencyNode{chainID: eth.ChainIDFromUInt64(8453), logIndex: 0}
+				a := &dependencyNode{chainID: chainA, logIndex: 0}
+				b := &dependencyNode{chainID: chainB, logIndex: 0}
 				g.addNode(a)
 				g.addNode(b)
 				// A depends on B, B depends on A (cycle!)
@@ -247,15 +264,15 @@ func TestCheckCycle(t *testing.T) {
 				g.addEdge(b, a)
 				return g
 			},
-			expectCycle: true,
+			expectChains: []eth.ChainID{chainA, chainB},
 		},
 		{
 			name: "triangle cycle A->B->C->A detected",
 			buildGraph: func() *dependencyGraph {
 				g := &dependencyGraph{}
-				a := &dependencyNode{chainID: eth.ChainIDFromUInt64(10), logIndex: 0}
-				b := &dependencyNode{chainID: eth.ChainIDFromUInt64(8453), logIndex: 0}
-				c := &dependencyNode{chainID: eth.ChainIDFromUInt64(420), logIndex: 0}
+				a := &dependencyNode{chainID: chainA, logIndex: 0}
+				b := &dependencyNode{chainID: chainB, logIndex: 0}
+				c := &dependencyNode{chainID: chainC, logIndex: 0}
 				g.addNode(a)
 				g.addNode(b)
 				g.addNode(c)
@@ -265,16 +282,73 @@ func TestCheckCycle(t *testing.T) {
 				g.addEdge(b, a)
 				return g
 			},
-			expectCycle: true,
+			expectChains: []eth.ChainID{chainA, chainB, chainC},
+		},
+		{
+			name: "two disjoint cycles both detected",
+			buildGraph: func() *dependencyGraph {
+				g := &dependencyGraph{}
+				a := &dependencyNode{chainID: chainA, logIndex: 0}
+				b := &dependencyNode{chainID: chainB, logIndex: 0}
+				c := &dependencyNode{chainID: chainC, logIndex: 0}
+				d := &dependencyNode{chainID: chainD, logIndex: 0}
+				g.addNode(a)
+				g.addNode(b)
+				g.addNode(c)
+				g.addNode(d)
+				g.addEdge(a, b)
+				g.addEdge(b, a)
+				g.addEdge(c, d)
+				g.addEdge(d, c)
+				return g
+			},
+			expectChains: []eth.ChainID{chainA, chainB, chainC, chainD},
+		},
+		{
+			name: "cycle spares its acyclic prerequisite",
+			buildGraph: func() *dependencyGraph {
+				g := &dependencyGraph{}
+				a := &dependencyNode{chainID: chainA, logIndex: 0}
+				b := &dependencyNode{chainID: chainB, logIndex: 0}
+				c := &dependencyNode{chainID: chainC, logIndex: 0}
+				g.addNode(a)
+				g.addNode(b)
+				g.addNode(c)
+				g.addEdge(a, b)
+				g.addEdge(b, a)
+				// The cycle depends on C, which depends on nothing.
+				g.addEdge(a, c)
+				return g
+			},
+			expectChains: []eth.ChainID{chainA, chainB},
+		},
+		{
+			name: "cycle spares a chain that depends on it",
+			buildGraph: func() *dependencyGraph {
+				// A dependent holds an EM that reads a log inside the cycle. A later
+				// round invalidates it, once the replacement removes that log.
+				g := &dependencyGraph{}
+				a := &dependencyNode{chainID: chainA, logIndex: 0}
+				b := &dependencyNode{chainID: chainB, logIndex: 0}
+				c := &dependencyNode{chainID: chainC, logIndex: 0}
+				g.addNode(a)
+				g.addNode(b)
+				g.addNode(c)
+				g.addEdge(a, b)
+				g.addEdge(b, a)
+				g.addEdge(c, a)
+				return g
+			},
+			expectChains: []eth.ChainID{chainA, chainB},
 		},
 		{
 			name: "diamond pattern A->B,C B,C->D resolves (acyclic)",
 			buildGraph: func() *dependencyGraph {
 				g := &dependencyGraph{}
-				a := &dependencyNode{chainID: eth.ChainIDFromUInt64(10), logIndex: 0}
-				b := &dependencyNode{chainID: eth.ChainIDFromUInt64(8453), logIndex: 0}
-				c := &dependencyNode{chainID: eth.ChainIDFromUInt64(420), logIndex: 0}
-				d := &dependencyNode{chainID: eth.ChainIDFromUInt64(999), logIndex: 0}
+				a := &dependencyNode{chainID: chainA, logIndex: 0}
+				b := &dependencyNode{chainID: chainB, logIndex: 0}
+				c := &dependencyNode{chainID: chainC, logIndex: 0}
+				d := &dependencyNode{chainID: chainD, logIndex: 0}
 				g.addNode(a)
 				g.addNode(b)
 				g.addNode(c)
@@ -286,17 +360,15 @@ func TestCheckCycle(t *testing.T) {
 				g.addEdge(c, a)
 				return g
 			},
-			expectCycle: false,
 		},
 		{
 			name: "intra-chain sequential logs resolve",
 			buildGraph: func() *dependencyGraph {
 				// Simulates a single chain with 3 logs where each depends on previous
 				g := &dependencyGraph{}
-				chain10 := eth.ChainIDFromUInt64(10)
-				l0 := &dependencyNode{chainID: chain10, logIndex: 0}
-				l1 := &dependencyNode{chainID: chain10, logIndex: 1}
-				l2 := &dependencyNode{chainID: chain10, logIndex: 2}
+				l0 := &dependencyNode{chainID: chainA, logIndex: 0}
+				l1 := &dependencyNode{chainID: chainA, logIndex: 1}
+				l2 := &dependencyNode{chainID: chainA, logIndex: 2}
 				g.addNode(l0)
 				g.addNode(l1)
 				g.addNode(l2)
@@ -305,7 +377,6 @@ func TestCheckCycle(t *testing.T) {
 				g.addEdge(l2, l1)
 				return g
 			},
-			expectCycle: false,
 		},
 		{
 			name: "cross-chain valid exec message resolves",
@@ -313,9 +384,6 @@ func TestCheckCycle(t *testing.T) {
 				// Chain A: [L0, L1(exec B:L0)]
 				// Chain B: [L0(init)]
 				g := &dependencyGraph{}
-				chainA := eth.ChainIDFromUInt64(10)
-				chainB := eth.ChainIDFromUInt64(8453)
-
 				aL0 := &dependencyNode{chainID: chainA, logIndex: 0}
 				aL1 := &dependencyNode{chainID: chainA, logIndex: 1, execMsg: &messages.ExecutingMessage{
 					ChainID: chainB, LogIdx: 0,
@@ -331,7 +399,6 @@ func TestCheckCycle(t *testing.T) {
 				g.addEdge(aL1, bL0)
 				return g
 			},
-			expectCycle: false,
 		},
 		{
 			name: "cross-chain mutual exec creates cycle",
@@ -339,9 +406,6 @@ func TestCheckCycle(t *testing.T) {
 				// Chain A: [L0(exec B:L0)]
 				// Chain B: [L0(exec A:L0)]
 				g := &dependencyGraph{}
-				chainA := eth.ChainIDFromUInt64(10)
-				chainB := eth.ChainIDFromUInt64(8453)
-
 				aL0 := &dependencyNode{chainID: chainA, logIndex: 0, execMsg: &messages.ExecutingMessage{
 					ChainID: chainB, LogIdx: 0,
 				}}
@@ -357,7 +421,7 @@ func TestCheckCycle(t *testing.T) {
 				g.addEdge(bL0, aL0)
 				return g
 			},
-			expectCycle: true,
+			expectChains: []eth.ChainID{chainA, chainB},
 		},
 	}
 
@@ -366,13 +430,40 @@ func TestCheckCycle(t *testing.T) {
 			t.Parallel()
 			g := tc.buildGraph()
 			err := checkCycle(g)
-			if tc.expectCycle {
-				require.Error(t, err, "expected cycle to be detected")
-			} else {
-				require.NoError(t, err, "expected no cycle")
+
+			expected := make(map[eth.ChainID]bool, len(tc.expectChains))
+			for _, chainID := range tc.expectChains {
+				expected[chainID] = true
 			}
+			if len(expected) > 0 {
+				require.ErrorIs(t, err, ErrCycle)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, expected, collectCycleParticipants(g))
 		})
 	}
+}
+
+// A long dependency path must not exhaust the call stack. Both traversals are iterative,
+// so depth costs heap, not stack.
+func TestCheckCycle_DeepDependencyChain(t *testing.T) {
+	t.Parallel()
+
+	const depth = 50_000
+	chainA := eth.ChainIDFromUInt64(10)
+	g := &dependencyGraph{}
+	var previous *dependencyNode
+	for i := range depth {
+		node := &dependencyNode{chainID: chainA, logIndex: uint32(i)}
+		g.addNode(node)
+		if previous != nil {
+			g.addEdge(node, previous)
+		}
+		previous = node
+	}
+
+	require.NoError(t, checkCycle(g))
 }
 
 // =============================================================================
@@ -476,7 +567,6 @@ func TestBuildCycleGraph(t *testing.T) {
 			expectCycle: false,
 		},
 	}
-
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()

--- a/op-supernode/supernode/activity/interop/cycle_test.go
+++ b/op-supernode/supernode/activity/interop/cycle_test.go
@@ -190,7 +190,7 @@ func TestExecutingMessageBefore(t *testing.T) {
 }
 
 // =============================================================================
-// Kahn's Algorithm Tests
+// Cycle Detection Tests
 // =============================================================================
 
 func TestCheckCycle(t *testing.T) {
@@ -429,6 +429,18 @@ func TestBuildCycleGraph(t *testing.T) {
 			expectNotInCycle: []eth.ChainID{testChainB},
 		},
 		{
+			name: "cycle with acyclic prerequisite",
+			chainEMs: mergeEMs(
+				oneWayRef(testChainA, testChainB, 0, 0),
+				oneWayRef(testChainB, testChainA, 0, 1),
+				oneWayRef(testChainA, testChainC, 1, 0),
+				oneWayRef(testChainC, testChainD, 0, 0),
+			),
+			expectCycle:      true,
+			expectInCycle:    []eth.ChainID{testChainA, testChainB},
+			expectNotInCycle: []eth.ChainID{testChainC},
+		},
+		{
 			name: "one-way dependency - no cycle",
 			chainEMs: map[eth.ChainID]map[uint32]*messages.ExecutingMessage{
 				testChainA: {0: {ChainID: testChainB, LogIdx: 5, Timestamp: testTS}},
@@ -475,12 +487,7 @@ func TestBuildCycleGraph(t *testing.T) {
 				require.Error(t, err, "expected cycle")
 
 				// Verify cycle participants
-				cycleChains := make(map[eth.ChainID]bool)
-				for _, node := range *graph {
-					if !node.resolved {
-						cycleChains[node.chainID] = true
-					}
-				}
+				cycleChains := collectCycleParticipants(graph)
 				for _, c := range tc.expectInCycle {
 					require.True(t, cycleChains[c], "chain %v should be in cycle", c)
 				}

--- a/rust/kona/crates/protocol/interop/src/graph.rs
+++ b/rust/kona/crates/protocol/interop/src/graph.rs
@@ -1331,6 +1331,70 @@ mod test {
         assert_eq!(detect_cycles(&messages, ts), vec![CHAIN_A_ID, CHAIN_B_ID]);
     }
 
+    /// An EM that names a log at or after its own index in its own block resolves to itself.
+    /// Mirrors op-supernode's "self-loop detected" test case.
+    #[test]
+    fn test_detect_cycles_self_loop() {
+        let ts = 1000;
+        let messages = vec![make_em(CHAIN_A_ID, 0, ts, CHAIN_A_ID, 0, ts)];
+
+        assert_eq!(detect_cycles(&messages, ts), vec![CHAIN_A_ID]);
+    }
+
+    /// Every disjoint cycle is reported, not just the first one found.
+    /// Mirrors op-supernode's "two disjoint cycles both detected" test case.
+    #[test]
+    fn test_detect_cycles_two_disjoint_cycles() {
+        const CHAIN_D_ID: u64 = 4;
+        let ts = 1000;
+        let messages = vec![
+            make_em(CHAIN_A_ID, 0, ts, CHAIN_B_ID, 0, ts),
+            make_em(CHAIN_B_ID, 0, ts, CHAIN_A_ID, 0, ts),
+            make_em(CHAIN_C_ID, 0, ts, CHAIN_D_ID, 0, ts),
+            make_em(CHAIN_D_ID, 0, ts, CHAIN_C_ID, 0, ts),
+        ];
+
+        assert_eq!(
+            detect_cycles(&messages, ts),
+            vec![CHAIN_A_ID, CHAIN_B_ID, CHAIN_C_ID, CHAIN_D_ID]
+        );
+    }
+
+    /// A chain that reads a log inside the cycle is not itself on the cycle. The replacement of
+    /// that block invalidates the dependent on a later pass, through the per-message check.
+    /// Mirrors op-supernode's "cycle spares a chain that depends on it" test case.
+    #[test]
+    fn test_detect_cycles_excludes_dependent_chain() {
+        let ts = 1000;
+        let messages = vec![
+            make_em(CHAIN_A_ID, 0, ts, CHAIN_B_ID, 0, ts),
+            make_em(CHAIN_B_ID, 0, ts, CHAIN_A_ID, 0, ts),
+            make_em(CHAIN_C_ID, 0, ts, CHAIN_A_ID, 0, ts),
+        ];
+
+        assert_eq!(detect_cycles(&messages, ts), vec![CHAIN_A_ID, CHAIN_B_ID]);
+    }
+
+    /// Mirrors op-supernode's "empty graph has no cycle" test case.
+    #[test]
+    fn test_detect_cycles_empty_message_set() {
+        assert!(detect_cycles(&[], 1000).is_empty());
+    }
+
+    /// A long dependency path must not exhaust the call stack. Both traversals are iterative,
+    /// so depth costs heap, not stack.
+    #[test]
+    fn test_detect_cycles_deep_dependency_chain() {
+        const DEPTH: u32 = 50_000;
+        let ts = 1000;
+        // Consecutive EMs on one chain form a path through the intra-chain edges. Chain B has
+        // no EMs, so no cross-chain edge shortens the path.
+        let messages: Vec<_> =
+            (0..DEPTH).map(|i| make_em(CHAIN_A_ID, i, ts, CHAIN_B_ID, 0, ts)).collect();
+
+        assert!(detect_cycles(&messages, ts).is_empty());
+    }
+
     /// An executing message with a past timestamp is filtered out of the cycle graph.
     /// Mirrors op-supernode's "past timestamp filtered out" test case.
     #[test]

--- a/rust/kona/crates/protocol/interop/src/graph.rs
+++ b/rust/kona/crates/protocol/interop/src/graph.rs
@@ -101,8 +101,8 @@ where
 
     /// Checks the validity of all messages within the graph.
     ///
-    /// First, detects cyclic dependencies among same-timestamp executing messages using Kahn's
-    /// topological sort. If a cycle is found, returns [`MessageGraphError::CyclicDependency`]
+    /// First, detects cyclic dependencies among same-timestamp executing messages through strongly
+    /// connected components. If a cycle exists, returns [`MessageGraphError::CyclicDependency`]
     /// with the chain IDs of cycle participants. Then, validates each message independently.
     ///
     /// _Note_: This function does not account for cascading dependency failures. When
@@ -1315,6 +1315,20 @@ mod test {
             executing_timestamp,
             executing_log_index,
         )
+    }
+
+    #[test]
+    fn test_detect_cycles_excludes_acyclic_prerequisite() {
+        const CHAIN_D_ID: u64 = 4;
+        let ts = 1000;
+        let messages = vec![
+            make_em(CHAIN_A_ID, 0, ts, CHAIN_B_ID, 0, ts),
+            make_em(CHAIN_B_ID, 0, ts, CHAIN_A_ID, 1, ts),
+            make_em(CHAIN_A_ID, 1, ts, CHAIN_C_ID, 0, ts),
+            make_em(CHAIN_C_ID, 0, ts, CHAIN_D_ID, 0, ts),
+        ];
+
+        assert_eq!(detect_cycles(&messages, ts), vec![CHAIN_A_ID, CHAIN_B_ID]);
     }
 
     /// An executing message with a past timestamp is filtered out of the cycle graph.

--- a/rust/kona/crates/protocol/interop/src/rules.rs
+++ b/rust/kona/crates/protocol/interop/src/rules.rs
@@ -176,78 +176,111 @@ fn executing_message_before(
     (pp > 0).then(|| chain_node_indices[pp - 1])
 }
 
-/// Finds strongly connected components with Kosaraju's algorithm.
+/// The cycle-detection dependency graph, held as one adjacency list per direction.
 ///
-/// Uses separate traversal state and leaves both adjacency lists unchanged.
-/// Returns the indices of nodes participating in cycles, or an empty vec if acyclic.
-fn check_cycles(depends_on: &[Vec<usize>], depended_on_by: &[Vec<usize>]) -> Vec<usize> {
-    let n = depends_on.len();
-    if n == 0 {
-        return vec![];
+/// `depends_on` holds the forward edges, from an executing message to the node it depends on.
+/// `depended_on_by` holds the same edges reversed. Kosaraju's algorithm needs both directions,
+/// and building them together keeps their lengths equal by construction.
+#[derive(Debug)]
+struct DependencyGraph {
+    /// Forward edges: `depends_on[from]` lists the nodes `from` depends on.
+    depends_on: Vec<Vec<usize>>,
+    /// Reverse edges: `depended_on_by[to]` lists the nodes that depend on `to`.
+    depended_on_by: Vec<Vec<usize>>,
+}
+
+impl DependencyGraph {
+    /// Creates an edgeless graph over `node_count` nodes.
+    fn new(node_count: usize) -> Self {
+        Self {
+            depends_on: vec![Vec::new(); node_count],
+            depended_on_by: vec![Vec::new(); node_count],
+        }
     }
 
-    debug_assert_eq!(depended_on_by.len(), n);
+    /// Records that `from` depends on `to`.
+    fn add_edge(&mut self, from: usize, to: usize) {
+        self.depends_on[from].push(to);
+        self.depended_on_by[to].push(from);
+    }
 
-    // Record nodes after all outgoing edges finish.
-    let mut visited = vec![false; n];
-    let mut finish_order = Vec::with_capacity(n);
-    let mut stack = Vec::with_capacity(n);
+    /// Returns the indices of the nodes that lie on a directed cycle, or an empty vec if the
+    /// graph is acyclic.
+    ///
+    /// Finds strongly connected components with Kosaraju's algorithm: collect the components
+    /// over the reverse edges, in decreasing finish order over the forward edges.
+    fn cycle_nodes(&self) -> Vec<usize> {
+        let finish_order = self.finish_order();
 
-    for start in 0..n {
-        if visited[start] {
-            continue;
-        }
-
-        visited[start] = true;
-        stack.push((start, 0));
-
-        while let Some((node, next_edge)) = stack.pop() {
-            if next_edge == depends_on[node].len() {
-                finish_order.push(node);
+        let mut assigned = vec![false; self.depends_on.len()];
+        let mut on_cycle = Vec::new();
+        for &start in finish_order.iter().rev() {
+            if assigned[start] {
                 continue;
             }
 
-            stack.push((node, next_edge + 1));
-            let adjacent = depends_on[node][next_edge];
-            if !visited[adjacent] {
-                visited[adjacent] = true;
-                stack.push((adjacent, 0));
+            // The component doubles as the queue: every appended node is still unvisited.
+            assigned[start] = true;
+            let mut component = vec![start];
+            let mut next = 0;
+            while next < component.len() {
+                for &dependent in &self.depended_on_by[component[next]] {
+                    if !assigned[dependent] {
+                        assigned[dependent] = true;
+                        component.push(dependent);
+                    }
+                }
+                next += 1;
+            }
+
+            if self.component_has_cycle(&component) {
+                on_cycle.extend_from_slice(&component);
             }
         }
+
+        on_cycle
     }
 
-    // Traverse reverse edges in decreasing finish order.
-    let mut assigned = vec![false; n];
-    let mut component = Vec::new();
-    let mut traversal = Vec::with_capacity(n);
-    let mut cycle_nodes = Vec::new();
+    /// Reports whether a strongly connected component holds a directed cycle. A component of
+    /// more than one node always does. A single node holds one only through a self-edge.
+    fn component_has_cycle(&self, component: &[usize]) -> bool {
+        component.len() > 1 || self.depends_on[component[0]].contains(&component[0])
+    }
 
-    for &start in finish_order.iter().rev() {
-        if assigned[start] {
-            continue;
-        }
+    /// Returns the nodes in depth-first finish order over the forward edges. The traversal is
+    /// iterative, so an adversarial dependency depth cannot exhaust the call stack.
+    fn finish_order(&self) -> Vec<usize> {
+        let node_count = self.depends_on.len();
 
-        component.clear();
-        assigned[start] = true;
-        traversal.push(start);
+        let mut visited = vec![false; node_count];
+        let mut finish_order = Vec::with_capacity(node_count);
+        let mut stack = Vec::with_capacity(node_count);
 
-        while let Some(node) = traversal.pop() {
-            component.push(node);
-            for &adjacent in &depended_on_by[node] {
-                if !assigned[adjacent] {
-                    assigned[adjacent] = true;
-                    traversal.push(adjacent);
+        for start in 0..node_count {
+            if visited[start] {
+                continue;
+            }
+
+            visited[start] = true;
+            stack.push((start, 0));
+
+            while let Some((node, next_edge)) = stack.pop() {
+                if next_edge == self.depends_on[node].len() {
+                    finish_order.push(node);
+                    continue;
+                }
+
+                stack.push((node, next_edge + 1));
+                let adjacent = self.depends_on[node][next_edge];
+                if !visited[adjacent] {
+                    visited[adjacent] = true;
+                    stack.push((adjacent, 0));
                 }
             }
         }
 
-        let is_cycle = component.len() > 1 || depends_on[component[0]].contains(&component[0]);
-        if is_cycle {
-            cycle_nodes.extend_from_slice(&component);
-        }
+        finish_order
     }
-
-    cycle_nodes
 }
 
 /// Builds a dependency graph from executing messages and checks for cycles.
@@ -300,18 +333,12 @@ pub(crate) fn detect_cycles(messages: &[EnrichedExecutingMessage], timestamp: u6
         indices.sort_by_key(|&idx| nodes[idx].log_index);
     }
 
-    // Build algorithm state: parallel vecs for depends_on / depended_on_by.
-    let mut depends_on: Vec<Vec<usize>> = vec![Vec::new(); nodes.len()];
-    let mut depended_on_by: Vec<Vec<usize>> = vec![Vec::new(); nodes.len()];
-
-    // Add edges.
+    let mut graph = DependencyGraph::new(nodes.len());
     for chain_indices in chain_nodes.values() {
         for (i, &node_idx) in chain_indices.iter().enumerate() {
             // Intra-chain: depends on previous EM on the same chain.
             if i > 0 {
-                let prev_idx = chain_indices[i - 1];
-                depends_on[node_idx].push(prev_idx);
-                depended_on_by[prev_idx].push(node_idx);
+                graph.add_edge(node_idx, chain_indices[i - 1]);
             }
 
             // Cross-chain: depends on executingMessageBefore(targetChain, targetLogIdx).
@@ -321,20 +348,14 @@ pub(crate) fn detect_cycles(messages: &[EnrichedExecutingMessage], timestamp: u6
                 let Some(dep_idx) =
                     executing_message_before(&nodes, target_indices, target_log_idx)
             {
-                depends_on[node_idx].push(dep_idx);
-                depended_on_by[dep_idx].push(node_idx);
+                graph.add_edge(node_idx, dep_idx);
             }
         }
     }
 
-    // Find exact cycle participants.
-    let cycle_indices = check_cycles(&depends_on, &depended_on_by);
-    if cycle_indices.is_empty() {
-        return vec![];
-    }
-
-    // Collect unique chain IDs of cycle participants.
-    let mut cycle_chains: Vec<u64> = cycle_indices.iter().map(|&i| nodes[i].chain_id).collect();
+    // Collect the unique chain IDs of the nodes on a cycle.
+    let mut cycle_chains: Vec<u64> =
+        graph.cycle_nodes().into_iter().map(|i| nodes[i].chain_id).collect();
     cycle_chains.sort();
     cycle_chains.dedup();
     cycle_chains

--- a/rust/kona/crates/protocol/interop/src/rules.rs
+++ b/rust/kona/crates/protocol/interop/src/rules.rs
@@ -176,40 +176,78 @@ fn executing_message_before(
     (pp > 0).then(|| chain_node_indices[pp - 1])
 }
 
-/// Runs Kahn's topological sort algorithm to detect cycles.
+/// Finds strongly connected components with Kosaraju's algorithm.
 ///
-/// Operates on algorithm state (parallel vecs) separately from the immutable graph nodes.
+/// Uses separate traversal state and leaves both adjacency lists unchanged.
 /// Returns the indices of nodes participating in cycles, or an empty vec if acyclic.
-fn check_cycles(depends_on: &[Vec<usize>], depended_on_by: &mut [Vec<usize>]) -> Vec<usize> {
+fn check_cycles(depends_on: &[Vec<usize>], depended_on_by: &[Vec<usize>]) -> Vec<usize> {
     let n = depends_on.len();
     if n == 0 {
         return vec![];
     }
 
-    let mut resolved = vec![false; n];
+    debug_assert_eq!(depended_on_by.len(), n);
 
-    loop {
-        // Find nodes with no depended_on_by and mark them resolved.
-        let mut remove_set = Vec::new();
-        for (i, deps) in depended_on_by.iter().enumerate() {
-            if !resolved[i] && deps.is_empty() {
-                resolved[i] = true;
-                remove_set.push(i);
+    // Record nodes after all outgoing edges finish.
+    let mut visited = vec![false; n];
+    let mut finish_order = Vec::with_capacity(n);
+    let mut stack = Vec::with_capacity(n);
+
+    for start in 0..n {
+        if visited[start] {
+            continue;
+        }
+
+        visited[start] = true;
+        stack.push((start, 0));
+
+        while let Some((node, next_edge)) = stack.pop() {
+            if next_edge == depends_on[node].len() {
+                finish_order.push(node);
+                continue;
             }
-        }
 
-        if remove_set.is_empty() {
-            // No progress, so we collect unresolved nodes (cycle participants).
-            return (0..n).filter(|&i| !resolved[i]).collect();
-        }
-
-        // Remove resolved nodes from depended_on_by of their dependencies.
-        for &removed_idx in &remove_set {
-            for &dep_idx in &depends_on[removed_idx] {
-                depended_on_by[dep_idx].retain(|&x| x != removed_idx);
+            stack.push((node, next_edge + 1));
+            let adjacent = depends_on[node][next_edge];
+            if !visited[adjacent] {
+                visited[adjacent] = true;
+                stack.push((adjacent, 0));
             }
         }
     }
+
+    // Traverse reverse edges in decreasing finish order.
+    let mut assigned = vec![false; n];
+    let mut component = Vec::new();
+    let mut traversal = Vec::with_capacity(n);
+    let mut cycle_nodes = Vec::new();
+
+    for &start in finish_order.iter().rev() {
+        if assigned[start] {
+            continue;
+        }
+
+        component.clear();
+        assigned[start] = true;
+        traversal.push(start);
+
+        while let Some(node) = traversal.pop() {
+            component.push(node);
+            for &adjacent in &depended_on_by[node] {
+                if !assigned[adjacent] {
+                    assigned[adjacent] = true;
+                    traversal.push(adjacent);
+                }
+            }
+        }
+
+        let is_cycle = component.len() > 1 || depends_on[component[0]].contains(&component[0]);
+        if is_cycle {
+            cycle_nodes.extend_from_slice(&component);
+        }
+    }
+
+    cycle_nodes
 }
 
 /// Builds a dependency graph from executing messages and checks for cycles.
@@ -289,8 +327,8 @@ pub(crate) fn detect_cycles(messages: &[EnrichedExecutingMessage], timestamp: u6
         }
     }
 
-    // Run Kahn's algorithm.
-    let cycle_indices = check_cycles(&depends_on, &mut depended_on_by);
+    // Find exact cycle participants.
+    let cycle_indices = check_cycles(&depends_on, &depended_on_by);
     if cycle_indices.is_empty() {
         return vec![];
     }


### PR DESCRIPTION
This PR stacks on ethereum-optimism/optimism#22832. It replaces residual indegree detection with iterative strongly connected component detection in Go and Kona.

The new logic returns only graph vertices that belong to cycles. It includes self-loops and excludes acyclic prerequisites. The Go and Kona implementations use the same cycle membership rule. Both avoid recursion, so adversarial dependency depth cannot exhaust the call stack.

Focused unit tests cover a two-chain cycle with an acyclic prerequisite. This PR also removes the skip from the three-chain acceptance regression in the base PR. The acceptance scenario verifies the Go and Kona fault-proof paths.

Closes ethereum-optimism/optimism#22825.