### PR TITLE
kona-sp1: embed the build commit in the guest ELFs

### DIFF
--- a/.circleci/continue/rust-e2e.yml
+++ b/.circleci/continue/rust-e2e.yml
@@ -301,6 +301,28 @@ jobs:
           # acceptance tests with stub artifacts.
           name: Check vkeys manifest names expected by consumers
           command: grep -q '^super-aggregation = "0x' rust/kona/sp1/elf/vkeys.toml
+      - run:
+          # The build recipe checks each ELF against the commit it injected; this pins that
+          # commit to the one under test. Scans permissively so a marker reading `unknown`
+          # reports as `unknown` rather than as a dropped literal.
+          name: Check guest ELFs embed the build commit
+          command: |
+            set -euo pipefail
+            EXPECTED=$(git rev-parse HEAD)
+            for ELF in super-range-elf super-aggregation-elf; do
+              PATH_TO_ELF="rust/kona/sp1/elf/${ELF}"
+              set +e
+              FOUND=$(grep -m1 -aoE 'KONA_SP1_BUILD\{git_sha=[^}]*\}' "${PATH_TO_ELF}")
+              RC=$?
+              set -e
+              [ "${RC}" -le 1 ] || { echo "ERROR: grep failed on ${PATH_TO_ELF} (exit ${RC})" >&2; exit 1; }
+              FOUND=${FOUND%%$'\n'*}
+              if [ "${FOUND}" != "KONA_SP1_BUILD{git_sha=${EXPECTED}}" ]; then
+                echo "ERROR: ${ELF} build marker is '${FOUND}'; expected KONA_SP1_BUILD{git_sha=${EXPECTED}}" >&2
+                exit 1
+              fi
+              echo "${ELF}: ${FOUND}"
+            done
       - store_artifacts:
           path: rust/kona/sp1/elf
       - persist_to_workspace:

--- a/.circleci/continue/rust-e2e.yml
+++ b/.circleci/continue/rust-e2e.yml
@@ -312,13 +312,13 @@ jobs:
             for ELF in super-range-elf super-aggregation-elf; do
               PATH_TO_ELF="rust/kona/sp1/elf/${ELF}"
               set +e
-              FOUND=$(grep -m1 -aoE 'KONA_SP1_BUILD\{git_sha=[^}]*\}' "${PATH_TO_ELF}")
+              FOUND=$(grep -aoE 'KONA_SP1_BUILD\{git_sha=[0-9A-Za-z._-]*\}' "${PATH_TO_ELF}" | sort -u)
               RC=$?
               set -e
               [ "${RC}" -le 1 ] || { echo "ERROR: grep failed on ${PATH_TO_ELF} (exit ${RC})" >&2; exit 1; }
-              FOUND=${FOUND%%$'\n'*}
               if [ "${FOUND}" != "KONA_SP1_BUILD{git_sha=${EXPECTED}}" ]; then
-                echo "ERROR: ${ELF} build marker is '${FOUND}'; expected KONA_SP1_BUILD{git_sha=${EXPECTED}}" >&2
+                echo "ERROR: ${ELF} build markers: ${FOUND:-<none>}" >&2
+                echo "       expected exactly KONA_SP1_BUILD{git_sha=${EXPECTED}}" >&2
                 exit 1
               fi
               echo "${ELF}: ${FOUND}"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -7600,6 +7600,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "kona-sp1-build-info"
