### PR TITLE
fix(op-node): retain undecided Holocene span batches for retry

### DIFF
--- a/op-node/rollup/derive/batch_stage.go
+++ b/op-node/rollup/derive/batch_stage.go
@@ -22,6 +22,12 @@ import (
 // Upon Holocene activation, it replaces the [BatchQueue].
 type BatchStage struct {
 	baseBatchStage
+
+	// pendingSpan retains a span batch that was already consumed from the
+	// previous stage while its validity was BatchUndecided, so it is retried
+	// instead of being skipped when the missing L1 or L2 context becomes
+	// available.
+	pendingSpan *SpanBatch
 }
 
 var _ SingularBatchProvider = (*BatchStage)(nil)
@@ -32,11 +38,13 @@ func NewBatchStage(log log.Logger, cfg *rollup.Config, prev NextBatchProvider, l
 
 func (bs *BatchStage) Reset(_ context.Context, base eth.L1BlockRef, _ eth.SystemConfig) error {
 	bs.reset(base)
+	bs.pendingSpan = nil
 	return io.EOF
 }
 
 func (bs *BatchStage) FlushChannel() {
 	bs.nextSpan = bs.nextSpan[:0]
+	bs.pendingSpan = nil
 	bs.prev.FlushChannel()
 }
 
@@ -110,6 +118,12 @@ func (bs *BatchStage) NextBatch(ctx context.Context, parent eth.L2BlockRef) (*Si
 }
 
 func (bs *BatchStage) nextSingularBatchCandidate(ctx context.Context, parent eth.L2BlockRef) (*SingularBatch, error) {
+	// Retry a retained span batch whose validity was undecided before pulling
+	// new data from the previous stage.
+	if bs.pendingSpan != nil {
+		return bs.nextFromPendingSpan(ctx, parent)
+	}
+
 	// First check for next span-derived batch
 	nextBatch, _ := bs.nextFromSpanBatch(parent)
 
@@ -148,8 +162,9 @@ func (bs *BatchStage) nextSingularBatchCandidate(ctx context.Context, parent eth
 			spanBatch.LogContext(bs.Log()).Warn("Dropping invalid span batch, flushing channel (span batch checks)")
 			bs.FlushChannel()
 			return nil, NotEnoughData
-		case BatchUndecided: // l2 fetcher error; the span was already consumed and is skipped, not retried
-			spanBatch.LogContext(bs.Log()).Warn("Undecided span batch")
+		case BatchUndecided: // l2 fetcher error or missing L1 context, retain the span for retry
+			spanBatch.LogContext(bs.Log()).Warn("Undecided span batch, retaining for retry")
+			bs.pendingSpan = spanBatch
 			return nil, NotEnoughData
 		case BatchFuture: // can't happen with Holocene
 			return nil, NewCriticalError(errors.New("impossible future batch validity"))
@@ -170,4 +185,47 @@ func (bs *BatchStage) nextSingularBatchCandidate(ctx context.Context, parent eth
 	default:
 		return nil, NewCriticalError(fmt.Errorf("unrecognized batch type: %d", typ))
 	}
+}
+
+// nextFromPendingSpan re-checks a retained span batch whose validity was
+// previously BatchUndecided. The pending slot is only cleared on a terminal
+// outcome (accepted, dropped or past); an undecided result retains the span
+// for another attempt.
+func (bs *BatchStage) nextFromPendingSpan(ctx context.Context, parent eth.L2BlockRef) (*SingularBatch, error) {
+	spanBatch := bs.pendingSpan
+
+	validity := checkSpanBatchHolocene(ctx, bs.config, bs.Log(), bs.l1Blocks, parent, spanBatch, bs.origin, bs.l2)
+	switch validity {
+	case BatchAccept:
+		spanBatch.LogContext(bs.Log()).Info("Found next valid span batch")
+	case BatchPast:
+		spanBatch.LogContext(bs.Log()).Warn("Dropping past span batch")
+		bs.pendingSpan = nil
+		return nil, NotEnoughData
+	case BatchDrop: // drop, flush, move onto next channel
+		spanBatch.LogContext(bs.Log()).Warn("Dropping invalid span batch, flushing channel (pending span batch checks)")
+		bs.pendingSpan = nil
+		bs.FlushChannel()
+		return nil, NotEnoughData
+	case BatchUndecided: // still missing context, keep retaining
+		spanBatch.LogContext(bs.Log()).Warn("Still undecided span batch, retaining for retry")
+		return nil, NotEnoughData
+	case BatchFuture: // can't happen with Holocene
+		return nil, NewCriticalError(errors.New("impossible future batch validity"))
+	}
+
+	// If next batch is SpanBatch, convert it to SingularBatches.
+	singularBatches, err := spanBatch.GetSingularBatches(bs.l1Blocks, parent)
+	// Errors can happen here because the Holocene span batch checks are not exhaustive (unlike
+	// the full span batch checks) so an error must be handled like an invalid span batch (DROP).
+	if err != nil {
+		spanBatch.LogContext(bs.Log()).Warn("Dropping invalid span batch, flushing channel (singular batch extraction)", "error", err)
+		bs.pendingSpan = nil
+		bs.FlushChannel()
+		return nil, NotEnoughData
+	}
+	bs.pendingSpan = nil
+	bs.nextSpan = singularBatches
+	// span-batches are non-empty, so the below pop is safe.
+	return bs.popNextBatch(parent), nil
 }

--- a/op-node/rollup/derive/batch_stage_undecided_test.go
+++ b/op-node/rollup/derive/batch_stage_undecided_test.go
@@ -1,0 +1,145 @@
+package derive
+
+import (
+	"context"
+	"io"
+	"math/big"
+	"math/rand"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-core/forks"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum-optimism/optimism/op-service/testutils"
+)
+
+// TestBatchStage_UndecidedSpanBatchRetained pins the retention of Holocene span batches whose
+// validity is BatchUndecided (see issue #22629): a span batch consumed from the previous stage
+// must be retried once the missing L1 context or L2 fetch result becomes available, instead of
+// being silently skipped. A skipped-but-valid span batch makes the local safe chain diverge from
+// other nodes until a pipeline replay or restart.
+func TestBatchStage_UndecidedSpanBatchRetained(t *testing.T) {
+	l1 := L1Chain([]uint64{10, 16, 22, 28})
+	chainId := big.NewInt(1234)
+	cfg := &rollup.Config{
+		Genesis: rollup.Genesis{
+			L2Time: 20,
+		},
+		BlockTime:         2,
+		MaxSequencerDrift: 600,
+		SeqWindowSize:     1000,
+		L2ChainID:         chainId,
+	}
+	cfg.ActivateAtGenesis(forks.Delta)
+
+	parentBatch := b(cfg.L2ChainID, 20, l1[0])
+	parentRef := singularBatchToBlockRef(t, parentBatch, 0)
+	parentPayload := singularBatchToPayload(t, parentBatch, 0)
+
+	safeBatch := b(cfg.L2ChainID, 22, l1[1])
+	safeHead := singularBatchToBlockRef(t, safeBatch, 1)
+	safePayload := singularBatchToPayload(t, safeBatch, 1)
+
+	// Span batch starting exactly at the safe head: element at ts 22 matches the safe-head
+	// block, element at ts 24 extends it.
+	nextBatch := b(cfg.L2ChainID, 24, l1[1])
+	span := func() *SpanBatch {
+		return initializedSpanBatch([]*SingularBatch{safeBatch, nextBatch}, cfg.Genesis.L2Time, chainId)
+	}
+
+	newStage := func(lgr log.Logger, fetcher SafeBlockFetcher, spans ...Batch) (*BatchStage, *fakeBatchQueueInput) {
+		input := &fakeBatchQueueInput{
+			batches: spans,
+			errors:  make([]error, len(spans)),
+			origin:  l1[2],
+		}
+		stage := NewBatchStage(lgr, cfg, input, fetcher)
+		_ = stage.Reset(context.Background(), l1[1], eth.SystemConfig{})
+		return stage, input
+	}
+
+	t.Run("transient parent lookup failure", func(t *testing.T) {
+		lgr, logs := testlog.CaptureLogger(t, log.LevelWarn)
+		fetcher := newFakeSafeBlockFetcher()
+		// The safe-head payload is present, but the parent block below the span start is not:
+		// the prefix check cannot determine the span's parent yet.
+		fetcher.addBlock(safeHead, &safePayload)
+		stage, _ := newStage(lgr, fetcher, span())
+
+		batch, _, err := stage.NextBatch(context.Background(), safeHead)
+		require.ErrorIs(t, err, NotEnoughData)
+		require.Nil(t, batch)
+		logs.RequireMessageContainedOnce(t, "failed to fetch L2 block")
+		logs.RequireMessageContainedOnce(t, "Undecided span batch, retaining for retry")
+
+		// The parent becomes available; the same span must be retried and accepted, without
+		// replaying the pipeline or re-reading the previous stage. The overlapped element is
+		// excluded from the split, so the next batch (ts 24) is returned directly.
+		fetcher.addBlock(parentRef, &parentPayload)
+		batch, _, err = stage.NextBatch(context.Background(), safeHead)
+		require.NoError(t, err)
+		require.Equal(t, uint64(24), batch.Timestamp)
+	})
+
+	t.Run("transient overlap payload failure", func(t *testing.T) {
+		lgr, logs := testlog.CaptureLogger(t, log.LevelWarn)
+		fetcher := newFakeSafeBlockFetcher()
+		// The parent ref is present so the prefix check succeeds, but the safe-head payload
+		// needed by the overlap check is missing.
+		fetcher.addBlock(parentRef, &parentPayload)
+		fetcher.addBlock(safeHead, nil)
+		stage, _ := newStage(lgr, fetcher, span())
+
+		batch, _, err := stage.NextBatch(context.Background(), safeHead)
+		require.ErrorIs(t, err, NotEnoughData)
+		require.Nil(t, batch)
+		logs.RequireMessageContainedOnce(t, "failed to fetch L2 block payload")
+		logs.RequireMessageContainedOnce(t, "Undecided span batch, retaining for retry")
+
+		fetcher.addBlock(safeHead, &safePayload)
+		batch, _, err = stage.NextBatch(context.Background(), safeHead)
+		require.NoError(t, err)
+		require.Equal(t, uint64(24), batch.Timestamp)
+	})
+
+	t.Run("permanent invalidity after undecided attempt drops the channel", func(t *testing.T) {
+		lgr, logs := testlog.CaptureLogger(t, log.LevelWarn)
+		fetcher := newFakeSafeBlockFetcher()
+		fetcher.addBlock(safeHead, &safePayload)
+		// The span's element at the safe-head height carries an extra transaction, so the
+		// overlap check rejects it once it can run, but the parent lookup fails first, making
+		// the first attempt undecided.
+		rng := rand.New(rand.NewSource(99))
+		signer := types.NewLondonSigner(chainId)
+		extraTx, err2 := testutils.RandomTx(rng, common.Big1, signer).MarshalBinary()
+		require.NoError(t, err2)
+		conflictingElem := *safeBatch
+		conflictingElem.Transactions = append(append([]hexutil.Bytes{}, safeBatch.Transactions...), extraTx)
+		conflictingSpan := initializedSpanBatch([]*SingularBatch{&conflictingElem, nextBatch}, cfg.Genesis.L2Time, chainId)
+		stage, _ := newStage(lgr, fetcher, conflictingSpan)
+
+		batch, _, err := stage.NextBatch(context.Background(), safeHead)
+		require.ErrorIs(t, err, NotEnoughData)
+		require.Nil(t, batch)
+
+		// The parent becomes available; the overlap check now rejects the batch and flushes
+		// the whole channel.
+		fetcher.addBlock(parentRef, &parentPayload)
+		batch, _, err = stage.NextBatch(context.Background(), safeHead)
+		require.ErrorIs(t, err, NotEnoughData)
+		require.Nil(t, batch)
+		logs.RequireMessageContainedOnce(t, "Dropping invalid span batch, flushing channel")
+
+		// The channel was flushed: nothing left to read, only empty-batch derivation remains.
+		batch, _, err = stage.NextBatch(context.Background(), safeHead)
+		require.ErrorIs(t, err, io.EOF)
+		require.Nil(t, batch)
+	})
+}


### PR DESCRIPTION
Fixes #22629 (op-node portion; the kona-side equivalent follows as a separate PR)

## Problem

The Holocene `BatchStage` consumed a span batch from the previous stage and, when validation returned `BatchUndecided` (transient L2 parent-block lookup failure or overlap-payload fetch failure), skipped the batch entirely instead of retrying it. A temporary local fetch failure could therefore make one node skip a valid span batch while others accept it, splitting the local safe chain until a pipeline replay or restart recovered the batch from L1. PR #22215 made the overlap path easier to hit by adding one payload lookup per overlapped block.

## Fix

Retain the consumed span batch in a `pendingSpan` slot when its validity is `BatchUndecided`, and re-check the same batch at the start of the next candidate lookup before pulling new data from the previous stage. The slot is cleared on accept, drop, past, channel flush and reset. `BatchDrop`, `BatchPast` and accepted-span behavior are unchanged.

Note: the singular-batch `BatchUndecided` path in `NextBatch` is unreachable from this stage, because the stage requires at least two buffered L1 blocks before any candidate check, so no pending slot is needed there.

## Tests

New `batch_stage_undecided_test.go` with fault-injection scenarios, all failing without the fix and passing with it:

- transient parent-block lookup failure: the retained span is accepted on retry without replaying the pipeline or re-reading the previous stage
- transient overlap-payload lookup failure: same lifecycle through the overlap path
- permanent invalidity discovered after an undecided attempt: the retry still drops the span and flushes the channel

Verified in a `golang:1.26` Linux container matching the repo toolchain: full `op-node/rollup/derive` suite green, `go vet` and `gofmt` clean.