### PR TITLE
release-notes: standardize kona-node callout

### DIFF
--- a/.claude/skills/release-notes/reference/house-style.md
+++ b/.claude/skills/release-notes/reference/house-style.md
@@ -77,7 +77,14 @@ operators never see.
 **The callout type follows the recommendation**: `> [!NOTE]` for `optional`,
 `> [!IMPORTANT]` for either recommended level, `> [!CAUTION]` for `required`. Those three and
 no others. This block is also the note's only callout — if you reach for a second, the
-content is an entry in the change list, or belongs in `## Breaking changes`.
+content is an entry in the change list, or belongs in `## Breaking changes`. The one exception
+is `kona-node`, whose callout should always be:
+
+```markdown
+> [!NOTE]
+>
+> `kona-node` is not production-ready. Production deployments should use `op-node`.
+```
 
 ## Impact, not implementation
 


### PR DESCRIPTION
Ensures every `kona-node` release clearly warns operators that it is not production-ready and directs production deployments to `op-node`. This affects release-note authoring only and has no runtime or end-user impact.