+version = "0.0.1"
+
+[[package]]
 name = "kona-sp1-client-utils"
 version = "0.0.1"
 dependencies = [

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -20,6 +20,7 @@ members = [
   "kona/crates/providers/*",
   "kona/crates/utilities/*",
   "kona/examples/*",
+  "kona/sp1/crates/build-info",
   "kona/sp1/crates/client",
   "kona/sp1/crates/elfs",
   "kona/sp1/crates/ethereum/client",

--- a/rust/kona/sp1/README.md
+++ b/rust/kona/sp1/README.md
@@ -23,6 +23,7 @@ zkVM programs that execute inside the SP1 prover:
 
 Supporting libraries for the SP1 fault proof system:
 
+- **`build-info`**: Compile-time build marker embedding the monorepo commit into both guests
 - **`client`**: Client-side utilities and types for witness execution in the zkVM
 - **`elfs`**: Runtime loading of compiled ELF binaries
 - **`ethereum/client`**: Ethereum-specific client-side data availability utilities
@@ -58,6 +59,34 @@ artifacts at runtime from `KONA_SP1_ELF_DIR`; a missing or empty artifact fails 
 infrastructure error. Release automation will eventually pin per-version vkeys from the generated
 manifest into `superchain-registry/validation/standard/standard-prestates.toml` and verify
 reproducible builds.
+
+#### Build provenance
+
+Both guests embed the commit they were built from, so a guest ELF identifies its own source
+without a manifest, a lookup table, or executing it:
+
+```bash
+grep -aoE 'KONA_SP1_BUILD\{git_sha=[^}]*\}' elf/super-aggregation-elf
+```
+
+The guests also print the marker at startup, which surfaces wherever the executor runs it —
+`kona-sp1-super-range-executor` locally and in the acceptance smoke tests, where a bare
+`println!` arrives as a WARN `Invalid JSON` line carrying the marker. Proving on the Succinct
+network sends guest output to the remote prover, so the ELF scan is the reliable path there.
+
+The commit is part of the compiled image, so it is part of the vkey: two builds from different
+commits produce different vkeys even when the program logic is identical. Range proofs are
+verified against the `SUPER_RANGE_VKEY` embedded in `super-aggregation`, so a range prover and an
+aggregator must come from the same commit, not merely the same code. The marker is recoverable,
+not attested: it records what an honest build embedded and proves nothing against a rewritten
+artifact.
+
+`just build-elfs` takes the commit from `git rev-parse HEAD`, resolved once per build so both
+guests agree. It appends `-dirty` when tracked files are modified and `-custom` for a
+`KONA_CUSTOM_CONFIGS_DIR` build, whose guest is compiled from configs the commit does not
+describe. Set `KONA_SP1_GIT_SHA` to override it. Builds outside the justfile record `unknown`.
+Each build recipe checks its own ELF; CI (`kona-build-sp1-elfs`) additionally pins the natively
+built ELFs to the commit under test.
 
 Custom chains and devnets can compile separate SP1 artifacts with custom kona
 registry inputs:

--- a/rust/kona/sp1/README.md
+++ b/rust/kona/sp1/README.md
@@ -66,7 +66,7 @@ Both guests embed the commit they were built from, so a guest ELF identifies its
 without a manifest, a lookup table, or executing it:
 
 ```bash
-grep -aoE 'KONA_SP1_BUILD\{git_sha=[^}]*\}' elf/super-aggregation-elf
+grep -aoE 'KONA_SP1_BUILD\{git_sha=[0-9A-Za-z._-]*\}' elf/super-aggregation-elf | sort -u
 ```
 
 The guests also print the marker at startup, which surfaces wherever the executor runs it —
@@ -84,7 +84,7 @@ artifact.
 `just build-elfs` takes the commit from `git rev-parse HEAD`, resolved once per build so both
 guests agree. It appends `-dirty` when tracked files are modified and `-custom` for a
 `KONA_CUSTOM_CONFIGS_DIR` build, whose guest is compiled from configs the commit does not
-describe. Set `KONA_SP1_GIT_SHA` to override it. Builds outside the justfile record `unknown`.
+describe. Builds outside the justfile record `unknown`.
 Each build recipe checks its own ELF; CI (`kona-build-sp1-elfs`) additionally pins the natively
 built ELFs to the commit under test.
 

--- a/rust/kona/sp1/crates/build-info/Cargo.toml
+++ b/rust/kona/sp1/crates/build-info/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "kona-sp1-build-info"
+version = "0.0.1"
+publish = false
+license.workspace = true
+edition.workspace = true
+
+[lints]
+workspace = true

--- a/rust/kona/sp1/crates/build-info/build.rs
+++ b/rust/kona/sp1/crates/build-info/build.rs
@@ -1,0 +1,29 @@
+//! Resolves the monorepo commit to embed in the SP1 guests.
+//!
+//! The commit arrives on two channels because `cargo prove build --docker` forwards neither the
+//! host environment nor `.git`: an environment variable for native builds, and a `--cfg` rustflag
+//! for Docker builds. Same dual channel `kona_custom_configs_dir` uses to reach `kona-registry`.
+
+use std::env;
+
+#[path = "src/sha.rs"]
+mod sha;
+
+fn main() {
+    println!("cargo:rerun-if-env-changed=KONA_SP1_GIT_SHA");
+    println!("cargo:rerun-if-env-changed=CARGO_CFG_KONA_SP1_GIT_SHA");
+
+    let sha = env::var("KONA_SP1_GIT_SHA")
+        .ok()
+        .filter(|sha| !sha.is_empty())
+        .or_else(|| env::var("CARGO_CFG_KONA_SP1_GIT_SHA").ok())
+        .unwrap_or_else(|| sha::UNKNOWN.to_string());
+
+    assert!(
+        sha::is_valid(&sha),
+        "KONA_SP1_GIT_SHA (or --cfg kona_sp1_git_sha=\"...\") must be a 40-character lowercase \
+         hex sha, optionally suffixed `-dirty` and `-custom`; got {sha:?}"
+    );
+
+    println!("cargo:rustc-env=KONA_SP1_GIT_SHA={sha}");
+}

--- a/rust/kona/sp1/crates/build-info/src/lib.rs
+++ b/rust/kona/sp1/crates/build-info/src/lib.rs
@@ -26,7 +26,7 @@ mod tests {
 
     #[test]
     fn accepts_every_shape_the_build_can_produce() {
-        let hex = "0".repeat(40);
+        let hex = "0af3".repeat(10);
         assert!(sha::is_valid("unknown"));
         assert!(sha::is_valid(&hex));
         assert!(sha::is_valid(&format!("{hex}-dirty")));

--- a/rust/kona/sp1/crates/build-info/src/lib.rs
+++ b/rust/kona/sp1/crates/build-info/src/lib.rs
@@ -1,0 +1,46 @@
+//! Build provenance embedded in the SP1 guest ELFs.
+
+#[cfg(test)]
+mod sha;
+
+/// The monorepo commit this guest was built from, recoverable from a guest ELF with
+/// `grep -aoE 'KONA_SP1_BUILD\{git_sha=[^}]*\}' <elf>`.
+///
+/// [`concat!`] keeps the delimiters and the sha in one `.rodata` literal; a record assembled from
+/// several literals is not guaranteed to land contiguously.
+pub const BUILD_MARKER: &str = concat!("KONA_SP1_BUILD{git_sha=", env!("KONA_SP1_GIT_SHA"), "}");
+
+#[cfg(test)]
+mod tests {
+    use super::{BUILD_MARKER, sha};
+
+    /// Pins the marker against the shape the ELF scanners in the justfile and CI accept.
+    #[test]
+    fn marker_payload_is_a_shape_the_scanners_accept() {
+        let payload = BUILD_MARKER
+            .strip_prefix("KONA_SP1_BUILD{git_sha=")
+            .and_then(|rest| rest.strip_suffix('}'))
+            .expect("marker is delimited");
+        assert!(sha::is_valid(payload), "marker payload {payload:?} is not an accepted shape");
+    }
+
+    #[test]
+    fn accepts_every_shape_the_build_can_produce() {
+        let hex = "0".repeat(40);
+        assert!(sha::is_valid("unknown"));
+        assert!(sha::is_valid(&hex));
+        assert!(sha::is_valid(&format!("{hex}-dirty")));
+        assert!(sha::is_valid(&format!("{hex}-custom")));
+        assert!(sha::is_valid(&format!("{hex}-dirty-custom")));
+    }
+
+    #[test]
+    fn rejects_shapes_the_scanners_would_miss() {
+        assert!(!sha::is_valid(""));
+        assert!(!sha::is_valid("-dirty"));
+        assert!(!sha::is_valid(&"0".repeat(39)));
+        assert!(!sha::is_valid(&"0".repeat(41)));
+        assert!(!sha::is_valid(&"A".repeat(40)));
+        assert!(!sha::is_valid(&format!("{}-custom-dirty", "0".repeat(40))));
+    }
+}

--- a/rust/kona/sp1/crates/build-info/src/sha.rs
+++ b/rust/kona/sp1/crates/build-info/src/sha.rs
@@ -1,0 +1,17 @@
+//! Shape of the embedded commit value. Shared by `build.rs` and the crate's tests via `#[path]`,
+//! the same arrangement `kona-sp1-range-vkeys` uses for its codec.
+
+/// Recorded when no commit was injected, so plain `cargo build`/`cargo test` stay buildable.
+pub(crate) const UNKNOWN: &str = "unknown";
+
+/// Accepts [`UNKNOWN`], or a 40-character lowercase hex sha carrying the optional `-dirty` and
+/// `-custom` suffixes in that order. Uppercase is rejected: `git rev-parse` emits lowercase, and
+/// the scanners in CI and the README match only lowercase.
+pub(crate) fn is_valid(sha: &str) -> bool {
+    if sha == UNKNOWN {
+        return true;
+    }
+    let rest = sha.strip_suffix("-custom").unwrap_or(sha);
+    let digits = rest.strip_suffix("-dirty").unwrap_or(rest);
+    digits.len() == 40 && digits.bytes().all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'f'))
+}

--- a/rust/kona/sp1/justfile
+++ b/rust/kona/sp1/justfile
@@ -15,6 +15,7 @@ build-super-range-executor:
 build-elfs:
     #!/usr/bin/env bash
     set -euo pipefail
+    export KONA_SP1_GIT_SHA="${KONA_SP1_GIT_SHA:-$(just _git-sha)}"
     m=elf/vkeys.toml
     just _vkeys-header > "$m"
     just build-super-range-elf
@@ -75,11 +76,20 @@ _build-elf NAME MODE:
       fi
     fi
 
+    # Commit for kona-sp1-build-info's marker, resolved by the calling recipe so both guests
+    # carry the same one; see crates/build-info/build.rs for the two channels.
+    : "${KONA_SP1_GIT_SHA:?resolve it via build-elfs or build-elfs-native}"
+    export KONA_SP1_GIT_SHA
+
     # --locked appears to be a no-op in upstream cargo-prove (regenerates the lock anyway).
     args=(--locked --ignore-rust-version --elf-name "{{NAME}}-elf" --workspace-directory "$root" --output-directory "{{justfile_directory()}}/elf")
     if [[ "{{MODE}}" == "docker" ]]; then
       mkdir -p "{{justfile_directory()}}/programs/target/elf-compilation/docker"
       args=(--docker --tag "{{SP1_TAG}}" "${args[@]}")
+      args+=(
+        --rustflags=--cfg
+        "--rustflags=kona_sp1_git_sha=\"${KONA_SP1_GIT_SHA}\""
+      )
       if [[ -n "${docker_configs_dir:-}" ]]; then
         args+=(
           --rustflags=--cfg
@@ -93,12 +103,38 @@ _build-elf NAME MODE:
     cd "{{justfile_directory()}}/programs/{{NAME}}"
     cargo prove build "${args[@]}"
 
+    # Nothing fails at compile time if the marker literal is dropped or an injection channel
+    # stops working, so check the artifact on every build path rather than only the one CI runs.
+    elf="{{justfile_directory()}}/elf/{{NAME}}-elf"
+    found=$(grep -m1 -aoE 'KONA_SP1_BUILD\{git_sha=[^}]*\}' "$elf" || true)
+    found=${found%%$'\n'*}
+    if [[ "$found" != "KONA_SP1_BUILD{git_sha=${KONA_SP1_GIT_SHA}}" ]]; then
+      echo "ERROR: {{NAME}}-elf carries build marker '${found}'" >&2
+      echo "       expected KONA_SP1_BUILD{git_sha=${KONA_SP1_GIT_SHA}}" >&2
+      exit 1
+    fi
+
+# Commit recorded in the guest build marker. Resolved once per build so both guests agree.
+# `-custom` marks a KONA_CUSTOM_CONFIGS_DIR build: those compile chain configs from outside the
+# repo into the guest, so the commit alone does not describe the artifact.
+[private]
+_git-sha:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    root="$(cd "{{justfile_directory()}}/../../.." && pwd)"
+    sha="$(git -C "$root" rev-parse HEAD)"
+    git -C "$root" diff --quiet HEAD || sha="${sha}-dirty"
+    [[ -z "${KONA_CUSTOM_CONFIGS_DIR:-}" ]] || sha="${sha}-custom"
+    echo "$sha"
+
 [private]
 _vkeys-header:
     #!/usr/bin/env bash
+    set -euo pipefail
     echo '# Generated SP1 guest verification-key hashes (bytes32).'
     echo '# Regenerate on linux/amd64 via "just build-elfs".'
     echo 'sp1_toolchain_tag = "{{SP1_TAG}}"'
+    echo "git_sha = \"${KONA_SP1_GIT_SHA:-$(just _git-sha)}\""
     echo ''
 
 [private]
@@ -113,6 +149,7 @@ _append-vkey NAME MANIFEST:
 build-elfs-native:
     #!/usr/bin/env bash
     set -euo pipefail
+    export KONA_SP1_GIT_SHA="${KONA_SP1_GIT_SHA:-$(just _git-sha)}"
     m=elf/vkeys.toml
     just _vkeys-header > "$m"
     for name in super-range super-aggregation; do

--- a/rust/kona/sp1/justfile
+++ b/rust/kona/sp1/justfile
@@ -15,7 +15,7 @@ build-super-range-executor:
 build-elfs:
     #!/usr/bin/env bash
     set -euo pipefail
-    export KONA_SP1_GIT_SHA="${KONA_SP1_GIT_SHA:-$(just _git-sha)}"
+    export KONA_SP1_GIT_SHA="$(just _git-sha)"
     m=elf/vkeys.toml
     just _vkeys-header > "$m"
     just build-super-range-elf
@@ -105,12 +105,13 @@ _build-elf NAME MODE:
 
     # Nothing fails at compile time if the marker literal is dropped or an injection channel
     # stops working, so check the artifact on every build path rather than only the one CI runs.
+    # Every distinct marker, so a second conflicting one fails rather than hiding behind the
+    # first. The character class excludes control bytes, which would otherwise reach a terminal.
     elf="{{justfile_directory()}}/elf/{{NAME}}-elf"
-    found=$(grep -m1 -aoE 'KONA_SP1_BUILD\{git_sha=[^}]*\}' "$elf" || true)
-    found=${found%%$'\n'*}
-    if [[ "$found" != "KONA_SP1_BUILD{git_sha=${KONA_SP1_GIT_SHA}}" ]]; then
-      echo "ERROR: {{NAME}}-elf carries build marker '${found}'" >&2
-      echo "       expected KONA_SP1_BUILD{git_sha=${KONA_SP1_GIT_SHA}}" >&2
+    markers=$(grep -aoE 'KONA_SP1_BUILD\{git_sha=[0-9A-Za-z._-]*\}' "$elf" | sort -u || true)
+    if [[ "$markers" != "KONA_SP1_BUILD{git_sha=${KONA_SP1_GIT_SHA}}" ]]; then
+      echo "ERROR: {{NAME}}-elf build markers: ${markers:-<none>}" >&2
+      echo "       expected exactly KONA_SP1_BUILD{git_sha=${KONA_SP1_GIT_SHA}}" >&2
       exit 1
     fi
 
@@ -149,7 +150,7 @@ _append-vkey NAME MANIFEST:
 build-elfs-native:
     #!/usr/bin/env bash
     set -euo pipefail
-    export KONA_SP1_GIT_SHA="${KONA_SP1_GIT_SHA:-$(just _git-sha)}"
+    export KONA_SP1_GIT_SHA="$(just _git-sha)"
     m=elf/vkeys.toml
     just _vkeys-header > "$m"
     for name in super-range super-aggregation; do

--- a/rust/kona/sp1/programs/Cargo.lock
+++ b/rust/kona/sp1/programs/Cargo.lock
@@ -1815,6 +1815,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "kona-sp1-build-info"
+version = "0.0.1"
+
+[[package]]
 name = "kona-sp1-client-utils"
 version = "0.0.1"
 dependencies = [
@@ -1883,6 +1887,7 @@ name = "kona-sp1-super-aggregation"
 version = "0.0.1"
 dependencies = [
  "bincode",
+ "kona-sp1-build-info",
  "kona-sp1-client-utils",
  "kona-sp1-range-vkeys",
  "sha2",
@@ -1896,6 +1901,7 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "kona-proof",
+ "kona-sp1-build-info",
  "kona-sp1-client-utils",
  "kona-sp1-ethereum-client-utils",
  "revm",

--- a/rust/kona/sp1/programs/Cargo.toml
+++ b/rust/kona/sp1/programs/Cargo.toml
@@ -117,6 +117,7 @@ too_long_first_doc_paragraph = "allow"
 [workspace.dependencies]
 # Guest path dependencies. Paths are relative to rust/kona/sp1/programs.
 kona-proof = { path = "../../crates/proof/proof", version = "0.3.0", default-features = false }
+kona-sp1-build-info = { path = "../crates/build-info" }
 kona-sp1-client-utils = { path = "../crates/client" }
 kona-sp1-ethereum-client-utils = { path = "../crates/ethereum/client" }
 kona-sp1-range-vkeys = { path = "../crates/range-vkeys" }

--- a/rust/kona/sp1/programs/super-aggregation/Cargo.toml
+++ b/rust/kona/sp1/programs/super-aggregation/Cargo.toml
@@ -10,6 +10,7 @@ repository.workspace = true
 
 [dependencies]
 bincode.workspace = true
+kona-sp1-build-info.workspace = true
 kona-sp1-client-utils.workspace = true
 kona-sp1-range-vkeys.workspace = true
 sha2.workspace = true

--- a/rust/kona/sp1/programs/super-aggregation/src/main.rs
+++ b/rust/kona/sp1/programs/super-aggregation/src/main.rs
@@ -12,6 +12,8 @@ use sha2::{Digest, Sha256};
 
 /// Entrypoint to the super-aggregation program.
 pub fn main() {
+    println!("{}", kona_sp1_build_info::BUILD_MARKER);
+
     let inputs = sp1_zkvm::io::read::<SuperAggregationInputs>();
     let public_values = aggregate(&inputs, sp1_lib::verify::verify_sp1_proof)
         .expect("invalid super-aggregation inputs");

--- a/rust/kona/sp1/programs/super-range/Cargo.toml
+++ b/rust/kona/sp1/programs/super-range/Cargo.toml
@@ -11,6 +11,7 @@ repository.workspace = true
 [dependencies]
 anyhow.workspace = true
 kona-proof.workspace = true
+kona-sp1-build-info.workspace = true
 kona-sp1-client-utils.workspace = true
 kona-sp1-ethereum-client-utils.workspace = true
 

--- a/rust/kona/sp1/programs/super-range/src/main.rs
+++ b/rust/kona/sp1/programs/super-range/src/main.rs
@@ -19,6 +19,8 @@ use rkyv::rancor::Error as RkyvError;
 
 /// Entrypoint to the unified super-root range program.
 pub fn main() {
+    println!("{}", kona_sp1_build_info::BUILD_MARKER);
+
     let inputs = sp1_zkvm::io::read::<SuperInteropInputs>();
     let outputs = kona_proof::block_on(run(inputs)).expect("super interop failed");
     sp1_zkvm::io::commit(&outputs);


### PR DESCRIPTION
Given a guest ELF and nothing else, there was no way to tell which commit built it. Whether it was reconstructed from tags, CI logs, or memory. Both guests now carry the commit as a single `.rodata` literal:

```bash
grep -aoE 'KONA_SP1_BUILD\{git_sha=[0-9A-Za-z._-]*\}' elf/super-aggregation-elf
```

Which are also printed at startup of both programs. We can also scan the ELF for the literal to determine the git commit associated with the prestate.

The commit reaches the compiler as an env var natively and a `--cfg` rustflag under Docker, since `cargo prove build --docker` forwards neither the environment nor `.git`. It's resolved once per build so both guests agree, and carries `-dirty` for a modified checkout or `-custom` for a `KONA_CUSTOM_CONFIGS_DIR` build, whose guest is compiled from configs the commit doesn't describe. Each recipe verifies its own ELF after building; CI also pins the native ELFs to `HEAD`.

Because the marker is in the compiled image it's part of the vkey, so every commit now yields new vkeys and a prestate pair to publish. Nothing is pinned — `elf/` and `vkeys.toml` are gitignored and read dynamically. The marker is recoverable, not attested: it proves nothing against a rewritten artifact.

### Testing

Built the real zkVM ELFs and read the marker back; exercised both injection channels, including `--cfg` with the env var unset. The checks reject as well as accept — a pre-change ELF and an `unknown` fallback are both refused. Unit tests cover every shape the build emits.

Not covered: a full `cargo prove build --docker` run (CI only builds native, so the in-recipe check is what guards that path), and linux/amd64. The `println!` is the first stdout use in the aggregation guest, costing 8.4 KB (~2%).