### PR TITLE
docs: remove stale op-supervisor entry from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,6 @@ The Optimism Immunefi program offers up to $2,000,042 for in-scope critical vuln
 ├── <a href="./op-preimage">op-preimage</a>: Go bindings for Preimage Oracle
 ├── <a href="./op-proposer">op-proposer</a>: L2-Output Submitter, submits proposals to L1
 ├── <a href="./op-service">op-service</a>: Common codebase utilities
-├── <a href="./op-supervisor">op-supervisor</a>: Service to monitor chains and determine cross-chain message safety
 ├── <a href="./op-sync-tester">op-sync-tester</a>: Sync testing utilities
 ├── <a href="./op-test-sequencer">op-test-sequencer</a>: Test sequencer for development
 ├── <a href="./op-up">op-up</a>: Deployment and management utilities


### PR DESCRIPTION
## Summary
README Directory Structure still links to `./op-supervisor`, but that package was removed from the tree (`chore: remove unused op-supervisor packages` #21369). The path 404s on develop tip. `op-interop-mon` is already listed for interop monitoring.

## Repro
```bash
TIP=e7df4d218da2ddfe0a928936adc50c733bea0d15
gh api repos/ethereum-optimism/optimism/contents/op-supervisor?ref=$TIP   # Not Found
rg -n 'op-supervisor' <(curl -sL https://raw.githubusercontent.com/ethereum-optimism/optimism/$TIP/README.md)
```

## Change
Delete the stale Directory Structure line for `op-supervisor`.
