### PR TITLE
ci: don't fail jobs when one Ubuntu mirror is unreachable

### DIFF
--- a/.circleci/continue/main.yml
+++ b/.circleci/continue/main.yml
@@ -1569,8 +1569,6 @@ jobs:
       - utils/checkout-with-mise:
           checkout-method: blobless
           enable-mise-cache: true
-      - apt-install:
-          packages: "ripgrep"
       - run:
           name: Check TODO issues
           command: ./ops/scripts/todo-checker.sh --verbose --strict

--- a/.circleci/scripts/apt-install.sh
+++ b/.circleci/scripts/apt-install.sh
@@ -2,23 +2,66 @@
 # apt-get update + install. Arguments are passed to `apt-get install`.
 set -euo pipefail
 
-# The machine images point apt at the single-region EC2 mirror
-# (us-east-1.ec2.archive.ubuntu.com), which is one set of AWS hosts with no
-# routing of its own: when it degrades, apt has nowhere else to go, and it is only
-# nearby when the runner happens to be in that region. archive.ubuntu.com is
-# Cloudflare anycast, so redundancy, geo-routing and caching are the CDN's job.
-# Third-party lists keep their own URIs.
-for f in /etc/apt/sources.list /etc/apt/sources.list.d/*.sources /etc/apt/sources.list.d/*.list; do
-  if [ -f "$f" ]; then
-    sudo sed -i -E "s#https?://[A-Za-z0-9.-]+\.ec2\.archive\.ubuntu\.com/ubuntu#http://archive.ubuntu.com/ubuntu#g" "$f"
-  fi
-done
-
 # Timeouts, so a mirror that stops responding errors out instead of being waited on.
 APT_OPTS=(-o Acquire::Retries=3 -o Acquire::http::Timeout=20 -o Acquire::https::Timeout=20)
 
 export NEEDRESTART_MODE=a
 export DEBIAN_FRONTEND=noninteractive
 
-sudo -E apt-get "${APT_OPTS[@]}" update --error-on=any
-sudo -E apt-get "${APT_OPTS[@]}" install -y "$@"
+# Copy of each list as the machine image shipped it. The suffix is not one apt
+# reads (it only picks up *.list and *.sources), so the copies sit inertly next
+# to the rewritten files until the fallback below needs them. Written once: some
+# jobs call this script more than once, and re-copying would capture the
+# already-rewritten file and make the fallback a no-op.
+BACKUP_SUFFIX=".shipped-mirrors"
+# Set once archive.ubuntu.com has been found unusable, so later calls in the
+# same job don't rewrite back onto it.
+FALLBACK_MARKER="/tmp/.apt-install-mirror-fallback"
+
+SOURCE_FILES=()
+for f in /etc/apt/sources.list /etc/apt/sources.list.d/*.sources /etc/apt/sources.list.d/*.list; do
+  if [ -f "$f" ]; then
+    SOURCE_FILES+=("$f")
+  fi
+done
+
+# The machine images point apt at the single-region EC2 mirror
+# (us-east-1.ec2.archive.ubuntu.com), which is one set of AWS hosts with no
+# routing of its own: when it degrades, apt has nowhere else to go, and it is only
+# nearby when the runner happens to be in that region. archive.ubuntu.com is
+# Cloudflare anycast, so redundancy, geo-routing and caching are the CDN's job.
+# Third-party lists keep their own URIs.
+if [ ! -f "$FALLBACK_MARKER" ]; then
+  for f in "${SOURCE_FILES[@]}"; do
+    if [ ! -f "$f$BACKUP_SUFFIX" ]; then
+      sudo cp -p -- "$f" "$f$BACKUP_SUFFIX"
+    fi
+    sudo sed -i -E "s#https?://[A-Za-z0-9.-]+\.ec2\.archive\.ubuntu\.com/ubuntu#http://archive.ubuntu.com/ubuntu#g" "$f"
+  done
+fi
+
+# The CDN is a single point of failure of its own: Canonical has had
+# archive.ubuntu.com outages that fail every job installing a package through it.
+# The EC2 mirror the image shipped is usually still serving when that happens, so
+# put it back and try once more instead of failing the job outright.
+restore_shipped_mirrors() {
+  for f in "${SOURCE_FILES[@]}"; do
+    if [ -f "$f$BACKUP_SUFFIX" ]; then
+      sudo cp -p -- "$f$BACKUP_SUFFIX" "$f"
+    fi
+  done
+  touch "$FALLBACK_MARKER"
+}
+
+apt_update_and_install() {
+  sudo -E apt-get "${APT_OPTS[@]}" update --error-on=any
+  sudo -E apt-get "${APT_OPTS[@]}" install -y "$@"
+}
+
+if apt_update_and_install "$@"; then
+  exit 0
+fi
+
+echo "apt failed against archive.ubuntu.com; retrying with the mirrors the machine image shipped." >&2
+restore_shipped_mirrors
+apt_update_and_install "$@"

--- a/mise.toml
+++ b/mise.toml
@@ -14,6 +14,10 @@ python = "3.12.13"
 uv = "0.5.5"
 jq = "1.7.1"
 yq = "4.44.5"
+# Used by ops/scripts/todo-checker.sh. Pinned here rather than apt-installed in
+# the todo-issues job so the check rides the mise cache instead of depending on
+# an Ubuntu mirror being reachable.
+ripgrep = "15.2.0"
 shellcheck = "0.10.0"
 shfmt = "3.11.0"
 direnv = "2.35.0"


### PR DESCRIPTION
Canonical's `archive.ubuntu.com` outage took down CI jobs that apt-install packages. Two independent fixes for that class of failure.

### 1. `ripgrep` comes from mise, not apt

`todo-issues` apt-installed ripgrep on every run. `mise.toml` already manages ~40 tools from GitHub releases and CI runs with `enable-mise-cache: true`, and ripgrep is in the mise registry (`aqua:BurntSushi/ripgrep`) — so it's pinned there and the `apt-install` step is gone. `ops/scripts/todo-checker.sh` only needs `rg` on `PATH`.

### 2. `apt-install.sh` falls back when the CDN is down

`apt-install.sh` rewrites the machine image's single-region EC2 mirror to `archive.ubuntu.com`, reasoning that geo-routing, caching and redundancy belong to Cloudflare anycast rather than one set of AWS hosts. That still holds — but it makes the CDN a single point of failure, and every job installing a package went down with it during the outage.

Now the script keeps a copy of each sources list as the image shipped it, and if apt fails against the CDN it restores those and retries once; the EC2 mirror is typically still serving. A `/tmp` marker stops later calls in the same job from rewriting back onto a CDN already known to be failing, and the backup is written only once per file so a second call can't capture the already-rewritten state.

### Not covered

The remaining apt packages have no GitHub-release or mise path, so they still need apt or a prebuilt image:

| package | job | executor |
|---|---|---|
| `zstd` | `install-zstd` (2 callers) | `machine` |
| `clang llvm-dev libclang-dev` | `kona-host-client-offline` | `machine` |
| `eatmydata` | `op-acceptance-tests` | `docker` |

`clang`/`libclang` are already baked into the Wolfi runner image, but `kona-host-client-offline` runs Docker in-job (`just cannon`, `just build-cannon-client`), so it can't simply move to that docker executor. `eatmydata` has no upstream release binary and needs a baked image.

### Possible follow-up

`todo-issues` no longer needs `sudo` or apt, so it may no longer need the `machine:` executor either — left alone here since that's an unverified behavior change.

### Testing

`bash -n` on the script; `main.yml` still parses. The fallback path itself only exercises under a real mirror failure.

Prompted by: @sebastianst