### PR TITLE
ci: rightsize go-tests executors

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -1795,7 +1795,9 @@ jobs:
         default: 1
     docker:
       - image: <<pipeline.parameters.c-default_docker_image>>
-    resource_class: 2xlarge.gen2
+    # Trial one tier down; nproc-based test parallelism falls from 16 to 8 while -p=4
+    # stays fixed. Monitor the 16 GiB limit after a 24.1 GiB cross-branch peak.
+    resource_class: xlarge.gen2
     parallelism: <<parameters.parallelism>>
     steps:
       - utils/checkout-with-mise:
@@ -1816,9 +1818,6 @@ jobs:
           command: |
             <<parameters.environment_overrides>>
             export TEST_TIMEOUT=<<parameters.test_timeout>>
-            # set to less than number CPUs (xlarge Docker is 16 CPU) so there's some buffer for things
-            # like Geth
-            export PARALLEL=12
             just <<parameters.rule>>
       - go-save-cache:
           namespace: go-tests


### PR DESCRIPTION
Cross-branch CircleCI telemetry recorded a 24.1 GiB peak for `go-tests`, while recent develop telemetry remains much lower: 41 runs averaged 1.55 GiB, had an 8.48 GiB p90 run peak, and reached 17.17 GiB once. This draft trials Docker `xlarge.gen2` (8 vCPU / 16 GiB) instead of `2xlarge.gen2` (16 vCPU / 32 GiB), preserving all 12 CircleCI shards, `go test -p=4`, package/test selection, caches, timeouts, dependencies, and `ci-gate` wiring.

The Just recipe derives Go test `-parallel` from `nproc`, so the smaller executor bounds it at 8 instead of 16. A dead CircleCI `PARALLEL=12` export and its stale 16-CPU comment are removed; the recipe already overwrote that value, so this cleanup does not otherwise change behavior. There is no operator or protocol behavior change.

The executor rate falls from 96 to 48 credits/min, a 50% per-minute reduction with a 2x duration break-even. The 41 runs returned for September 3–10 consumed 192,228 credits (4,688/run) with 997s average wall duration, so flat execution time would save about 96,114 credits over that observed volume.

The CI-config review finding about the target sitting below the historical peak is accepted: do not mark this ready until a representative hosted run proves all 12 executors, exact JUnit coverage, memory comfortably below 16 GiB, and favorable duration/credits. Investigate memory at or above 14 GiB; revert for any OOM/process kill or execution duration at least 2x baseline, with less than 25% regression preferred.

Local validation: merged and setup configs validate; processing with `c-run_main=true` resolves `xlarge.gen2`, parallelism 12, unchanged `go-tests-ci`, and the direct `ci-gate` dependency; the decision-tree suite passes 21/21; `git diff --check` passes.

Related: https://github.com/ethereum-optimism/core-team/issues/3094