### PR TITLE
contracts-bedrock: reduce opcm codesize

### DIFF
--- a/packages/contracts-bedrock/interfaces/L1/opcm/IOPContractsManagerV2.sol
+++ b/packages/contracts-bedrock/interfaces/L1/opcm/IOPContractsManagerV2.sol
@@ -120,7 +120,7 @@ interface IOPContractsManagerV2 {
     function version() external view returns (string memory);
 
     /// @notice Upgrades Superchain-wide contracts.
-    function upgradeSuperchain(SuperchainUpgradeInput memory _inp) external returns (SuperchainContracts memory);
+    function upgradeSuperchain(SuperchainUpgradeInput calldata _inp) external returns (SuperchainContracts memory);
 
     /// @notice Deploys and wires a complete OP Chain per the provided configuration.
     function deploy(FullConfig memory _cfg) external returns (ChainContracts memory);

--- a/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
@@ -127,7 +127,7 @@ contract DeployOPChain is Script {
         bool enableSuperPermissioned =
             enableSuperCannonKona || respectedGameType.raw() == GameTypes.SUPER_PERMISSIONED.raw();
         // Build dispute game configs - OPCMV2 requires all 6 game type configs.
-        // Order must match validGameTypes in OPContractsManagerV2._assertValidFullConfig().
+        // Order must match VALID_GAME_TYPES in OPContractsManagerV2._assertValidFullConfig().
         IOPContractsManagerUtils.DisputeGameConfig[] memory disputeGameConfigs =
             new IOPContractsManagerUtils.DisputeGameConfig[](6);
 

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -37,7 +37,7 @@
   },
   "src/L1/opcm/OPContractsManagerV2.sol:OPContractsManagerV2": {
     "initCodeHash": "0xa22117656e17e8533a0cb01188ea10eb59c7a13483d3a1cbce99d4dc931f34c7",
-    "sourceCodeHash": "0x57978025f4c2068ee52c7904a8d3424f7a146ae33e304bad483619c972399881"
+    "sourceCodeHash": "0x0902dcb343a90447b9d46f6604a7ca1a7bc360e2d0e5390b3967de36ff92254d"
   },
   "src/L2/BaseFeeVault.sol:BaseFeeVault": {
     "initCodeHash": "0x18650c65fa6f23fefc6f0c5fff605f12be99fce0bfbcbc0644403138e4c8bb12",

--- a/packages/contracts-bedrock/snapshots/semver-lock.json
+++ b/packages/contracts-bedrock/snapshots/semver-lock.json
@@ -36,8 +36,8 @@
     "sourceCodeHash": "0x2ddb084512dc887520fb96eddcf01cdde8804ad1c02735c1a2fb9445ad923fa4"
   },
   "src/L1/opcm/OPContractsManagerV2.sol:OPContractsManagerV2": {
-    "initCodeHash": "0x1233c423569d79d0e5953fdcea1e7de3bc98f8bb93d9b1b744c215cadf8e0ceb",
-    "sourceCodeHash": "0x5c8cef68d3f08615183fadc749f483ded6616c38651d1c32ea211195dfcb1690"
+    "initCodeHash": "0xa22117656e17e8533a0cb01188ea10eb59c7a13483d3a1cbce99d4dc931f34c7",
+    "sourceCodeHash": "0x57978025f4c2068ee52c7904a8d3424f7a146ae33e304bad483619c972399881"
   },
   "src/L2/BaseFeeVault.sol:BaseFeeVault": {
     "initCodeHash": "0x18650c65fa6f23fefc6f0c5fff605f12be99fce0bfbcbc0644403138e4c8bb12",

--- a/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
+++ b/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerV2.sol
@@ -143,6 +143,14 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
     /// @notice Thrown when an enabled game type resolves to a zero implementation in the container.
     error OPContractsManagerV2_ZeroGameImplementation(GameType _gameType);
 
+    /// @notice Number of dispute game configs a full config must supply.
+    uint256 internal constant VALID_GAME_TYPE_COUNT = 6;
+
+    /// @notice The valid game types, packed low-to-high as six uint32s in the order the dispute
+    ///         game configs must be supplied: CANNON, PERMISSIONED_CANNON, CANNON_KONA,
+    ///         SUPER_PERMISSIONED, SUPER_CANNON_KONA, ZK_DISPUTE_GAME.
+    uint256 internal constant VALID_GAME_TYPES = 0x0000000a_00000009_00000005_00000008_00000001_00000000;
+
     /// @notice Address of the Standard Validator for this OPCM release.
     IOPContractsManagerStandardValidator public immutable opcmStandardValidator;
 
@@ -186,7 +194,7 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
     ///         SuperchainConfig contract, but may eventually expand to include other
     ///         Superchain-wide contracts.
     /// @param _inp The input for the Superchain upgrade.
-    function upgradeSuperchain(SuperchainUpgradeInput memory _inp) external returns (SuperchainContracts memory) {
+    function upgradeSuperchain(SuperchainUpgradeInput calldata _inp) external returns (SuperchainContracts memory) {
         _onlyDelegateCall();
 
         // NOTE: Since this function is very minimal and only upgrades the SuperchainConfig
@@ -689,18 +697,8 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
     /// @param _cfg The full config.
     /// @param _isInitialDeployment Whether or not this is an initial deployment.
     function _assertValidFullConfig(FullConfig memory _cfg, bool _isInitialDeployment) internal view {
-        // All valid game types. StandardValidator is responsible for rejecting game types that
-        // should not be used in a given mode (e.g., legacy types in super root mode).
-        GameType[] memory validGameTypes = new GameType[](6);
-        validGameTypes[0] = GameTypes.CANNON;
-        validGameTypes[1] = GameTypes.PERMISSIONED_CANNON;
-        validGameTypes[2] = GameTypes.CANNON_KONA;
-        validGameTypes[3] = GameTypes.SUPER_PERMISSIONED;
-        validGameTypes[4] = GameTypes.SUPER_CANNON_KONA;
-        validGameTypes[5] = GameTypes.ZK_DISPUTE_GAME;
-
         // We must have a config for each valid game type.
-        if (_cfg.disputeGameConfigs.length != validGameTypes.length) {
+        if (_cfg.disputeGameConfigs.length != VALID_GAME_TYPE_COUNT) {
             revert OPContractsManagerV2_InvalidGameConfigs();
         }
 
@@ -717,11 +715,11 @@ contract OPContractsManagerV2 is ISemver, OPContractsManagerUtilsCaller {
 
         bool superRootGamesMigrationEnabled = isDevFeatureEnabled(DevFeatures.SUPER_ROOT_GAMES_MIGRATION);
 
-        // Iterate over each provided config and confirm that it matches the game type array.
+        // Iterate over each provided config and confirm that it matches the expected game type.
         // This places a requirement on the user to order the configs properly but that's
         // probably a good thing, keeps the config consistent.
         for (uint256 i = 0; i < _cfg.disputeGameConfigs.length; i++) {
-            uint32 rawGameType = validGameTypes[i].raw();
+            uint32 rawGameType = uint32(VALID_GAME_TYPES >> (i * 32));
             bool isCannonGame = rawGameType == GameTypes.CANNON.raw();
             bool isPermissionedCannonGame = rawGameType == GameTypes.PERMISSIONED_CANNON.raw();
             bool isCannonKonaGame = rawGameType == GameTypes.CANNON_KONA.raw();

--- a/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
+++ b/packages/contracts-bedrock/test/L1/opcm/OPContractsManagerV2.t.sol
@@ -1284,7 +1284,7 @@ contract OPContractsManagerV2_Upgrade_Test is OPContractsManagerV2_Upgrade_TestI
             Proposal({ root: Hash.wrap(keccak256("superRootAnchorRoot")), l2SequenceNumber: currentSeqNum + 1 });
 
         // Rebuild dispute game configs: legacy (disabled) + super types.
-        // Order must match validGameTypes in OPContractsManagerV2._assertValidFullConfig().
+        // Order must match VALID_GAME_TYPES in OPContractsManagerV2._assertValidFullConfig().
         delete v2UpgradeInput.disputeGameConfigs;
 
         // Legacy types (all disabled).
@@ -3732,7 +3732,7 @@ contract OPContractsManagerV2_Migrate_Test is OPContractsManagerV2_TestInit {
     }
 
     /// @notice Builds the dispute game configs for upgrading a migrated super-permissioned
-    ///         interop chain. Order must match validGameTypes in
+    ///         interop chain. Order must match VALID_GAME_TYPES in
     ///         OPContractsManagerV2._assertValidFullConfig(): only SUPER_PERMISSIONED is enabled,
     ///         matching the respected game type the migration installs on the shared registry.
     /// @return configs_ The dispute game configs.

--- a/packages/contracts-bedrock/test/setup/ForkL1Live.s.sol
+++ b/packages/contracts-bedrock/test/setup/ForkL1Live.s.sol
@@ -298,7 +298,7 @@ contract ForkL1Live is Deployer, StdAssertions, FeatureFlags {
             (, uint256 currentAnchorSeqNum) = asr.getAnchorRoot();
 
             // Migration upgrade: legacy types disabled, super types enabled.
-            // Order must match validGameTypes in OPContractsManagerV2._assertValidFullConfig().
+            // Order must match VALID_GAME_TYPES in OPContractsManagerV2._assertValidFullConfig().
             disputeGameConfigs = new IOPContractsManagerUtils.DisputeGameConfig[](6);
             disputeGameConfigs[0] = IOPContractsManagerUtils.DisputeGameConfig({
                 enabled: false,
@@ -366,7 +366,7 @@ contract ForkL1Live is Deployer, StdAssertions, FeatureFlags {
             address challenger = DisputeGames.permissionedGameChallenger(disputeGameFactory);
             address proposer = DisputeGames.permissionedGameProposer(disputeGameFactory);
             // Standard upgrade path: CANNON disabled, remaining legacy types enabled, super types disabled.
-            // Order must match validGameTypes in OPContractsManagerV2._assertValidFullConfig().
+            // Order must match VALID_GAME_TYPES in OPContractsManagerV2._assertValidFullConfig().
             uint256 cannonKonaInitBond = DisputeGames.permissionlessGameInitBondForUpgrade(
                 disputeGameFactory, GameTypes.CANNON_KONA, DEFAULT_PERMISSIONLESS_INIT_BOND
             );

--- a/packages/contracts-bedrock/test/setup/PastUpgrades.sol
+++ b/packages/contracts-bedrock/test/setup/PastUpgrades.sol
@@ -188,7 +188,7 @@ library PastUpgrades {
         scSuccess;
 
         // Build dispute game configs with dummy prestates.
-        // Order must match validGameTypes in OPContractsManagerV2._assertValidFullConfig().
+        // Order must match VALID_GAME_TYPES in OPContractsManagerV2._assertValidFullConfig().
         IOPContractsManagerUtils.DisputeGameConfig[] memory disputeGameConfigs =
             new IOPContractsManagerUtils.DisputeGameConfig[](6);
 


### PR DESCRIPTION
## Context
`OPContractsManagerV2` has been on the verge of exceeding the code size limit for some time. It has been using external contracts like `OPContractsManagerMigrator.sol` and `OPContractsManagerContainer.sol` to externalize features and stay under that limit. Recent additions to the migration process and validation have pushed it over.

This PR is the minimal diff needed to regain some room for the migration features, without a heavier refactor.

## Changes
- Moves the array used to validate the configuration of the games on initial deployment into a packed uint.
- Replaces `SuperchainUpgradeInput memory _inp` with `SuperchainUpgradeInput calldata _inp` in `upgradeSuperchain`.

## Test plan
- No tests were changed. The existing suite passing must catch any regression.

Stacked on top of https://github.com/ethereum-optimism/optimism/pull/22807