### PR TITLE
op-node: prefetch L1 receipts for sequencing

### DIFF
--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -73,6 +73,10 @@ type closableSafeDB interface {
 }
 
 // L1Source provides the necessary L1 blockchain data for the node.
+type l1ReceiptsPrefetcher interface {
+	PrefetchReceipts(blockHash common.Hash)
+}
+
 type L1Source interface {
 	L1BlockRefByLabel(ctx context.Context, label eth.BlockLabel) (eth.L1BlockRef, error)
 	L1BlockRefByNumber(ctx context.Context, num uint64) (eth.L1BlockRef, error)
@@ -338,6 +342,12 @@ func initL1Handlers(cfg *config.Config, node *OpNode) (ethereum.Subscription, et
 	onL1Head := func(ctx context.Context, sig eth.L1BlockRef) {
 		if node.cfg.Tracer != nil {
 			node.cfg.Tracer.OnNewL1Head(ctx, sig)
+		}
+		// Fetch the complete L1 origin data as soon as the head is observed.
+		// Derivation and sequencing share this source, so either consumer will
+		// join the in-flight request or hit the warmed caches.
+		if prefetcher, ok := node.l1Source.(l1ReceiptsPrefetcher); ok {
+			prefetcher.PrefetchReceipts(sig.Hash)
 		}
 		node.l2Driver.SyncDeriver.L1Tracker.OnL1Unsafe(sig)
 		node.l2Driver.StatusTracker.OnL1Unsafe(sig)

--- a/op-service/sources/eth_client.go
+++ b/op-service/sources/eth_client.go
@@ -147,6 +147,10 @@ type EthClient struct {
 	// cache BlockRef by hash
 	// common.Hash -> eth.BlockRef
 	blockRefsCache *caching.LRUCache[common.Hash, eth.BlockRef]
+
+	// Deduplicates the complete block-body and receipt fetch, and permits L1
+	// heads to warm the caches before derivation or sequencing needs them.
+	receiptsFetcher *asyncReceiptsFetcher
 }
 
 var _ apis.EthClient = (*EthClient)(nil)
@@ -163,7 +167,7 @@ func NewEthClient(client client.RPC, log log.Logger, metrics caching.Metrics, co
 	if recProvider.isInnerNil() {
 		return nil, errors.New("failed to establish receipts provider")
 	}
-	return &EthClient{
+	ethClient := &EthClient{
 		client:            client,
 		recProvider:       recProvider,
 		trustRPC:          config.TrustRPC,
@@ -173,7 +177,9 @@ func NewEthClient(client client.RPC, log log.Logger, metrics caching.Metrics, co
 		headersCache:      caching.NewLRUCache[common.Hash, *types.Header](metrics, "headers", config.HeadersCacheSize),
 		payloadsCache:     caching.NewLRUCache[common.Hash, *eth.ExecutionPayloadEnvelope](metrics, "payloads", config.PayloadsCacheSize),
 		blockRefsCache:    caching.NewLRUCache[common.Hash, eth.L1BlockRef](metrics, "blockrefs", config.BlockRefsCacheSize),
-	}, nil
+	}
+	ethClient.receiptsFetcher = newAsyncReceiptsFetcher(ethClient.fetchReceipts)
+	return ethClient, nil
 }
 
 // SubscribeNewHead subscribes to notifications about the current blockchain head on the given channel.
@@ -527,6 +533,25 @@ func (s *EthClient) FetchReceiptsByNumber(ctx context.Context, number uint64) (e
 // It verifies the receipt hash in the block header against the receipt hash of the fetched receipts
 // to ensure that the execution engine did not fail to return any receipts.
 func (s *EthClient) FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, optypes.Receipts, error) {
+	// Tests and specialized users may construct an EthClient directly instead
+	// of using NewEthClient. Keep that unsupported construction pattern working
+	// without an asynchronous fetcher.
+	if s.receiptsFetcher == nil {
+		return s.fetchReceipts(ctx, blockHash)
+	}
+	return s.receiptsFetcher.Fetch(ctx, blockHash)
+}
+
+// PrefetchReceipts starts fetching and validating a block body and its receipts
+// without waiting. A later FetchReceipts call joins the same in-flight request
+// or reads the caches populated by it.
+func (s *EthClient) PrefetchReceipts(blockHash common.Hash) {
+	if s.receiptsFetcher != nil {
+		s.receiptsFetcher.Prefetch(blockHash)
+	}
+}
+
+func (s *EthClient) fetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, optypes.Receipts, error) {
 	// Tx hashes are computed from the raw encodings: decoding the txs into
 	// go-ethereum types would fail on the OP Stack synthetic tx classes of L2
 	// blocks under upstream go-ethereum.
@@ -627,6 +652,9 @@ func (s *EthClient) ReadStorageAt(ctx context.Context, address common.Address, s
 }
 
 func (s *EthClient) Close() {
+	if s.receiptsFetcher != nil {
+		s.receiptsFetcher.Close()
+	}
 	s.client.Close()
 }
 

--- a/op-service/sources/receipts_async.go
+++ b/op-service/sources/receipts_async.go
@@ -1,0 +1,102 @@
+package sources
+
+import (
+	"context"
+	"sync"
+
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type receiptsFetchFn func(context.Context, common.Hash) (eth.BlockInfo, optypes.Receipts, error)
+
+type receiptsRequest struct {
+	done chan struct{}
+	info eth.BlockInfo
+	recs optypes.Receipts
+	err  error
+}
+
+// asyncReceiptsFetcher owns block-receipt fetches independently of callers.
+// Requests for the same block hash share one in-flight fetch. A caller may stop
+// waiting without cancelling the fetch for other callers or future cache users.
+type asyncReceiptsFetcher struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+	fetch  receiptsFetchFn
+
+	mu       sync.Mutex
+	requests map[common.Hash]*receiptsRequest
+	closed   bool
+	wg       sync.WaitGroup
+}
+
+func newAsyncReceiptsFetcher(fetch receiptsFetchFn) *asyncReceiptsFetcher {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &asyncReceiptsFetcher{
+		ctx:      ctx,
+		cancel:   cancel,
+		fetch:    fetch,
+		requests: make(map[common.Hash]*receiptsRequest),
+	}
+}
+
+// Prefetch starts fetching the block and its receipts, if they are not already
+// being fetched. It does not wait for the result.
+func (f *asyncReceiptsFetcher) Prefetch(hash common.Hash) {
+	f.getOrStart(hash)
+}
+
+func (f *asyncReceiptsFetcher) Fetch(ctx context.Context, hash common.Hash) (eth.BlockInfo, optypes.Receipts, error) {
+	req := f.getOrStart(hash)
+	if req == nil {
+		return nil, nil, context.Canceled
+	}
+	select {
+	case <-ctx.Done():
+		return nil, nil, ctx.Err()
+	case <-req.done:
+		return req.info, req.recs, req.err
+	}
+}
+
+func (f *asyncReceiptsFetcher) getOrStart(hash common.Hash) *receiptsRequest {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.closed {
+		return nil
+	}
+	if req, ok := f.requests[hash]; ok {
+		return req
+	}
+	req := &receiptsRequest{done: make(chan struct{})}
+	f.requests[hash] = req
+	f.wg.Add(1)
+	go f.run(hash, req)
+	return req
+}
+
+func (f *asyncReceiptsFetcher) run(hash common.Hash, req *receiptsRequest) {
+	defer f.wg.Done()
+	req.info, req.recs, req.err = f.fetch(f.ctx, hash)
+	close(req.done)
+
+	f.mu.Lock()
+	if f.requests[hash] == req {
+		delete(f.requests, hash)
+	}
+	f.mu.Unlock()
+}
+
+func (f *asyncReceiptsFetcher) Close() {
+	f.mu.Lock()
+	if f.closed {
+		f.mu.Unlock()
+		return
+	}
+	f.closed = true
+	f.cancel()
+	f.mu.Unlock()
+	f.wg.Wait()
+}

--- a/op-service/sources/receipts_async_test.go
+++ b/op-service/sources/receipts_async_test.go
@@ -1,0 +1,115 @@
+package sources
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	optypes "github.com/ethereum-optimism/optimism/op-core/types"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAsyncReceiptsFetcherPrefetchAndFetchShareRequest(t *testing.T) {
+	var calls atomic.Int32
+	started := make(chan struct{})
+	release := make(chan struct{})
+	fetcher := newAsyncReceiptsFetcher(func(ctx context.Context, hash common.Hash) (eth.BlockInfo, optypes.Receipts, error) {
+		calls.Add(1)
+		close(started)
+		select {
+		case <-ctx.Done():
+			return nil, nil, ctx.Err()
+		case <-release:
+			return nil, nil, nil
+		}
+	})
+	defer fetcher.Close()
+
+	hash := common.Hash{0x01}
+	fetcher.Prefetch(hash)
+	<-started
+
+	req := fetcher.getOrStart(hash)
+	require.Same(t, fetcher.requests[hash], req)
+	require.Equal(t, int32(1), calls.Load())
+	close(release)
+	<-req.done
+}
+
+func TestAsyncReceiptsFetcherCallerCancellationDoesNotCancelRequest(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	fetcher := newAsyncReceiptsFetcher(func(ctx context.Context, hash common.Hash) (eth.BlockInfo, optypes.Receipts, error) {
+		close(started)
+		select {
+		case <-ctx.Done():
+			return nil, nil, ctx.Err()
+		case <-release:
+			return nil, nil, nil
+		}
+	})
+	defer fetcher.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	result := make(chan error, 1)
+	go func() {
+		_, _, err := fetcher.Fetch(ctx, common.Hash{0x02})
+		result <- err
+	}()
+	<-started
+	cancel()
+	require.ErrorIs(t, <-result, context.Canceled)
+
+	req := fetcher.getOrStart(common.Hash{0x02})
+	close(release)
+	<-req.done
+}
+
+func TestAsyncReceiptsFetcherRetriesAfterError(t *testing.T) {
+	var calls atomic.Int32
+	testErr := errors.New("test error")
+	fetcher := newAsyncReceiptsFetcher(func(context.Context, common.Hash) (eth.BlockInfo, optypes.Receipts, error) {
+		if calls.Add(1) == 1 {
+			return nil, nil, testErr
+		}
+		return nil, nil, nil
+	})
+	defer fetcher.Close()
+
+	hash := common.Hash{0x03}
+	_, _, err := fetcher.Fetch(context.Background(), hash)
+	require.ErrorIs(t, err, testErr)
+	_, _, err = fetcher.Fetch(context.Background(), hash)
+	require.NoError(t, err)
+	require.Equal(t, int32(2), calls.Load())
+}
+
+func TestAsyncReceiptsFetcherCloseCancelsRequests(t *testing.T) {
+	started := make(chan struct{})
+	fetcher := newAsyncReceiptsFetcher(func(ctx context.Context, hash common.Hash) (eth.BlockInfo, optypes.Receipts, error) {
+		close(started)
+		<-ctx.Done()
+		return nil, nil, ctx.Err()
+	})
+
+	fetcher.Prefetch(common.Hash{0x04})
+	<-started
+
+	closed := make(chan struct{})
+	go func() {
+		fetcher.Close()
+		close(closed)
+	}()
+	select {
+	case <-closed:
+	case <-time.After(time.Second):
+		t.Fatal("fetcher did not close after cancelling its request")
+	}
+
+	_, _, err := fetcher.Fetch(context.Background(), common.Hash{0x04})
+	require.ErrorIs(t, err, context.Canceled)
+}


### PR DESCRIPTION
Light-CL sequencers lose the incidental L1 cache warming provided by derivation, causing full block-body and receipt fetches to consume the build window at L1-origin transitions. This makes L1 origin data preparation explicit and shared across modes: observed heads begin fetching immediately, while derivation and sequencing join the same independently owned request without weakening transaction-root or receipt validation.

Operators should recover the normal EL build budget at origin transitions, at the cost of proactively fetching receipts for each observed L1 head. Closes https://github.com/ethereum-optimism/protocol-team/issues/315.
