### PR TITLE
kona-sp1-proposer: avoid proposals on invalid anchors

### DIFF
--- a/rust/kona/sp1/README.md
+++ b/rust/kona/sp1/README.md
@@ -140,31 +140,18 @@ super-root `ZKDisputeGame` (game type 10) end to end:
 
 ### Anchor validation
 
-At startup, the proposer compares the registered anchor root with the supernode's
-canonical super root at the anchor timestamp. It repeats this check when
-scheduling an anchor-based proposal and before submitting a new creation
-transaction. Each check reads the registry and anchor at one L1 block hash.
-Explicit-parent proposals use the parent's claim instead and keep their existing
-eligibility checks.
+At startup, the proposer waits until the registered anchor root matches a trusted
+supernode response at the exact anchor timestamp. Registry and anchor reads use
+one L1 block hash.
 
-A zero root, a timestamp exceeding `u64`, or a mismatch with trusted supernode
-data produces an ERROR log. Missing data, RPC errors, and mismatches with
-untrusted data produce WARN logs. Anchor diagnostics include the registry, L1
-block, root, timestamp, and comparison details when available. Startup also logs
-its first validation failure at ERROR, then retries.
+A zero root, a timestamp exceeding `u64`, or a trusted mismatch produces an ERROR
+log. Missing data, RPC errors, and untrusted responses produce WARN logs. Startup
+also logs its first validation failure at ERROR, then retries.
 
-Startup waits for a valid anchor. During normal operation, an invalid or
-unavailable anchor pauses anchor-based creation without blocking eligible
-defense, fast-finality proofs, resolution, bond claims, or reconciliation of a
-creation already submitted. All anchor failures remain retryable.
-
-Check the registry's root and timestamp and the supernode's canonical history.
-Correct the registry or restore access to matching history; the next eligible
-attempt can resume without a restart. Timestamp zero has no special fallback:
-the RPC rejects it if it predates L2 genesis.
-
-These checks cannot prevent the registry from changing after submission but
-before transaction inclusion.
+Correct the registry or restore access to trusted, matching history; startup
+resumes without a restart. Timestamp zero has no fallback if the RPC rejects it.
+Normal proposal scheduling and submission retain their existing retry behavior;
+anchor validation is not repeated after startup.
 
 ### Ownership (which games it defends)
 

--- a/rust/kona/sp1/README.md
+++ b/rust/kona/sp1/README.md
@@ -138,6 +138,34 @@ super-root `ZKDisputeGame` (game type 10) end to end:
 3. **Resolve and claim**: resolves finished games and claims bonds (including the
    challenger bond earned by proving).
 
+### Anchor validation
+
+At startup, the proposer compares the registered anchor root with the supernode's
+canonical super root at the anchor timestamp. It repeats this check when
+scheduling an anchor-based proposal and before submitting a new creation
+transaction. Each check reads the registry and anchor at one L1 block hash.
+Explicit-parent proposals use the parent's claim instead and keep their existing
+eligibility checks.
+
+A zero root, a timestamp exceeding `u64`, or a mismatch with trusted supernode
+data produces an ERROR log. Missing data, RPC errors, and mismatches with
+untrusted data produce WARN logs. Anchor diagnostics include the registry, L1
+block, root, timestamp, and comparison details when available. Startup also logs
+its first validation failure at ERROR, then retries.
+
+Startup waits for a valid anchor. During normal operation, an invalid or
+unavailable anchor pauses anchor-based creation without blocking eligible
+defense, fast-finality proofs, resolution, bond claims, or reconciliation of a
+creation already submitted. All anchor failures remain retryable.
+
+Check the registry's root and timestamp and the supernode's canonical history.
+Correct the registry or restore access to matching history; the next eligible
+attempt can resume without a restart. Timestamp zero has no special fallback:
+the RPC rejects it if it predates L2 genesis.
+
+These checks cannot prevent the registry from changing after submission but
+before transaction inclusion.
+
 ### Ownership (which games it defends)
 
 Defense, resolution, and bond claims use prestate-based ownership. The proposer

--- a/rust/kona/sp1/crates/proposer/src/proposer.rs
+++ b/rust/kona/sp1/crates/proposer/src/proposer.rs
@@ -968,14 +968,99 @@ impl Proposer {
         let _ = self.max_prove_duration.set(game_args.max_prove_duration);
         let _ = self.max_challenge_duration.set(game_args.max_challenge_duration);
 
-        // Fetch and validate the anchor root from the currently registered registry.
-        let anchor =
-            self.l1_view.anchor_root(game_args.anchor_state_registry, BlockId::latest()).await?;
-        anyhow::ensure!(
-            anchor.root != B256::ZERO,
-            "anchor state registry has no anchor root (game creation would revert)"
-        );
-        anchor.sequence_number.try_into().context("anchor sequence number exceeds u64")
+        self.validated_anchor_timestamp().await
+    }
+
+    /// Return the timestamp only when the registered anchor matches the supernode root.
+    /// Registry and anchor reads share one L1 block hash; the supernode lookup uses
+    /// the exact anchor timestamp. Failures log diagnostics and remain retryable.
+    async fn validated_anchor_timestamp(&self) -> Result<u64> {
+        let head = self
+            .l1_view
+            .latest_head()
+            .await
+            .and_then(|head| head.context("latest L1 block unavailable"))
+            .inspect_err(|error| {
+                tracing::warn!(%error, "cannot observe anchor L1 block");
+            })?;
+        let block = BlockId::hash(head.hash);
+        let args = self.l1_view.registered_game_args(block).await.inspect_err(|error| {
+            tracing::warn!(l1_block = ?head, %error, "cannot resolve anchor registry");
+        })?;
+        let registry = args.anchor_state_registry;
+        let anchor = self.l1_view.anchor_root(registry, block).await.inspect_err(|error| {
+            tracing::warn!(%registry, l1_block = ?head, %error, "cannot read anchor root");
+        })?;
+        if anchor.root == B256::ZERO {
+            tracing::error!(
+                %registry,
+                l1_block = ?head,
+                anchor_root = %anchor.root,
+                sequence_number = %anchor.sequence_number,
+                "anchor root is zero"
+            );
+            bail!("anchor validation: zero root");
+        }
+        let timestamp: u64 = anchor.sequence_number.try_into().map_err(|error| {
+            tracing::error!(
+                %registry,
+                l1_block = ?head,
+                anchor_root = %anchor.root,
+                sequence_number = %anchor.sequence_number,
+                %error,
+                "anchor sequence number exceeds u64"
+            );
+            anyhow::anyhow!("anchor validation: timestamp exceeds u64")
+        })?;
+        let canonical =
+            self.superroot_source.super_root_at_timestamp(timestamp).await.inspect_err(
+                |error| {
+                    tracing::warn!(
+                        %registry,
+                        l1_block = ?head,
+                        anchor_root = %anchor.root,
+                        timestamp,
+                        %error,
+                        "canonical anchor root unavailable"
+                    );
+                },
+            )?;
+        let Some(root) = canonical.root else {
+            tracing::warn!(
+                %registry,
+                l1_block = ?head,
+                anchor_root = %anchor.root,
+                timestamp,
+                "canonical anchor root missing"
+            );
+            bail!("anchor validation: canonical root missing");
+        };
+        if root.super_root != anchor.root {
+            let trusted = response_trusted(&canonical.response);
+            if trusted {
+                tracing::error!(
+                    %registry,
+                    l1_block = ?head,
+                    anchor_root = %anchor.root,
+                    expected_root = %root.super_root,
+                    timestamp,
+                    trusted,
+                    "anchor root disagrees with canonical super root"
+                );
+            } else {
+                tracing::warn!(
+                    %registry,
+                    l1_block = ?head,
+                    anchor_root = %anchor.root,
+                    expected_root = %root.super_root,
+                    timestamp,
+                    trusted,
+                    "anchor root disagrees with untrusted super root"
+                );
+            }
+            bail!("anchor validation: root mismatch");
+        }
+        Ok(timestamp)
     }
 
     /// Synchronizes the proposer's cached view of the dispute-game tree with the on-chain state.
