### PR TITLE
docs: pin component versions and dates for Upgrade 20

### DIFF
--- a/docs/public-docs/.vale/styles/config/vocabularies/Optimism/accept.txt
+++ b/docs/public-docs/.vale/styles/config/vocabularies/Optimism/accept.txt
@@ -350,6 +350,7 @@ cpu
 crosschain
 crypto
 cryptocurrencies
+cutover
 da_challenge_address
 da_challenge_window
 da_resolve_window
@@ -628,6 +629,7 @@ viem's
 vmdebug
 vmtrace
 vmodule
+wagmi
 websocket
 websockets
 wei

--- a/docs/public-docs/notices/upgrade-20.mdx
+++ b/docs/public-docs/notices/upgrade-20.mdx
@@ -73,6 +73,7 @@ To preserve the two-word `FEE_SCALARS` event payload without requiring a hardfor
 Chain operators must coordinate the L1 contract cutover with the services that propose, challenge, and monitor Fault Proofs.
 
 * Switch `op-proposer` to the new Super Root RPC and game type at the contract cutover.
+* Update `op-proposer` dashboards and alerts that use `op_proposer_default_refs_number{layer="l2"}` to `op_proposer_default_proposed_sequence_number`.
 * Configure `op-challenger` and `op-dispute-mon` to support Super Root Dispute Games while retaining the configuration needed to finish games already in progress.
 * For permissionless Fault Proofs, stage the reviewed `kona-client` Interop variant prestate before the cutover.
 * Update operational tooling that calls the removed `SystemConfig` functions.

