### PR TITLE
ci: rightsize Kona acceptance executors

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -1930,6 +1930,10 @@ jobs:
         description: Timeout for when CircleCI kills the job if there's no output
         type: string
         default: 30m
+      resource_class:
+        description: Docker resource class for this acceptance job
+        type: string
+        default: 2xlarge+.gen2
       parallelism:
         description: Number of machines to distribute the tests across
         type: integer
@@ -1941,7 +1945,7 @@ jobs:
         default: ""
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
-    resource_class: 2xlarge+.gen2
+    resource_class: <<parameters.resource_class>>
     parallelism: <<parameters.parallelism>>
     steps:
       # apt-install needs the working tree, so it runs after checkout.
@@ -2591,6 +2595,8 @@ workflows:
             - prep-go-modules
           context:
             - circleci-repo-readonly-authenticated-github-token
+      # OP Node retains 20 vCPU / 40 GiB after a 38.5 GiB observed peak; Kona trials
+      # 16 vCPU / 32 GiB after a 21.3 GiB observed peak.
       # IN-MEMORY - op-node/op-reth
       - op-acceptance-tests:
           name: memory-all-opn-op-reth-<<matrix.l1_fork>>
@@ -2622,6 +2628,7 @@ workflows:
               l1_fork: *acceptance_l1_forks
           l2_cl_kind: kona-node
           l2_el_kind: op-reth
+          resource_class: 2xlarge.gen2
           parallelism: 8
           acceptance_test_jobs: "8"
           no_output_timeout: 120m


### PR DESCRIPTION
Across 263 logical runs from 2026-09-03 through 2026-09-10, `memory-all-kona-op-reth-fusaka` averaged 2.435 CPU cores and 2.91 GiB memory on a 20-vCPU / 40-GiB executor, with a 21.32 GiB peak and 2,183,696 credits charged (8,303 credits/run). This trials only that Kona job on Docker `2xlarge.gen2` (16 vCPU / 32 GiB) instead of `2xlarge+.gen2` (20 vCPU / 40 GiB); the OP Node acceptance job retains the larger default because its recent peak was 38.5 GiB.

The acceptance suite, CircleCI parallelism 8, internal `ACCEPTANCE_TEST_JOBS=8`, test selection, timeouts, dependencies, environment, caches, and `ci-gate` wiring are preserved. The executor rate falls from 120 to 96 credits/minute (20%); at observed volume and flat runtime, the expected saving is about 436,739 credits/week (~$262/week or ~$1.1k/month at $0.0006/credit). The trial breaks even at 1.25x baseline duration and should be rejected at or above that slowdown.

Related: https://github.com/ethereum-optimism/core-team/issues/3094

Local validation:

- Merged continuation config generated successfully.
- Merged and setup configs validate with CircleCI CLI 0.1.38646 using its current `--org-slug` / `CIRCLECI_CLI_TOKEN` equivalents.
- Processed continuation with `c-run_main=true`: Kona resolves to `2xlarge.gen2`; OP Node resolves to `2xlarge+.gen2`; both retain parallelism 8, internal concurrency 8, and direct `ci-gate` dependencies.
- Decision-tree tests: 21 passed, 0 failed under Homebrew Bash 5.3.9.
- `git diff --check` passed.
- CI-config review agent: no findings.

Hosted CI should reject or roll back this sizing if the Kona job regresses to at least 1.25x baseline execution time, hits OOM/process kills/timeouts/devstack starvation, loses test records or shards, shows cadence/reorg/recovery regressions, or approaches the 32 GiB ceiling (investigate above 28 GiB).
