### PR TITLE
docs: add preconfirmation architecture transition notice

### DIFF
--- a/docs/public-docs/chain-operators/guides/features/subblocks-guide.mdx
+++ b/docs/public-docs/chain-operators/guides/features/subblocks-guide.mdx
@@ -6,6 +6,7 @@ diataxis: how-to
 
 <Warning>
   Subblocks replace Flashblocks. Flashblocks are no longer officially supported on OP Stack chains.
+  See the [preconfirmation architecture transition notice](/notices/preconfirmation-architecture-transition) for the wind-down timeline.
 </Warning>
 
 Subblocks are a private feature available only to OP Enterprise customers. If you are interested in becoming an OP Enterprise customer, [contact the OP Enterprise team](https://optimism.io/learn-more). See [this explainer on Subblocks](/op-stack/features/subblocks) for more details.

--- a/docs/public-docs/docs.json
+++ b/docs/public-docs/docs.json
@@ -3627,9 +3627,9 @@
               {
                 "group": "Operations",
                 "pages": [
-                  "notices/specialized-node-topology",
+                  "notices/preconfirmation-architecture-transition",
                   "notices/subblocks",
-                  "notices/preconfirmation-architecture-transition"
+                  "notices/specialized-node-topology"
                 ]
               },
               "notices/archive/index"

--- a/docs/public-docs/docs.json
+++ b/docs/public-docs/docs.json
@@ -3628,7 +3628,8 @@
                 "group": "Operations",
                 "pages": [
                   "notices/specialized-node-topology",
-                  "notices/subblocks"
+                  "notices/subblocks",
+                  "notices/preconfirmation-architecture-transition"
                 ]
               },
               "notices/archive/index"

--- a/docs/public-docs/notices/index.mdx
+++ b/docs/public-docs/notices/index.mdx
@@ -56,4 +56,7 @@ notices are archived after activation, registry pages are forever.
   <Card title="Subblocks: 200 ms interval and payload changes" href="/notices/subblocks" icon="circle-info" horizontal>
     A 200 ms subblock interval and four zeroed stream payload fields on OP Sepolia and OP Mainnet
   </Card>
+  <Card title="Preconfirmation Architecture Transition" href="/notices/preconfirmation-architecture-transition" icon="circle-info" horizontal>
+    OP Labs is ending support for the Flashblocks stack; Subblocks is the supported path
+  </Card>
 </CardGroup>

--- a/docs/public-docs/notices/preconfirmation-architecture-transition.mdx
+++ b/docs/public-docs/notices/preconfirmation-architecture-transition.mdx
@@ -1,6 +1,6 @@
 ---
-title: Preconfirmation architecture transition
-description: OP Labs is ending support for the Flashblocks preconfirmation architecture. Subblocks is the supported path for OP Stack chains that produce preconfirmations.
+title: Preconfirmation Architecture Transition
+description: OP Labs is ending its support for the Flashblocks preconfirmation architecture in favor of Subblocks, an in-house solution built and maintained by OP Labs.
 diataxis: reference
 lang: en-US
 content_type: notice
@@ -9,68 +9,49 @@ personas:
   - chain-operator
   - node-operator
   - app-developer
+  - partner
 categories:
   - infrastructure
   - protocol
 is_imported_content: 'false'
 ---
 
-Subblocks replace Flashblocks as the preconfirmation architecture that OP Labs builds, runs, and supports.
-A preconfirmation is a partial block the sequencer streams while it is still building the full block, so an application can act on a transaction's outcome before the block is sealed.
-Subblocks is an in-house implementation maintained by OP Labs, live on OP Sepolia and OP Mainnet since August 2026.
-Flashblocks is built and maintained by Flashbots and remains their project.
+## Summary
 
-This notice records what OP Labs stops running and supporting, and what chains still on the Flashblocks stack should do.
-It does not change the subblock stream itself.
-For the current interval and payload behavior, see the [Subblocks notice](/notices/subblocks).
+OP Labs is ending its support for the Flashblocks preconfirmation architecture in favor of [Subblocks](/notices/subblocks), an in-house solution built and maintained by OP Labs. Flashblocks is built and maintained by Flashbots. This notice covers what OP Labs runs, tests, and supports.
 
