### PR TITLE
docs: link security policy to Immunefi bounty program

### DIFF
--- a/docs/public-docs/op-stack/security/security-policy.mdx
+++ b/docs/public-docs/op-stack/security/security-policy.mdx
@@ -27,7 +27,7 @@ If you think you have found a significant bug or vulnerability in OP Stack smart
 
 ## Reporting other vulnerabilities
 
-For vulnerabilities in any websites, email servers, or other non-critical infrastructure within the OP Stack, please contact the Foundation's service provider at [security@oplabs.co](mailto:security@oplabs.co) and include detailed instructions for confirming and reproducing the vulnerability.
+For vulnerabilities in any websites, email servers, or other non-critical infrastructure within the OP Stack, please report them through the [Optimism bug bounty program on Immunefi](https://immunefi.com/bug-bounty/optimism/information/) and include detailed instructions for confirming and reproducing the vulnerability.
 
 ### Vulnerability disclosure
 


### PR DESCRIPTION
## Summary

Unpublishes the security-contact email in the OP Stack security policy and replaces it with a link to the [Optimism bug bounty program on Immunefi](https://immunefi.com/bug-bounty/optimism/information/).

This is the source file for the security policy page rendered on docs.optimism.io.

## Notes

- The canonical policy in `ethereum-optimism/.github/SECURITY.md` already points to Immunefi with no email, so no change is needed there.
- A companion PR updates `ethereum-optimism/infra/SECURITY.md`, which still carried the same contact.
- Historical postmortems that mention a security email are left unchanged since they are factual records of past events.