@@ -1519,10 +1604,6 @@ impl Proposer {
                 );
             }
         } else {
-            // Preserve canonical_head_sequence_number as the anchor baseline for
-            // the first proposal. Clearing it would block creation on fresh
-            // deployments or pinned snapshots without games.
-            // canonical_head_index = -1 reports the no-head state.
             state.canonical_head_index = None;
 
             if previous_canonical_index.is_some() {
@@ -2091,6 +2172,18 @@ impl Proposer {
                 self.l1_view.game_by_uuid(super_root.super_root, extra_data.clone()).await?;
 
             if existing_game == Address::ZERO {
+                // The anchor can advance while UUID collisions are checked.
+                if parent_game_index == u32::MAX {
+                    let anchor_timestamp = self.validated_anchor_timestamp().await?;
+                    if sequence_number <= anchor_timestamp {
+                        tracing::info!(
+                            sequence_number,
+                            anchor_timestamp,
+                            "Skipping creation: claim does not follow current anchor"
+                        );
+                        return Ok(());
+                    }
+                }
                 tracing::info!(
                     sequence_number,
                     parent_game_index,
@@ -2737,11 +2830,6 @@ impl Proposer {
         let (canonical_head_sequence_number, parent_game_index) = {
             let state = self.state.read().await;
 
-            let Some(canonical_head_sequence_number) = state.canonical_head_sequence_number else {
-                tracing::info!("No canonical head; skipping game creation");
-                return Ok((false, 0, u32::MAX));
-            };
-
             // When the canonical head IS the anchor game, use u32::MAX (anchor path) instead of
             // referencing it by index. The contract requires parent.l2SeqNum > anchor.l2SeqNum,
             // so the anchor itself cannot be used as a parent via index.
@@ -2752,7 +2840,16 @@ impl Proposer {
                 .map(|index| index.to::<u32>())
                 .unwrap_or(u32::MAX);
 
-            (canonical_head_sequence_number, parent_game_index)
+            (state.canonical_head_sequence_number, parent_game_index)
+        };
+        let canonical_head_sequence_number = if parent_game_index == u32::MAX {
+            self.validated_anchor_timestamp().await?
+        } else {
+            let Some(timestamp) = canonical_head_sequence_number else {
+                tracing::info!("No canonical head; skipping game creation");
+                return Ok((false, 0, u32::MAX));
+            };
+            timestamp
         };
 
         let max_proposable = self.max_proposable_timestamp().await?;
@@ -3761,7 +3858,7 @@ mod tests {
         next_proposal_timestamp,
     };
     use crate::{
-        ZK_GAME_TYPE,
+        TxErrorExt, ZK_GAME_TYPE,
         adapters::ProductionL1View,
         config::{
             PrestatePrograms, ProofProviderConfig, ProofProviderKind, ProposalSafety,
@@ -3879,7 +3976,7 @@ mod tests {
     }
 
     #[derive(Clone, Debug, PartialEq, Eq)]
-    enum ActionCall {
+    pub(super) enum ActionCall {
         Create { root_claim: B256, extra_data: Vec<u8>, init_bond: U256 },
         Prove { game: Address, proof: Vec<u8> },
         Resolve(Address),
@@ -3893,8 +3990,8 @@ mod tests {
     }
 
     #[derive(Default)]
-    struct RecordingActionExecutor {
-        calls: StdMutex<Vec<ActionCall>>,
+    pub(super) struct RecordingActionExecutor {
+        pub(super) calls: parking_lot::Mutex<Vec<ActionCall>>,
         create_failure: Option<CreateFailure>,
         prove_failures: StdMutex<usize>,
     }
@@ -3916,11 +4013,7 @@ mod tests {
                 }
                 None => {}
             }
-            self.calls.lock().unwrap().push(ActionCall::Create {
-                root_claim,
-                extra_data,
-                init_bond,
-            });
+            self.calls.lock().push(ActionCall::Create { root_claim, extra_data, init_bond });
             Ok(GameCreationReceipt {
                 game_address: Address::left_padding_from(&[0xc1]),
                 transaction_hash: B256::left_padding_from(&[0xc2]),
@@ -3928,7 +4021,7 @@ mod tests {
         }
 
         async fn prove_game(&self, game: Address, proof: Vec<u8>) -> anyhow::Result<B256> {
-            self.calls.lock().unwrap().push(ActionCall::Prove { game, proof });
+            self.calls.lock().push(ActionCall::Prove { game, proof });
             let mut failures = self.prove_failures.lock().unwrap();
             if *failures > 0 {
                 *failures -= 1;
@@ -3938,12 +4031,12 @@ mod tests {
         }
 
         async fn resolve_game(&self, game: Address) -> anyhow::Result<B256> {
-            self.calls.lock().unwrap().push(ActionCall::Resolve(game));
+            self.calls.lock().push(ActionCall::Resolve(game));
             Ok(B256::left_padding_from(&[0xd1]))
         }
 
         async fn claim_credit(&self, game: Address, recipient: Address) -> anyhow::Result<B256> {
-            self.calls.lock().unwrap().push(ActionCall::ClaimCredit { game, recipient });
+            self.calls.lock().push(ActionCall::ClaimCredit { game, recipient });
             Ok(B256::left_padding_from(&[0xf1]))
         }
     }
@@ -3961,6 +4054,7 @@ mod tests {
         anchor_game: Address,
         registered_args: ZKGameArgs,
         anchor_root: AnchorRoot,
+        anchor_snapshot: Option<(B256, Address, AnchorRoot)>,
         factory_game: FactoryGame,
         game_claim: GameClaim,
         game_identity: GameIdentity,
@@ -4003,6 +4097,7 @@ mod tests {
                     root: B256::left_padding_from(&[1]),
                     sequence_number: U256::ZERO,
                 },
+                anchor_snapshot: None,
                 factory_game: FactoryGame { address: Address::ZERO, game_type: ZK_GAME_TYPE },
                 game_claim: GameClaim {
                     status: ProposalStatus::Unchallenged as u8,
@@ -4087,7 +4182,13 @@ mod tests {
         async fn registered_game_args(&self, block: BlockId) -> anyhow::Result<ZKGameArgs> {
             self.record("registered_game_args");
             self.record_block("registered_game_args", block);
-            Ok(self.registered_args.clone())
+            let mut args = self.registered_args.clone();
+            if let Some((hash, registry, _)) = self.anchor_snapshot &&
+                block == BlockId::hash(hash)
+            {
+                args.anchor_state_registry = registry;
+            }
+            Ok(args)
         }
 
         async fn anchor_root(
@@ -4098,6 +4199,12 @@ mod tests {
             self.record("anchor_root");
             self.record_block("anchor_root", block);
             self.anchor_targets.lock().unwrap().push((registry, block));
+            if let Some((hash, snapshot_registry, anchor)) = self.anchor_snapshot &&
+                block == BlockId::hash(hash) &&
+                registry == snapshot_registry
+            {
+                return Ok(anchor);
+            }
             Ok(self.anchor_root)
         }
 
@@ -4299,6 +4406,27 @@ mod tests {
                 super_root: root,
             }),
         }
+    }
+
+    pub(super) fn canonical_super_root_at_timestamp(timestamp: u64) -> SuperRootAtTimestamp {
+        use kona_sp1_super_range_executor::{ChainId, ChainIdAndOutput, proof_from_super_v1};
+
+        let mut canonical = super_root_at_timestamp(timestamp, B256::ZERO, 12, 11);
+        let data = canonical.response.data.as_mut().unwrap();
+        data.super_v1.chains = vec![ChainIdAndOutput {
+            chain_id: ChainId(U256::from(10)),
+            output: B256::repeat_byte(0xab),
+        }];
+        data.super_root = B256::from(
+            *kona_sp1_client_utils::super_root::hash_super_root_proof(
+                &proof_from_super_v1(&data.super_v1).unwrap(),
+            )
+            .unwrap(),
+        );
+        canonical.root =
+            crate::superroot::SuperrootClient::super_root_at(&canonical.response, timestamp)
+                .unwrap();
+        canonical
     }
 
     fn absent_super_root_at_timestamp(local_safe: u64) -> SuperRootAtTimestamp {
@@ -5384,6 +5512,116 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn anchor_validation_uses_one_l1_snapshot() {
+        let pinned = canonical_super_root_at_timestamp(100);
+        let latest = canonical_super_root_at_timestamp(200);
+        let head = L1BlockRef { hash: B256::repeat_byte(0x11), number: 1, timestamp: 1_000 };
+        let mut proposer = test_proposer().await;
+        proposer.l1_view = Arc::new(RecordingL1View {
+            latest_head: Some(head),
+            registered_args: ZKGameArgs {
+                anchor_state_registry: Address::repeat_byte(0xbb),
+                ..RecordingL1View::default().registered_args
+            },
+            anchor_root: AnchorRoot {
+                root: latest.root.as_ref().unwrap().super_root,
+                sequence_number: U256::from(200),
+            },
+            anchor_snapshot: Some((
+                head.hash,
+                Address::repeat_byte(0xaa),
+                AnchorRoot {
+                    root: pinned.root.as_ref().unwrap().super_root,
+                    sequence_number: U256::from(100),
+                },
+            )),
+            ..Default::default()
+        });
+        proposer.superroot_source = Arc::new(ScriptedSuperRootSource {
+            horizon: ProposalHorizon { safe_timestamp: 200, finalized_timestamp: 200 },
+            roots: vec![(100, pinned), (200, latest)],
+        });
+
+        proposer.validate_and_init().await.unwrap();
+
+        assert_eq!(proposer.state.read().await.canonical_head_sequence_number, Some(100));
+    }
+
+    #[tokio::test]
+    async fn anchor_validation_rejects_mismatched_starting_root() {
+        let canonical = canonical_super_root_at_timestamp(100);
+        let mut proposer = test_proposer().await;
+        proposer.l1_view = Arc::new(RecordingL1View {
+            anchor_root: AnchorRoot {
+                root: B256::repeat_byte(0xff),
+                sequence_number: U256::from(100),
+            },
+            ..Default::default()
+        });
+        proposer.superroot_source = Arc::new(ScriptedSuperRootSource {
+            horizon: ProposalHorizon { safe_timestamp: 200, finalized_timestamp: 200 },
+            roots: vec![(100, canonical)],
+        });
+
+        assert!(
+            proposer.validate_and_init().await.is_err(),
+            "initialization accepted a mismatched anchor root"
+        );
+        assert_eq!(proposer.state.read().await.canonical_head_sequence_number, None);
+    }
+
+    #[tokio::test]
+    async fn anchor_validation_rejects_zero_root_and_timestamp_overflow() {
+        for anchor in [
+            AnchorRoot { root: B256::ZERO, sequence_number: U256::ZERO },
+            AnchorRoot { root: B256::repeat_byte(0x11), sequence_number: U256::MAX },
+        ] {
+            let mut proposer = test_proposer().await;
+            proposer.l1_view =
+                Arc::new(RecordingL1View { anchor_root: anchor, ..Default::default() });
+            proposer.superroot_source = Arc::new(ScriptedSuperRootSource {
+                horizon: ProposalHorizon {
+                    safe_timestamp: u64::MAX,
+                    finalized_timestamp: u64::MAX,
+                },
+                roots: vec![
+                    (0, super_root_at_timestamp(0, anchor.root, 12, 11)),
+                    (u64::MAX, super_root_at_timestamp(u64::MAX, anchor.root, 12, 11)),
+                ],
+            });
+
+            assert!(proposer.validate_and_init().await.is_err());
+            assert_eq!(proposer.state.read().await.canonical_head_sequence_number, None);
+        }
+    }
+
+    #[tokio::test]
+    async fn anchor_validation_timestamp_zero_requires_matching_data() {
+        let canonical = canonical_super_root_at_timestamp(0);
+        for (response, expected) in [
+            (Some(canonical.clone()), Some(0)),
+            (Some(absent_super_root_at_timestamp(0)), None),
+            (None, None),
+        ] {
+            let mut proposer = test_proposer().await;
+            proposer.l1_view = Arc::new(RecordingL1View {
+                anchor_root: AnchorRoot {
+                    root: canonical.root.as_ref().unwrap().super_root,
+                    sequence_number: U256::ZERO,
+                },
+                ..Default::default()
+            });
+            proposer.superroot_source = Arc::new(ScriptedSuperRootSource {
+                horizon: ProposalHorizon { safe_timestamp: 100, finalized_timestamp: 100 },
+                roots: response.into_iter().map(|response| (0, response)).collect(),
+            });
+
+            assert_eq!(proposer.validate_and_init().await.is_ok(), expected.is_some());
+            assert_eq!(proposer.state.read().await.canonical_head_sequence_number, expected);
+        }
+    }
+
+    #[tokio::test]
     async fn initialization_snapshots_proving_durations_across_registry_rotation() {
         fn registered_view(
             prestate: B256,
@@ -5403,7 +5641,10 @@ mod tests {
                     weth,
                 },
                 anchor_root: AnchorRoot {
-                    root: B256::left_padding_from(&[sequence_number as u8]),
+                    root: canonical_super_root_at_timestamp(sequence_number)
+                        .root
+                        .unwrap()
+                        .super_root,
                     sequence_number: U256::from(sequence_number),
                 },
                 ..Default::default()
@@ -5438,26 +5679,21 @@ mod tests {
                 )
                 .await;
         }
+        proposer.superroot_source = Arc::new(ScriptedSuperRootSource {
+            horizon: ProposalHorizon { safe_timestamp: 200, finalized_timestamp: 200 },
+            roots: vec![
+                (100, canonical_super_root_at_timestamp(100)),
+                (200, canonical_super_root_at_timestamp(200)),
+            ],
+        });
 
-        proposer.l1_view = first.clone();
+        proposer.l1_view = first;
         assert_eq!(proposer.startup_validations().await.unwrap(), 100);
-        proposer.l1_view = second.clone();
+        proposer.l1_view = second;
         assert_eq!(proposer.startup_validations().await.unwrap(), 200);
 
         assert_eq!(proposer.max_challenge_duration.get(), Some(&10));
         assert_eq!(proposer.max_prove_duration.get(), Some(&20));
-        assert_eq!(
-            *first.anchor_targets.lock().unwrap(),
-            vec![(first_registry, BlockId::latest())]
-        );
-        assert_eq!(
-            *second.anchor_targets.lock().unwrap(),
-            vec![(second_registry, BlockId::latest())]
-        );
-        let expected_blocks =
-            vec![("registered_game_args", BlockId::latest()), ("anchor_root", BlockId::latest())];
-        assert_eq!(first.block_calls(), expected_blocks);
-        assert_eq!(second.block_calls(), expected_blocks);
     }
 
     #[tokio::test]
@@ -5519,7 +5755,7 @@ mod tests {
         proposer.claim_bonds().await.unwrap();
 
         assert_eq!(
-            *actions.calls.lock().unwrap(),
+            *actions.calls.lock(),
             vec![
                 ActionCall::Create { root_claim, extra_data, init_bond: U256::ZERO },
                 ActionCall::Resolve(game.address),
@@ -5589,7 +5825,7 @@ mod tests {
         drop(calls);
         assert_eq!(engine.generations.load(AtomicOrdering::SeqCst), 1);
         assert_eq!(
-            *actions.calls.lock().unwrap(),
+            *actions.calls.lock(),
             vec![
                 ActionCall::Prove { game: game.address, proof: proof.clone() },
                 ActionCall::Prove { game: game.address, proof },
@@ -5648,7 +5884,7 @@ mod tests {
 
             let result = proposer.prove_game(game.address).await;
             assert_eq!(result.is_err(), fail);
-            assert!(actions.calls.lock().unwrap().is_empty());
+            assert!(actions.calls.lock().is_empty());
             let expected_clears = if fail { Vec::new() } else { vec![game.address] };
             assert_eq!(*engine.cleared.lock().unwrap(), expected_clears);
         }
@@ -5661,17 +5897,25 @@ mod tests {
         {
             let root = B256::repeat_byte(0x11);
             let mut proposer = test_proposer().await;
-            proposer.l1_view = Arc::new(RecordingL1View::default());
+            let anchor = canonical_super_root_at_timestamp(0);
+            proposer.l1_view = Arc::new(RecordingL1View {
+                anchor_root: AnchorRoot {
+                    root: anchor.root.as_ref().unwrap().super_root,
+                    sequence_number: U256::ZERO,
+                },
+                ..Default::default()
+            });
             proposer.superroot_source = Arc::new(ScriptedSuperRootSource {
                 horizon: ProposalHorizon { safe_timestamp: 100, finalized_timestamp: 100 },
-                roots: vec![(100, super_root_at_timestamp(100, root, 12, 11))],
+                roots: vec![(0, anchor), (100, super_root_at_timestamp(100, root, 12, 11))],
             });
             proposer.action_executor = Arc::new(RecordingActionExecutor {
                 create_failure: Some(failure),
                 ..Default::default()
             });
 
-            assert!(proposer.handle_game_creation(100, u32::MAX).await.is_err());
+            let error = proposer.handle_game_creation(100, u32::MAX).await.unwrap_err();
+            assert_eq!(error.is_revert(), !should_retain);
             assert_eq!(proposer.in_flight_creation.lock().await.is_some(), should_retain);
         }
     }

--- a/rust/kona/sp1/crates/proposer/src/proposer.rs
+++ b/rust/kona/sp1/crates/proposer/src/proposer.rs
@@ -971,7 +971,7 @@ impl Proposer {
         self.validated_anchor_timestamp().await
     }
 
-    /// Return the timestamp only when the registered anchor matches the supernode root.
+    /// Return the timestamp only when the anchor matches a trusted supernode root.
     /// Registry and anchor reads share one L1 block hash; the supernode lookup uses
     /// the exact anchor timestamp. Failures log diagnostics and remain retryable.
     async fn validated_anchor_timestamp(&self) -> Result<u64> {
@@ -1035,29 +1035,25 @@ impl Proposer {
             );
             bail!("anchor validation: canonical root missing");
         };
+        if !response_trusted(&canonical.response) {
+            tracing::warn!(
+                %registry,
+                l1_block = ?head,
+                anchor_root = %anchor.root,
+                timestamp,
+                "canonical anchor root is not yet trusted"
+            );
+            bail!("anchor validation: canonical root untrusted");
+        }
         if root.super_root != anchor.root {
-            let trusted = response_trusted(&canonical.response);
-            if trusted {
-                tracing::error!(
-                    %registry,
-                    l1_block = ?head,
-                    anchor_root = %anchor.root,
-                    expected_root = %root.super_root,
-                    timestamp,
-                    trusted,
-                    "anchor root disagrees with canonical super root"
-                );
-            } else {
-                tracing::warn!(
-                    %registry,
-                    l1_block = ?head,
-                    anchor_root = %anchor.root,
-                    expected_root = %root.super_root,
-                    timestamp,
-                    trusted,
-                    "anchor root disagrees with untrusted super root"
-                );
-            }
+            tracing::error!(
+                %registry,
+                l1_block = ?head,
+                anchor_root = %anchor.root,
+                expected_root = %root.super_root,
+                timestamp,
+                "anchor root disagrees with canonical super root"
+            );
             bail!("anchor validation: root mismatch");
         }
         Ok(timestamp)
@@ -1604,6 +1600,10 @@ impl Proposer {
                 );
             }
         } else {
+            // Preserve canonical_head_sequence_number as the anchor baseline for
+            // the first proposal. Clearing it would block creation on fresh
+            // deployments or pinned snapshots without games.
+            // canonical_head_index = -1 reports the no-head state.
             state.canonical_head_index = None;
 
             if previous_canonical_index.is_some() {
@@ -2172,18 +2172,6 @@ impl Proposer {
                 self.l1_view.game_by_uuid(super_root.super_root, extra_data.clone()).await?;
 
             if existing_game == Address::ZERO {
-                // The anchor can advance while UUID collisions are checked.
-                if parent_game_index == u32::MAX {
-                    let anchor_timestamp = self.validated_anchor_timestamp().await?;
-                    if sequence_number <= anchor_timestamp {
-                        tracing::info!(
-                            sequence_number,
-                            anchor_timestamp,
-                            "Skipping creation: claim does not follow current anchor"
-                        );
-                        return Ok(());
-                    }
-                }
                 tracing::info!(
                     sequence_number,
                     parent_game_index,
@@ -2830,6 +2818,11 @@ impl Proposer {
         let (canonical_head_sequence_number, parent_game_index) = {
             let state = self.state.read().await;
 
+            let Some(canonical_head_sequence_number) = state.canonical_head_sequence_number else {
+                tracing::info!("No canonical head; skipping game creation");
+                return Ok((false, 0, u32::MAX));
+            };
+
             // When the canonical head IS the anchor game, use u32::MAX (anchor path) instead of
             // referencing it by index. The contract requires parent.l2SeqNum > anchor.l2SeqNum,
             // so the anchor itself cannot be used as a parent via index.
@@ -2840,16 +2833,7 @@ impl Proposer {
                 .map(|index| index.to::<u32>())
                 .unwrap_or(u32::MAX);
 
-            (state.canonical_head_sequence_number, parent_game_index)
-        };
-        let canonical_head_sequence_number = if parent_game_index == u32::MAX {
-            self.validated_anchor_timestamp().await?
-        } else {
-            let Some(timestamp) = canonical_head_sequence_number else {
-                tracing::info!("No canonical head; skipping game creation");
-                return Ok((false, 0, u32::MAX));
-            };
-            timestamp
+            (canonical_head_sequence_number, parent_game_index)
         };
 
         let max_proposable = self.max_proposable_timestamp().await?;
@@ -3976,7 +3960,7 @@ mod tests {
     }
 
     #[derive(Clone, Debug, PartialEq, Eq)]
-    pub(super) enum ActionCall {
+    enum ActionCall {
         Create { root_claim: B256, extra_data: Vec<u8>, init_bond: U256 },
         Prove { game: Address, proof: Vec<u8> },
         Resolve(Address),
@@ -3990,8 +3974,8 @@ mod tests {
     }
 
     #[derive(Default)]
-    pub(super) struct RecordingActionExecutor {
-        pub(super) calls: parking_lot::Mutex<Vec<ActionCall>>,
+    struct RecordingActionExecutor {
+        calls: parking_lot::Mutex<Vec<ActionCall>>,
         create_failure: Option<CreateFailure>,
         prove_failures: StdMutex<usize>,
     }
@@ -4408,7 +4392,7 @@ mod tests {
         }
     }
 
-    pub(super) fn canonical_super_root_at_timestamp(timestamp: u64) -> SuperRootAtTimestamp {
+    fn canonical_super_root_at_timestamp(timestamp: u64) -> SuperRootAtTimestamp {
         use kona_sp1_super_range_executor::{ChainId, ChainIdAndOutput, proof_from_super_v1};
 
         let mut canonical = super_root_at_timestamp(timestamp, B256::ZERO, 12, 11);
@@ -5596,10 +5580,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn anchor_validation_timestamp_zero_requires_matching_data() {
+    async fn anchor_validation_timestamp_zero_requires_trusted_matching_data() {
         let canonical = canonical_super_root_at_timestamp(0);
+        let mut untrusted = canonical.clone();
+        untrusted.response.current_l1.number =
+            untrusted.response.data.as_ref().unwrap().verified_required_l1.number;
         for (response, expected) in [
             (Some(canonical.clone()), Some(0)),
+            (Some(untrusted), None),
             (Some(absent_super_root_at_timestamp(0)), None),
             (None, None),
         ] {
@@ -5897,17 +5885,10 @@ mod tests {
         {
             let root = B256::repeat_byte(0x11);
             let mut proposer = test_proposer().await;
-            let anchor = canonical_super_root_at_timestamp(0);
-            proposer.l1_view = Arc::new(RecordingL1View {
-                anchor_root: AnchorRoot {
-                    root: anchor.root.as_ref().unwrap().super_root,
-                    sequence_number: U256::ZERO,
-                },
-                ..Default::default()
-            });
+            proposer.l1_view = Arc::new(RecordingL1View::default());
             proposer.superroot_source = Arc::new(ScriptedSuperRootSource {
                 horizon: ProposalHorizon { safe_timestamp: 100, finalized_timestamp: 100 },
-                roots: vec![(0, anchor), (100, super_root_at_timestamp(100, root, 12, 11))],
+                roots: vec![(100, super_root_at_timestamp(100, root, 12, 11))],
             });
             proposer.action_executor = Arc::new(RecordingActionExecutor {
                 create_failure: Some(failure),

--- a/rust/kona/sp1/crates/proposer/src/proposer/scenario/tests.rs
+++ b/rust/kona/sp1/crates/proposer/src/proposer/scenario/tests.rs
@@ -1,7 +1,8 @@
 use std::{
+    collections::HashMap,
     num::{NonZeroU64, NonZeroUsize},
     sync::{
-        Arc, Mutex as StdMutex,
+        Arc,
         atomic::{AtomicBool, AtomicU64, Ordering},
     },
     time::Duration,
@@ -11,9 +12,8 @@ use alloy_eips::BlockId;
 use alloy_primitives::{Address, B256, U256};
 use async_trait::async_trait;
 use kona_sp1_host_utils::metrics::MetricsListen;
-use kona_sp1_super_range_executor::{
-    BlockId as SuperBlockId, SuperRootAtTimestampResponse, SuperRootResponseData, SuperV1,
-};
+use kona_sp1_super_range_executor::SuperRootAtTimestampResponse;
+use parking_lot::Mutex;
 use tokio::sync::{Notify, oneshot};
 
 use super::{NamedBarrier, ScenarioControl, ScenarioError, world::*};
@@ -33,12 +33,13 @@ use crate::{
     prover::ProofKeys,
     proving::GameProofInputs,
     signer::NUM_CONFIRMATIONS,
-    superroot::{SuperRootAt, zk_extra_data},
+    superroot::zk_extra_data,
 };
 
 use crate::proposer::{
     CompactGameSummary, InFlightCreation, OperationSummary, Proposer, ProvingPurpose,
     SyncDisposition, TaskClass, TaskCompletionOutcome, TaskFailureClass, TaskId, TaskSuccess,
+    tests::{ActionCall, RecordingActionExecutor, canonical_super_root_at_timestamp},
 };
 
 const HEAD_NUMBER: u64 = 1;
@@ -46,25 +47,41 @@ const HEAD_TIMESTAMP: u64 = 1_000;
 
 #[derive(Default)]
 struct ScenarioL1View {
-    latest_head_calls: AtomicU64,
-    latest_head_notify: Notify,
+    creation_plan_calls: AtomicU64,
+    creation_plan_notify: Notify,
     fail_latest_head: AtomicBool,
     fail_respected_game_type: AtomicBool,
     fail_latest_l1_timestamp_on: AtomicU64,
     latest_l1_timestamp_calls: AtomicU64,
-    release_barrier: StdMutex<Option<NamedBarrier>>,
-    task_finished: StdMutex<Option<oneshot::Receiver<()>>>,
+    release_barrier: Mutex<Option<NamedBarrier>>,
+    task_finished: Mutex<Option<oneshot::Receiver<()>>>,
+    head_number: AtomicU64,
+    registry: Mutex<Address>,
+    anchors: Mutex<HashMap<Address, AnchorRoot>>,
+    uuids: Mutex<HashMap<B256, Address>>,
+    creators: Mutex<HashMap<Address, Address>>,
+    uuid_barrier: Mutex<Option<(B256, oneshot::Receiver<TaskId>, NamedBarrier)>>,
 }
 
 impl ScenarioL1View {
     fn new() -> Self {
-        Self::default()
+        Self {
+            head_number: AtomicU64::new(HEAD_NUMBER),
+            anchors: Mutex::new(HashMap::from([(
+                Address::ZERO,
+                AnchorRoot {
+                    root: canonical_super_root_at_timestamp(0).root.unwrap().super_root,
+                    sequence_number: U256::ZERO,
+                },
+            )])),
+            ..Self::default()
+        }
     }
 
-    async fn wait_for_cycles(&self, expected: u64) {
+    async fn wait_for_creation_plans(&self, expected: u64) {
         loop {
-            let notified = self.latest_head_notify.notified();
-            if self.latest_head_calls.load(Ordering::Relaxed) >= expected {
+            let notified = self.creation_plan_notify.notified();
+            if self.creation_plan_calls.load(Ordering::Relaxed) >= expected {
                 return;
             }
             notified.await;
@@ -75,12 +92,14 @@ impl ScenarioL1View {
 #[async_trait]
 impl L1View for ScenarioL1View {
     async fn latest_head(&self) -> anyhow::Result<Option<L1BlockRef>> {
-        self.latest_head_calls.fetch_add(1, Ordering::Relaxed);
-        self.latest_head_notify.notify_waiters();
         if self.fail_latest_head.load(Ordering::Relaxed) {
             anyhow::bail!("latest head unavailable")
         }
-        Ok(Some(L1BlockRef { hash: B256::ZERO, number: HEAD_NUMBER, timestamp: HEAD_TIMESTAMP }))
+        Ok(Some(L1BlockRef {
+            hash: B256::ZERO,
+            number: self.head_number.load(Ordering::Relaxed),
+            timestamp: HEAD_TIMESTAMP,
+        }))
     }
 
     async fn block_ref(&self, number: u64) -> anyhow::Result<Option<L1BlockRef>> {
@@ -94,13 +113,13 @@ impl L1View for ScenarioL1View {
             max_challenge_duration: 3_600,
             max_prove_duration: 3_600,
             challenger_bond: U256::ZERO,
-            anchor_state_registry: Address::ZERO,
+            anchor_state_registry: *self.registry.lock(),
             weth: Address::ZERO,
         })
     }
 
-    async fn anchor_root(&self, _registry: Address, _block: BlockId) -> anyhow::Result<AnchorRoot> {
-        Ok(AnchorRoot { root: B256::left_padding_from(&[1]), sequence_number: U256::ZERO })
+    async fn anchor_root(&self, registry: Address, _block: BlockId) -> anyhow::Result<AnchorRoot> {
+        Ok(*self.anchors.lock().get(&registry).expect("configured registry"))
     }
 
     async fn latest_game_index(&self, _block: BlockId) -> anyhow::Result<Option<U256>> {
@@ -181,14 +200,26 @@ impl L1View for ScenarioL1View {
 
     async fn game_by_uuid(
         &self,
-        _root_claim: B256,
+        root_claim: B256,
         _extra_data: Vec<u8>,
     ) -> anyhow::Result<Address> {
-        Ok(Address::ZERO)
+        let existing = self.uuids.lock().get(&root_claim).copied().unwrap_or_default();
+        let pause = {
+            let mut barrier = self.uuid_barrier.lock();
+            if barrier.as_ref().is_some_and(|(root, _, _)| *root == root_claim) {
+                barrier.take()
+            } else {
+                None
+            }
+        };
+        if let Some((_, task_id, barrier)) = pause {
+            barrier.park(task_id.await?).await;
+        }
+        Ok(existing)
     }
 
-    async fn game_creator(&self, _game: Address) -> anyhow::Result<Address> {
-        Ok(Address::ZERO)
+    async fn game_creator(&self, game: Address) -> anyhow::Result<Address> {
+        Ok(self.creators.lock().get(&game).copied().unwrap_or_default())
     }
 
     async fn nonce_state(&self, _proposer: Address) -> anyhow::Result<NonceState> {
@@ -196,8 +227,10 @@ impl L1View for ScenarioL1View {
     }
 
     async fn respected_game_type(&self, _block: BlockId) -> anyhow::Result<u32> {
-        let release_barrier = self.release_barrier.lock().unwrap().take();
-        let task_finished = self.task_finished.lock().unwrap().take();
+        self.creation_plan_calls.fetch_add(1, Ordering::Relaxed);
+        self.creation_plan_notify.notify_waiters();
+        let release_barrier = self.release_barrier.lock().take();
+        let task_finished = self.task_finished.lock().take();
         if let Some(release_barrier) = release_barrier {
             release_barrier.release();
         }
@@ -255,35 +288,24 @@ impl QueryTime for FixedQueryTime {
     }
 }
 
-struct FixedSuperRootSource;
+struct FixedSuperRootSource {
+    horizon: u64,
+}
 
 #[async_trait]
 impl SuperRootSource for FixedSuperRootSource {
     async fn proposal_horizon(&self, _timestamp: u64) -> anyhow::Result<ProposalHorizon> {
-        Ok(ProposalHorizon { safe_timestamp: 3_600, finalized_timestamp: 3_600 })
+        Ok(ProposalHorizon { safe_timestamp: self.horizon, finalized_timestamp: self.horizon })
     }
 
     async fn super_root_at_timestamp(
         &self,
         timestamp: u64,
     ) -> anyhow::Result<SuperRootAtTimestamp> {
-        let root = B256::left_padding_from(&timestamp.to_be_bytes());
-        Ok(SuperRootAtTimestamp {
-            response: SuperRootAtTimestampResponse {
-                current_l1: SuperBlockId::default(),
-                current_safe_timestamp: timestamp,
-                current_local_safe_timestamp: timestamp,
-                current_finalized_timestamp: timestamp,
-                optimistic_at_timestamp: Default::default(),
-                chain_ids: Vec::new(),
-                data: Some(SuperRootResponseData {
-                    verified_required_l1: SuperBlockId::default(),
-                    super_v1: SuperV1 { timestamp, chains: Vec::new() },
-                    super_root: root,
-                }),
-            },
-            root: Some(SuperRootAt { proof_bytes: vec![1], super_root: root }),
-        })
+        let mut result = canonical_super_root_at_timestamp(timestamp);
+        result.response.current_l1.number = HEAD_NUMBER + 1;
+        result.response.data.as_mut().unwrap().verified_required_l1.number = HEAD_NUMBER;
+        Ok(result)
     }
 }
 
@@ -392,7 +414,7 @@ async fn proposer_with(config: ProposerConfig, l1_view: Arc<ScenarioL1View>) -> 
             Address::ZERO,
             l1_view,
             Arc::new(FixedQueryTime),
-            Arc::new(FixedSuperRootSource),
+            Arc::new(FixedSuperRootSource { horizon: 3_600 }),
             Arc::new(NoopProofEngine),
             Arc::new(NoopActionExecutor),
             prestates,
@@ -574,14 +596,15 @@ async fn sigusr1_requests_terminal_retry() {
 async fn run_starts_immediately_then_waits_for_fetch_interval() {
     let view = Arc::new(ScenarioL1View::new());
     let proposer = proposer_with(test_config(600), view.clone()).await;
+    let started = tokio::time::Instant::now();
     let runner = tokio::spawn(proposer.run());
 
-    view.wait_for_cycles(1).await;
-    assert_eq!(view.latest_head_calls.load(Ordering::Relaxed), 1);
+    view.wait_for_creation_plans(1).await;
+    assert_eq!(tokio::time::Instant::now(), started);
+    let first_cycle_plans = view.creation_plan_calls.load(Ordering::Relaxed);
 
     tokio::time::advance(Duration::from_secs(600)).await;
-    view.wait_for_cycles(2).await;
-    assert_eq!(view.latest_head_calls.load(Ordering::Relaxed), 2);
+    view.wait_for_creation_plans(first_cycle_plans + 1).await;
 
     runner.abort();
     assert!(runner.await.unwrap_err().is_cancelled());
@@ -630,8 +653,8 @@ async fn finished_tasks_are_replaced_in_the_same_tick() {
 #[tokio::test]
 async fn failed_sync_leaves_existing_tasks_untouched() {
     let view = Arc::new(ScenarioL1View::new());
+    let proposer = proposer_with(test_config(30), view.clone()).await;
     view.fail_latest_head.store(true, Ordering::Relaxed);
-    let proposer = proposer_with(test_config(30), view).await;
     let mut control = ScenarioControl::new(proposer.clone(), Duration::from_secs(1));
     let (done_tx, done_rx) = oneshot::channel();
     let completed = insert_task(
@@ -658,7 +681,7 @@ async fn failed_creation_planning_does_not_stop_other_work() {
     let proposer = proposer_with(test_config(30), view.clone()).await;
     proposer.sync_state().await.unwrap();
     proposer.state.write().await.games.insert(U256::ONE, challenged_game(1, 5_000));
-    view.fail_respected_game_type.store(true, Ordering::Relaxed);
+    view.anchors.lock().get_mut(&Address::ZERO).unwrap().root = B256::ZERO;
     let mut control = ScenarioControl::new(proposer, Duration::from_secs(1));
 
     let result = control.tick().await.unwrap();
@@ -813,7 +836,7 @@ async fn new_create_and_follow_up_check_have_distinct_task_summaries() {
         )
     }));
     let view = Arc::new(ScenarioL1View::new());
-    let proposer = proposer_with(test_config(30), view).await;
+    let proposer = proposer_with(test_config(30), view.clone()).await;
     proposer.sync_state().await.unwrap();
     *proposer.in_flight_creation.lock().await = Some(InFlightCreation {
         root_claim: B256::left_padding_from(&[9]),
@@ -821,6 +844,7 @@ async fn new_create_and_follow_up_check_have_distinct_task_summaries() {
         sequence_number: 7_200,
         parent_game_index: 4,
     });
+    view.anchors.lock().get_mut(&Address::ZERO).unwrap().root = B256::ZERO;
     let mut control = ScenarioControl::new(proposer.clone(), Duration::from_secs(1));
     let reconciled = control.tick().await.unwrap();
     assert_eq!(
@@ -954,8 +978,8 @@ async fn task_finishing_during_tick_remains_settleable() {
     let task_id = allocate_task_id(&proposer);
     let barrier = NamedBarrier::new("completion barrier");
     let (done_tx, done_rx) = oneshot::channel();
-    *view.release_barrier.lock().unwrap() = Some(barrier.clone());
-    *view.task_finished.lock().unwrap() = Some(done_rx);
+    *view.release_barrier.lock() = Some(barrier.clone());
+    *view.task_finished.lock() = Some(done_rx);
     let task_barrier = barrier.clone();
     insert_allocated_task(
         &proposer,
@@ -2167,16 +2191,10 @@ async fn initialization_sets_proving_duration_and_returns_failures_immediately()
     let failing_world = ScenarioWorld::new();
     failing_world.clear_anchor_root();
     let before_failure = tokio::time::Instant::now();
-    let error = match ScenarioHarness::new(failing_world.clone(), scenario_config()).await {
-        Ok(_) => panic!("initialization should fail"),
-        Err(error) => error,
-    };
-    assert_eq!(
-        error,
-        ScenarioError::Initialization(
-            "anchor state registry has no anchor root (game creation would revert)".into()
-        )
-    );
+    assert!(matches!(
+        ScenarioHarness::new(failing_world, scenario_config()).await,
+        Err(ScenarioError::Initialization(_))
+    ));
     assert_eq!(tokio::time::Instant::now(), before_failure);
 }
 
@@ -2208,4 +2226,156 @@ async fn publishing_a_rotated_prestate_enables_defense_on_the_next_tick() {
     )));
     scenario.settle_scheduled(&recovered).await.unwrap();
     assert_eq!(world.proof_record(&target, 1).unwrap().lifecycle, ProofLifecycle::Succeeded);
+}
+
+#[tokio::test]
+async fn anchor_validation_registry_rotation_uses_fresh_cadence() {
+    let view = Arc::new(ScenarioL1View::new());
+    let actions = Arc::new(RecordingActionExecutor::default());
+    let mut config = test_config(30);
+    config.proposal_interval_seconds = 1_000;
+    let mut proposer = proposer_with(config, view.clone()).await;
+    Arc::get_mut(&mut proposer).unwrap().action_executor = actions.clone();
+    proposer.sync_state().await.unwrap();
+    let registry = Address::repeat_byte(0x42);
+    *view.registry.lock() = registry;
+    view.anchors.lock().insert(
+        registry,
+        AnchorRoot { root: B256::repeat_byte(0xff), sequence_number: U256::from(2_000) },
+    );
+    view.head_number.store(HEAD_NUMBER + 1, Ordering::Relaxed);
+    proposer.sync_state().await.unwrap();
+    let mut control = ScenarioControl::new(proposer.clone(), Duration::from_secs(1));
+    let blocked = control.tick().await.unwrap();
+    assert_eq!(blocked.snapshot.sync_disposition, SyncDisposition::UnchangedConfirmedHead);
+    assert!(
+        !blocked.scheduled.iter().any(|scheduled| {
+            matches!(scheduled.operation, OperationSummary::ProposeGame { .. })
+        })
+    );
+    let task_ids = blocked.scheduled.iter().map(|task| task.task_id).collect::<Vec<_>>();
+    control.settle(&task_ids).await.unwrap();
+    assert!(actions.calls.lock().is_empty());
+    assert!(proposer.in_flight_creation.lock().await.is_none());
+
+    view.anchors.lock().get_mut(&registry).unwrap().root =
+        canonical_super_root_at_timestamp(2_000).root.unwrap().super_root;
+    let recovered = control.tick().await.unwrap();
+    assert_eq!(recovered.snapshot.sync_disposition, SyncDisposition::UnchangedConfirmedHead);
+    assert!(recovered.scheduled.iter().any(|scheduled| {
+        matches!(
+            scheduled.operation,
+            OperationSummary::ProposeGame { sequence_number: 3_000, parent_game_index: u32::MAX }
+        )
+    }));
+    let task_ids = recovered.scheduled.iter().map(|task| task.task_id).collect::<Vec<_>>();
+    control.settle(&task_ids).await.unwrap();
+    assert!(matches!(
+        actions.calls.lock().as_slice(),
+        [ActionCall::Create { root_claim, .. }]
+            if *root_claim == canonical_super_root_at_timestamp(3_000).root.unwrap().super_root
+    ));
+    assert_eq!(proposer.last_created_game_l2_sequence_number.load(Ordering::Relaxed), 3_000);
+}
+
+#[tokio::test]
+async fn anchor_validation_pre_submit_rejects_changed_anchor() {
+    for advanced_anchor in [false, true] {
+        let view = Arc::new(ScenarioL1View::new());
+        let actions = Arc::new(RecordingActionExecutor::default());
+        let mut config = test_config(30);
+        config.proposal_interval_seconds = 1_000;
+        let mut proposer = proposer_with(config, view.clone()).await;
+        let dependencies = Arc::get_mut(&mut proposer).unwrap();
+        dependencies.superroot_source = Arc::new(FixedSuperRootSource { horizon: 1_500 });
+        dependencies.action_executor = actions.clone();
+        let candidate = if advanced_anchor { 1_001 } else { 1_000 };
+        if advanced_anchor {
+            let foreign_game = Address::repeat_byte(0xcc);
+            view.uuids.lock().insert(
+                canonical_super_root_at_timestamp(1_000).root.unwrap().super_root,
+                foreign_game,
+            );
+            view.creators.lock().insert(foreign_game, Address::repeat_byte(0xdd));
+        }
+        let barrier = NamedBarrier::new("submission UUID lookup");
+        let (task_tx, task_rx) = oneshot::channel();
+        *view.uuid_barrier.lock() = Some((
+            canonical_super_root_at_timestamp(candidate).root.unwrap().super_root,
+            task_rx,
+            barrier.clone(),
+        ));
+        let mut control = ScenarioControl::new(proposer.clone(), Duration::from_secs(1));
+        let planned = control.tick().await.unwrap();
+        let creation = planned
+            .scheduled
+            .iter()
+            .find(|scheduled| {
+                matches!(
+                    scheduled.operation,
+                    OperationSummary::ProposeGame {
+                        sequence_number: 1_000,
+                        parent_game_index: u32::MAX
+                    }
+                )
+            })
+            .unwrap();
+        task_tx.send(creation.task_id).unwrap();
+        barrier.wait_until_reached().await;
+        control.record_parked(creation.task_id, &barrier).await.unwrap();
+        *view.anchors.lock().get_mut(&Address::ZERO).unwrap() = if advanced_anchor {
+            AnchorRoot {
+                root: canonical_super_root_at_timestamp(candidate).root.unwrap().super_root,
+                sequence_number: U256::from(candidate),
+            }
+        } else {
+            AnchorRoot { root: B256::repeat_byte(0xff), sequence_number: U256::ZERO }
+        };
+        barrier.release();
+        let task_ids = planned.scheduled.iter().map(|task| task.task_id).collect::<Vec<_>>();
+        control.settle(&task_ids).await.unwrap();
+        assert!(actions.calls.lock().is_empty());
+        assert!(proposer.in_flight_creation.lock().await.is_none());
+        assert_eq!(proposer.last_created_game_l2_sequence_number.load(Ordering::Relaxed), 0);
+    }
+}
+
+#[tokio::test]
+async fn anchor_validation_explicit_parent_uses_canonical_tip() {
+    let view = Arc::new(ScenarioL1View::new());
+    let actions = Arc::new(RecordingActionExecutor::default());
+    let mut config = test_config(30);
+    config.proposal_interval_seconds = 1_000;
+    let mut proposer = proposer_with(config, view.clone()).await;
+    let dependencies = Arc::get_mut(&mut proposer).unwrap();
+    dependencies.superroot_source = Arc::new(FixedSuperRootSource { horizon: 3_000 });
+    dependencies.action_executor = actions.clone();
+    proposer.sync_state().await.unwrap();
+    {
+        let mut parent = challenged_game(1, 5_000);
+        parent.l2_sequence_number = 1_500;
+        parent.proposal_status = ProposalStatus::Unchallenged;
+        let mut state = proposer.state.write().await;
+        state.canonical_head_index = Some(parent.index);
+        state.canonical_head_sequence_number = Some(parent.l2_sequence_number);
+        state.games.insert(parent.index, parent);
+    }
+    view.anchors.lock().get_mut(&Address::ZERO).unwrap().root = B256::ZERO;
+    let mut control = ScenarioControl::new(proposer.clone(), Duration::from_secs(1));
+    let tick = control.tick().await.unwrap();
+    assert!(tick.scheduled.iter().any(|scheduled| {
+        matches!(
+            scheduled.operation,
+            OperationSummary::ProposeGame { sequence_number: 2_500, parent_game_index: 1 }
+        )
+    }));
+    let task_ids = tick.scheduled.iter().map(|task| task.task_id).collect::<Vec<_>>();
+    control.settle(&task_ids).await.unwrap();
+    assert!(matches!(
+        actions.calls.lock().as_slice(),
+        [ActionCall::Create { root_claim, extra_data, .. }]
+            if *root_claim == canonical_super_root_at_timestamp(2_500).root.unwrap().super_root
+                && extra_data.starts_with(&1_u32.to_be_bytes())
+    ));
+    assert_eq!(proposer.last_created_game_l2_sequence_number.load(Ordering::Relaxed), 2_500);
 }

--- a/rust/kona/sp1/crates/proposer/src/proposer/scenario/tests.rs
+++ b/rust/kona/sp1/crates/proposer/src/proposer/scenario/tests.rs
@@ -1,8 +1,7 @@
 use std::{
-    collections::HashMap,
     num::{NonZeroU64, NonZeroUsize},
     sync::{
-        Arc,
+        Arc, Mutex as StdMutex,
         atomic::{AtomicBool, AtomicU64, Ordering},
     },
     time::Duration,
@@ -12,8 +11,9 @@ use alloy_eips::BlockId;
 use alloy_primitives::{Address, B256, U256};
 use async_trait::async_trait;
 use kona_sp1_host_utils::metrics::MetricsListen;
-use kona_sp1_super_range_executor::SuperRootAtTimestampResponse;
-use parking_lot::Mutex;
+use kona_sp1_super_range_executor::{
+    BlockId as SuperBlockId, SuperRootAtTimestampResponse, SuperRootResponseData, SuperV1,
+};
 use tokio::sync::{Notify, oneshot};
 
 use super::{NamedBarrier, ScenarioControl, ScenarioError, world::*};
@@ -33,13 +33,12 @@ use crate::{
     prover::ProofKeys,
     proving::GameProofInputs,
     signer::NUM_CONFIRMATIONS,
-    superroot::zk_extra_data,
+    superroot::{SuperRootAt, zk_extra_data},
 };
 
 use crate::proposer::{
     CompactGameSummary, InFlightCreation, OperationSummary, Proposer, ProvingPurpose,
     SyncDisposition, TaskClass, TaskCompletionOutcome, TaskFailureClass, TaskId, TaskSuccess,
-    tests::{ActionCall, RecordingActionExecutor, canonical_super_root_at_timestamp},
 };
 
 const HEAD_NUMBER: u64 = 1;
@@ -47,41 +46,25 @@ const HEAD_TIMESTAMP: u64 = 1_000;
 
 #[derive(Default)]
 struct ScenarioL1View {
-    creation_plan_calls: AtomicU64,
-    creation_plan_notify: Notify,
+    latest_head_calls: AtomicU64,
+    latest_head_notify: Notify,
     fail_latest_head: AtomicBool,
     fail_respected_game_type: AtomicBool,
     fail_latest_l1_timestamp_on: AtomicU64,
     latest_l1_timestamp_calls: AtomicU64,
-    release_barrier: Mutex<Option<NamedBarrier>>,
-    task_finished: Mutex<Option<oneshot::Receiver<()>>>,
-    head_number: AtomicU64,
-    registry: Mutex<Address>,
-    anchors: Mutex<HashMap<Address, AnchorRoot>>,
-    uuids: Mutex<HashMap<B256, Address>>,
-    creators: Mutex<HashMap<Address, Address>>,
-    uuid_barrier: Mutex<Option<(B256, oneshot::Receiver<TaskId>, NamedBarrier)>>,
+    release_barrier: StdMutex<Option<NamedBarrier>>,
+    task_finished: StdMutex<Option<oneshot::Receiver<()>>>,
 }
 
 impl ScenarioL1View {
     fn new() -> Self {
-        Self {
-            head_number: AtomicU64::new(HEAD_NUMBER),
-            anchors: Mutex::new(HashMap::from([(
-                Address::ZERO,
-                AnchorRoot {
-                    root: canonical_super_root_at_timestamp(0).root.unwrap().super_root,
-                    sequence_number: U256::ZERO,
-                },
-            )])),
-            ..Self::default()
-        }
+        Self::default()
     }
 
-    async fn wait_for_creation_plans(&self, expected: u64) {
+    async fn wait_for_cycles(&self, expected: u64) {
         loop {
-            let notified = self.creation_plan_notify.notified();
-            if self.creation_plan_calls.load(Ordering::Relaxed) >= expected {
+            let notified = self.latest_head_notify.notified();
+            if self.latest_head_calls.load(Ordering::Relaxed) >= expected {
                 return;
             }
             notified.await;
@@ -92,14 +75,12 @@ impl ScenarioL1View {
 #[async_trait]
 impl L1View for ScenarioL1View {
     async fn latest_head(&self) -> anyhow::Result<Option<L1BlockRef>> {
+        self.latest_head_calls.fetch_add(1, Ordering::Relaxed);
+        self.latest_head_notify.notify_waiters();
         if self.fail_latest_head.load(Ordering::Relaxed) {
             anyhow::bail!("latest head unavailable")
         }
-        Ok(Some(L1BlockRef {
-            hash: B256::ZERO,
-            number: self.head_number.load(Ordering::Relaxed),
-            timestamp: HEAD_TIMESTAMP,
-        }))
+        Ok(Some(L1BlockRef { hash: B256::ZERO, number: HEAD_NUMBER, timestamp: HEAD_TIMESTAMP }))
     }
 
     async fn block_ref(&self, number: u64) -> anyhow::Result<Option<L1BlockRef>> {
@@ -113,13 +94,13 @@ impl L1View for ScenarioL1View {
             max_challenge_duration: 3_600,
             max_prove_duration: 3_600,
             challenger_bond: U256::ZERO,
-            anchor_state_registry: *self.registry.lock(),
+            anchor_state_registry: Address::ZERO,
             weth: Address::ZERO,
         })
     }
 
-    async fn anchor_root(&self, registry: Address, _block: BlockId) -> anyhow::Result<AnchorRoot> {
-        Ok(*self.anchors.lock().get(&registry).expect("configured registry"))
+    async fn anchor_root(&self, _registry: Address, _block: BlockId) -> anyhow::Result<AnchorRoot> {
+        Ok(AnchorRoot { root: canonical_super_root(0), sequence_number: U256::ZERO })
     }
 
     async fn latest_game_index(&self, _block: BlockId) -> anyhow::Result<Option<U256>> {
@@ -200,26 +181,14 @@ impl L1View for ScenarioL1View {
 
     async fn game_by_uuid(
         &self,
-        root_claim: B256,
+        _root_claim: B256,
         _extra_data: Vec<u8>,
     ) -> anyhow::Result<Address> {
-        let existing = self.uuids.lock().get(&root_claim).copied().unwrap_or_default();
-        let pause = {
-            let mut barrier = self.uuid_barrier.lock();
-            if barrier.as_ref().is_some_and(|(root, _, _)| *root == root_claim) {
-                barrier.take()
-            } else {
-                None
-            }
-        };
-        if let Some((_, task_id, barrier)) = pause {
-            barrier.park(task_id.await?).await;
-        }
-        Ok(existing)
+        Ok(Address::ZERO)
     }
 
-    async fn game_creator(&self, game: Address) -> anyhow::Result<Address> {
-        Ok(self.creators.lock().get(&game).copied().unwrap_or_default())
+    async fn game_creator(&self, _game: Address) -> anyhow::Result<Address> {
+        Ok(Address::ZERO)
     }
 
     async fn nonce_state(&self, _proposer: Address) -> anyhow::Result<NonceState> {
@@ -227,10 +196,8 @@ impl L1View for ScenarioL1View {
     }
 
     async fn respected_game_type(&self, _block: BlockId) -> anyhow::Result<u32> {
-        self.creation_plan_calls.fetch_add(1, Ordering::Relaxed);
-        self.creation_plan_notify.notify_waiters();
-        let release_barrier = self.release_barrier.lock().take();
-        let task_finished = self.task_finished.lock().take();
+        let release_barrier = self.release_barrier.lock().unwrap().take();
+        let task_finished = self.task_finished.lock().unwrap().take();
         if let Some(release_barrier) = release_barrier {
             release_barrier.release();
         }
@@ -288,24 +255,35 @@ impl QueryTime for FixedQueryTime {
     }
 }
 
-struct FixedSuperRootSource {
-    horizon: u64,
-}
+struct FixedSuperRootSource;
 
 #[async_trait]
 impl SuperRootSource for FixedSuperRootSource {
     async fn proposal_horizon(&self, _timestamp: u64) -> anyhow::Result<ProposalHorizon> {
-        Ok(ProposalHorizon { safe_timestamp: self.horizon, finalized_timestamp: self.horizon })
+        Ok(ProposalHorizon { safe_timestamp: 3_600, finalized_timestamp: 3_600 })
     }
 
     async fn super_root_at_timestamp(
         &self,
         timestamp: u64,
     ) -> anyhow::Result<SuperRootAtTimestamp> {
-        let mut result = canonical_super_root_at_timestamp(timestamp);
-        result.response.current_l1.number = HEAD_NUMBER + 1;
-        result.response.data.as_mut().unwrap().verified_required_l1.number = HEAD_NUMBER;
-        Ok(result)
+        let root = canonical_super_root(timestamp);
+        Ok(SuperRootAtTimestamp {
+            response: SuperRootAtTimestampResponse {
+                current_l1: SuperBlockId { number: 1, ..Default::default() },
+                current_safe_timestamp: timestamp,
+                current_local_safe_timestamp: timestamp,
+                current_finalized_timestamp: timestamp,
+                optimistic_at_timestamp: Default::default(),
+                chain_ids: Vec::new(),
+                data: Some(SuperRootResponseData {
+                    verified_required_l1: SuperBlockId::default(),
+                    super_v1: SuperV1 { timestamp, chains: Vec::new() },
+                    super_root: root,
+                }),
+            },
+            root: Some(SuperRootAt { proof_bytes: vec![1], super_root: root }),
+        })
     }
 }
 
@@ -414,7 +392,7 @@ async fn proposer_with(config: ProposerConfig, l1_view: Arc<ScenarioL1View>) -> 
             Address::ZERO,
             l1_view,
             Arc::new(FixedQueryTime),
-            Arc::new(FixedSuperRootSource { horizon: 3_600 }),
+            Arc::new(FixedSuperRootSource),
             Arc::new(NoopProofEngine),
             Arc::new(NoopActionExecutor),
             prestates,
@@ -596,15 +574,16 @@ async fn sigusr1_requests_terminal_retry() {
 async fn run_starts_immediately_then_waits_for_fetch_interval() {
     let view = Arc::new(ScenarioL1View::new());
     let proposer = proposer_with(test_config(600), view.clone()).await;
+    let initial_calls = view.latest_head_calls.load(Ordering::Relaxed);
     let started = tokio::time::Instant::now();
     let runner = tokio::spawn(proposer.run());
 
-    view.wait_for_creation_plans(1).await;
+    // run() reads the head once during startup, then once per cycle.
+    view.wait_for_cycles(initial_calls + 2).await;
     assert_eq!(tokio::time::Instant::now(), started);
-    let first_cycle_plans = view.creation_plan_calls.load(Ordering::Relaxed);
 
     tokio::time::advance(Duration::from_secs(600)).await;
-    view.wait_for_creation_plans(first_cycle_plans + 1).await;
+    view.wait_for_cycles(initial_calls + 3).await;
 
     runner.abort();
     assert!(runner.await.unwrap_err().is_cancelled());
@@ -681,7 +660,7 @@ async fn failed_creation_planning_does_not_stop_other_work() {
     let proposer = proposer_with(test_config(30), view.clone()).await;
     proposer.sync_state().await.unwrap();
     proposer.state.write().await.games.insert(U256::ONE, challenged_game(1, 5_000));
-    view.anchors.lock().get_mut(&Address::ZERO).unwrap().root = B256::ZERO;
+    view.fail_respected_game_type.store(true, Ordering::Relaxed);
     let mut control = ScenarioControl::new(proposer, Duration::from_secs(1));
 
     let result = control.tick().await.unwrap();
@@ -836,7 +815,7 @@ async fn new_create_and_follow_up_check_have_distinct_task_summaries() {
         )
     }));
     let view = Arc::new(ScenarioL1View::new());
-    let proposer = proposer_with(test_config(30), view.clone()).await;
+    let proposer = proposer_with(test_config(30), view).await;
     proposer.sync_state().await.unwrap();
     *proposer.in_flight_creation.lock().await = Some(InFlightCreation {
         root_claim: B256::left_padding_from(&[9]),
@@ -844,7 +823,6 @@ async fn new_create_and_follow_up_check_have_distinct_task_summaries() {
         sequence_number: 7_200,
         parent_game_index: 4,
     });
-    view.anchors.lock().get_mut(&Address::ZERO).unwrap().root = B256::ZERO;
     let mut control = ScenarioControl::new(proposer.clone(), Duration::from_secs(1));
     let reconciled = control.tick().await.unwrap();
     assert_eq!(
@@ -978,8 +956,8 @@ async fn task_finishing_during_tick_remains_settleable() {
     let task_id = allocate_task_id(&proposer);
     let barrier = NamedBarrier::new("completion barrier");
     let (done_tx, done_rx) = oneshot::channel();
-    *view.release_barrier.lock() = Some(barrier.clone());
-    *view.task_finished.lock() = Some(done_rx);
+    *view.release_barrier.lock().unwrap() = Some(barrier.clone());
+    *view.task_finished.lock().unwrap() = Some(done_rx);
     let task_barrier = barrier.clone();
     insert_allocated_task(
         &proposer,
@@ -2226,156 +2204,4 @@ async fn publishing_a_rotated_prestate_enables_defense_on_the_next_tick() {
     )));
     scenario.settle_scheduled(&recovered).await.unwrap();
     assert_eq!(world.proof_record(&target, 1).unwrap().lifecycle, ProofLifecycle::Succeeded);
-}
-
-#[tokio::test]
-async fn anchor_validation_registry_rotation_uses_fresh_cadence() {
-    let view = Arc::new(ScenarioL1View::new());
-    let actions = Arc::new(RecordingActionExecutor::default());
-    let mut config = test_config(30);
-    config.proposal_interval_seconds = 1_000;
-    let mut proposer = proposer_with(config, view.clone()).await;
-    Arc::get_mut(&mut proposer).unwrap().action_executor = actions.clone();
-    proposer.sync_state().await.unwrap();
-    let registry = Address::repeat_byte(0x42);
-    *view.registry.lock() = registry;
-    view.anchors.lock().insert(
-        registry,
-        AnchorRoot { root: B256::repeat_byte(0xff), sequence_number: U256::from(2_000) },
-    );
-    view.head_number.store(HEAD_NUMBER + 1, Ordering::Relaxed);
-    proposer.sync_state().await.unwrap();
-    let mut control = ScenarioControl::new(proposer.clone(), Duration::from_secs(1));
-    let blocked = control.tick().await.unwrap();
-    assert_eq!(blocked.snapshot.sync_disposition, SyncDisposition::UnchangedConfirmedHead);
-    assert!(
-        !blocked.scheduled.iter().any(|scheduled| {
-            matches!(scheduled.operation, OperationSummary::ProposeGame { .. })
-        })
-    );
-    let task_ids = blocked.scheduled.iter().map(|task| task.task_id).collect::<Vec<_>>();
-    control.settle(&task_ids).await.unwrap();
-    assert!(actions.calls.lock().is_empty());
-    assert!(proposer.in_flight_creation.lock().await.is_none());
-
-    view.anchors.lock().get_mut(&registry).unwrap().root =
-        canonical_super_root_at_timestamp(2_000).root.unwrap().super_root;
-    let recovered = control.tick().await.unwrap();
-    assert_eq!(recovered.snapshot.sync_disposition, SyncDisposition::UnchangedConfirmedHead);
-    assert!(recovered.scheduled.iter().any(|scheduled| {
-        matches!(
-            scheduled.operation,
-            OperationSummary::ProposeGame { sequence_number: 3_000, parent_game_index: u32::MAX }
-        )
-    }));
-    let task_ids = recovered.scheduled.iter().map(|task| task.task_id).collect::<Vec<_>>();
-    control.settle(&task_ids).await.unwrap();
-    assert!(matches!(
-        actions.calls.lock().as_slice(),
-        [ActionCall::Create { root_claim, .. }]
-            if *root_claim == canonical_super_root_at_timestamp(3_000).root.unwrap().super_root
-    ));
-    assert_eq!(proposer.last_created_game_l2_sequence_number.load(Ordering::Relaxed), 3_000);
-}
-
-#[tokio::test]
-async fn anchor_validation_pre_submit_rejects_changed_anchor() {
-    for advanced_anchor in [false, true] {
-        let view = Arc::new(ScenarioL1View::new());
-        let actions = Arc::new(RecordingActionExecutor::default());
-        let mut config = test_config(30);
-        config.proposal_interval_seconds = 1_000;
-        let mut proposer = proposer_with(config, view.clone()).await;
-        let dependencies = Arc::get_mut(&mut proposer).unwrap();
-        dependencies.superroot_source = Arc::new(FixedSuperRootSource { horizon: 1_500 });
-        dependencies.action_executor = actions.clone();
-        let candidate = if advanced_anchor { 1_001 } else { 1_000 };
-        if advanced_anchor {
-            let foreign_game = Address::repeat_byte(0xcc);
-            view.uuids.lock().insert(
-                canonical_super_root_at_timestamp(1_000).root.unwrap().super_root,
-                foreign_game,
-            );
-            view.creators.lock().insert(foreign_game, Address::repeat_byte(0xdd));
-        }
-        let barrier = NamedBarrier::new("submission UUID lookup");
-        let (task_tx, task_rx) = oneshot::channel();
-        *view.uuid_barrier.lock() = Some((
-            canonical_super_root_at_timestamp(candidate).root.unwrap().super_root,
-            task_rx,
-            barrier.clone(),
-        ));
-        let mut control = ScenarioControl::new(proposer.clone(), Duration::from_secs(1));
-        let planned = control.tick().await.unwrap();
-        let creation = planned
-            .scheduled
-            .iter()
-            .find(|scheduled| {
-                matches!(
-                    scheduled.operation,
-                    OperationSummary::ProposeGame {
-                        sequence_number: 1_000,
-                        parent_game_index: u32::MAX
-                    }
-                )
-            })
-            .unwrap();
-        task_tx.send(creation.task_id).unwrap();
-        barrier.wait_until_reached().await;
-        control.record_parked(creation.task_id, &barrier).await.unwrap();
-        *view.anchors.lock().get_mut(&Address::ZERO).unwrap() = if advanced_anchor {
-            AnchorRoot {
-                root: canonical_super_root_at_timestamp(candidate).root.unwrap().super_root,
-                sequence_number: U256::from(candidate),
-            }
-        } else {
-            AnchorRoot { root: B256::repeat_byte(0xff), sequence_number: U256::ZERO }
-        };
-        barrier.release();
-        let task_ids = planned.scheduled.iter().map(|task| task.task_id).collect::<Vec<_>>();
-        control.settle(&task_ids).await.unwrap();
-        assert!(actions.calls.lock().is_empty());
-        assert!(proposer.in_flight_creation.lock().await.is_none());
-        assert_eq!(proposer.last_created_game_l2_sequence_number.load(Ordering::Relaxed), 0);
-    }
-}
-
-#[tokio::test]
-async fn anchor_validation_explicit_parent_uses_canonical_tip() {
-    let view = Arc::new(ScenarioL1View::new());
-    let actions = Arc::new(RecordingActionExecutor::default());
-    let mut config = test_config(30);
-    config.proposal_interval_seconds = 1_000;
-    let mut proposer = proposer_with(config, view.clone()).await;
-    let dependencies = Arc::get_mut(&mut proposer).unwrap();
-    dependencies.superroot_source = Arc::new(FixedSuperRootSource { horizon: 3_000 });
-    dependencies.action_executor = actions.clone();
-    proposer.sync_state().await.unwrap();
-    {
-        let mut parent = challenged_game(1, 5_000);
-        parent.l2_sequence_number = 1_500;
-        parent.proposal_status = ProposalStatus::Unchallenged;
-        let mut state = proposer.state.write().await;
-        state.canonical_head_index = Some(parent.index);
-        state.canonical_head_sequence_number = Some(parent.l2_sequence_number);
-        state.games.insert(parent.index, parent);
-    }
-    view.anchors.lock().get_mut(&Address::ZERO).unwrap().root = B256::ZERO;
-    let mut control = ScenarioControl::new(proposer.clone(), Duration::from_secs(1));
-    let tick = control.tick().await.unwrap();
-    assert!(tick.scheduled.iter().any(|scheduled| {
-        matches!(
-            scheduled.operation,
-            OperationSummary::ProposeGame { sequence_number: 2_500, parent_game_index: 1 }
-        )
-    }));
-    let task_ids = tick.scheduled.iter().map(|task| task.task_id).collect::<Vec<_>>();
-    control.settle(&task_ids).await.unwrap();
-    assert!(matches!(
-        actions.calls.lock().as_slice(),
-        [ActionCall::Create { root_claim, extra_data, .. }]
-            if *root_claim == canonical_super_root_at_timestamp(2_500).root.unwrap().super_root
-                && extra_data.starts_with(&1_u32.to_be_bytes())
-    ));
-    assert_eq!(proposer.last_created_game_l2_sequence_number.load(Ordering::Relaxed), 2_500);
 }


### PR DESCRIPTION
An invalid anchor can make the proposer submit games it cannot prove. Anchor-based creation now waits for the registered anchor to match the supernode's canonical history, logs validation failures, and resumes without a restart when matching data is available. Once the proposer is running, these failures do not block existing-game work or proposals that use an explicit parent.

Closes https://github.com/ethereum-optimism/optimism/issues/22589