-<Warning>
-  OP Labs offers no support for the Flashblocks stack.
-  Chains running `rollup-boost` and `op-rbuilder` should plan a migration to Subblocks.
-  The Flashblocks stack may stop working at a future fork.
-</Warning>
+Preconfirmations on OP Enterprise chains are delivered by Subblocks, which OP Labs builds and maintains. Subblocks has been running on OP Mainnet since August 31, 2026 and exposes the same consumer-facing interface as Flashblocks, so applications and infrastructure that consume preconfirmations do not need to change.
 
 ## What is changing
 
-*   **New OP Enterprise deployments use Subblocks.** Flashblocks is not offered for new deployments.
-*   **Existing OP Enterprise chains on Flashblocks migrate to Subblocks.** OP Labs schedules and runs each migration.
-*   **OP Labs stops running and testing `op-rbuilder`.** Once the last OP Enterprise chain has migrated, `op-rbuilder` leaves OP Labs infrastructure and the internal code fork is retired.
-*   **A transition window follows.** For a period after the final migration, OP Labs forwards critical Flashblocks issues to Flashbots on a best-effort basis for OP Enterprise chains. Flashbots remains responsible for fixes and releases. The end date for that window will be published in this notice.
+*   New OP Enterprise deployments use Subblocks to achieve sub-second blocktimes. Flashblocks is not offered for new deployments.
+*   Existing OP Enterprise chains running Flashblocks will migrate to Subblocks.
+*   After the last OP Enterprise chain migrates, OP Labs stops running and testing op-rbuilder in its infrastructure.
+*   For a transition window after that, OP Labs forwards critical Flashblocks issues to Flashbots on a best-effort basis. Flashbots remains responsible for fixes and releases.
+*   After the transition window closes, OP Labs provides no Flashblocks support.
 
 ## What is not changing
 
