### PR TITLE
docs: Correct super-root bond comment

### DIFF
--- a/docs/public-docs/chain-operators/tutorials/upgrade-chain-to-super-roots.mdx
+++ b/docs/public-docs/chain-operators/tutorials/upgrade-chain-to-super-roots.mdx
@@ -166,7 +166,7 @@ chainId = <chain id>
 # or not interop is enabled or scheduled on the chain.
 cannonKonaPrestate = "0x<kona-interop super prestate>"
 expectedValidationErrors = ""   # fill in after the dry run
-initBond = 80000000000000000    # 0.8 ether, applied to `SUPER_CANNON_KONA` games; the template always forces SUPER_PERMISSIONED to 0
+initBond = 80000000000000000    # 0.08 ether, applied to `SUPER_CANNON_KONA` games; the template always forces SUPER_PERMISSIONED to 0
 startingRespectedGameType = <9 or 5>   # 9 permissionless, 5 permissioned
 
 # Pending template extension — see the "Generate the Starting Anchor Super Root" section.


### PR DESCRIPTION
The tutorial uses `80000000000000000` wei for `initBond`, but its inline comment says `0.8 ether`.

The value equals `0.08 ether`. It matches the `SUPER_CANNON_KONA` bond described earlier.

This correction prevents operators from misreading the required bond amount. It does not change executable behavior.