### PR TITLE
op-acceptance-tests: Add skipped cycle prerequisite regression

### DIFF
--- a/op-acceptance-tests/tests/interop/proofs/serial/interop_fault_proofs_test.go
+++ b/op-acceptance-tests/tests/interop/proofs/serial/interop_fault_proofs_test.go
@@ -85,6 +85,13 @@ func TestInteropFaultProofs_IntraBlock(gt *testing.T) {
 	}
 }
 
+func TestInteropFaultProofs_CycleReplacementPreservesAcyclicPrerequisite(gt *testing.T) {
+	gt.Skip("requires exact cycle participant detection; see ethereum-optimism/optimism#22825")
+	t := devtest.SerialT(gt)
+	sys := presets.NewThreeChainInterop(t, presets.WithoutHonestProposer())
+	sfp.RunCycleReplacementPreservesAcyclicPrerequisiteTest(t, sys, proofRunners()...)
+}
+
 func TestInteropFaultProofs_DepositMessage_InvalidExecution(gt *testing.T) {
 	t := devtest.SerialT(gt)
 	sys := presets.NewSimpleInterop(t)

--- a/op-acceptance-tests/tests/proofs/zk/zk_proposer_test.go
+++ b/op-acceptance-tests/tests/proofs/zk/zk_proposer_test.go
@@ -120,7 +120,7 @@ func TestProposerDoesNotBuildOnGameCreatedAheadOfSuperRootRPC(gt *testing.T) {
 	_, outputRoots := factory.WaitForSafeSuperRootAfter(anchorSequence)
 
 	supernode := sys.Supernode()
-	futureSequence := supernode.EnsureInteropPaused(sys.L2CLA, sys.L2CLB, 10)
+	futureSequence := supernode.EnsureInteropPaused(10, sys.L2CLA, sys.L2CLB)
 	t.Cleanup(supernode.ResumeInterop)
 	t.Require().Nil(sys.SuperRoots.SuperRootAtTimestamp(futureSequence).Data,
 		"super-root RPC must be behind the future game's timestamp")

--- a/op-acceptance-tests/tests/superfaultproofs/cycle_prerequisite.go
+++ b/op-acceptance-tests/tests/superfaultproofs/cycle_prerequisite.go
@@ -1,0 +1,125 @@
+package superfaultproofs
+
+import (
+	"math/rand"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/eth/safety"
+)
+
+// RunCycleReplacementPreservesAcyclicPrerequisiteTest checks that cycle replacement excludes chain C.
+func RunCycleReplacementPreservesAcyclicPrerequisiteTest(
+	t devtest.T,
+	sys *presets.ThreeChainInterop,
+	runners ...ProofRunner,
+) {
+	t.Require().NotNil(sys.SuperRoots, "supernode is required for this test")
+	t.Require().NotNil(sys.TestSequencer, "test sequencer is required for this test")
+
+	alice := sys.FunderA.NewFundedEOA(eth.OneEther)
+	bob := sys.FunderB.NewFundedEOA(eth.OneEther)
+	carol := sys.FunderC.NewFundedEOA(eth.OneEther)
+	eventLoggerC := carol.DeployEventLogger()
+
+	sys.Supernode().EnsureInteropPaused(10, sys.L2CLA, sys.L2CLB, sys.L2CLC)
+	sys.L2CLA.StopSequencer()
+	sys.L2CLB.StopSequencer()
+	sys.L2CLC.StopSequencer()
+
+	parentA := sys.L2ELA.BlockRefByLabel(eth.Unsafe)
+	parentB := sys.L2ELB.BlockRefByLabel(eth.Unsafe)
+	parentC := sys.L2ELC.BlockRefByLabel(eth.Unsafe)
+	nextTimestamp := max(
+		sys.L2ChainA.TimestampForBlockNum(parentA.Number+1),
+		sys.L2ChainB.TimestampForBlockNum(parentB.Number+1),
+		sys.L2ChainC.TimestampForBlockNum(parentC.Number+1),
+	)
+	parentA = sys.TestSequencer.AdvanceToBlockParent(t, sys.L2ChainA, nextTimestamp)
+	parentB = sys.TestSequencer.AdvanceToBlockParent(t, sys.L2ChainB, nextTimestamp)
+	parentC = sys.TestSequencer.AdvanceToBlockParent(t, sys.L2ChainC, nextTimestamp)
+
+	blockA, blockB, blockC := parentA.Number+1, parentB.Number+1, parentC.Number+1
+	initC := carol.PrepareSameTimestampInit(rand.New(rand.NewSource(22825)), eventLoggerC, blockC, 0, nextTimestamp)
+	c0 := dsl.PrecomputeExecEventMessage(initC.Message, sys.L2ChainC.ChainID(), blockC, 1, nextTimestamp)
+	a1 := dsl.PrecomputeExecEventMessage(c0, sys.L2ChainA.ChainID(), blockA, 1, nextTimestamp)
+	b0 := dsl.PrecomputeExecEventMessage(a1, sys.L2ChainB.ChainID(), blockB, 0, nextTimestamp)
+
+	sys.TestSequencer.SequenceBlockWithPlannedTxs(t, parentA.Hash, alice,
+		dsl.SubmitExecForMessage(b0, alice),
+		dsl.SubmitExecForMessage(c0, alice),
+	)
+	sys.TestSequencer.SequenceBlockWithPlannedTxs(t, parentB.Hash, bob,
+		dsl.SubmitExecForMessage(a1, bob),
+	)
+	sys.TestSequencer.SequenceBlockWithPlannedTxs(t, parentC.Hash, carol,
+		initC.SubmitInit(),
+		dsl.SubmitExecForMessage(initC.Message, carol),
+	)
+	targetA := sys.L2ELA.BlockRefByLabel(eth.Unsafe).Number
+	sys.L2BatcherA.Start()
+	sys.L2CLA.Reached(safety.LocalSafe, targetA, 60)
+	sys.L2BatcherA.Stop()
+	targetB := sys.L2ELB.BlockRefByLabel(eth.Unsafe).Number
+	sys.L2BatcherB.Start()
+	sys.L2CLB.Reached(safety.LocalSafe, targetB, 60)
+	sys.L2BatcherB.Stop()
+	targetC := sys.L2ELC.BlockRefByLabel(eth.Unsafe).Number
+	sys.L2BatcherC.Start()
+	sys.L2CLC.Reached(safety.LocalSafe, targetC, 60)
+	sys.L2BatcherC.Stop()
+
+	optimisticA := sys.Supernode().AwaitOptimisticBlockAtTimestamp(sys.L2ChainA.ChainID(), nextTimestamp)
+	optimisticB := sys.Supernode().AwaitOptimisticBlockAtTimestamp(sys.L2ChainB.ChainID(), nextTimestamp)
+	optimisticC := sys.Supernode().AwaitOptimisticBlockAtTimestamp(sys.L2ChainC.ChainID(), nextTimestamp)
+
+	sys.Supernode().ResumeInterop()
+	sys.SuperRoots.AwaitValidatedTimestamp(nextTimestamp)
+	response := sys.SuperRoots.SuperRootAtTimestamp(nextTimestamp)
+	t.Require().NotNil(response.Data, "expected verified super root at timestamp %d", nextTimestamp)
+	verified, ok := response.Data.Super.(*eth.SuperV1)
+	t.Require().True(ok, "verified super root must be SuperV1")
+	t.Require().Len(verified.Chains, 3, "verified super root must contain three chains")
+	t.Require().Equal(sys.L2ChainA.ChainID(), verified.Chains[0].ChainID, "verified chain A order must match the dependency set")
+	t.Require().Equal(sys.L2ChainB.ChainID(), verified.Chains[1].ChainID, "verified chain B order must match the dependency set")
+	t.Require().Equal(sys.L2ChainC.ChainID(), verified.Chains[2].ChainID, "verified chain C order must match the dependency set")
+
+	expected := eth.NewSuperV1(
+		nextTimestamp,
+		verified.Chains[0],
+		verified.Chains[1],
+		eth.ChainIDAndOutput{ChainID: sys.L2ChainC.ChainID(), Output: optimisticC.OutputRoot},
+	)
+	startTimestamp := nextTimestamp - 1
+	start := *eth.NewSuperV1(
+		startTimestamp,
+		eth.ChainIDAndOutput{ChainID: sys.L2ChainA.ChainID(), Output: sys.L2CLA.OutputAtBlock(parentA.Number).OutputRoot},
+		eth.ChainIDAndOutput{ChainID: sys.L2ChainB.ChainID(), Output: sys.L2CLB.OutputAtBlock(parentB.Number).OutputRoot},
+		eth.ChainIDAndOutput{ChainID: sys.L2ChainC.ChainID(), Output: sys.L2CLC.OutputAtBlock(parentC.Number).OutputRoot},
+	)
+	preConsolidation := marshalTransition(start, consolidateStep, optimisticA, optimisticB, optimisticC)
+	l1Head := latestRequiredL1(response)
+
+	t.Require().NotEqual(optimisticA.OutputRoot, verified.Chains[0].Output,
+		"supernode preserved cyclic chain A")
+	t.Require().NotEqual(optimisticB.OutputRoot, verified.Chains[1].Output,
+		"supernode preserved cyclic chain B")
+	t.Require().Equal(optimisticC.OutputRoot, verified.Chains[2].Output,
+		"supernode did not preserve acyclic prerequisite chain C")
+
+	runThreeChainScenarioProofs(t, sys, &scenarioProofData{
+		fpvmTransitions: []*transitionTest{{
+			Name:               "PreservesAcyclicPrerequisite",
+			AgreedClaim:        preConsolidation,
+			DisputedClaim:      expected.Marshal(),
+			DisputedTraceIndex: consolidateStep,
+			L1Head:             l1Head,
+			ClaimTimestamp:     nextTimestamp,
+			ExpectValid:        true,
+		}},
+		fpvmStartTimestamp: startTimestamp,
+		zkCheckpoint:       newZKCheckpointForRunners(t, &sys.SingleChainInterop, nextTimestamp, true, runners),
+	}, runners...)
+}

--- a/op-acceptance-tests/tests/superfaultproofs/intrablock.go
+++ b/op-acceptance-tests/tests/superfaultproofs/intrablock.go
@@ -65,7 +65,7 @@ func RunIntraBlockConsolidationTest(t devtest.T, sys *presets.SimpleInterop, tc 
 	// --- Sync chains and prepare for same-timestamp block building -----------
 	sys.L2ChainB.CatchUpTo(sys.L2ChainA)
 	sys.L2ChainA.CatchUpTo(sys.L2ChainB)
-	sys.Supernode().EnsureInteropPaused(sys.L2CLA, sys.L2CLB, 10)
+	sys.Supernode().EnsureInteropPaused(10, sys.L2CLA, sys.L2CLB)
 
 	sys.L2CLA.StopSequencer()
 	sys.L2CLB.StopSequencer()
@@ -108,35 +108,8 @@ func RunIntraBlockConsolidationTest(t devtest.T, sys *presets.SimpleInterop, tc 
 	// --- Build and include transactions in same-timestamp blocks -------------
 	txsA, txsB := tc.BuildTxs(setup)
 
-	// Assign deterministic nonces
-	baseNonceA := alice.PendingNonce()
-	for i, ptx := range txsA {
-		txplan.WithStaticNonce(baseNonceA + uint64(i))(ptx)
-	}
-	baseNonceB := bob.PendingNonce()
-	for i, ptx := range txsB {
-		txplan.WithStaticNonce(baseNonceB + uint64(i))(ptx)
-	}
-
-	ctx := t.Ctx()
-	var rawTxsA, rawTxsB [][]byte
-	for _, ptx := range txsA {
-		signedTx, err := ptx.Signed.Eval(ctx)
-		t.Require().NoError(err, "failed to sign tx for chain A")
-		rawBytes, err := signedTx.MarshalBinary()
-		t.Require().NoError(err, "failed to marshal tx for chain A")
-		rawTxsA = append(rawTxsA, rawBytes)
-	}
-	for _, ptx := range txsB {
-		signedTx, err := ptx.Signed.Eval(ctx)
-		t.Require().NoError(err, "failed to sign tx for chain B")
-		rawBytes, err := signedTx.MarshalBinary()
-		t.Require().NoError(err, "failed to marshal tx for chain B")
-		rawTxsB = append(rawTxsB, rawBytes)
-	}
-
-	sys.TestSequencer.SequenceBlockWithTxs(t, sys.L2ChainA.ChainID(), unsafeA.Hash, rawTxsA)
-	sys.TestSequencer.SequenceBlockWithTxs(t, sys.L2ChainB.ChainID(), unsafeB.Hash, rawTxsB)
+	sys.TestSequencer.SequenceBlockWithPlannedTxs(t, unsafeA.Hash, alice, txsA...)
+	sys.TestSequencer.SequenceBlockWithPlannedTxs(t, unsafeB.Hash, bob, txsB...)
 
 	// --- Resume interop and wait for validation ------------------------------
 	sys.Supernode().ResumeInterop()

--- a/op-acceptance-tests/tests/superfaultproofs/proof_runner.go
+++ b/op-acceptance-tests/tests/superfaultproofs/proof_runner.go
@@ -17,13 +17,18 @@ import (
 // ProofRunner executes the proof checks attached to one shared interop scenario.
 // Implementations are constructed here so scenario internals remain private.
 type ProofRunner interface {
-	run(t devtest.T, sys *presets.SingleChainInterop, chains []*chain, data *scenarioProofData)
+	run(t devtest.T, sys *presets.SingleChainInterop, chains []proofChain, data *scenarioProofData)
 }
 
 type scenarioProofData struct {
 	fpvmTransitions    []*transitionTest
 	fpvmStartTimestamp uint64
 	zkCheckpoint       *zkCheckpoint
+}
+
+type proofChain struct {
+	id            eth.ChainID
+	l2NodeAddress string
 }
 
 type zkCheckpoint struct {
@@ -56,6 +61,33 @@ func NewSP1FullProofRunner(executorPath string) ProofRunner {
 }
 
 func runScenarioProofs(t devtest.T, sys *presets.SingleChainInterop, chains []*chain, data *scenarioProofData, runners ...ProofRunner) {
+	proofChains := make([]proofChain, len(chains))
+	for i, chain := range chains {
+		proofChains[i] = proofChain{id: chain.ID, l2NodeAddress: chain.EL.UserRPC()}
+	}
+	runProofs(t, sys, proofChains, data, runners...)
+}
+
+func runThreeChainScenarioProofs(
+	t devtest.T,
+	sys *presets.ThreeChainInterop,
+	data *scenarioProofData,
+	runners ...ProofRunner,
+) {
+	runProofs(t, &sys.SingleChainInterop, []proofChain{
+		{id: sys.L2ChainA.ChainID(), l2NodeAddress: sys.L2ELA.UserRPC()},
+		{id: sys.L2ChainB.ChainID(), l2NodeAddress: sys.L2ELB.UserRPC()},
+		{id: sys.L2ChainC.ChainID(), l2NodeAddress: sys.L2ELC.UserRPC()},
+	}, data, runners...)
+}
+
+func runProofs(
+	t devtest.T,
+	sys *presets.SingleChainInterop,
+	chains []proofChain,
+	data *scenarioProofData,
+	runners ...ProofRunner,
+) {
 	if len(runners) == 0 {
 		runners = []ProofRunner{NewKonaProofRunner()}
 	}
@@ -73,7 +105,7 @@ func hasSP1Runner(runners []ProofRunner) bool {
 	return false
 }
 
-func (konaProofRunner) run(t devtest.T, sys *presets.SingleChainInterop, _ []*chain, data *scenarioProofData) {
+func (konaProofRunner) run(t devtest.T, sys *presets.SingleChainInterop, _ []proofChain, data *scenarioProofData) {
 	t.Require().NotEmpty(data.fpvmTransitions, "Kona runner requires FPVM transition cases")
 	challengerCfg := sys.L2ChainA.Escape().L2Challengers()[0].Config()
 	gameDepth := sys.DisputeGameFactory().GameImpl(gameTypes.SuperCannonKonaGameType).SplitDepth()
@@ -90,7 +122,7 @@ func (konaProofRunner) run(t devtest.T, sys *presets.SingleChainInterop, _ []*ch
 	}
 }
 
-func (r sp1ProofRunner) run(t devtest.T, sys *presets.SingleChainInterop, chains []*chain, data *scenarioProofData) {
+func (r sp1ProofRunner) run(t devtest.T, sys *presets.SingleChainInterop, chains []proofChain, data *scenarioProofData) {
 	executorPath := r.executorPath
 	if r.nativeCore {
 		var err error
@@ -149,14 +181,14 @@ func newZKCheckpointForRunners(
 	return newZKCheckpoint(t, sys, endTimestamp, expectReplacement)
 }
 
-func validateZKCheckpoint(t devtest.T, sys *presets.SingleChainInterop, chains []*chain, checkpoint *zkCheckpoint) {
+func validateZKCheckpoint(t devtest.T, sys *presets.SingleChainInterop, chains []proofChain, checkpoint *zkCheckpoint) {
 	resp := sys.SuperRoots.SuperRootAtTimestamp(checkpoint.endTimestamp)
 	t.Require().NotNil(resp.Data, "expected verified super-root data at timestamp %d", checkpoint.endTimestamp)
 	t.Require().Equal(checkpoint.trustedL1Head, resp.Data.VerifiedRequiredL1,
 		"verified required L1 changed for timestamp %d", checkpoint.endTimestamp)
 	expectedChainIDs := make([]eth.ChainID, len(chains))
 	for i, chain := range chains {
-		expectedChainIDs[i] = chain.ID
+		expectedChainIDs[i] = chain.id
 	}
 	t.Require().NotEmpty(expectedChainIDs, "dependency set must contain at least one chain")
 	t.Require().Equal(expectedChainIDs, resp.ChainIDs,
@@ -216,7 +248,7 @@ func validateZKCheckpoint(t devtest.T, sys *presets.SingleChainInterop, chains [
 func superRangeExecutorArgs(
 	t devtest.T,
 	sys *presets.SingleChainInterop,
-	chains []*chain,
+	chains []proofChain,
 	cfg vm.Config,
 	l1Head eth.BlockID,
 	endTimestamp uint64,
@@ -226,7 +258,7 @@ func superRangeExecutorArgs(
 	t.Require().NotEmpty(cfg.DepsetConfigPath, "SP1 super-range requires a dependency-set config")
 	l2NodeAddresses := make([]string, len(chains))
 	for i, chain := range chains {
-		l2NodeAddresses[i] = chain.EL.Escape().UserRPC()
+		l2NodeAddresses[i] = chain.l2NodeAddress
 	}
 	args := []string{
 		"--supernode-address", sys.SuperRoots.UserRPC(),

--- a/op-acceptance-tests/tests/supernode/interop/follow_l2/sync_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/follow_l2/sync_test.go
@@ -47,7 +47,7 @@ func TestFollowSource_HeadsDivergeThenConverge(gt *testing.T) {
 	}
 	dsl.CheckAll(t, initialChecks...)
 
-	pausedAt := sys.Supernode.EnsureInteropPaused(sys.L2ACL, sys.L2BCL, 10)
+	pausedAt := sys.Supernode.EnsureInteropPaused(10, sys.L2ACL, sys.L2BCL)
 	t.Logger().Info("interop paused", "timestamp", pausedAt)
 
 	baselines := make(map[string]headSnapshot, len(chains))

--- a/op-acceptance-tests/tests/supernode/interop/head_progression_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/head_progression_test.go
@@ -43,7 +43,7 @@ func TestSupernodeInterop_SafeHeadProgression(gt *testing.T) {
 
 	// Pause interop and verify it has stopped
 	// Uses max local safe timestamp from both chains, pauses at +10, awaits validation at +9
-	pausedTimestamp := sys.Supernode.EnsureInteropPaused(sys.L2ACL, sys.L2BCL, 10)
+	pausedTimestamp := sys.Supernode.EnsureInteropPaused(10, sys.L2ACL, sys.L2BCL)
 	t.Logger().Info("interop paused", "paused", pausedTimestamp)
 
 	// Compute the initial target block number for each chain based on the paused timestamp

--- a/op-acceptance-tests/tests/supernode/interop/reorg/invalid_message_reorg_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/reorg/invalid_message_reorg_test.go
@@ -73,7 +73,7 @@ func runInteropInvalidMessageReplacementScenario(t devtest.T, sys *presets.TwoL2
 
 	// Pause interop and verify it has stopped
 	// Uses max local safe timestamp from both chains, pauses at +10, awaits validation at +9
-	paused := sys.Supernode.EnsureInteropPaused(sys.L2ACL, sys.L2BCL, 10)
+	paused := sys.Supernode.EnsureInteropPaused(10, sys.L2ACL, sys.L2BCL)
 	t.Logger().Info("interop paused", "paused", paused)
 
 	rng := rand.New(rand.NewSource(12345))

--- a/op-acceptance-tests/tests/supernode/interop/reorg/rpc_gate_test.go
+++ b/op-acceptance-tests/tests/supernode/interop/reorg/rpc_gate_test.go
@@ -32,7 +32,7 @@ func TestSupernodeInteropRPCGatedDuringReorg(gt *testing.T) {
 	sys.L2B.CatchUpTo(sys.L2A)
 	sys.L2A.CatchUpTo(sys.L2B)
 
-	paused := sys.Supernode.EnsureInteropPaused(sys.L2ACL, sys.L2BCL, 10)
+	paused := sys.Supernode.EnsureInteropPaused(10, sys.L2ACL, sys.L2BCL)
 	t.Logger().Info("interop paused", "paused", paused)
 
 	rng := rand.New(rand.NewSource(12345))

--- a/op-devstack/dsl/l2_cl.go
+++ b/op-devstack/dsl/l2_cl.go
@@ -159,6 +159,13 @@ func (cl *L2CLNode) SyncStatus() *eth.SyncStatus {
 	return syncStatus
 }
 
+// OutputAtBlock returns the output response for a block number.
+func (cl *L2CLNode) OutputAtBlock(blockNumber uint64) *eth.OutputResponse {
+	output, err := cl.inner.RollupAPI().OutputAtBlock(cl.ctx, blockNumber)
+	cl.require.NoError(err, "failed to fetch output at block %d", blockNumber)
+	return output
+}
+
 // headBlockRef is the error-returning variant of HeadBlockRef, for use inside
 // retry/eventually loops.
 func (cl *L2CLNode) headBlockRef(lvl safety.Level) (eth.L2BlockRef, error) {

--- a/op-devstack/dsl/l2_el.go
+++ b/op-devstack/dsl/l2_el.go
@@ -50,6 +50,11 @@ func (el *L2ELNode) Escape() stack.L2ELNode {
 	return el.inner
 }
 
+// UserRPC returns the execution node's user RPC endpoint.
+func (el *L2ELNode) UserRPC() string {
+	return el.inner.UserRPC()
+}
+
 func (el *L2ELNode) EthClient() apis.EthClient {
 	return el.inner.EthClient()
 }

--- a/op-devstack/dsl/sequencer.go
+++ b/op-devstack/dsl/sequencer.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
 	"github.com/ethereum-optimism/optimism/op-devstack/stack"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/txplan"
 	"github.com/ethereum-optimism/optimism/op-test-sequencer/sequencer/seqtypes"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
@@ -41,6 +42,21 @@ func (s *TestSequencer) SequenceBlock(t devtest.T, chainID eth.ChainID, parent c
 	require.NoError(t, ca.Next(t.Ctx()))
 }
 
+// AdvanceToBlockParent sequences empty blocks until the next block lands at timestamp.
+// It returns that next block's parent.
+func (s *TestSequencer) AdvanceToBlockParent(t devtest.T, network *L2Network, timestamp uint64) eth.L2BlockRef {
+	for {
+		parent := network.PrimaryEL().BlockRefByLabel(eth.Unsafe)
+		nextTimestamp := network.TimestampForBlockNum(parent.Number + 1)
+		t.Require().LessOrEqual(nextTimestamp, timestamp,
+			"chain %s advanced past target timestamp %d", network.ChainID(), timestamp)
+		if nextTimestamp == timestamp {
+			return parent
+		}
+		s.SequenceBlock(t, network.ChainID(), parent.Hash)
+	}
+}
+
 // SequenceBlockWithTxs builds a block with timestamp parent.Time + blockTime with the supplied transactions (bypassing the mempool).
 // This makes it ideal for same-timestamp interop testing, and avoids the chance that transactions are sequenced into later blocks.
 func (s *TestSequencer) SequenceBlockWithTxs(t devtest.T, chainID eth.ChainID, parent common.Hash, rawTxs [][]byte) {
@@ -68,4 +84,27 @@ func (s *TestSequencer) SequenceBlockWithTxs(t devtest.T, chainID eth.ChainID, p
 	// Publish is optional - it broadcasts via P2P which may not be enabled in tests.
 	// The block is already committed and canonical at this point.
 	_ = ca.Publish(ctx) // ignore publish errors
+}
+
+// SequenceBlockWithPlannedTxs assigns consecutive nonces and includes the planned transactions in one block.
+func (s *TestSequencer) SequenceBlockWithPlannedTxs(
+	t devtest.T,
+	parent common.Hash,
+	sender *EOA,
+	planned ...*txplan.PlannedTx,
+) {
+	s.log.Info("sequencing block with planned transactions",
+		"chain_id", sender.ChainID(),
+		"transaction_count", len(planned),
+	)
+	baseNonce := sender.PendingNonce()
+	rawTxs := make([][]byte, len(planned))
+	for i, plannedTx := range planned {
+		txplan.WithStaticNonce(baseNonce + uint64(i))(plannedTx)
+		signed, err := plannedTx.Signed.Eval(t.Ctx())
+		t.Require().NoError(err, "failed to sign transaction %d", i)
+		rawTxs[i], err = signed.MarshalBinary()
+		t.Require().NoError(err, "failed to marshal transaction %d", i)
+	}
+	s.SequenceBlockWithTxs(t, sender.ChainID(), parent, rawTxs)
 }

--- a/op-devstack/dsl/super_root_source.go
+++ b/op-devstack/dsl/super_root_source.go
@@ -98,6 +98,57 @@ func (s *SuperRootQuerier) AwaitValidatedTimestamp(timestamp uint64) {
 	s.require.NoError(err, "super-root at timestamp %d was not validated in time", timestamp)
 }
 
+// AwaitOptimisticBlockAtTimestamp waits for one chain's optimistic output to become available.
+func (s *SuperRootQuerier) AwaitOptimisticBlockAtTimestamp(
+	chainID eth.ChainID,
+	timestamp uint64,
+) eth.OptimisticBlock {
+	ctx, cancel := context.WithTimeout(s.ctx, 5*DefaultTimeout)
+	defer cancel()
+
+	var result eth.OptimisticBlock
+	var lastErr error
+	var lastCurrentL1 eth.BlockID
+	var chainPresent bool
+	var outputPresent bool
+	err := wait.For(ctx, time.Second, func() (bool, error) {
+		resp, err := s.api.SuperRootAtTimestamp(ctx, timestamp)
+		if err != nil {
+			lastErr = err
+			s.log.Warn("optimistic output query failed",
+				"chain_id", chainID,
+				"timestamp", timestamp,
+				"error", err,
+			)
+			return false, nil
+		}
+		lastErr = nil
+		lastCurrentL1 = resp.CurrentL1
+		out, ok := resp.OptimisticAtTimestamp[chainID]
+		chainPresent = ok
+		outputPresent = ok && out.Output != nil
+		s.log.Info("checked optimistic output",
+			"chain_id", chainID,
+			"timestamp", timestamp,
+			"chain_present", chainPresent,
+			"output_present", outputPresent,
+			"current_l1", lastCurrentL1,
+		)
+		if !outputPresent {
+			return false, nil
+		}
+		result = eth.OptimisticBlock{
+			BlockHash:  out.Output.BlockHash,
+			OutputRoot: out.OutputRoot,
+		}
+		return true, nil
+	})
+	s.require.NoErrorf(err,
+		"optimistic output for chain %s at timestamp %d was not available in time; last error: %v, chain present: %t, output present: %t, current L1: %s",
+		chainID, timestamp, lastErr, chainPresent, outputPresent, lastCurrentL1)
+	return result
+}
+
 // AwaitFullyProcessedL1 waits until the source has fully processed the given L1 block
 // number. SuperRootAtTimestamp's CurrentL1 names the block currently being processed
 // (L1[<CurrentL1] is fully processed), so this returns once CurrentL1.Number > targetL1.

--- a/op-devstack/dsl/supernode.go
+++ b/op-devstack/dsl/supernode.go
@@ -293,63 +293,43 @@ func (s *Supernode) AssertBackfillCovers(depth time.Duration, blockTime uint64, 
 	}
 }
 
-// EnsureInteropPaused pauses the interop activity and verifies it has stopped.
-// It takes the local safe timestamps from two CL nodes, uses the maximum, then:
-// 1. Pauses interop at localSafeTimestamp + pauseOffset
-// 2. Awaits validation of localSafeTimestamp + pauseOffset - 1
-// 3. Finds the first timestamp that is NOT verified (the actual pause point)
-// Returns the first unverified timestamp (adjusted if pause came in late).
+// EnsureInteropPaused pauses interop after the latest local-safe timestamp.
+// It verifies the last timestamp before the pause and returns the first unverified timestamp.
 // Requires the Supernode to be created with NewSupernodeWithTestControl.
-func (s *Supernode) EnsureInteropPaused(clA, clB *L2CLNode, pauseOffset uint64) uint64 {
+func (s *Supernode) EnsureInteropPaused(pauseOffset uint64, clNodes ...*L2CLNode) uint64 {
+	s.require.NotEmpty(clNodes, "EnsureInteropPaused requires at least one CL node")
 	ia := s.interopActivity()
 
-	// Get the local safe of both chains from sync status
-	statusA := clA.SyncStatus()
-	statusB := clB.SyncStatus()
-
-	// Use the maximum local safe timestamp between both chains
-	localSafeTimestamp := max(statusA.LocalSafeL2.Time, statusB.LocalSafeL2.Time)
-
-	s.log.Info("EnsureInteropPaused: initial sync status",
-		"chainA_local_safe_num", statusA.LocalSafeL2.Number,
-		"chainA_local_safe_ts", statusA.LocalSafeL2.Time,
-		"chainB_local_safe_num", statusB.LocalSafeL2.Number,
-		"chainB_local_safe_ts", statusB.LocalSafeL2.Time,
-		"localSafeTimestamp", localSafeTimestamp,
-	)
+	var localSafeTimestamp uint64
+	for _, cl := range clNodes {
+		status := cl.SyncStatus()
+		localSafeTimestamp = max(localSafeTimestamp, status.LocalSafeL2.Time)
+		s.log.Info("EnsureInteropPaused: initial sync status",
+			"chain", cl.ChainID(),
+			"local_safe_num", status.LocalSafeL2.Number,
+			"local_safe_ts", status.LocalSafeL2.Time)
+	}
 
 	pauseTimestamp := localSafeTimestamp + pauseOffset
 	awaitTimestamp := pauseTimestamp - 1
-
-	// Pause interop activity at the pause timestamp
 	ia.PauseAt(pauseTimestamp)
-
-	// Await interop validation of the timestamp before the pause
 	s.AwaitValidatedTimestamp(awaitTimestamp)
-
 	s.log.Info("EnsureInteropPaused: validation confirmed before pause", "timestamp", awaitTimestamp)
 
-	// Find the first timestamp that is NOT verified.
-	// If the pause came in late, some timestamps past pauseTimestamp may already be verified.
-	// We scan forward to find where interop actually stopped.
 	ctx, cancel := context.WithTimeout(s.ctx, DefaultTimeout)
 	defer cancel()
 
 	for ts := pauseTimestamp; ts < pauseTimestamp+100; ts++ {
 		resp, err := s.inner.QueryAPI().SuperRootAtTimestamp(ctx, ts)
 		if err != nil || resp.Data == nil {
-			// Found the first unverified timestamp
 			s.log.Info("EnsureInteropPaused: confirmed interop is paused",
 				"intendedPauseTimestamp", pauseTimestamp,
-				"actualPauseTimestamp", ts,
-			)
+				"actualPauseTimestamp", ts)
 			return ts
 		}
-		// This timestamp is verified, continue scanning
 		s.log.Warn("EnsureInteropPaused: pause came in late, timestamp already verified",
 			"timestamp", ts,
-			"intendedPause", pauseTimestamp,
-		)
+			"intendedPause", pauseTimestamp)
 	}
 
 	s.t.Error("EnsureInteropPaused: failed to find unverified timestamp within 100 timestamps")

--- a/op-devstack/presets/interop.go
+++ b/op-devstack/presets/interop.go
@@ -106,6 +106,24 @@ func (s *SimpleInterop) proofValidationContext() (devtest.T, *dsl.L1ELNode, []*d
 	return s.T, s.L1EL, s.L2Networks()
 }
 
+type ThreeChainInterop struct {
+	*SimpleInterop
+
+	L2ChainC   *dsl.L2Network
+	L2BatcherC *dsl.L2Batcher
+	L2ELC      *dsl.L2ELNode
+	L2CLC      *dsl.L2CLNode
+	FunderC    *dsl.FunderEOA
+}
+
+func (s *ThreeChainInterop) L2Networks() []*dsl.L2Network {
+	return []*dsl.L2Network{s.L2ChainA, s.L2ChainB, s.L2ChainC}
+}
+
+func (s *ThreeChainInterop) proofValidationContext() (devtest.T, *dsl.L1ELNode, []*dsl.L2Network) {
+	return s.T, s.L1EL, s.L2Networks()
+}
+
 // Supernode returns the op-supernode backing this system's super roots. SimpleInterop
 // is always supernode-backed, so this exposes supernode-only test controls (e.g.
 // interop pause/resume) that are not part of the SuperRootSource interface.
@@ -124,6 +142,12 @@ func (s *SingleChainInterop) StandardBridge(l2Chain *dsl.L2Network) *dsl.Standar
 func NewSimpleInterop(t devtest.T, opts ...Option) *SimpleInterop {
 	presetCfg, _ := collectSupportedPresetConfig(t, "NewSimpleInterop", opts, twoL2SupernodeProofsPresetSupportedOptionKinds)
 	return simpleInteropFromSupernodeProofsRuntime(t, sysgo.NewTwoL2SupernodeProofsRuntimeWithConfig(t, true, presetCfg))
+}
+
+// NewThreeChainInterop creates a three-chain supernode proofs system.
+func NewThreeChainInterop(t devtest.T, opts ...Option) *ThreeChainInterop {
+	presetCfg, _ := collectSupportedPresetConfig(t, "NewThreeChainInterop", opts, twoL2SupernodeProofsPresetSupportedOptionKinds)
+	return threeChainInteropFromSupernodeProofsRuntime(t, sysgo.NewThreeL2SupernodeProofsRuntimeWithConfig(t, true, presetCfg))
 }
 
 // NewSingleChainInterop creates a fresh SingleChainInterop target for the

--- a/op-devstack/presets/superproofs_from_runtime.go
+++ b/op-devstack/presets/superproofs_from_runtime.go
@@ -25,11 +25,23 @@ func newL1ProposerEOA(t devtest.T, runtime *sysgo.MultiChainRuntime, l2ChainID e
 }
 
 func simpleInteropFromSupernodeProofsRuntime(t devtest.T, runtime *sysgo.MultiChainRuntime) *SimpleInterop {
+	components := multiL2FromRuntime(t, runtime, "l2a", "l2b")
+	return simpleInteropFromRuntimeComponents(t, runtime, components)
+}
+
+func simpleInteropFromRuntimeComponents(
+	t devtest.T,
+	runtime *sysgo.MultiChainRuntime,
+	components *multiL2RuntimePresetComponents,
+) *SimpleInterop {
 	chainA := runtime.Chains["l2a"]
 	chainB := runtime.Chains["l2b"]
 	t.Require().NotNil(chainA, "missing l2a superproofs chain")
 	t.Require().NotNil(chainB, "missing l2b superproofs chain")
-	twoL2, components := twoL2FromRuntime(t, runtime)
+	l2A := components.chains["l2a"]
+	l2B := components.chains["l2b"]
+	t.Require().NotNil(l2A, "missing l2a preset components")
+	t.Require().NotNil(l2B, "missing l2b preset components")
 
 	supernodeFrontend := newSupernodeFrontend(t, "supernode-two-l2-system", runtime.Supernode.UserRPC(), runtime.Supernode)
 	testSequencer := newTestSequencerFrontend(
@@ -47,21 +59,21 @@ func simpleInteropFromSupernodeProofsRuntime(t devtest.T, runtime *sysgo.MultiCh
 			timeTravel:       runtime.TimeTravel,
 			SuperRoots:       dsl.NewSupernodeWithTestControl(supernodeFrontend, runtime.Supernode),
 			TestSequencer:    dsl.NewTestSequencer(testSequencer),
-			L1Network:        twoL2.L1Network,
-			L1EL:             twoL2.L1EL,
-			L1CL:             twoL2.L1CL,
-			L2ChainA:         twoL2.L2A,
-			L2BatcherA:       dsl.NewL2Batcher(components.l2ABatcher),
-			L2ELA:            dsl.NewL2ELNode(components.l2AEL),
-			L2CLA:            twoL2.L2ACL,
+			L1Network:        components.l1Network,
+			L1EL:             components.l1EL,
+			L1CL:             components.l1CL,
+			L2ChainA:         l2A.network,
+			L2BatcherA:       l2A.batcher,
+			L2ELA:            l2A.el,
+			L2CLA:            l2A.cl,
 			Wallet:           dsl.NewRandomHDWallet(t, 30),
 			challengerConfig: runtime.L2ChallengerConfig,
 			sysgoRuntime:     runtime,
 		},
-		L2ChainB:   twoL2.L2B,
-		L2BatcherB: dsl.NewL2Batcher(components.l2BBatcher),
-		L2ELB:      dsl.NewL2ELNode(components.l2BEL),
-		L2CLB:      twoL2.L2BCL,
+		L2ChainB:   l2B.network,
+		L2BatcherB: l2B.batcher,
+		L2ELB:      l2B.el,
+		L2CLB:      l2B.cl,
 	}
 	out.l1Proposer = newL1ProposerEOA(t, runtime, chainA.Network.ChainID(), out.L1EL)
 	out.FunderL1 = newFunderEOA(t, runtime.Keys, out.L1EL, out.Wallet)
@@ -70,6 +82,26 @@ func simpleInteropFromSupernodeProofsRuntime(t devtest.T, runtime *sysgo.MultiCh
 
 	attachChallenger(t, out.L2ChainA, "main", chainA.Network.ChainID(), out.challengerConfig)
 	attachChallenger(t, out.L2ChainB, "main", chainB.Network.ChainID(), out.challengerConfig)
+	return out
+}
+
+func threeChainInteropFromSupernodeProofsRuntime(t devtest.T, runtime *sysgo.MultiChainRuntime) *ThreeChainInterop {
+	components := multiL2FromRuntime(t, runtime, "l2a", "l2b", "l2c")
+	base := simpleInteropFromRuntimeComponents(t, runtime, components)
+	chainC := runtime.Chains["l2c"]
+	t.Require().NotNil(chainC, "missing l2c superproofs chain")
+	l2C := components.chains["l2c"]
+	t.Require().NotNil(l2C, "missing l2c preset components")
+
+	out := &ThreeChainInterop{
+		SimpleInterop: base,
+		L2ChainC:      l2C.network,
+		L2BatcherC:    l2C.batcher,
+		L2ELC:         l2C.el,
+		L2CLC:         l2C.cl,
+	}
+	out.FunderC = newFunderEOA(t, runtime.Keys, out.L2ELC, out.Wallet)
+	attachChallenger(t, out.L2ChainC, "main", chainC.Network.ChainID(), out.challengerConfig)
 	return out
 }
 

--- a/op-devstack/presets/twol2.go
+++ b/op-devstack/presets/twol2.go
@@ -231,7 +231,7 @@ func (s *TwoL2SupernodeInterop) ForSameTimestampTesting(t devtest.T) *SameTimest
 	// Sync chains and pause interop
 	s.L2B.CatchUpTo(s.L2A)
 	s.L2A.CatchUpTo(s.L2B)
-	s.Supernode.EnsureInteropPaused(s.L2ACL, s.L2BCL, 10)
+	s.Supernode.EnsureInteropPaused(10, s.L2ACL, s.L2BCL)
 
 	// Stop sequencers
 	s.L2ACL.StopSequencer()

--- a/op-devstack/presets/twol2_from_runtime.go
+++ b/op-devstack/presets/twol2_from_runtime.go
@@ -14,83 +14,116 @@ type twoL2RuntimeComponents struct {
 	l2BBatcher *l2BatcherFrontend
 }
 
+type l2RuntimePresetComponents struct {
+	network *dsl.L2Network
+	el      *dsl.L2ELNode
+	cl      *dsl.L2CLNode
+	batcher *dsl.L2Batcher
+
+	elFrontend      *l2ELFrontend
+	batcherFrontend *l2BatcherFrontend
+}
+
+type multiL2RuntimePresetComponents struct {
+	l1Network *dsl.L1Network
+	l1EL      *dsl.L1ELNode
+	l1CL      *dsl.L1CLNode
+	chains    map[string]*l2RuntimePresetComponents
+}
+
 func twoL2SupernodeFromRuntime(t devtest.T, runtime *sysgo.MultiChainRuntime) *TwoL2 {
 	preset, _ := twoL2FromRuntime(t, runtime)
 	return preset
 }
 
 func twoL2FromRuntime(t devtest.T, runtime *sysgo.MultiChainRuntime) (*TwoL2, *twoL2RuntimeComponents) {
-	chainA := runtime.Chains["l2a"]
-	chainB := runtime.Chains["l2b"]
-	t.Require().NotNil(chainA, "missing l2a runtime chain")
-	t.Require().NotNil(chainB, "missing l2b runtime chain")
-	l1ChainID := runtime.L1Network.ChainID()
-	l2AChainID := chainA.Network.ChainID()
-	l2BChainID := chainB.Network.ChainID()
+	components := multiL2FromRuntime(t, runtime, "l2a", "l2b")
+	chainA := components.chains["l2a"]
+	chainB := components.chains["l2b"]
+	preset := &TwoL2{
+		Log:       t.Logger(),
+		T:         t,
+		L1Network: components.l1Network,
+		L1EL:      components.l1EL,
+		L1CL:      components.l1CL,
+		L2A:       chainA.network,
+		L2B:       chainB.network,
+		L2ACL:     chainA.cl,
+		L2BCL:     chainB.cl,
+	}
+	return preset, &twoL2RuntimeComponents{
+		l2AEL:      chainA.elFrontend,
+		l2BEL:      chainB.elFrontend,
+		l2ABatcher: chainA.batcherFrontend,
+		l2BBatcher: chainB.batcherFrontend,
+	}
+}
 
+func multiL2FromRuntime(
+	t devtest.T,
+	runtime *sysgo.MultiChainRuntime,
+	chainNames ...string,
+) *multiL2RuntimePresetComponents {
+	t.Require().Len(runtime.Chains, len(chainNames), "runtime must contain exactly the requested L2 chains")
+
+	l1ChainID := runtime.L1Network.ChainID()
 	l1Network := newPresetL1Network(t, "l1", runtime.L1Network.ChainConfig())
 	l1EL := newL1ELFrontend(t, "l1", l1ChainID, runtime.L1EL.UserRPC())
 	l1CL := newL1CLFrontend(t, "l1", l1ChainID, runtime.L1CL.BeaconHTTPAddr(), runtime.L1CL.FakePoS())
 	l1Network.AddL1ELNode(l1EL)
 	l1Network.AddL1CLNode(l1CL)
-
-	l2A := newPresetL2Network(
-		t,
-		"l2a",
-		chainA.Network.ChainConfig(),
-		chainA.Network.RollupConfig(),
-		chainA.Network.Deployment(),
-		newKeyring(runtime.Keys, t.Require()),
-		l1Network,
-	)
-	l2AEL := newL2ELFrontend(t, "sequencer", l2AChainID, chainA.EL.UserRPC(), chainA.EL.EngineRPC(), chainA.EL.JWTPath(), chainA.Network.RollupConfig(), chainA.EL)
-	l2ACL := newL2CLFrontend(t, "sequencer", l2AChainID, chainA.CL.UserRPC(), chainA.CL)
-	l2ACL.attachEL(l2AEL)
-	l2ABatcher := newL2BatcherFrontend(t, "main", l2AChainID, chainA.Batcher.UserRPC())
-	l2A.AddL2ELNode(l2AEL)
-	l2A.AddL2CLNode(l2ACL)
-	l2A.AddL2Batcher(l2ABatcher)
-
-	l2B := newPresetL2Network(
-		t,
-		"l2b",
-		chainB.Network.ChainConfig(),
-		chainB.Network.RollupConfig(),
-		chainB.Network.Deployment(),
-		newKeyring(runtime.Keys, t.Require()),
-		l1Network,
-	)
-	l2BEL := newL2ELFrontend(t, "sequencer", l2BChainID, chainB.EL.UserRPC(), chainB.EL.EngineRPC(), chainB.EL.JWTPath(), chainB.Network.RollupConfig(), chainB.EL)
-	l2BCL := newL2CLFrontend(t, "sequencer", l2BChainID, chainB.CL.UserRPC(), chainB.CL)
-	l2BCL.attachEL(l2BEL)
-	l2BBatcher := newL2BatcherFrontend(t, "main", l2BChainID, chainB.Batcher.UserRPC())
-	l2B.AddL2ELNode(l2BEL)
-	l2B.AddL2CLNode(l2BCL)
-	l2B.AddL2Batcher(l2BBatcher)
-
 	l1ELDSL := dsl.NewL1ELNode(l1EL)
 	l1CLDSL := dsl.NewL1CLNode(l1CL)
-	l2AELDSL := dsl.NewL2ELNode(l2AEL)
-	l2ACLDSL := dsl.NewL2CLNode(l2ACL)
-	l2BELDSL := dsl.NewL2ELNode(l2BEL)
-	l2BCLDSL := dsl.NewL2CLNode(l2BCL)
 
-	preset := &TwoL2{
-		Log:       t.Logger(),
-		T:         t,
-		L1Network: dsl.NewL1Network(l1Network, l1ELDSL, l1CLDSL),
-		L1EL:      l1ELDSL,
-		L1CL:      l1CLDSL,
-		L2A:       dsl.NewL2Network(l2A, l2AELDSL, l2ACLDSL, l1ELDSL, nil, nil),
-		L2B:       dsl.NewL2Network(l2B, l2BELDSL, l2BCLDSL, l1ELDSL, nil, nil),
-		L2ACL:     l2ACLDSL,
-		L2BCL:     l2BCLDSL,
+	chains := make(map[string]*l2RuntimePresetComponents, len(chainNames))
+	keyring := newKeyring(runtime.Keys, t.Require())
+	for _, name := range chainNames {
+		runtimeChain := runtime.Chains[name]
+		t.Require().NotNil(runtimeChain, "missing %s runtime chain", name)
+		chainID := runtimeChain.Network.ChainID()
+		l2Network := newPresetL2Network(
+			t,
+			name,
+			runtimeChain.Network.ChainConfig(),
+			runtimeChain.Network.RollupConfig(),
+			runtimeChain.Network.Deployment(),
+			keyring,
+			l1Network,
+		)
+		l2EL := newL2ELFrontend(
+			t,
+			"sequencer",
+			chainID,
+			runtimeChain.EL.UserRPC(),
+			runtimeChain.EL.EngineRPC(),
+			runtimeChain.EL.JWTPath(),
+			runtimeChain.Network.RollupConfig(),
+			runtimeChain.EL,
+		)
+		l2CL := newL2CLFrontend(t, "sequencer", chainID, runtimeChain.CL.UserRPC(), runtimeChain.CL)
+		l2CL.attachEL(l2EL)
+		l2Batcher := newL2BatcherFrontend(t, "main", chainID, runtimeChain.Batcher.UserRPC())
+		l2Network.AddL2ELNode(l2EL)
+		l2Network.AddL2CLNode(l2CL)
+		l2Network.AddL2Batcher(l2Batcher)
+
+		l2ELDSL := dsl.NewL2ELNode(l2EL)
+		l2CLDSL := dsl.NewL2CLNode(l2CL)
+		chains[name] = &l2RuntimePresetComponents{
+			network:         dsl.NewL2Network(l2Network, l2ELDSL, l2CLDSL, l1ELDSL, nil, nil),
+			el:              l2ELDSL,
+			cl:              l2CLDSL,
+			batcher:         dsl.NewL2Batcher(l2Batcher),
+			elFrontend:      l2EL,
+			batcherFrontend: l2Batcher,
+		}
 	}
-	return preset, &twoL2RuntimeComponents{
-		l2AEL:      l2AEL,
-		l2BEL:      l2BEL,
-		l2ABatcher: l2ABatcher,
-		l2BBatcher: l2BBatcher,
+
+	return &multiL2RuntimePresetComponents{
+		l1Network: dsl.NewL1Network(l1Network, l1ELDSL, l1CLDSL),
+		l1EL:      l1ELDSL,
+		l1CL:      l1CLDSL,
+		chains:    chains,
 	}
 }
 

--- a/op-devstack/sysgo/default_chain_ids.go
+++ b/op-devstack/sysgo/default_chain_ids.go
@@ -6,4 +6,5 @@ var (
 	DefaultL1ID  = eth.ChainIDFromUInt64(900)
 	DefaultL2AID = eth.ChainIDFromUInt64(901)
 	DefaultL2BID = eth.ChainIDFromUInt64(902)
+	DefaultL2CID = eth.ChainIDFromUInt64(903)
 )

--- a/op-devstack/sysgo/multichain_proofs.go
+++ b/op-devstack/sysgo/multichain_proofs.go
@@ -225,13 +225,54 @@ func attachSuperChallengerAndProposer(
 // NewTwoL2SupernodeProofsRuntimeWithConfig creates a two-chain supernode proofs
 // runtime. lagoonAtGenesis controls whether Lagoon activates interop at genesis.
 func NewTwoL2SupernodeProofsRuntimeWithConfig(t devtest.T, lagoonAtGenesis bool, cfg PresetConfig) *MultiChainRuntime {
+	return newMultiL2SupernodeProofsRuntimeWithConfig(
+		t,
+		lagoonAtGenesis,
+		cfg,
+		"test-sequencer-2l2",
+		[]runtimeChainSpec{
+			{Name: "l2a", ID: DefaultL2AID},
+			{Name: "l2b", ID: DefaultL2BID},
+		},
+	)
+}
+
+// NewThreeL2SupernodeProofsRuntimeWithConfig creates a three-chain supernode proofs runtime.
+func NewThreeL2SupernodeProofsRuntimeWithConfig(t devtest.T, lagoonAtGenesis bool, cfg PresetConfig) *MultiChainRuntime {
+	return newMultiL2SupernodeProofsRuntimeWithConfig(
+		t,
+		lagoonAtGenesis,
+		cfg,
+		"test-sequencer-3l2",
+		[]runtimeChainSpec{
+			{Name: "l2a", ID: DefaultL2AID},
+			{Name: "l2b", ID: DefaultL2BID},
+			{Name: "l2c", ID: DefaultL2CID},
+		},
+	)
+}
+
+func newMultiL2SupernodeProofsRuntimeWithConfig(
+	t devtest.T,
+	lagoonAtGenesis bool,
+	cfg PresetConfig,
+	testSequencerName string,
+	chainSpecs []runtimeChainSpec,
+) *MultiChainRuntime {
 	if cfg.ZKDisputeGame != nil {
 		t.Require().NoError(cfg.ZKDisputeGame.validate(), "invalid ZK dispute game config")
 		t.Require().Nil(cfg.PreGenesisSuperGame, "ZK dispute game does not support the pre-genesis game fixture")
 	}
 	cfg = withSuperProofsDeployerFeature(cfg)
-	runtime, _ := newTwoL2SupernodeRuntimeWithConfig(t, lagoonAtGenesis, 0, cfg)
-	attachTestSequencerToRuntime(t, runtime, "test-sequencer-2l2")
+	runtime, _ := newMultiL2SupernodeRuntimeWithConfigAndSequencerMode(
+		t,
+		lagoonAtGenesis,
+		0,
+		cfg,
+		true,
+		chainSpecs,
+	)
+	attachTestSequencerToRuntime(t, runtime, testSequencerName)
 	return attachSupernodeSuperProofs(t, runtime, cfg)
 }
 

--- a/op-devstack/sysgo/multichain_supernode_runtime.go
+++ b/op-devstack/sysgo/multichain_supernode_runtime.go
@@ -227,12 +227,47 @@ func newTwoL2SupernodeRuntimeWithConfig(t devtest.T, enableInterop bool, delaySe
 }
 
 func newTwoL2SupernodeRuntimeWithConfigAndSequencerMode(t devtest.T, enableInterop bool, delaySeconds uint64, cfg PresetConfig, supernodeSequencerEnabled bool) (*MultiChainRuntime, uint64) {
+	return newMultiL2SupernodeRuntimeWithConfigAndSequencerMode(
+		t,
+		enableInterop,
+		delaySeconds,
+		cfg,
+		supernodeSequencerEnabled,
+		[]runtimeChainSpec{
+			{Name: "l2a", ID: DefaultL2AID},
+			{Name: "l2b", ID: DefaultL2BID},
+		},
+	)
+}
+
+type runtimeChainSpec struct {
+	Name string
+	ID   eth.ChainID
+}
+
+func newMultiL2SupernodeRuntimeWithConfigAndSequencerMode(
+	t devtest.T,
+	enableInterop bool,
+	delaySeconds uint64,
+	cfg PresetConfig,
+	supernodeSequencerEnabled bool,
+	chainSpecs []runtimeChainSpec,
+) (*MultiChainRuntime, uint64) {
 	require := t.Require()
+	require.NotEmpty(chainSpecs, "multi-chain runtime needs at least one L2 chain")
 
 	keys, err := devkeys.NewMnemonicDevKeys(devkeys.TestMnemonic)
 	require.NoError(err, "failed to derive dev keys from mnemonic")
 
-	wb, l1Net, l2ANet, l2BNet := buildTwoL2RuntimeWorld(t, keys, enableInterop, delaySeconds, cfg.LocalContractArtifactsPath, cfg.DeployerOptions...)
+	wb, l1Net, l2Nets := buildMultiL2RuntimeWorld(
+		t,
+		keys,
+		enableInterop,
+		delaySeconds,
+		cfg.LocalContractArtifactsPath,
+		chainSpecs,
+		cfg.DeployerOptions...,
+	)
 	migration := newInteropMigrationState(wb)
 	jwtPath, jwtSecret := writeJWTSecret(t)
 	l1Clock := clock.SystemClock
@@ -243,46 +278,36 @@ func newTwoL2SupernodeRuntimeWithConfigAndSequencerMode(t devtest.T, enableInter
 	}
 	l1EL, l1CL := startInProcessL1WithClockConfig(t, l1Net, jwtPath, l1Clock, cfg)
 	if cfg.PreGenesisSuperGame != nil {
-		preparePreGenesisSuperGame(t, keys, wb, l1Net, l1EL, migration, cfg.PreGenesisSuperGame, l2ANet, l2BNet)
+		preparePreGenesisSuperGame(t, keys, wb, l1Net, l1EL, migration, cfg.PreGenesisSuperGame, l2Nets...)
 	}
 
-	var l2AEL, l2BEL L2ELNode
+	l2ELs := make([]L2ELNode, len(l2Nets))
 	var interopFilter *InteropFilter
-
 	if cfg.UseInteropFilter {
-		// Proxy pattern: allocate stable address before ELs start
 		filterProxy := tcpproxy.New(t.Logger().New("proxy", "interop-filter"))
 		require.NoError(filterProxy.Start())
 		t.Cleanup(func() { filterProxy.Close() })
 		filterRPC := "http://" + filterProxy.Addr()
 
-		// Start ELs with filter proxy URL
-		l2AEL = startSupernodeELWithInteropURL(t, l2ANet, "sequencer", jwtPath, jwtSecret, filterRPC)
-		l2BEL = startSupernodeELWithInteropURL(t, l2BNet, "sequencer", jwtPath, jwtSecret, filterRPC)
-
-		// Build rollup config map from L2 networks (Go structs, no file I/O)
-		rollupConfigs := map[eth.ChainID]*rollup.Config{
-			eth.ChainIDFromBig(l2ANet.RollupConfig().L2ChainID): l2ANet.RollupConfig(),
-			eth.ChainIDFromBig(l2BNet.RollupConfig().L2ChainID): l2BNet.RollupConfig(),
+		rollupConfigs := make(map[eth.ChainID]*rollup.Config, len(l2Nets))
+		l2RPCs := make([]string, len(l2Nets))
+		for i, l2Net := range l2Nets {
+			l2ELs[i] = startSupernodeELWithInteropURL(t, l2Net, "sequencer", jwtPath, jwtSecret, filterRPC)
+			rollupConfigs[l2Net.ChainID()] = l2Net.RollupConfig()
+			l2RPCs[i] = l2ELs[i].UserRPC()
 		}
-
-		// Create and start interop filter in-process
-		interopFilter = startInteropFilter(t, "interop-filter",
-			[]string{l2AEL.UserRPC(), l2BEL.UserRPC()},
-			rollupConfigs)
-
-		// Connect proxy to the filter's actual RPC endpoint
+		interopFilter = startInteropFilter(t, "interop-filter", l2RPCs, rollupConfigs)
 		filterProxy.SetUpstream(ProxyAddr(require, interopFilter.HTTPEndpoint()))
 	} else {
-		// No interop filter — ELs start without an interop filter URL (existing behavior)
-		l2AEL = startSupernodeEL(t, l2ANet, jwtPath, jwtSecret)
-		l2BEL = startSupernodeEL(t, l2BNet, jwtPath, jwtSecret)
+		for i, l2Net := range l2Nets {
+			l2ELs[i] = startSupernodeEL(t, l2Net, jwtPath, jwtSecret)
+		}
 	}
 
 	var activationTime uint64
 	var interopActivationTimestamp *uint64
 	if enableInterop {
-		activationTime = l2ANet.rollupCfg.Genesis.L2Time + delaySeconds
+		activationTime = l2Nets[0].rollupCfg.Genesis.L2Time + delaySeconds
 		interopActivationTimestamp = &activationTime
 	}
 
@@ -292,9 +317,7 @@ func newTwoL2SupernodeRuntimeWithConfigAndSequencerMode(t devtest.T, enableInter
 		require.True(ok, "expected static dependency set")
 		depSet = cast
 	}
-
 	if cfg.MessageExpiryWindow != nil && depSet != nil {
-		var err error
 		depSet, err = depset.NewStaticConfigDependencySetWithMessageExpiryOverride(
 			depSet.Dependencies(), *cfg.MessageExpiryWindow)
 		require.NoError(err, "failed to override message expiry window")
@@ -307,15 +330,13 @@ func newTwoL2SupernodeRuntimeWithConfigAndSequencerMode(t devtest.T, enableInter
 		runtimeDepSet = wb.outFullCfgSet.DependencySet
 	}
 
-	supernode, supernodeL2ACL, supernodeL2BCL := startTwoL2SharedSupernode(
+	supernode, supernodeCLs := startSharedSupernode(
 		t,
 		l1Net,
 		l1EL,
 		l1CL,
-		l2ANet,
-		l2AEL,
-		l2BNet,
-		l2BEL,
+		l2Nets,
+		l2ELs,
 		depSet,
 		interopActivationTimestamp,
 		cfg.InteropLogBackfillDepth,
@@ -323,81 +344,56 @@ func newTwoL2SupernodeRuntimeWithConfigAndSequencerMode(t devtest.T, enableInter
 		supernodeSequencerEnabled || cfg.SupernodeVNSequencerForBootstrap,
 	)
 
-	var l2ACL L2CLNode = supernodeL2ACL
-	var l2BCL L2CLNode = supernodeL2BCL
-	// supernode VN ELs (always distinct identity from any follow-mode sequencer EL).
-	supernodeL2AEL, supernodeL2BEL := l2AEL, l2BEL
-	// sequencer ELs default to the supernode ELs in virtual-sequencer mode;
-	// in light-sequencer mode each follow-mode sequencer gets its own EL.
-	seqL2AEL, seqL2BEL := l2AEL, l2BEL
+	l2CLs := make([]L2CLNode, len(supernodeCLs))
+	for i, supernodeCL := range supernodeCLs {
+		l2CLs[i] = supernodeCL
+	}
+	supernodeELs := make([]L2ELNode, len(l2ELs))
+	copy(supernodeELs, l2ELs)
+	sequencerELs := make([]L2ELNode, len(l2ELs))
+	copy(sequencerELs, l2ELs)
+
 	if !supernodeSequencerEnabled {
-		// Production-faithful topology: each follow-mode sequencer runs its own
-		// EL, distinct from the supernode VN's EL, joined only by L1 and P2P.
 		sequencerELOpts := ResolveMixedL2ELOpts(t)
-		seqL2AEL = startSequencerEL(t, l2ANet, jwtPath, jwtSecret, NewELNodeIdentity(0), sequencerELOpts...)
-		seqL2BEL = startSequencerEL(t, l2BNet, jwtPath, jwtSecret, NewELNodeIdentity(0), sequencerELOpts...)
-
-		// Light sequencers follow the supernode's safe head (production:
-		// kind=sequencer, lightNode=true, deps on op-supernode). They sequence
-		// unsafe blocks but disable L1 derivation, importing safe/finalized state
-		// from the supernode route and reorging onto its invalid-message
-		// replacements.
-		//
-		// When the supernode VN bootstraps + sequences, the light sequencers start
-		// stopped; a test hands off sequencing to them once they leave willStartEL.
 		lightSeqStopped := cfg.SupernodeVNSequencerForBootstrap
-		l2ACL = startL2CLNode(t, keys, l1Net, l2ANet, l1EL, l1CL, seqL2AEL, jwtSecret, l2CLNodeStartConfig{
-			Key:              "sequencer",
-			IsSequencer:      true,
-			NoDiscovery:      true,
-			EnableReqResp:    true,
-			DependencySet:    runtimeDepSet,
-			L2FollowSource:   supernodeL2ACL.UserRPC(),
-			L2CLOptions:      cfg.GlobalL2CLOptions,
-			SequencerStopped: lightSeqStopped,
-			// Follow-mode sequencers reorg onto the supernode's invalid-message
-			// replacement via EL sync.
-			SyncMode: nodeSync.ELSync,
-		})
-		l2BCL = startL2CLNode(t, keys, l1Net, l2BNet, l1EL, l1CL, seqL2BEL, jwtSecret, l2CLNodeStartConfig{
-			Key:              "sequencer",
-			IsSequencer:      true,
-			NoDiscovery:      true,
-			EnableReqResp:    true,
-			DependencySet:    runtimeDepSet,
-			L2FollowSource:   supernodeL2BCL.UserRPC(),
-			L2CLOptions:      cfg.GlobalL2CLOptions,
-			SequencerStopped: lightSeqStopped,
-			SyncMode:         nodeSync.ELSync,
-		})
-		// CL gossip: unsafe blocks (incl. the supernode's deposits-only
-		// replacement) propagate between the sequencer CLs and the VN CLs.
-		connectL2CLPeers(t, t.Logger(), l2ACL, supernodeL2ACL)
-		connectL2CLPeers(t, t.Logger(), l2BCL, supernodeL2BCL)
-		// EL P2P: block bodies sync between each sequencer EL and its paired
-		// supernode EL (required for the ELSync follow path).
-		connectL2ELPeers(t, t.Logger(), supernodeL2AEL.UserRPC(), seqL2AEL.UserRPC())
-		connectL2ELPeers(t, t.Logger(), supernodeL2BEL.UserRPC(), seqL2BEL.UserRPC())
+		for i, l2Net := range l2Nets {
+			sequencerELs[i] = startSequencerEL(t, l2Net, jwtPath, jwtSecret, NewELNodeIdentity(0), sequencerELOpts...)
+			l2CLs[i] = startL2CLNode(t, keys, l1Net, l2Net, l1EL, l1CL, sequencerELs[i], jwtSecret, l2CLNodeStartConfig{
+				Key:              "sequencer",
+				IsSequencer:      true,
+				NoDiscovery:      true,
+				EnableReqResp:    true,
+				DependencySet:    runtimeDepSet,
+				L2FollowSource:   supernodeCLs[i].UserRPC(),
+				L2CLOptions:      cfg.GlobalL2CLOptions,
+				SequencerStopped: lightSeqStopped,
+				SyncMode:         nodeSync.ELSync,
+			})
+			connectL2CLPeers(t, t.Logger(), l2CLs[i], supernodeCLs[i])
+			connectL2ELPeers(t, t.Logger(), supernodeELs[i].UserRPC(), sequencerELs[i].UserRPC())
+		}
 	}
 
-	// Batchers follow the active sequencer's CL + EL so the L1-derived safe chain stays
-	// contiguous (interop verification depends on the safe head advancing). In a VN-sequencer
-	// bootstrap the light CL is stopped + EL-syncing, so batch from the VN: it produces during
-	// bootstrap and tracks the light sequencers via gossip after handoff, keeping a gap-free
-	// batch stream across the switch.
-	batchACL, batchAEL := l2ACL, seqL2AEL
-	batchBCL, batchBEL := l2BCL, seqL2BEL
-	if cfg.SupernodeVNSequencerForBootstrap {
-		batchACL, batchAEL = supernodeL2ACL, supernodeL2AEL
-		batchBCL, batchBEL = supernodeL2BCL, supernodeL2BEL
+	runtimeChains := make(map[string]*MultiChainNodeRuntime, len(chainSpecs))
+	for i, chainSpec := range chainSpecs {
+		batchCL, batchEL := l2CLs[i], sequencerELs[i]
+		if cfg.SupernodeVNSequencerForBootstrap {
+			batchCL, batchEL = supernodeCLs[i], supernodeELs[i]
+		}
+		batcher := startMinimalBatcher(t, keys, l2Nets[i], l1EL, batchCL, batchEL, cfg.BatcherOptions...)
+		proposer := startMinimalProposer(t, keys, l2Nets[i], l1EL, supernodeCLs[i])
+		runtimeChains[chainSpec.Name] = &MultiChainNodeRuntime{
+			Name:        chainSpec.Name,
+			Network:     l2Nets[i],
+			EL:          sequencerELs[i],
+			CL:          l2CLs[i],
+			SupernodeCL: supernodeCLs[i],
+			SupernodeEL: supernodeELs[i],
+			Batcher:     batcher,
+			Proposer:    proposer,
+		}
 	}
-	l2ABatcher := startMinimalBatcher(t, keys, l2ANet, l1EL, batchACL, batchAEL, cfg.BatcherOptions...)
-	l2AProposer := startMinimalProposer(t, keys, l2ANet, l1EL, supernodeL2ACL)
-	l2BBatcher := startMinimalBatcher(t, keys, l2BNet, l1EL, batchBCL, batchBEL, cfg.BatcherOptions...)
-	l2BProposer := startMinimalProposer(t, keys, l2BNet, l1EL, supernodeL2BCL)
 
-	// Wait for interop filter readiness now that the supernode and batchers are running.
-	// The filter needs blocks to be produced before its chain ingesters can backfill.
 	if interopFilter != nil {
 		interopFilter.WaitForReady(t, 120*time.Second)
 	}
@@ -409,35 +405,22 @@ func newTwoL2SupernodeRuntimeWithConfigAndSequencerMode(t devtest.T, enableInter
 		L1Network:     l1Net,
 		L1EL:          l1EL,
 		L1CL:          l1CL,
-		Chains: map[string]*MultiChainNodeRuntime{
-			"l2a": {
-				Name:        "l2a",
-				Network:     l2ANet,
-				EL:          seqL2AEL,
-				CL:          l2ACL,
-				SupernodeCL: supernodeL2ACL,
-				SupernodeEL: supernodeL2AEL,
-				Batcher:     l2ABatcher,
-				Proposer:    l2AProposer,
-			},
-			"l2b": {
-				Name:        "l2b",
-				Network:     l2BNet,
-				EL:          seqL2BEL,
-				CL:          l2BCL,
-				SupernodeCL: supernodeL2BCL,
-				SupernodeEL: supernodeL2BEL,
-				Batcher:     l2BBatcher,
-				Proposer:    l2BProposer,
-			},
-		},
+		Chains:        runtimeChains,
 		Supernode:     supernode,
 		TimeTravel:    timeTravelClock,
 		InteropFilter: interopFilter,
 	}, activationTime
 }
 
-func buildTwoL2RuntimeWorld(t devtest.T, keys devkeys.Keys, enableInterop bool, delaySeconds uint64, localContractArtifactsPath string, deployerOpts ...DeployerOption) (*worldBuilder, *L1Network, *L2Network, *L2Network) {
+func buildMultiL2RuntimeWorld(
+	t devtest.T,
+	keys devkeys.Keys,
+	enableInterop bool,
+	delaySeconds uint64,
+	localContractArtifactsPath string,
+	chainSpecs []runtimeChainSpec,
+	deployerOpts ...DeployerOption,
+) (*worldBuilder, *L1Network, []*L2Network) {
 	wb := &worldBuilder{
 		p:       t,
 		logger:  t.Logger(),
@@ -448,18 +431,15 @@ func buildTwoL2RuntimeWorld(t devtest.T, keys devkeys.Keys, enableInterop bool, 
 
 	applyConfigLocalContractSources(t, keys, wb.builder, localContractArtifactsPath)
 	applyConfigCommons(t, keys, DefaultL1ID, wb.builder)
-	applyConfigPrefundedL2(t, keys, DefaultL1ID, DefaultL2AID, wb.builder)
-	applyConfigPrefundedL2(t, keys, DefaultL1ID, DefaultL2BID, wb.builder)
+	for _, chainSpec := range chainSpecs {
+		applyConfigPrefundedL2(t, keys, DefaultL1ID, chainSpec.ID, wb.builder)
+	}
 	if enableInterop {
 		deployerOpts = append([]DeployerOption{
 			WithDevFeatureEnabled(devfeatures.OptimismPortalInteropFlag),
 		}, deployerOpts...)
 		for _, l2Cfg := range wb.builder.L2s() {
 			if delaySeconds > 0 {
-				// Set all forks up to but not including Interop at genesis,
-				// then set Interop at offset so the L2 chain starts in a
-				// pre-interop state. This matches the supernode's
-				// InteropActivationTimestamp and allows testing the fork transition.
 				l2Cfg.WithForkAtGenesis(opforks.Karst)
 				l2Cfg.WithForkAtOffset(opforks.Lagoon, &delaySeconds)
 			} else {
@@ -467,8 +447,6 @@ func buildTwoL2RuntimeWorld(t devtest.T, keys devkeys.Keys, enableInterop bool, 
 			}
 		}
 		if delaySeconds > 0 {
-			// The chain starts pre-Lagoon (at Karst) and activates Lagoon at
-			// runtime via its frozen NUT bundle.
 			preForkAllocs, err := nutsstate.PreForkState(opforks.Lagoon)
 			t.Require().NoError(err, "need frozen pre-Lagoon predeploy state")
 			wb.preForkPredeployAllocs = preForkAllocs
@@ -477,35 +455,34 @@ func buildTwoL2RuntimeWorld(t devtest.T, keys devkeys.Keys, enableInterop bool, 
 	applyConfigDeployerOptions(t, keys, wb.builder, deployerOpts)
 	wb.Build()
 
-	t.Require().Len(wb.l2Chains, 2, "expected exactly two L2 chains in TwoL2 world")
+	t.Require().Len(wb.l2Chains, len(chainSpecs), "unexpected L2 chain count")
 	l1ID := eth.ChainIDFromUInt64(wb.output.AppliedIntent.L1ChainID)
-
 	l1Net := &L1Network{
 		name:      "l1",
 		chainID:   l1ID,
 		genesis:   wb.outL1Genesis,
 		blockTime: 6,
 	}
-
-	l2ANet := l2NetworkFromWorldBuilder(t, wb, l1ID, DefaultL2AID, keys)
-	l2BNet := l2NetworkFromWorldBuilder(t, wb, l1ID, DefaultL2BID, keys)
-
-	return wb, l1Net, l2ANet, l2BNet
+	l2Nets := make([]*L2Network, len(chainSpecs))
+	for i, chainSpec := range chainSpecs {
+		l2Nets[i] = l2NetworkFromWorldBuilder(t, wb, l1ID, chainSpec, keys)
+	}
+	return wb, l1Net, l2Nets
 }
 
-func l2NetworkFromWorldBuilder(t devtest.T, wb *worldBuilder, l1ChainID, l2ChainID eth.ChainID, keys devkeys.Keys) *L2Network {
+func l2NetworkFromWorldBuilder(t devtest.T, wb *worldBuilder, l1ChainID eth.ChainID, chainSpec runtimeChainSpec, keys devkeys.Keys) *L2Network {
 	require := t.Require()
 
-	l2Genesis, ok := wb.outL2Genesis[l2ChainID]
-	require.Truef(ok, "missing L2 genesis for chain %s", l2ChainID)
-	l2RollupCfg, ok := wb.outL2RollupCfg[l2ChainID]
-	require.Truef(ok, "missing L2 rollup config for chain %s", l2ChainID)
-	l2Dep, ok := wb.outL2Deployment[l2ChainID]
-	require.Truef(ok, "missing L2 deployment for chain %s", l2ChainID)
+	l2Genesis, ok := wb.outL2Genesis[chainSpec.ID]
+	require.Truef(ok, "missing L2 genesis for chain %s", chainSpec.ID)
+	l2RollupCfg, ok := wb.outL2RollupCfg[chainSpec.ID]
+	require.Truef(ok, "missing L2 rollup config for chain %s", chainSpec.ID)
+	l2Dep, ok := wb.outL2Deployment[chainSpec.ID]
+	require.Truef(ok, "missing L2 deployment for chain %s", chainSpec.ID)
 
 	return &L2Network{
-		name:       map[eth.ChainID]string{DefaultL2AID: "l2a", DefaultL2BID: "l2b"}[l2ChainID],
-		chainID:    l2ChainID,
+		name:       chainSpec.Name,
+		chainID:    chainSpec.ID,
 		l1ChainID:  l1ChainID,
 		genesis:    l2Genesis,
 		rollupCfg:  l2RollupCfg,
@@ -551,22 +528,22 @@ func addMultiChainFollowL2Node(t devtest.T, runtime *MultiChainRuntime, chainKey
 	return node
 }
 
-func startTwoL2SharedSupernode(
+func startSharedSupernode(
 	t devtest.T,
 	l1Net *L1Network,
 	l1EL *L1Geth,
 	l1CL *L1CLNode,
-	l2ANet *L2Network,
-	l2AEL L2ELNode,
-	l2BNet *L2Network,
-	l2BEL L2ELNode,
+	l2Nets []*L2Network,
+	l2ELs []L2ELNode,
 	depSet *depset.StaticConfigDependencySet,
 	interopActivationTimestamp *uint64,
 	interopLogBackfillDepth time.Duration,
 	jwtSecret [32]byte,
 	sequencerEnabled bool,
-) (*SuperNode, *SuperNodeProxy, *SuperNodeProxy) {
+) (*SuperNode, []*SuperNodeProxy) {
 	require := t.Require()
+	require.NotEmpty(l2Nets, "supernode needs at least one L2 chain")
+	require.Len(l2ELs, len(l2Nets), "supernode needs one EL for each L2 chain")
 	logger := t.Logger().New("component", "supernode")
 	makeNodeCfg := func(l2Net *L2Network, l2EL L2ELNode) *opnodeconfig.Config {
 		var sequencerP2PKeyHex string
@@ -619,11 +596,15 @@ func startTwoL2SharedSupernode(
 		return cfg
 	}
 
-	vnCfgs := map[eth.ChainID]*opnodeconfig.Config{
-		l2ANet.ChainID(): makeNodeCfg(l2ANet, l2AEL),
-		l2BNet.ChainID(): makeNodeCfg(l2BNet, l2BEL),
+	vnCfgs := make(map[eth.ChainID]*opnodeconfig.Config, len(l2Nets))
+	chainIDs := make([]uint64, len(l2Nets))
+	supernodeChainIDs := make([]eth.ChainID, len(l2Nets))
+	for i, l2Net := range l2Nets {
+		chainID := l2Net.ChainID()
+		vnCfgs[chainID] = makeNodeCfg(l2Net, l2ELs[i])
+		chainIDs[i] = eth.EvilChainIDToUInt64(chainID)
+		supernodeChainIDs[i] = chainID
 	}
-	chainIDs := []uint64{eth.EvilChainIDToUInt64(l2ANet.ChainID()), eth.EvilChainIDToUInt64(l2BNet.ChainID())}
 
 	snCfg := &snconfig.CLIConfig{
 		Chains:                     chainIDs,
@@ -635,12 +616,10 @@ func startTwoL2SharedSupernode(
 		InteropActivationTimestamp: interopActivationTimestamp,
 		InteropLogBackfillDepth:    interopLogBackfillDepth,
 	}
-
 	supernode := &SuperNode{
-		userRPC:      "",
 		p:            t,
 		logger:       logger,
-		chains:       []eth.ChainID{l2ANet.ChainID(), l2BNet.ChainID()},
+		chains:       supernodeChainIDs,
 		l1UserRPC:    l1EL.UserRPC(),
 		l1BeaconAddr: l1CL.beaconHTTPAddr,
 		snCfg:        snCfg,
@@ -650,24 +629,17 @@ func startTwoL2SharedSupernode(
 	t.Cleanup(supernode.Stop)
 
 	base := supernode.UserRPC()
-	l2ARPC := base + "/" + strconv.FormatUint(eth.EvilChainIDToUInt64(l2ANet.ChainID()), 10)
-	l2BRPC := base + "/" + strconv.FormatUint(eth.EvilChainIDToUInt64(l2BNet.ChainID()), 10)
-
-	waitForSupernodeRoute(t, logger, l2ARPC)
-	waitForSupernodeRoute(t, logger, l2BRPC)
-
-	l2ACL := &SuperNodeProxy{
-		p:       t,
-		logger:  logger,
-		userRPC: l2ARPC,
+	proxies := make([]*SuperNodeProxy, len(l2Nets))
+	for i, l2Net := range l2Nets {
+		rpc := base + "/" + strconv.FormatUint(eth.EvilChainIDToUInt64(l2Net.ChainID()), 10)
+		waitForSupernodeRoute(t, logger, rpc)
+		proxies[i] = &SuperNodeProxy{
+			p:       t,
+			logger:  logger,
+			userRPC: rpc,
+		}
 	}
-	l2BCL := &SuperNodeProxy{
-		p:       t,
-		logger:  logger,
-		userRPC: l2BRPC,
-	}
-
-	return supernode, l2ACL, l2BCL
+	return supernode, proxies
 }
 
 func startSingleChainSharedSupernode(


### PR DESCRIPTION
This PR adds a reusable exact-chain interop setup for acceptance tests. The two-chain preset now starts exactly two chains. The three-chain preset starts exactly three chains. Both presets use the same runtime projection path.

It also adds a three-chain fault-proof scenario. Chains A and B form a dependency cycle. Chain C is an acyclic prerequisite of chain A. The scenario verifies that consolidation replaces only A and B, while preserving C. It runs through the shared Go and Kona proof runner path.

The regression remains skipped because the current cycle detection includes acyclic prerequisites. ethereum-optimism/optimism#22827 will stack on this PR, implement exact cycle participant detection, and enable the regression. This PR references ethereum-optimism/optimism#22825 without closing it.