### PR TITLE
contracts-bedrock: git-ignore foundry.lock

### DIFF
--- a/packages/contracts-bedrock/.gitignore
+++ b/packages/contracts-bedrock/.gitignore
@@ -5,6 +5,7 @@ cache
 broadcast
 kout-proofs
 test/kontrol/logs
+foundry.lock
 
 # Metrics
 coverage.out


### PR DESCRIPTION
Foundry 1.7.1+ writes a `foundry.lock` recording the resolved revision of each git dependency. The repo pins forge 1.2.3 via mise, which neither writes nor reads it — so the file only appears for developers running a newer foundry from their own PATH, where it shows up as untracked noise. It has already been committed by accident: caught in review on #22216, and a tracked copy currently sits on `jm/glamsterdam-test` (never on `develop`).

Dependency revisions here are pinned by the git submodule gitlinks, which CI installs via `git submodule update`, so a bump stays visible in a PR diff as a gitlink SHA change. Tracking the lockfile would add a second source of truth that nothing reads or enforces.

No effect on CI or on anyone using the pinned toolchain.

If the forge pin is ever raised to 1.7+, revisit this: `just install` runs `forge install` (`packages/contracts-bedrock/justfile:7`), so the file would then be generated for everyone and consumed by forge — and a gitignore entry can silently swallow an intended commit.

Verified by generating the file with `~/.foundry/bin/forge install` (1.7.1) and confirming `git status` stays clean; the pinned 1.2.3 does not produce it under `install`, `build`, `test`, `config`, `remappings`, `update`, or `soldeer update`.

Reviews: security review run (APPROVE, no findings). No code review agent triggers matched — no Go, Rust, Solidity, or CI-config changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0112mnFMqeazCLxKZ8orqEBT