### PR TITLE
op-node: reject simultaneous fork activations after genesis

### DIFF
--- a/docs/public-docs/op-stack/protocol/network-upgrades.mdx
+++ b/docs/public-docs/op-stack/protocol/network-upgrades.mdx
@@ -42,6 +42,26 @@ All of the above build on **Bedrock**, the
 that the hardfork series starts from. Sepolia OP Stack chains launched on
 Bedrock directly.
 
+### One upgrade per activation timestamp
+
+Two network upgrades must never be configured to activate at the same L2 block
+timestamp after genesis. Every upgrade's activation-block behavior — the
+upgrade transactions it deposits, the state it changes, the block attributes it
+derives — is only defined against a chain on which every earlier upgrade is
+already active, so two upgrades sharing an activation block is an unsupported
+configuration whose combined behavior no specification covers. Activation
+timestamps must be strictly increasing in upgrade order, and `op-node` rejects
+a rollup config that schedules two upgrades to activate together. See the
+[activation rules](https://specs.optimism.io/protocol/superchain-upgrades.html?utm_source=op-docs&utm_medium=docs#activation-rules)
+in the superchain upgrades specification.
+
+Chains that launch after an upgrade already exists activate that upgrade in
+their genesis block instead, conventionally by setting its activation timestamp
+to `0` — so upgrades that are active from genesis do share a timestamp, and
+that is the one case the rule allows. This restriction covers OP Stack upgrades
+only: it does not constrain an OP Stack upgrade timestamp against an L1 fork
+timestamp on the same chain, which may coincide.
+
 ## Contract upgrades
 
 Not every governance-approved upgrade is a hardfork: hardforks activate by L2

--- a/op-node/rollup/types.go
+++ b/op-node/rollup/types.go
@@ -385,25 +385,7 @@ func (cfg *Config) Check() error {
 		return err
 	}
 
-	if err := checkFork(cfg.RegolithTime, cfg.CanyonTime, forks.Regolith, forks.Canyon); err != nil {
-		return err
-	}
-	if err := checkFork(cfg.CanyonTime, cfg.DeltaTime, forks.Canyon, forks.Delta); err != nil {
-		return err
-	}
-	if err := checkFork(cfg.DeltaTime, cfg.EcotoneTime, forks.Delta, forks.Ecotone); err != nil {
-		return err
-	}
-	if err := checkFork(cfg.EcotoneTime, cfg.FjordTime, forks.Ecotone, forks.Fjord); err != nil {
-		return err
-	}
-	if err := checkFork(cfg.FjordTime, cfg.GraniteTime, forks.Fjord, forks.Granite); err != nil {
-		return err
-	}
-	if err := checkFork(cfg.GraniteTime, cfg.HoloceneTime, forks.Granite, forks.Holocene); err != nil {
-		return err
-	}
-	if err := checkFork(cfg.HoloceneTime, cfg.IsthmusTime, forks.Holocene, forks.Isthmus); err != nil {
+	if err := cfg.checkForkOrder(); err != nil {
 		return err
 	}
 
@@ -462,19 +444,56 @@ func validateAltDAConfig(cfg *Config) error {
 	return nil
 }
 
-// checkFork checks that fork A is before or at the same time as fork B
-func checkFork(a, b *uint64, aName, bName ForkName) error {
-	if a == nil && b == nil {
+// strictActivationOrderFrom is the first fork for which sharing a post-genesis activation
+// timestamp with its predecessor is rejected rather than merely unsupported.
+//
+// Simultaneous activation is not a supported configuration for any fork, but six chains in the
+// superchain registry were configured that way before the rule was written down — Celo mainnet
+// activated Holocene and Isthmus in the same block, and five Sepolia chains did the same for
+// earlier pairs. Their activations are chain history and cannot be changed, so op-node must keep
+// syncing them. Every one of those pairs predates Jovian, so enforcing from Jovian onwards rejects
+// new simultaneous activations without locking those chains out.
+const strictActivationOrderFrom = forks.Jovian
+
+// checkForkOrder checks that the scheduled mainline forks activate in the order given by
+// [forks.All]: a fork may only be scheduled if all of its predecessors are, and each fork must
+// activate after its predecessor.
+func (cfg *Config) checkForkOrder() error {
+	// forks.All starts at Bedrock, which is not activated by timestamp.
+	ordered := forks.From(forks.Regolith)
+	var strict bool
+	for i, name := range ordered[1:] {
+		strict = strict || name == strictActivationOrderFrom
+		if err := cfg.checkFork(ordered[i], name, strict); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// checkFork checks the activation time of fork B against that of fork A, its immediate
+// predecessor. Fork A must be scheduled if fork B is, and must activate before fork B.
+//
+// When strict is set, fork B may only share fork A's activation time at or before genesis, where
+// both activate in the genesis block and no activation-block processing happens. Past genesis,
+// activating two forks at the same timestamp is not supported: each fork's activation-block
+// behavior is only defined against a chain on which every preceding fork is already active, so
+// sharing an activation block leaves the combined behavior undefined. See the activation rules of
+// the superchain upgrades specification:
+// https://specs.optimism.io/protocol/superchain-upgrades.html#activation-rules
+func (cfg *Config) checkFork(aName, bName ForkName, strict bool) error {
+	a, b := cfg.ActivationTime(aName), cfg.ActivationTime(bName)
+	if b == nil {
 		return nil
 	}
-	if a == nil && b != nil {
+	if a == nil {
 		return fmt.Errorf("fork %s set (to %d), but prior fork %s missing", bName, *b, aName)
-	}
-	if a != nil && b == nil {
-		return nil
 	}
 	if *a > *b {
 		return fmt.Errorf("fork %s set to %d, but prior fork %s has higher offset %d", bName, *b, aName, *a)
+	}
+	if strict && *a == *b && *b > cfg.Genesis.L2Time {
+		return fmt.Errorf("fork %s and prior fork %s both set to %d, but activating multiple forks at the same time after genesis is not supported", bName, aName, *b)
 	}
 	return nil
 }

--- a/op-node/rollup/types_test.go
+++ b/op-node/rollup/types_test.go
@@ -706,6 +706,13 @@ func TestConfig_Check(t *testing.T) {
 			expectedErr: fmt.Errorf("fork ecotone set (to 1), but prior fork delta missing"),
 		},
 		{
+			name: "PriorForkMissingPastIsthmus",
+			modifier: func(cfg *Config) {
+				cfg.KarstTime = ptr.New(uint64(1))
+			},
+			expectedErr: fmt.Errorf("fork karst set (to 1), but prior fork jovian missing"),
+		},
+		{
 			name: "PriorForkHasHigherOffset",
 			modifier: func(cfg *Config) {
 				regolithTime := uint64(2)
@@ -753,6 +760,53 @@ func TestConfig_Check(t *testing.T) {
 			assert.Equal(t, err, test.expectedErr)
 		})
 	}
+}
+
+// TestConfigCheckSimultaneousForkActivation checks that two forks may only share an activation
+// time when they activate at or before genesis.
+func TestConfigCheckSimultaneousForkActivation(t *testing.T) {
+	scheduleAll := func(cfg *Config, activation uint64) {
+		for _, fork := range forks.From(forks.Regolith) {
+			cfg.SetActivationTime(fork, ptr.New(activation))
+		}
+	}
+
+	t.Run("AtGenesis", func(t *testing.T) {
+		cfg := randConfig()
+		scheduleAll(cfg, cfg.Genesis.L2Time)
+		require.NoError(t, cfg.Check())
+	})
+
+	t.Run("BeforeGenesis", func(t *testing.T) {
+		cfg := randConfig()
+		scheduleAll(cfg, 0)
+		require.NoError(t, cfg.Check())
+	})
+
+	t.Run("AfterGenesis", func(t *testing.T) {
+		cfg := randConfig()
+		scheduleAll(cfg, 0)
+		activation := cfg.Genesis.L2Time + cfg.BlockTime
+		cfg.SetActivationTime(forks.Karst, ptr.New(activation))
+		cfg.SetActivationTime(forks.Lagoon, ptr.New(activation))
+		require.EqualError(t, cfg.Check(), fmt.Sprintf(
+			"fork lagoon and prior fork karst both set to %d, but activating multiple forks at the same time after genesis is not supported",
+			activation))
+	})
+
+	// Chains that shared an activation timestamp before strictActivationOrderFrom must keep
+	// loading — Celo mainnet activated Holocene and Isthmus in the same block.
+	t.Run("AfterGenesisBeforeStrictFork", func(t *testing.T) {
+		cfg := randConfig()
+		scheduleAll(cfg, 0)
+		activation := cfg.Genesis.L2Time + cfg.BlockTime
+		cfg.SetActivationTime(forks.Holocene, ptr.New(activation))
+		cfg.SetActivationTime(forks.Isthmus, ptr.New(activation))
+		cfg.SetActivationTime(forks.Jovian, ptr.New(activation+cfg.BlockTime))
+		cfg.SetActivationTime(forks.Karst, ptr.New(activation+2*cfg.BlockTime))
+		cfg.SetActivationTime(forks.Lagoon, ptr.New(activation+3*cfg.BlockTime))
+		require.NoError(t, cfg.Check())
+	})
 }
 
 func TestTimestampForBlock(t *testing.T) {


### PR DESCRIPTION
Companion to [ethereum-optimism/specs#942](https://github.com/ethereum-optimism/specs/pull/942), which adds the rule to the specs. This PR documents it and enforces it.

### Validation

`Config.Check` hand-rolled a `checkFork` chain that stopped at Isthmus and, per its own comment, allowed "before or at the same time as fork B". This drives the check off `forks.All` instead, so Jovian, Karst, Lagoon and every future fork are ordered too, and rejects two forks activating at the same timestamp after genesis. Forks activating at or before the genesis timestamp all activate in the genesis block and may keep sharing a timestamp — that is how chains launched after an upgrade enable their upgrade history.

Simultaneous activation is what [#22828](https://github.com/ethereum-optimism/optimism/issues/22828) fell over: Karst and Lagoon at the same timestamp both add upgrade gas, but the reconstruction helpers only subtract Karst's. Each fork's activation-block behavior is only defined against a chain where every earlier fork is already active, so validating the combinations is the alternative to disallowing them.

### The one wrinkle — enforcement starts at Jovian

Six chains in the superchain registry already share a post-genesis activation timestamp:

| Chain | Forks | Shared timestamp | Genesis L2 time |
| --- | --- | --- | --- |
| mainnet/celo | holocene, isthmus | 1752073200 | 1742957258 |
| sepolia/boba | delta, ecotone | 1709078400 | 1705600788 |
| sepolia/lisk | canyon, delta | 1705312994 | 1705312992 |
| sepolia/mode | canyon, delta | 1703203200 | 1687867932 |
| sepolia/race | fjord, granite | 1749686400 | 1719646560 |
| sepolia/soneium-minato | fjord, granite | 1730106000 | 1723194336 |

(mainnet/boba also has `canyon_time == delta_time`, but exactly at its genesis L2 time, so it is fine either way.)

That history cannot be changed and op-node has to keep syncing those chains, so `strictActivationOrderFrom = forks.Jovian` scopes the hard error to forks no chain has grandfathered. Every existing violation predates Jovian, so nothing live breaks and no new simultaneous activation can be scheduled. **Happy to drop the cutoff and enforce unconditionally if you'd rather force those configs to be fixed first** — that is a one-line change, but it would stop op-node from loading Celo mainnet today.

### Docs

`docs/public-docs/op-stack/protocol/network-upgrades.mdx` gains a short "One upgrade per activation timestamp" section under Activations, linking to the spec. The chain-operator reference already stated the rule under "Hardfork activation guidance"; the protocol page did not.

### Testing

Not run locally — the sandbox has no Go toolchain and a monorepo build exceeds its ~1Gi disk, so this is on CI. Added `TestConfigCheckSimultaneousForkActivation` (rejected after genesis, allowed at/before genesis, and the pre-Jovian grandfather case) plus a `PriorForkMissingPastIsthmus` case covering the newly ordered forks. The existing `TestConfig_Check` fork cases are unchanged and still pass by construction — the loop reproduces the old pairwise chain exactly.

Prompted by: @sebastianst