### PR TITLE
ci: rightsize cargo-hack executors

### DIFF
--- a/.circleci/continue/rust-ci.yml
+++ b/.circleci/continue/rust-ci.yml
@@ -423,7 +423,8 @@ jobs:
         default: 1
     docker:
       - image: <<pipeline.parameters.c-rust_base_image>>
-    resource_class: xlarge.gen2
+    # Trial one tier down after current V3 telemetry peaked at 7.0 GiB across 141 runs.
+    resource_class: large.gen2
     parallelism: <<parameters.parallelism>>
     steps:
       - utils/checkout-with-mise:


### PR DESCRIPTION
CircleCI V3 telemetry shows that the available 141 recent `rust-cargo-hack` runs averaged 2.47 GiB and peaked at 6.96 GiB on Docker `xlarge.gen2` (8 vCPU / 16 GiB). CPU averaged 2.76 cores, with p90 4.94 and peak 7.73 cores. This draft trials `large.gen2` (4 vCPU / 8 GiB) while preserving all 10 partitions, both Cargo-hack checks, caches, timeouts, and the `required-rust-ci` gate.

The executor rate falls from 48 to 24 credits/min, a 50% per-minute reduction with a 2x duration break-even. The 38 runs returned for September 3–10 consumed 118,895 credits (3,129/run), so flat duration would save about 59,448 credits over that observed volume. There is no operator or protocol behavior change.

An earlier recommendation reported an 8.5 GiB peak, so this must remain a hosted trial until all ten executors pass without memory pressure and measured execution time and credits are favorable. Investigate memory at or above 7 GiB; revert for any OOM/process kill or execution duration at least 2x baseline, with less than 25% regression preferred. The CI-config review finding about tight memory and CPU margins is accepted and will be resolved with this hosted evidence before review readiness.

Local validation: merged and setup configs validate; processing with `c-run_rust_ci=true` resolves `large.gen2`, parallelism 10, and the direct `required-rust-ci` dependency; the decision-tree suite passes 21/21; `git diff --check` passes.

Related: https://github.com/ethereum-optimism/core-team/issues/3094