### PR TITLE
op-challenger: Support super permissioned games in list-games

### DIFF
--- a/op-challenger/cmd/list_games.go
+++ b/op-challenger/cmd/list_games.go
@@ -23,6 +23,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/urfave/cli/v2"
 )
 
@@ -132,8 +133,11 @@ func listGames(ctx context.Context, caller *batching.MultiCaller, factory *contr
 			if fdg, ok := gameContract.(contracts.FaultDisputeGameContract); ok {
 				claimCount, err := fdg.GetClaimCount(ctx)
 				if err != nil {
-					infos[idx].err = fmt.Errorf("failed to retrieve claim count for game %v: %w", gameProxy, err)
-					return
+					_, reverted := ethclient.RevertErrorData(err)
+					if types.GameType(game.GameType) != types.SuperPermissionedGameType || !reverted {
+						infos[idx].err = fmt.Errorf("failed to retrieve claim count for game %v: %w", gameProxy, err)
+						return
+					}
 				}
 				infos[idx].claimCount = claimCount
 			}

--- a/op-challenger/cmd/list_games.go
+++ b/op-challenger/cmd/list_games.go
@@ -23,7 +23,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
 	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/urfave/cli/v2"
 )
 
@@ -130,14 +129,12 @@ func listGames(ctx context.Context, caller *batching.MultiCaller, factory *contr
 			infos[idx].status = metadata.Status
 			infos[idx].l2BlockNum = metadata.L2SequenceNum
 			infos[idx].rootClaim = metadata.ProposedRoot
-			if fdg, ok := gameContract.(contracts.FaultDisputeGameContract); ok {
+			if fdg, ok := gameContract.(contracts.FaultDisputeGameContract); ok &&
+				types.GameType(game.GameType) != types.SuperPermissionedGameType {
 				claimCount, err := fdg.GetClaimCount(ctx)
 				if err != nil {
-					_, reverted := ethclient.RevertErrorData(err)
-					if types.GameType(game.GameType) != types.SuperPermissionedGameType || !reverted {
-						infos[idx].err = fmt.Errorf("failed to retrieve claim count for game %v: %w", gameProxy, err)
-						return
-					}
+					infos[idx].err = fmt.Errorf("failed to retrieve claim count for game %v: %w", gameProxy, err)
+					return
 				}
 				infos[idx].claimCount = claimCount
 			}

--- a/op-challenger/cmd/list_games_test.go
+++ b/op-challenger/cmd/list_games_test.go
@@ -2,9 +2,24 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
+	"io"
+	"math/big"
+	"os"
 	"testing"
 
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts"
+	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts/metrics"
+	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
+	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
+	batchingTest "github.com/ethereum-optimism/optimism/op-service/sources/batching/test"
+	"github.com/ethereum-optimism/optimism/packages/contracts-bedrock/snapshots"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/stretchr/testify/require"
 )
 
@@ -40,6 +55,150 @@ func TestRenderGamesJSON(t *testing.T) {
 	require.Equal(t, "In Progress", got.Games[0].Status)
 	require.Equal(t, uint32(1), got.Games[1].GameType)
 	require.Equal(t, "Defender Won", got.Games[1].Status)
+}
+
+func TestListGamesSuperPermissioned(t *testing.T) {
+	factoryAddr := common.Address{0xfa}
+	simplifiedGameAddr := common.Address{0xab}
+	legacyGameAddr := common.Address{0xbc}
+	blockHash := common.Hash{0xcd}
+	faultGameABI := snapshots.LoadSuperFaultDisputeGameABI()
+	stubRPC := batchingTest.NewAbiBasedRpc(t, factoryAddr, snapshots.LoadDisputeGameFactoryABI())
+	rpcClient := &claimCountRevertingRPC{
+		AbiBasedRpc:        stubRPC,
+		revertingAddr:      simplifiedGameAddr,
+		claimCountSelector: faultGameABI.Methods["claimDataLen"].ID,
+	}
+	caller := batching.NewMultiCaller(rpcClient, batching.DefaultBatchSize)
+	stubRPC.SetResponse(factoryAddr, "version", rpcblock.Latest, nil, []any{"1.4.0"})
+	factory, err := contracts.NewDisputeGameFactoryContract(
+		context.Background(),
+		metrics.NoopContractMetrics,
+		factoryAddr,
+		caller,
+	)
+	require.NoError(t, err)
+
+	block := rpcblock.ByHash(blockHash)
+	stubRPC.SetResponse(factoryAddr, "gameCount", block, nil, []any{big.NewInt(2)})
+	stubRPC.SetResponse(
+		factoryAddr,
+		"gameAtIndex",
+		block,
+		[]any{big.NewInt(0)},
+		[]any{uint32(gameTypes.SuperPermissionedGameType), uint64(1234), simplifiedGameAddr},
+	)
+	stubRPC.SetResponse(
+		factoryAddr,
+		"gameAtIndex",
+		block,
+		[]any{big.NewInt(1)},
+		[]any{uint32(gameTypes.SuperPermissionedGameType), uint64(1235), legacyGameAddr},
+	)
+	stubRPC.AddContract(simplifiedGameAddr, faultGameABI)
+	stubRPC.AddContract(legacyGameAddr, faultGameABI)
+	setGameMetadataResponses(stubRPC, simplifiedGameAddr, block)
+	setGameMetadataResponses(stubRPC, legacyGameAddr, block)
+	stubRPC.SetResponse(legacyGameAddr, "claimDataLen", rpcblock.Latest, nil, []any{big.NewInt(7)})
+
+	output, err := captureStdout(t, func() error {
+		return listGames(
+			context.Background(),
+			caller,
+			factory,
+			blockHash,
+			0,
+			"time",
+			"asc",
+			formatJSON,
+		)
+	})
+	require.NoError(t, err)
+
+	var got struct {
+		Games []gameRecord `json:"games"`
+	}
+	require.NoError(t, json.Unmarshal(output, &got))
+	require.Len(t, got.Games, 2)
+	require.Equal(t, simplifiedGameAddr.Hex(), got.Games[0].Game)
+	require.Zero(t, got.Games[0].ClaimCount)
+	require.Equal(t, legacyGameAddr.Hex(), got.Games[1].Game)
+	require.Equal(t, uint64(7), got.Games[1].ClaimCount)
+}
+
+func setGameMetadataResponses(stubRPC *batchingTest.AbiBasedRpc, gameAddr common.Address, block rpcblock.Block) {
+	stubRPC.SetResponse(gameAddr, "l1Head", block, nil, []any{common.Hash{0x11}})
+	stubRPC.SetResponse(gameAddr, "l2SequenceNumber", block, nil, []any{big.NewInt(1234)})
+	stubRPC.SetResponse(gameAddr, "rootClaim", block, nil, []any{common.Hash{0x22}})
+	stubRPC.SetResponse(
+		gameAddr,
+		"status",
+		block,
+		nil,
+		[]any{uint8(gameTypes.GameStatusDefenderWon)},
+	)
+}
+
+type claimCountRevertingRPC struct {
+	*batchingTest.AbiBasedRpc
+	revertingAddr      common.Address
+	claimCountSelector []byte
+}
+
+func (r *claimCountRevertingRPC) CallContext(ctx context.Context, result any, method string, args ...any) error {
+	if method == "eth_call" && len(args) > 0 {
+		call, ok := args[0].(map[string]any)
+		if ok {
+			to, toOK := call["to"].(*common.Address)
+			input, inputOK := call["input"].(hexutil.Bytes)
+			if toOK && to != nil && *to == r.revertingAddr &&
+				inputOK && len(input) >= 4 && bytes.Equal(input[:4], r.claimCountSelector) {
+				return executionRevertedError{}
+			}
+		}
+	}
+	return r.AbiBasedRpc.CallContext(ctx, result, method, args...)
+}
+
+func (r *claimCountRevertingRPC) BatchCallContext(ctx context.Context, batch []rpc.BatchElem) error {
+	errs := make([]error, 0, len(batch))
+	for i := range batch {
+		batch[i].Error = r.CallContext(ctx, batch[i].Result, batch[i].Method, batch[i].Args...)
+		errs = append(errs, batch[i].Error)
+	}
+	return errors.Join(errs...)
+}
+
+type executionRevertedError struct{}
+
+func (executionRevertedError) Error() string {
+	return "execution reverted"
+}
+
+func (executionRevertedError) ErrorCode() int {
+	return 3
+}
+
+func (executionRevertedError) ErrorData() any {
+	return "0x"
+}
+
+func captureStdout(t *testing.T, fn func() error) ([]byte, error) {
+	t.Helper()
+	original := os.Stdout
+	reader, writer, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = writer
+	defer func() {
+		os.Stdout = original
+	}()
+
+	callErr := fn()
+	require.NoError(t, writer.Close())
+	output, readErr := io.ReadAll(reader)
+	require.NoError(t, reader.Close())
+	require.NoError(t, readErr)
+	return output, callErr
 }
 
 func TestRenderGamesText(t *testing.T) {

--- a/op-challenger/cmd/list_games_test.go
+++ b/op-challenger/cmd/list_games_test.go
@@ -2,25 +2,9 @@ package main
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
-	"errors"
-	"io"
-	"math/big"
-	"os"
-	"sync/atomic"
 	"testing"
 
-	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts"
-	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts/metrics"
-	gameTypes "github.com/ethereum-optimism/optimism/op-challenger/game/types"
-	"github.com/ethereum-optimism/optimism/op-service/sources/batching"
-	"github.com/ethereum-optimism/optimism/op-service/sources/batching/rpcblock"
-	batchingTest "github.com/ethereum-optimism/optimism/op-service/sources/batching/test"
-	"github.com/ethereum-optimism/optimism/packages/contracts-bedrock/snapshots"
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/stretchr/testify/require"
 )
 
@@ -56,122 +40,6 @@ func TestRenderGamesJSON(t *testing.T) {
 	require.Equal(t, "In Progress", got.Games[0].Status)
 	require.Equal(t, uint32(1), got.Games[1].GameType)
 	require.Equal(t, "Defender Won", got.Games[1].Status)
-}
-
-func TestListGamesSkipsClaimsForSuperPermissioned(t *testing.T) {
-	factoryAddr := common.Address{0xfa}
-	gameAddr := common.Address{0xab}
-	blockHash := common.Hash{0xcd}
-	faultGameABI := snapshots.LoadSuperFaultDisputeGameABI()
-	stubRPC := batchingTest.NewAbiBasedRpc(t, factoryAddr, snapshots.LoadDisputeGameFactoryABI())
-	rpcClient := &claimCountTrackingRPC{
-		AbiBasedRpc:        stubRPC,
-		claimCountSelector: faultGameABI.Methods["claimDataLen"].ID,
-	}
-	caller := batching.NewMultiCaller(rpcClient, batching.DefaultBatchSize)
-	stubRPC.SetResponse(factoryAddr, "version", rpcblock.Latest, nil, []any{"1.4.0"})
-	factory, err := contracts.NewDisputeGameFactoryContract(
-		context.Background(),
-		metrics.NoopContractMetrics,
-		factoryAddr,
-		caller,
-	)
-	require.NoError(t, err)
-
-	block := rpcblock.ByHash(blockHash)
-	stubRPC.SetResponse(factoryAddr, "gameCount", block, nil, []any{big.NewInt(1)})
-	stubRPC.SetResponse(
-		factoryAddr,
-		"gameAtIndex",
-		block,
-		[]any{big.NewInt(0)},
-		[]any{uint32(gameTypes.SuperPermissionedGameType), uint64(1234), gameAddr},
-	)
-	stubRPC.AddContract(gameAddr, faultGameABI)
-	setGameMetadataResponses(stubRPC, gameAddr, block)
-	stubRPC.SetResponse(gameAddr, "claimDataLen", rpcblock.Latest, nil, []any{big.NewInt(9)})
-
-	output, err := captureStdout(t, func() error {
-		return listGames(
-			context.Background(),
-			caller,
-			factory,
-			blockHash,
-			0,
-			"time",
-			"asc",
-			formatJSON,
-		)
-	})
-	require.NoError(t, err)
-
-	var got struct {
-		Games []gameRecord `json:"games"`
-	}
-	require.NoError(t, json.Unmarshal(output, &got))
-	require.Len(t, got.Games, 1)
-	require.Equal(t, gameAddr.Hex(), got.Games[0].Game)
-	require.Zero(t, got.Games[0].ClaimCount)
-	require.Zero(t, rpcClient.claimCountCalls.Load())
-}
-
-func setGameMetadataResponses(stubRPC *batchingTest.AbiBasedRpc, gameAddr common.Address, block rpcblock.Block) {
-	stubRPC.SetResponse(gameAddr, "l1Head", block, nil, []any{common.Hash{0x11}})
-	stubRPC.SetResponse(gameAddr, "l2SequenceNumber", block, nil, []any{big.NewInt(1234)})
-	stubRPC.SetResponse(gameAddr, "rootClaim", block, nil, []any{common.Hash{0x22}})
-	stubRPC.SetResponse(
-		gameAddr,
-		"status",
-		block,
-		nil,
-		[]any{uint8(gameTypes.GameStatusDefenderWon)},
-	)
-}
-
-type claimCountTrackingRPC struct {
-	*batchingTest.AbiBasedRpc
-	claimCountSelector []byte
-	claimCountCalls    atomic.Uint64
-}
-
-func (r *claimCountTrackingRPC) CallContext(ctx context.Context, result any, method string, args ...any) error {
-	if method == "eth_call" && len(args) > 0 {
-		call, ok := args[0].(map[string]any)
-		if ok {
-			input, inputOK := call["input"].(hexutil.Bytes)
-			if inputOK && len(input) >= 4 && bytes.Equal(input[:4], r.claimCountSelector) {
-				r.claimCountCalls.Add(1)
-			}
-		}
-	}
-	return r.AbiBasedRpc.CallContext(ctx, result, method, args...)
-}
-
-func (r *claimCountTrackingRPC) BatchCallContext(ctx context.Context, batch []rpc.BatchElem) error {
-	errs := make([]error, 0, len(batch))
-	for i := range batch {
-		batch[i].Error = r.CallContext(ctx, batch[i].Result, batch[i].Method, batch[i].Args...)
-		errs = append(errs, batch[i].Error)
-	}
-	return errors.Join(errs...)
-}
-
-func captureStdout(t *testing.T, fn func() error) ([]byte, error) {
-	t.Helper()
-	original := os.Stdout
-	reader, writer, err := os.Pipe()
-	require.NoError(t, err)
-	os.Stdout = writer
-	defer func() {
-		os.Stdout = original
-	}()
-
-	callErr := fn()
-	require.NoError(t, writer.Close())
-	output, readErr := io.ReadAll(reader)
-	require.NoError(t, reader.Close())
-	require.NoError(t, readErr)
-	return output, callErr
 }
 
 func TestRenderGamesText(t *testing.T) {

--- a/op-challenger/cmd/list_games_test.go
+++ b/op-challenger/cmd/list_games_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"math/big"
 	"os"
+	"sync/atomic"
 	"testing"
 
 	"github.com/ethereum-optimism/optimism/op-challenger/game/fault/contracts"
@@ -57,16 +58,14 @@ func TestRenderGamesJSON(t *testing.T) {
 	require.Equal(t, "Defender Won", got.Games[1].Status)
 }
 
-func TestListGamesSuperPermissioned(t *testing.T) {
+func TestListGamesSkipsClaimsForSuperPermissioned(t *testing.T) {
 	factoryAddr := common.Address{0xfa}
-	simplifiedGameAddr := common.Address{0xab}
-	legacyGameAddr := common.Address{0xbc}
+	gameAddr := common.Address{0xab}
 	blockHash := common.Hash{0xcd}
 	faultGameABI := snapshots.LoadSuperFaultDisputeGameABI()
 	stubRPC := batchingTest.NewAbiBasedRpc(t, factoryAddr, snapshots.LoadDisputeGameFactoryABI())
-	rpcClient := &claimCountRevertingRPC{
+	rpcClient := &claimCountTrackingRPC{
 		AbiBasedRpc:        stubRPC,
-		revertingAddr:      simplifiedGameAddr,
 		claimCountSelector: faultGameABI.Methods["claimDataLen"].ID,
 	}
 	caller := batching.NewMultiCaller(rpcClient, batching.DefaultBatchSize)
@@ -80,26 +79,17 @@ func TestListGamesSuperPermissioned(t *testing.T) {
 	require.NoError(t, err)
 
 	block := rpcblock.ByHash(blockHash)
-	stubRPC.SetResponse(factoryAddr, "gameCount", block, nil, []any{big.NewInt(2)})
+	stubRPC.SetResponse(factoryAddr, "gameCount", block, nil, []any{big.NewInt(1)})
 	stubRPC.SetResponse(
 		factoryAddr,
 		"gameAtIndex",
 		block,
 		[]any{big.NewInt(0)},
-		[]any{uint32(gameTypes.SuperPermissionedGameType), uint64(1234), simplifiedGameAddr},
+		[]any{uint32(gameTypes.SuperPermissionedGameType), uint64(1234), gameAddr},
 	)
-	stubRPC.SetResponse(
-		factoryAddr,
-		"gameAtIndex",
-		block,
-		[]any{big.NewInt(1)},
-		[]any{uint32(gameTypes.SuperPermissionedGameType), uint64(1235), legacyGameAddr},
-	)
-	stubRPC.AddContract(simplifiedGameAddr, faultGameABI)
-	stubRPC.AddContract(legacyGameAddr, faultGameABI)
-	setGameMetadataResponses(stubRPC, simplifiedGameAddr, block)
-	setGameMetadataResponses(stubRPC, legacyGameAddr, block)
-	stubRPC.SetResponse(legacyGameAddr, "claimDataLen", rpcblock.Latest, nil, []any{big.NewInt(7)})
+	stubRPC.AddContract(gameAddr, faultGameABI)
+	setGameMetadataResponses(stubRPC, gameAddr, block)
+	stubRPC.SetResponse(gameAddr, "claimDataLen", rpcblock.Latest, nil, []any{big.NewInt(9)})
 
 	output, err := captureStdout(t, func() error {
 		return listGames(
@@ -119,11 +109,10 @@ func TestListGamesSuperPermissioned(t *testing.T) {
 		Games []gameRecord `json:"games"`
 	}
 	require.NoError(t, json.Unmarshal(output, &got))
-	require.Len(t, got.Games, 2)
-	require.Equal(t, simplifiedGameAddr.Hex(), got.Games[0].Game)
+	require.Len(t, got.Games, 1)
+	require.Equal(t, gameAddr.Hex(), got.Games[0].Game)
 	require.Zero(t, got.Games[0].ClaimCount)
-	require.Equal(t, legacyGameAddr.Hex(), got.Games[1].Game)
-	require.Equal(t, uint64(7), got.Games[1].ClaimCount)
+	require.Zero(t, rpcClient.claimCountCalls.Load())
 }
 
 func setGameMetadataResponses(stubRPC *batchingTest.AbiBasedRpc, gameAddr common.Address, block rpcblock.Block) {
@@ -139,48 +128,32 @@ func setGameMetadataResponses(stubRPC *batchingTest.AbiBasedRpc, gameAddr common
 	)
 }
 
-type claimCountRevertingRPC struct {
+type claimCountTrackingRPC struct {
 	*batchingTest.AbiBasedRpc
-	revertingAddr      common.Address
 	claimCountSelector []byte
+	claimCountCalls    atomic.Uint64
 }
 
-func (r *claimCountRevertingRPC) CallContext(ctx context.Context, result any, method string, args ...any) error {
+func (r *claimCountTrackingRPC) CallContext(ctx context.Context, result any, method string, args ...any) error {
 	if method == "eth_call" && len(args) > 0 {
 		call, ok := args[0].(map[string]any)
 		if ok {
-			to, toOK := call["to"].(*common.Address)
 			input, inputOK := call["input"].(hexutil.Bytes)
-			if toOK && to != nil && *to == r.revertingAddr &&
-				inputOK && len(input) >= 4 && bytes.Equal(input[:4], r.claimCountSelector) {
-				return executionRevertedError{}
+			if inputOK && len(input) >= 4 && bytes.Equal(input[:4], r.claimCountSelector) {
+				r.claimCountCalls.Add(1)
 			}
 		}
 	}
 	return r.AbiBasedRpc.CallContext(ctx, result, method, args...)
 }
 
-func (r *claimCountRevertingRPC) BatchCallContext(ctx context.Context, batch []rpc.BatchElem) error {
+func (r *claimCountTrackingRPC) BatchCallContext(ctx context.Context, batch []rpc.BatchElem) error {
 	errs := make([]error, 0, len(batch))
 	for i := range batch {
 		batch[i].Error = r.CallContext(ctx, batch[i].Result, batch[i].Method, batch[i].Args...)
 		errs = append(errs, batch[i].Error)
 	}
 	return errors.Join(errs...)
-}
-
-type executionRevertedError struct{}
-
-func (executionRevertedError) Error() string {
-	return "execution reverted"
-}
-
-func (executionRevertedError) ErrorCode() int {
-	return 3
-}
-
-func (executionRevertedError) ErrorData() any {
-	return "0x"
 }
 
 func captureStdout(t *testing.T, fn func() error) ([]byte, error) {


### PR DESCRIPTION
Super permissioned games from the simplified contract do not expose `claimDataLen`. This caused `list-games` to abort for mixed factories. The command now skips claim count queries for type-5 games and reports zero claims.