-*   **Flashbots continues to own, maintain, and release Flashblocks.** Chains running the Flashblocks stack outside OP Enterprise are unaffected by this notice and should work with Flashbots directly.
-*   **The consumer-facing preconfirmation interface.** Subblocks keeps the wire format Flashblocks used, and the payload type is still named `ExecutionPayloadFlashblockDeltaV1`. Moving from Flashblocks to Subblocks does not by itself require an integration change.
-
-<Warning>
-  This notice adds no new integration work, but it does not clear the audit the [Subblocks notice](/notices/subblocks#action-required) requires.
-  `state_root`, `block_hash`, `withdrawals_root`, and `withdrawals` carry a zero value on the stream, and a read of any of them returns that zero rather than raising an error.
-  If you have not audited your integration for those reads, do that first.
-</Warning>
-
-## What this means for you
-
-| If you | Then |
-| --- | --- |
-| Consume the subblock stream, or read preconfirmations from a provider | No action from this notice. The stream and its wire format are unchanged. Confirm you have completed the audit in the [Subblocks notice](/notices/subblocks#action-required). |
-| Run an OP Enterprise chain on Flashblocks | OP Labs contacts you to scope and schedule the migration, and runs it. |
-| Run an OP Enterprise chain self-managed | [Contact the OP Enterprise team](https://optimism.io/learn-more) about Subblocks availability. Staying on Flashblocks means you operate and support it yourself, with Flashbots as the support path. |
-| Run the Flashblocks stack independently | This notice is informational. OP Labs carries no Flashblocks support commitment for your chain. |
+*   Flashbots continues to own, maintain, and release Flashblocks. Chains running Flashblocks outside OP Enterprise are unaffected by this notice and should continue to work with Flashbots directly.
+*   The consumer-facing preconfirmation interface is unchanged under Subblocks. Note that some payload values have been zeroed since the August subblocks migration — see [what this means](/notices/subblocks#what-this-means).
 
 ## Timeline
 
-| Milestone | Date |
+| Milestone | Target |
 | --- | --- |
-| Subblocks live on OP Sepolia | August 17, 2026 |
-| Subblocks live on OP Mainnet | August 31, 2026 |
-| `op-rbuilder` leaves OP Labs infrastructure | After the final OP Enterprise migration |
-| Best-effort issue forwarding to Flashbots ends | To be announced |
+| Subblocks live on OP Sepolia | Completed: August 17, 2026 |
+| Subblocks live on OP Mainnet | Completed: August 31, 2026 |
+| Final OP Enterprise chain migrated to Subblocks | End of September 2026 — TBC |
+| OP Labs stops running and testing op-rbuilder; internal fork removed | After final migration |
+| Best-effort issue forwarding to Flashbots ends | October 31 / November 30, 2026 — TBC |
 
-## Key links
+## What this means for you
 
-| Resource | Link |
-| --- | --- |
-| Subblocks explainer | [How Subblocks work](/op-stack/features/subblocks) |
-| Current stream behavior | [Subblocks notice](/notices/subblocks) |
-| Enabling Subblocks | [Enabling Subblocks](/chain-operators/guides/features/subblocks-guide) |
-| App integration guide | [Integrate Subblocks in your app](/app-developers/guides/transactions/integrating-subblocks) |
+*   **OP Enterprise, Fully Managed, running Flashblocks today.** OP Labs schedules and runs the migration to Subblocks as part of your service. We will contact you to confirm scope and a window.
+*   **OP Enterprise, Self Managed.** Contact your Partnership Lead to discuss Subblocks availability for self-managed deployments. If you choose to keep running Flashblocks, you operate and support it yourself, and Flashbots is the support path.
+*   **New OP Enterprise deployments.** Subblocks by default. No action.
+*   **Non-OP Enterprise customers running Flashblocks independently.** This notice is informational. OP Labs does not carry a Flashblocks support commitment for your chain. Continue to work with your providers.
+
+## Questions
+
+Reach out to your OP Labs point of contact, or open a ticket through your support channel.

--- a/docs/public-docs/notices/preconfirmation-architecture-transition.mdx
+++ b/docs/public-docs/notices/preconfirmation-architecture-transition.mdx
@@ -43,7 +43,7 @@ Preconfirmations on OP Enterprise chains are delivered by Subblocks, which OP La
 | Subblocks live on OP Mainnet | Completed: August 31, 2026 |
 | Final OP Enterprise chain migrated to Subblocks | End of September 2026 — TBC |
 | OP Labs stops running and testing op-rbuilder; internal fork removed | After final migration |
-| Best-effort issue forwarding to Flashbots ends | October 31 / November 30, 2026 — TBC |
+| Best-effort issue forwarding to Flashbots ends | October 31, 2026 — TBC |
 
 ## What this means for you
 

--- a/docs/public-docs/notices/preconfirmation-architecture-transition.mdx
+++ b/docs/public-docs/notices/preconfirmation-architecture-transition.mdx
@@ -1,0 +1,76 @@
+---
+title: Preconfirmation architecture transition
+description: OP Labs is ending support for the Flashblocks preconfirmation architecture. Subblocks is the supported path for OP Stack chains that produce preconfirmations.
+diataxis: reference
+lang: en-US
+content_type: notice
+topic: preconfirmation-architecture-transition
+personas:
+  - chain-operator
+  - node-operator
+  - app-developer
+categories:
+  - infrastructure
+  - protocol
+is_imported_content: 'false'
+---
+
+Subblocks replace Flashblocks as the preconfirmation architecture that OP Labs builds, runs, and supports.
+A preconfirmation is a partial block the sequencer streams while it is still building the full block, so an application can act on a transaction's outcome before the block is sealed.
+Subblocks is an in-house implementation maintained by OP Labs, live on OP Sepolia and OP Mainnet since August 2026.
+Flashblocks is built and maintained by Flashbots and remains their project.
+
+This notice records what OP Labs stops running and supporting, and what chains still on the Flashblocks stack should do.
+It does not change the subblock stream itself.
+For the current interval and payload behavior, see the [Subblocks notice](/notices/subblocks).
+
+<Warning>
+  OP Labs offers no support for the Flashblocks stack.
+  Chains running `rollup-boost` and `op-rbuilder` should plan a migration to Subblocks.
+  The Flashblocks stack may stop working at a future fork.
+</Warning>
+
+## What is changing
+
+*   **New OP Enterprise deployments use Subblocks.** Flashblocks is not offered for new deployments.
+*   **Existing OP Enterprise chains on Flashblocks migrate to Subblocks.** OP Labs schedules and runs each migration.
+*   **OP Labs stops running and testing `op-rbuilder`.** Once the last OP Enterprise chain has migrated, `op-rbuilder` leaves OP Labs infrastructure and the internal code fork is retired.
+*   **A transition window follows.** For a period after the final migration, OP Labs forwards critical Flashblocks issues to Flashbots on a best-effort basis for OP Enterprise chains. Flashbots remains responsible for fixes and releases. The end date for that window will be published in this notice.
+
+## What is not changing
+
+*   **Flashbots continues to own, maintain, and release Flashblocks.** Chains running the Flashblocks stack outside OP Enterprise are unaffected by this notice and should work with Flashbots directly.
+*   **The consumer-facing preconfirmation interface.** Subblocks keeps the wire format Flashblocks used, and the payload type is still named `ExecutionPayloadFlashblockDeltaV1`. Moving from Flashblocks to Subblocks does not by itself require an integration change.
+
+<Warning>
+  This notice adds no new integration work, but it does not clear the audit the [Subblocks notice](/notices/subblocks#action-required) requires.
+  `state_root`, `block_hash`, `withdrawals_root`, and `withdrawals` carry a zero value on the stream, and a read of any of them returns that zero rather than raising an error.
+  If you have not audited your integration for those reads, do that first.
+</Warning>
+
+## What this means for you
+
+| If you | Then |
+| --- | --- |
+| Consume the subblock stream, or read preconfirmations from a provider | No action from this notice. The stream and its wire format are unchanged. Confirm you have completed the audit in the [Subblocks notice](/notices/subblocks#action-required). |
+| Run an OP Enterprise chain on Flashblocks | OP Labs contacts you to scope and schedule the migration, and runs it. |
+| Run an OP Enterprise chain self-managed | [Contact the OP Enterprise team](https://optimism.io/learn-more) about Subblocks availability. Staying on Flashblocks means you operate and support it yourself, with Flashbots as the support path. |
+| Run the Flashblocks stack independently | This notice is informational. OP Labs carries no Flashblocks support commitment for your chain. |
+
+## Timeline
+
+| Milestone | Date |
+| --- | --- |
+| Subblocks live on OP Sepolia | August 17, 2026 |
+| Subblocks live on OP Mainnet | August 31, 2026 |
+| `op-rbuilder` leaves OP Labs infrastructure | After the final OP Enterprise migration |
+| Best-effort issue forwarding to Flashbots ends | To be announced |
+
+## Key links
+
+| Resource | Link |
+| --- | --- |
+| Subblocks explainer | [How Subblocks work](/op-stack/features/subblocks) |
+| Current stream behavior | [Subblocks notice](/notices/subblocks) |
+| Enabling Subblocks | [Enabling Subblocks](/chain-operators/guides/features/subblocks-guide) |
+| App integration guide | [Integrate Subblocks in your app](/app-developers/guides/transactions/integrating-subblocks) |

--- a/docs/public-docs/op-stack/features/subblocks.mdx
+++ b/docs/public-docs/op-stack/features/subblocks.mdx
@@ -102,6 +102,7 @@ Before subblocks, pre-confirmations were produced by the Flashblocks stack: `rol
   The Flashblocks stack may still run, but OP Labs offers **no support** for it.
   It may stop working at a future fork.
   Chains running `rollup-boost` and `op-rbuilder` should plan a migration.
+  See the [preconfirmation architecture transition notice](/notices/preconfirmation-architecture-transition) for the wind-down timeline.
 </Warning>
 
 For availability information, see [Enabling Subblocks](/chain-operators/guides/features/subblocks-guide).


### PR DESCRIPTION
## Summary

New **notice** page at `docs/public-docs/notices/preconfirmation-architecture-transition.mdx`, plus 4 companion edits to make it discoverable and cross-linked.

The page body is the Partnerships-reviewed draft **reproduced verbatim**. Only mechanical changes were made to fit MDX: frontmatter added, bold pseudo-headings promoted to `##` so the page gets anchors and a right-hand TOC, absolute `docs.optimism.io` links made internal, Notion comment spans stripped, and the timeline table converted to Markdown. No wording was changed.

Suggestions from the docs review are listed below as **suggestions only** — none are applied.

Opened as a **draft**: the body carries two `TBC` dates.

## Files changed

| File | Change |
|---|---|
| `notices/preconfirmation-architecture-transition.mdx` | New notice page (reviewed draft, verbatim). |
| `docs.json` | Adds the page to `Network Notices` → `Operations`, after `notices/subblocks`. |
| `notices/index.mdx` | Adds the matching card under `## Operations`, per that page's maintenance comment. |
| `op-stack/features/subblocks.mdx` | Existing Flashblocks warning now links to this notice. |
| `chain-operators/guides/features/subblocks-guide.mdx` | Existing Flashblocks warning now links to this notice. |

## Suggestions (not applied — content owner's call)

1. **`do not need to change` may send app developers past a required audit.** The Summary says applications "do not need to change." The sibling [Subblocks notice](https://docs.optimism.io/notices/subblocks) has an **Action required** section instructing teams to audit integrations for reads of `state_root`, `block_hash`, `withdrawals_root`, and `withdrawals`, and the explainer notes such a read fails *silently*. The "What is not changing" bullet does mention the zeroed values, but a reader who stops at the Summary gets a clean "no action." Suggest scoping the Summary sentence to this transition specifically, so it does not read as clearing the outstanding audit.

2. **Two `TBC` rows will publish to a live docs page.** "End of September 2026 — TBC" and "October 31 / November 30, 2026 — TBC". The second is an undecided either/or rather than a target. The sibling notice's precedent for soft dates is a single date plus "Both dates are targets and may move." Suggest either resolving the dates before merge or replacing the either/or with "To be announced."

3. **"Partnership Lead" appears nowhere else in public docs** (0 other occurrences). The established pattern is `[contact the OP Enterprise team](https://optimism.io/learn-more)`, used in the chain-operator Subblocks guide. Suggest matching it so external readers have a working route.

4. **Title case vs house sentence case.** Every other notice uses sentence case (`Specialized op-node topology with light nodes`, `Subblocks: 200 ms interval and stream payload changes`). This page keeps `Preconfirmation Architecture Transition` as reviewed. Flagging only for consistency.

5. **The page reads as a first announcement, but the position is already published.** The Subblocks explainer already says "OP Labs offers **no support** for it. It may stop working at a future fork," and the chain-operator guide says "Flashblocks are no longer officially supported on OP Stack chains." What this notice genuinely adds is the wind-down shape and dates. A sentence acknowledging the existing position would stop readers wondering which of the three pages is authoritative.

6. **`notices/subblocks.mdx` is now inconsistent with this page.** It still calls August 17 and August 31 "targets" that "may move"; this page marks both **Completed**. Deliberately not edited here — changing another live notice's timeline needs its own confirmation. Worth a follow-up PR.

## Out of scope

- **OP Enterprise migration mechanics** — private registry, per-account scope, migration scheduling. Those live in the partner comms, not public docs.
- **Archiving.** No existing notice is superseded.
- **Editing `notices/subblocks.mdx`** — see suggestion 6.

## Test plan

- [x] `lint_draft.py`: 0 issues, 2/2 internal links resolved, 0 render breaks.
- [x] `check_snippets.py`: no code blocks to check.
- [x] `pnpm lint:nav`: OK — 428 pages on disk, 409 distinct nav entries.
- [x] `docs.json` parses as valid JSON.
- [x] `mint dev` renders the page and the updated sidebar.
- [x] `TBC` dates resolved, or an explicit decision to ship with them.
- [ ] Content owner rules on the 6 suggestions above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)