--- a/docs/public-docs/notices/upgrade-20.mdx
+++ b/docs/public-docs/notices/upgrade-20.mdx
@@ -81,8 +81,9 @@ The [OP Stack component changes](#prepare-op-stack-components), [`SystemConfig` 
 
 ### Node Operators
 
-Upgrade 20 has no L2 hardfork, and it does not require an `op-node` or `op-reth` configuration change.
-If the node also provides a Super Root RPC to Fault Proof services, keep that endpoint reachable during and after the cutover.
+Upgrade 20 has no L2 hardfork, and it does not require an `op-node` or `op-reth` configuration change to follow the chain.
+If the node also provides a Super Root RPC to Fault Proof services, keep that endpoint reachable during and after the cutover, and run `op-node` with `--safedb.path` enabled and populated through derivation.
+See the [`op-node` row](#prepare-op-stack-components) for details.
 
 ### App Developers and Infrastructure Integrators
 
@@ -110,17 +111,29 @@ Existing Output Root Dispute Games continue to resolve, and the `OptimismPortal`
 
 ## Prepare OP Stack components
 
-Use the following configuration changes when staging the Upgrade 20 component releases:
+Update the following components and apply the configuration changes when staging the Upgrade 20 releases.
+Each version below is the latest release of that component, and running the latest release of every component is recommended regardless of whether Upgrade 20 requires a change to it.
+Treat the listed version as a minimum for every component except `kona-client`, where the absolute prestate hash is specific to the exact release tag:
 
-| Component | Required change |
-| --- | --- |
-| `op-challenger` | Add `--superroot-rpc` (`OP_CHALLENGER_SUPERROOT_RPC`) and keep the existing game types so the challenger can finish games already in progress. On a permissionless chain, append `super-cannon-kona` to `--game-types` (`OP_CHALLENGER_GAME_TYPES`) and configure the reviewed Kona Interop prestate. On a permissioned chain, do not add `super-permissioned`; the simplified game does not require a trace type, and `op-challenger` handles its lifecycle automatically. |
-| `op-dispute-mon` | Add `--superroot-rpc` (`OP_DISPUTE_MON_SUPERROOT_RPC`). Keep `--rollup-rpc` while Output Root Dispute Games remain in progress. |
-| `op-proposer` | Switch at the contract upgrade cutover. Replace `--rollup-rpc` with `--superroot-rpcs` (`OP_PROPOSER_SUPERROOT_RPCS`) and set `OP_PROPOSER_GAME_TYPE=5` for a permissioned chain or `OP_PROPOSER_GAME_TYPE=9` for a permissionless chain. |
-| `op-node`, `op-reth`, and `op-batcher` | No configuration change is required. Upgrade 20 has no hardfork activation. |
+| Component | Version | Required change |
+| --- | --- | --- |
+| `op-challenger` | [v1.9.5](https://github.com/ethereum-optimism/optimism/releases/tag/op-challenger%2Fv1.9.5) | Add `--superroot-rpc` (`OP_CHALLENGER_SUPERROOT_RPC`) and keep the existing game types so the challenger can finish games already in progress. On a permissionless chain, append `super-cannon-kona` to `--game-types` (`OP_CHALLENGER_GAME_TYPES`) and configure the reviewed Kona Interop prestate. On a permissioned chain, do not add `super-permissioned`; the simplified game does not require a trace type, and `op-challenger` handles its lifecycle automatically. |
+| `op-dispute-mon` | [v1.6.0](https://github.com/ethereum-optimism/optimism/releases/tag/op-dispute-mon%2Fv1.6.0) | Add `--superroot-rpc` (`OP_DISPUTE_MON_SUPERROOT_RPC`). Keep `--rollup-rpc` while Output Root Dispute Games remain in progress. |
+| `op-proposer` | [v1.16.4](https://github.com/ethereum-optimism/optimism/releases/tag/op-proposer%2Fv1.16.4) | Switch at the contract upgrade cutover, as described in [Update order](#update-order). Replace `--rollup-rpc` with `--superroot-rpcs` (`OP_PROPOSER_SUPERROOT_RPCS`) and set `OP_PROPOSER_GAME_TYPE=5` for a permissioned chain or `OP_PROPOSER_GAME_TYPE=9` for a permissionless chain. |
+| `kona-client` | [v1.7.0](https://github.com/ethereum-optimism/optimism/releases/tag/kona-client%2Fv1.7.0) exactly | Permissionless chains only. This release produces the `SUPER_CANNON_KONA` absolute prestate. Build or locate the Interop variant prestate from this exact tag and host it for `op-challenger`, as described in [Locate or build the absolute prestate](#locate-or-build-the-absolute-prestate). A later tag produces a different hash that does not match the reviewed Upgrade 20 value. |
+| `op-node` | [v1.19.6](https://github.com/ethereum-optimism/optimism/releases/tag/op-node%2Fv1.19.6) | No hardfork activation, so an `op-node` that only serves the chain needs no configuration change. An `op-node` that serves the Super Root RPC to Fault Proof services must run with `--safedb.path` enabled and populated through derivation; `superroot_atTimestamp` cannot serve a non-genesis timestamp without SafeDB. |
+| `op-reth` | [v2.5.2](https://github.com/paradigmxyz/reth/releases/tag/v2.5.2) | No Upgrade 20 configuration change is required, and there is no hardfork activation. |
+| `op-batcher` | [v1.16.13](https://github.com/ethereum-optimism/optimism/releases/tag/op-batcher%2Fv1.16.13) | No Upgrade 20 configuration change is required. |
 
 The Super Root RPC must return a root for the chain or dependency set that the Dispute Game covers.
 For a single-chain upgrade, use the chain's `op-node` RPC endpoint or the chain-specific endpoint exposed by an `op-supernode`.
+
+### Update order
+
+Sequence the service updates around the L1 contract cutover:
+
+* Update `op-challenger` and `op-dispute-mon` **before** the L1 contract cutover. Both services need the Super Root configuration in place when the first Super Root Dispute Game is created.
+* Switch `op-proposer` **at the cutover**, or immediately after it. The proposer cannot propose against the new game type until the contracts are upgraded, and it logs proposal errors from the cutover until it is switched, so do not leave a deliberate gap.
 
 ## Update `SystemConfig` integrations
 
@@ -177,9 +190,13 @@ Permissionless chains need the Upgrade 20 `kona-client` Interop variant absolute
 
 <Tabs>
   <Tab title="Standard chain configuration">
-    Use the `cannon64-kona-interop` hash published for the Upgrade 20 release in [`standard-prestates.toml`](https://github.com/ethereum-optimism/superchain-registry/blob/main/validation/standard/standard-prestates.toml).
+    Use the `cannon64-kona-interop` hash published for `1.7.0` in [`standard-prestates.toml`](https://github.com/ethereum-optimism/superchain-registry/blob/main/validation/standard/standard-prestates.toml):
 
-    Check out the Kona release tag associated with the published Upgrade 20 prestate hash, reproduce both Kona prestates, and read the interop hash:
+    ```
+    0x031ac6f15c19010da258f5cb633ef6ca9318c2d0f244bea6b2045ce6b790e1df
+    ```
+
+    Check out `kona-client/v1.7.0`, reproduce both Kona prestates, and read the interop hash:
 
     ```bash
     just reproducible-prestate-kona
@@ -192,7 +209,7 @@ Permissionless chains need the Upgrade 20 `kona-client` Interop variant absolute
 
   <Tab title="Custom chain configuration">
     First, stage the chain data described in [Generating a custom kona-client absolute prestate](/chain-operators/tutorials/kona-custom-prestate).
-    Check out the Kona release tag associated with the reviewed Upgrade 20 prestate and build the interop variant with the same custom configuration:
+    Check out `kona-client/v1.7.0` and build the interop variant with the same custom configuration:
 
     ```bash
     cd rust
@@ -210,8 +227,19 @@ Permissionless chains need the Upgrade 20 `kona-client` Interop variant absolute
 
 ## Upgrade timing
 
-Upgrade 20 is applied as an L1 contract upgrade and has no L2 hardfork activation timestamp.
-Pending governance approval, we expect the upgrade to be executed in September.
+Upgrade 20 is applied as an L1 contract upgrade: each network is upgraded by executing an onchain task, so there is no L2 hardfork activation timestamp to configure.
+
+| Milestone | Target date |
+| --- | --- |
+| Governance vote closes | **Wednesday, September 16, 2026** |
+| Sepolia execution | **Thursday, September 17, 2026** |
+| Mainnet execution | **Thursday, September 24, 2026** |
+
+Governed Sepolia OP Stack chains are upgraded first, followed by a seven-day soak period before mainnet execution.
+Mainnet execution depends on Optimism Governance approval and a healthy Sepolia soak, so these dates can move.
+
+Upgrade 20 is described in the [Upgrade 20 - Super Root Dispute Games & OPCM v8.0.0](https://gov.optimism.io/t/upgrade-20-super-root-dispute-games-opcm-v8-0-0/10856) governance proposal.
+The [onchain vote](https://vote.optimism.io/proposals/4301234447578476958698627660572767846172082315795452528680486495303632100182) records the approval status.
 
 The [Output Root to Super Root upgrade runbook](/chain-operators/tutorials/upgrade-chain-to-super-roots) describes the onchain upgrade and cutover checks.
 

--- a/docs/public-docs/notices/upgrade-20.mdx
+++ b/docs/public-docs/notices/upgrade-20.mdx
@@ -117,7 +117,7 @@ Treat the listed version as a minimum for every component except `kona-client`, 
 
 | Component | Version | Required change |
 | --- | --- | --- |
-| `op-challenger` | [v1.9.5](https://github.com/ethereum-optimism/optimism/releases/tag/op-challenger%2Fv1.9.5) | Add `--superroot-rpc` (`OP_CHALLENGER_SUPERROOT_RPC`) and keep the existing game types so the challenger can finish games already in progress. On a permissionless chain, append `super-cannon-kona` to `--game-types` (`OP_CHALLENGER_GAME_TYPES`) and configure the reviewed Kona Interop prestate. On a permissioned chain, do not add `super-permissioned`; the simplified game does not require a trace type, and `op-challenger` handles its lifecycle automatically. |
+| `op-challenger` | [v1.9.5](https://github.com/ethereum-optimism/optimism/releases/tag/op-challenger%2Fv1.9.5) | Add `--superroot-rpc` (`OP_CHALLENGER_SUPERROOT_RPC`) and keep the existing game types so the challenger can finish games already in progress. On a permissionless chain, append `super-cannon-kona` to `--game-types` (`OP_CHALLENGER_GAME_TYPES`) and configure the reviewed Kona Interop prestate, as described in [Locate or build the absolute prestate](#locate-or-build-the-absolute-prestate). On a permissioned chain, do not add `super-permissioned`; the simplified game does not require a trace type, and `op-challenger` handles its lifecycle automatically. |
 | `op-dispute-mon` | [v1.6.0](https://github.com/ethereum-optimism/optimism/releases/tag/op-dispute-mon%2Fv1.6.0) | Add `--superroot-rpc` (`OP_DISPUTE_MON_SUPERROOT_RPC`). Keep `--rollup-rpc` while Output Root Dispute Games remain in progress. |
 | `op-proposer` | [v1.16.4](https://github.com/ethereum-optimism/optimism/releases/tag/op-proposer%2Fv1.16.4) | Switch at the contract upgrade cutover, as described in [Update order](#update-order). Replace `--rollup-rpc` with `--superroot-rpcs` (`OP_PROPOSER_SUPERROOT_RPCS`) and set `OP_PROPOSER_GAME_TYPE=5` for a permissioned chain or `OP_PROPOSER_GAME_TYPE=9` for a permissionless chain. |
 | `kona-client` | [v1.7.0](https://github.com/ethereum-optimism/optimism/releases/tag/kona-client%2Fv1.7.0) exactly | Permissionless chains only. This release produces the `SUPER_CANNON_KONA` absolute prestate. Build or locate the Interop variant prestate from this exact tag and host it for `op-challenger`, as described in [Locate or build the absolute prestate](#locate-or-build-the-absolute-prestate). A later tag produces a different hash that does not match the reviewed Upgrade 20 value. |
@@ -188,42 +188,105 @@ See the [`viem` Super Root withdrawal support release](https://github.com/wevm/v
 
 Permissionless chains need the Upgrade 20 `kona-client` Interop variant absolute prestate for `SUPER_CANNON_KONA`. Use the `kona-client-int` artifact even when Interop is not scheduled for the chain.
 
-<Tabs>
-  <Tab title="Standard chain configuration">
-    Use the `cannon64-kona-interop` hash published for `1.7.0` in [`standard-prestates.toml`](https://github.com/ethereum-optimism/superchain-registry/blob/main/validation/standard/standard-prestates.toml):
+<Info>
+  The reviewed Upgrade 20 prestate covers **OP, Ink, Unichain, and Soneium, on both Sepolia and Mainnet**.
+  Those eight chains are embedded in the standard build, so their operators can use the published hash directly.
+
+  Optimism completes the onchain upgrade for chains managed by the Optimism Security Council, but off-chain components must still be configured by each operator.
+  A permissionless chain outside that set is not covered by the reviewed prestate and must build and verify its own, then work through every step below.
+</Info>
+
+<Steps>
+  <Step title="Verify the absolute prestate">
+    <Tabs>
+      <Tab title="Standard chain configuration">
+        Use the `cannon64-kona-interop` hash published for `1.7.0` in [`standard-prestates.toml`](https://github.com/ethereum-optimism/superchain-registry/blob/main/validation/standard/standard-prestates.toml):
+
+        ```
+        0x031ac6f15c19010da258f5cb633ef6ca9318c2d0f244bea6b2045ce6b790e1df
+        ```
+
+        Check out `kona-client/v1.7.0`, reproduce both Kona prestates, and read the interop hash:
+
+        ```bash
+        just reproducible-prestate-kona
+        jq -r .pre rust/kona/prestate-artifacts-cannon-interop/prestate-proof.json
+        ```
+
+        Confirm the output matches the published hash.
+      </Tab>
+
+      <Tab title="Custom chain configuration">
+        First, stage the chain data described in [Generating a custom kona-client absolute prestate](/chain-operators/tutorials/kona-custom-prestate).
+        Check out `kona-client/v1.7.0` and build the interop variant with the same custom configuration:
+
+        ```bash
+        cd rust
+        KONA_CUSTOM_CONFIGS_DIR=/absolute/path/to/custom-configs \
+          just build-kona-reproducible-prestate-variant \
+          kona-client-int prestate-artifacts-cannon-interop
+        jq -r .pre kona/prestate-artifacts-cannon-interop/prestate-proof.json
+        ```
+
+        Rebuild from a clean checkout with the same inputs and confirm the hash is identical.
+        A custom prestate hash is specific to its embedded chain configuration and does not appear in `standard-prestates.toml`.
+      </Tab>
+    </Tabs>
+  </Step>
+
+  <Step title="Upload your new preimage file">
+    Upload the new preimage file to wherever you store your other absolute preimage files. This is the location `--prestates-url` points at. `op-challenger` fetches the file from there when it needs to play a game.
+
+    Rename the file so the absolute prestate hash is the filename, for example `0x031ac6f15c19010da258f5cb633ef6ca9318c2d0f244bea6b2045ce6b790e1df.bin.gz`.
+
+    Operators who use the OP Labs prestate bucket rather than hosting their own do not need to upload anything — the Upgrade 20 prestate is already published there:
 
     ```
-    0x031ac6f15c19010da258f5cb633ef6ca9318c2d0f244bea6b2045ce6b790e1df
+    https://storage.googleapis.com/oplabs-network-data/proofs/kona/cannon/0x031ac6f15c19010da258f5cb633ef6ca9318c2d0f244bea6b2045ce6b790e1df.bin.gz
     ```
 
-    Check out `kona-client/v1.7.0`, reproduce both Kona prestates, and read the interop hash:
+    A custom prestate must be hosted at a URL reachable by every challenger that participates on the chain.
+  </Step>
+
+  <Step title="Configure op-challenger for super-cannon-kona">
+    Add `super-cannon-kona` to the game types, keeping the existing entries so the challenger can finish games already in progress:
 
     ```bash
-    just reproducible-prestate-kona
-    jq -r .pre rust/kona/prestate-artifacts-cannon-interop/prestate-proof.json
+    OP_CHALLENGER_GAME_TYPES="cannon-kona,permissioned,super-cannon-kona"
+    # or
+    --game-types=cannon-kona,permissioned,super-cannon-kona
     ```
 
-    Confirm the output matches the published hash.
-    Host the generated hash-named `.bin.gz` file on the prestate server used by `op-challenger`.
-  </Tab>
-
-  <Tab title="Custom chain configuration">
-    First, stage the chain data described in [Generating a custom kona-client absolute prestate](/chain-operators/tutorials/kona-custom-prestate).
-    Check out `kona-client/v1.7.0` and build the interop variant with the same custom configuration:
+    Point the challenger at the prestate. If every prestate is served from one location:
 
     ```bash
-    cd rust
-    KONA_CUSTOM_CONFIGS_DIR=/absolute/path/to/custom-configs \
-      just build-kona-reproducible-prestate-variant \
-      kona-client-int prestate-artifacts-cannon-interop
-    jq -r .pre kona/prestate-artifacts-cannon-interop/prestate-proof.json
+    --prestates-url=<PRESTATES_URL>
     ```
 
-    Rebuild from a clean checkout with the same inputs and confirm the hash is identical.
-    Host the generated hash-named `.bin.gz` file at a URL reachable by every challenger that participates on the chain.
-    A custom prestate hash is specific to its embedded chain configuration and does not appear in `standard-prestates.toml`.
-  </Tab>
-</Tabs>
+    If the Kona prestates are stored separately:
+
+    ```bash
+    --cannon-kona-prestates-url=<CANNON_KONA_PRESTATES_URL>
+    ```
+
+    `super-cannon-kona` also requires a Super Root RPC and a dependency set. `--network` supplies the dependency set for a registry chain; a chain outside the registry must pass one explicitly:
+
+    ```bash
+    --superroot-rpc=<SUPER_ROOT_RPC>
+    --cannon-kona-depset-config=/path/to/depset.json   # only if --network is not set
+    ```
+
+    If you do not use the standard OP Labs `op-challenger` Docker image, set the `kona-host` binary path, built from the same release as the configured prestate:
+
+    ```bash
+    OP_CHALLENGER_CANNON_KONA_SERVER=/path/to/kona-host
+    # or
+    --cannon-kona-server=/path/to/kona-host
+    ```
+
+    Complete this before the L1 contract cutover, as described in [Update order](#update-order).
+  </Step>
+</Steps>
 
 ## Upgrade timing
 


### PR DESCRIPTION
Chain operators reading the [Upgrade 20 notice](https://docs.optimism.io/notices/upgrade-20) could see which flags to change but not which releases contain them, and the timing section said only "we expect the upgrade to be executed in September" — no date to plan the cutover around. Operators had to ask for both.

The notice now states, for each component, the release that carries the Upgrade 20 change; the ordering constraint between the service updates and the L1 cutover; and the target execution dates, with links to the governance proposal and the onchain vote.

### Where the values come from

Versions are the ones pinned in the U20 coordination thread in `#eng-network-upgrades` and confirmed in the Sep 8 OP Stack Network Upgrades Weekly: `op-challenger` v1.9.5, `op-dispute-mon` v1.6.0, `op-proposer` v1.16.4. `op-batcher` needs no U20 change (confirmed by the batcher owner in that thread), so it and the other unaffected components are listed at their latest release instead, since running latest is the standing recommendation. `kona-client` is pinned to v1.7.0, the final release cut on Sep 8; the superchain-registry `1.7.0` entry carries the same `cannon64-kona-interop` hash as the `1.7.0-rc.2` prestate cited in the governance proposal. Dates match the governance proposal and the live vote.

I verified via the GitHub API that all seven tags are published and neither draft nor prerelease, and that each is the newest published release of its component.

### For the reviewer

- **Two rows will go stale shortly.** `op-node/v1.19.7` and `op-batcher/v1.17.0` exist as drafts cut on Sep 10; those rows need a bump once the releases publish.
- **One correctness fix beyond the version tables.** The notice told node operators that Upgrade 20 requires no `op-node` configuration change, but `superroot_atTimestamp` reads SafeDB (`op-node/node/superroot_api.go`), so an `op-node` serving the Super Root RPC to Fault Proof services must run with `--safedb.path` enabled and populated. The linked cutover runbook already said this; the notice contradicted it. Both the `op-node` row and the Node Operators section now state it.
- **`kona-client` is the one exact-tag pin.** Every other version is a minimum, but a later Kona tag yields a prestate hash that will not match the reviewed U20 value, so that row and the lead-in call it out explicitly. The prestate section now also names the tag and the expected hash inline, so the "Verify readiness" check no longer requires a registry lookup.
- **Deliberate omission.** In the Sep 8 meeting it was noted that `op-challenger` technically has until ~3.5 days after the L1 upgrade. The notice says to update it *before* the cutover, which is the framing requested for operator comms — publishing the grace window invites operators to defer. Happy to add the real deadline if reviewers would rather it be visible.

### Reviews

No language-specific review agent applies to a docs-only diff (no Go, Rust, Solidity, or CI config touched). A general documentation review was run over the diff; its findings are addressed above and in the diff, except two dismissed as out of scope for this change:

- Adding `op-supernode` and `kona-node` rows to the component table. `op-supernode` was never part of the U20 pinned set, and asserting a version we have not validated for U20 would invent a requirement.
- Documenting that `kona-node` cannot yet serve `superroot_atTimestamp` (tracked by #21861). Real operator trap, but it needs its own verification and PR.

Both are worth a follow-up if reviewers agree.